### PR TITLE
fix: filter internal OLE entries, layer serialization, and append mode

### DIFF
--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -252,57 +252,77 @@ pub struct Model3D {
 pub enum Layer {
     // Copper layers
     /// Top copper layer.
+    #[serde(rename = "Top Layer", alias = "TopLayer")]
     TopLayer,
     /// Bottom copper layer.
+    #[serde(rename = "Bottom Layer", alias = "BottomLayer")]
     BottomLayer,
     /// Multi-layer (all copper layers, for through-hole pads).
     #[default]
+    #[serde(rename = "Multi-Layer", alias = "MultiLayer")]
     MultiLayer,
 
     // Silkscreen
     /// Top silkscreen (overlay).
+    #[serde(rename = "Top Overlay", alias = "TopOverlay")]
     TopOverlay,
     /// Bottom silkscreen.
+    #[serde(rename = "Bottom Overlay", alias = "BottomOverlay")]
     BottomOverlay,
 
     // Solder mask
     /// Top solder mask.
+    #[serde(rename = "Top Solder", alias = "TopSolder")]
     TopSolder,
     /// Bottom solder mask.
+    #[serde(rename = "Bottom Solder", alias = "BottomSolder")]
     BottomSolder,
 
     // Paste
     /// Top solder paste.
+    #[serde(rename = "Top Paste", alias = "TopPaste")]
     TopPaste,
     /// Bottom solder paste.
+    #[serde(rename = "Bottom Paste", alias = "BottomPaste")]
     BottomPaste,
 
     // Component layer pairs (preferred over generic mechanical layers)
     /// Top assembly outline (component body outline for documentation).
+    #[serde(rename = "Top Assembly", alias = "TopAssembly")]
     TopAssembly,
     /// Bottom assembly outline.
+    #[serde(rename = "Bottom Assembly", alias = "BottomAssembly")]
     BottomAssembly,
     /// Top courtyard (component keepout area per IPC-7351).
+    #[serde(rename = "Top Courtyard", alias = "TopCourtyard")]
     TopCourtyard,
     /// Bottom courtyard.
+    #[serde(rename = "Bottom Courtyard", alias = "BottomCourtyard")]
     BottomCourtyard,
     /// Top 3D body outline (for 3D model placement).
+    #[serde(rename = "Top 3D Body", alias = "Top3DBody")]
     Top3DBody,
     /// Bottom 3D body outline.
+    #[serde(rename = "Bottom 3D Body", alias = "Bottom3DBody")]
     Bottom3DBody,
 
     // Generic mechanical layers (use component layer pairs when possible)
     /// Mechanical layer 1.
+    #[serde(rename = "Mechanical 1", alias = "Mechanical1")]
     Mechanical1,
     /// Mechanical layer 2.
+    #[serde(rename = "Mechanical 2", alias = "Mechanical2")]
     Mechanical2,
     /// Mechanical layer 13.
+    #[serde(rename = "Mechanical 13", alias = "Mechanical13")]
     Mechanical13,
     /// Mechanical layer 15.
+    #[serde(rename = "Mechanical 15", alias = "Mechanical15")]
     Mechanical15,
 
     // Keep-out
     /// Keep-out layer.
+    #[serde(rename = "Keep-Out Layer", alias = "KeepOut")]
     KeepOut,
 }
 


### PR DESCRIPTION
Bug fixes from debugging session addressing issues discovered during practical usage.

## Changes

### 1. Filter internal OLE storage entries in PcbLib reads
Internal OLE storage entries (`Library`, `Models`, `Textures`, `ModelsNoEmbed`, `PadViaLibrary`, `LayerKindMapping`, `ComponentParamsTOC`, `FileVersionInfo`, `PrimitiveGuids`, `UniqueIDPrimitiveInformation`) are now filtered out when reading `.PcbLib` files. Previously, these internal Altium data structures were incorrectly returned as footprints.

### 2. Layer enum serialisation consistency
Added `#[serde(rename = "...", alias = "...")]` attributes to the `Layer` enum variants. This ensures consistent JSON serialisation (e.g., `"Top Overlay"` instead of `"TopOverlay"`) whilst maintaining backwards compatibility through aliases for deserialisation.

### 3. Append mode fix for write operations
Fixed `write_pcblib` and `write_schlib` MCP tools to correctly implement append mode. When `append: true` is specified and the target file exists, the existing library is now properly read before appending new components, rather than overwriting with only the new components.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)