### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,37 +4,3 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Changed
-
-- **Major architectural refactor**: Shifted from calculator-based to primitive-based approach
-    - Removed IPC-7351B calculators from the tool (AI now handles calculations)
-    - Tool now provides pure file I/O and primitive placement
-    - Any footprint type can now be created (not limited to pre-programmed packages)
-
-### Removed
-
-- `src/ipc7351/` module (chip.rs, sot.rs, density.rs, naming.rs, error.rs)
-- Calculator-based MCP tools (`calculate_footprint`, `list_package_types`, `get_ipc_name`)
-- Old approach preserved in `stale/calculator-approach` branch
-
-### Added
-
-- `src/altium/` module for Altium file I/O
-    - `pcblib/mod.rs` - PcbLib reading and writing with OLE compound document handling
-    - `pcblib/primitives.rs` - Pad, Track, Arc, Region, Text, Model3D types
-    - `error.rs` - Altium-specific error types
-- New primitive-based MCP tools
-    - `read_pcblib` - Read footprints from .PcbLib files
-    - `write_pcblib` - Write footprints with primitive definitions
-    - `list_components` - List component names in a library
-
-### Documentation
-
-- Rewrote README.md with new architecture vision
-- Rewrote docs/ARCHITECTURE.md with responsibility split diagram
-- Rewrote docs/AI_WORKFLOW.md with primitive-based workflow
-- Updated docs/VISION.md with simplified approach
-- Updated .claude/CLAUDE.md with new project structure

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -439,6 +439,8 @@ mod tests {
         assert_eq!(read_lib.len(), 1);
         let read_symbol = read_lib.get("RESISTOR").expect("Symbol not found");
         assert_eq!(read_symbol.name, "RESISTOR");
+        assert_eq!(read_symbol.designator, "R?", "Designator should be preserved");
+        assert_eq!(read_symbol.part_count, 1, "part_count should be 1");
         assert_eq!(read_symbol.pins.len(), 2);
         assert_eq!(read_symbol.rectangles.len(), 1);
         assert_eq!(read_symbol.parameters.len(), 1);
@@ -513,6 +515,8 @@ mod tests {
         let read_lib = SchLib::read(buffer).expect("Failed to read SchLib");
 
         let read_symbol = read_lib.get("OPAMP_DUAL").expect("Symbol not found");
+        assert_eq!(read_symbol.designator, "U?", "Designator should be preserved");
+        assert_eq!(read_symbol.part_count, 2, "part_count should be 2");
         assert_eq!(read_symbol.pins.len(), 6);
         assert_eq!(read_symbol.rectangles.len(), 2);
 

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -439,7 +439,10 @@ mod tests {
         assert_eq!(read_lib.len(), 1);
         let read_symbol = read_lib.get("RESISTOR").expect("Symbol not found");
         assert_eq!(read_symbol.name, "RESISTOR");
-        assert_eq!(read_symbol.designator, "R?", "Designator should be preserved");
+        assert_eq!(
+            read_symbol.designator, "R?",
+            "Designator should be preserved"
+        );
         assert_eq!(read_symbol.part_count, 1, "part_count should be 1");
         assert_eq!(read_symbol.pins.len(), 2);
         assert_eq!(read_symbol.rectangles.len(), 1);
@@ -515,7 +518,10 @@ mod tests {
         let read_lib = SchLib::read(buffer).expect("Failed to read SchLib");
 
         let read_symbol = read_lib.get("OPAMP_DUAL").expect("Symbol not found");
-        assert_eq!(read_symbol.designator, "U?", "Designator should be preserved");
+        assert_eq!(
+            read_symbol.designator, "U?",
+            "Designator should be preserved"
+        );
         assert_eq!(read_symbol.part_count, 2, "part_count should be 2");
         assert_eq!(read_symbol.pins.len(), 6);
         assert_eq!(read_symbol.rectangles.len(), 2);

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -103,7 +103,9 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
                 symbol.description.clone_from(desc);
             }
             if let Some(part_count) = props.get("partcount") {
-                symbol.part_count = part_count.trim().parse().unwrap_or(1);
+                // Altium stores part_count + 1, so we subtract 1 when reading
+                let raw_count: u32 = part_count.trim().parse().unwrap_or(2);
+                symbol.part_count = raw_count.saturating_sub(1).max(1);
             }
         }
         14 => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -219,8 +219,12 @@ impl McpServer {
                 .map_err(|e| format!("Failed to resolve path: {e}"))?
         } else {
             // For new files, check the parent directory
-            let parent = path.parent().ok_or_else(|| "Invalid path: no parent directory".to_string())?;
-            let filename = path.file_name().ok_or_else(|| "Invalid path: no filename".to_string())?;
+            let parent = path
+                .parent()
+                .ok_or_else(|| "Invalid path: no parent directory".to_string())?;
+            let filename = path
+                .file_name()
+                .ok_or_else(|| "Invalid path: no filename".to_string())?;
             let canonical_parent = parent
                 .canonicalize()
                 .map_err(|e| format!("Failed to resolve parent directory: {e}"))?;


### PR DESCRIPTION
## Description

Security and bug fixes for the MCP server, plus cleanup of the CHANGELOG.

**Key changes:**
- **Path validation security**: All MCP tool handlers (`read_pcblib`, `write_pcblib`, `read_schlib`, `write_schlib`, `list_components`, `extract_style`) now validate that file paths are within the configured `allowed_paths`, preventing access to files outside permitted directories
- **SchLib part_count fix**: Corrects an off-by-one error when reading SchLib files—Altium stores `part_count + 1` internally, so the reader now subtracts 1 when parsing
- **Duplicate footprint validation**: `write_pcblib` now checks for duplicate footprint names both within the same request and against existing footprints when in append mode
- **CHANGELOG cleanup**: Removed the unpublished `[Unreleased]` section content that was left over from the previous architecture
- **Code quality**: Applied rustfmt formatting and removed unnecessary `#[allow(dead_code)]` / `#[allow(clippy::unused_self)]` annotations

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security improvement
- [x] Refactoring (no functional changes)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have added tests that prove my fix/feature works (designator and part_count round-trip assertions)
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
