### PR TITLE
Updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,13 +4,7 @@
 
 **The AI handles the intelligence. The tool handles file I/O.**
 
-| Responsibility | Owner |
-|---------------|-------|
-| IPC-7351B calculations | AI |
-| Package layout decisions | AI |
-| Style choices | AI |
-| Reading/writing Altium files | This tool |
-| Primitive placement | This tool |
+See `docs/VISION.md` for the full responsibility split.
 
 ## What Is This Project?
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,6 @@
 {
     // Files owned by repository owner - do not modify
     // GitHub issue templates have their own format requirements
-    "ignores": ["CODE_OF_CONDUCT.md", ".github/ISSUE_TEMPLATE/**"]
+    // Third-party packages in virtual environments
+    "ignores": ["CODE_OF_CONDUCT.md", ".github/ISSUE_TEMPLATE/**", "**/.venv/**"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+*This changelog will be populated once the first official release is published.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@
 We pledge to make our community welcoming, safe, and equitable for all.
 
 We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of
-characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or
+characteristics including race, ethnicity, caste, colour, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or
 expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status.
 The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ component libraries.
 
 ## The Core Idea
 
-**The AI handles the intelligence. The tool handles the file I/O.**
+**The AI handles the intelligence. The tool handles file I/O.**
 
 | Responsibility | Owner |
 |---------------|-------|
@@ -23,6 +23,7 @@ component libraries.
 | STEP model attachment | This tool |
 
 This means the AI can create **any footprint** — not just pre-programmed package types.
+See [docs/VISION.md](docs/VISION.md) for the full architectural rationale.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This means the AI can create **any footprint** — not just pre-programmed packa
 
 ---
 
+## Quick Start with Claude Code
+
+> **[Claude Code Setup Guide](docs/CLAUDE_CODE_GUIDE.md)** — Complete step-by-step instructions
+> for using this MCP server with Claude Code CLI on **Windows**, **Linux**, and **macOS**.
+
+---
+
 ## How It Works
 
 ```text

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,4 +110,4 @@ We thank the security researchers and community members who help keep this proje
 
 ---
 
-*This security policy was last updated on 2025-01-17.*
+*This security policy was last updated on 2026-01-17.*

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -4,16 +4,9 @@ This document explains how an AI assistant uses altium-designer-mcp to create Al
 
 ## Core Principle
 
-**The AI handles the intelligence. The tool handles the file I/O.**
+**The AI handles the intelligence. The tool handles file I/O.**
 
-| Responsibility | Owner |
-|---------------|-------|
-| IPC-7351B calculations | AI |
-| Package layout decisions | AI |
-| Style choices | AI |
-| Datasheet interpretation | AI |
-| Reading/writing Altium files | This tool |
-| Primitive placement | This tool |
+See [VISION.md](VISION.md) for the full responsibility split and architectural rationale.
 
 ---
 
@@ -70,10 +63,10 @@ IPC-7351B Calculations (Nominal density):
 - Heel extension: 0.35mm
 - Side extension: 0.05mm
 
-Pad dimensions:
-- Width: 0.3 + 0.35 + 0.35 = 1.0mm (but typically 0.9mm)
-- Height: 0.8 + 2×0.05 = 0.9mm (but typically 0.95mm)
-- Span: 1.6 - 0.3 + 0.9 = 2.2mm (centre-to-centre: 1.5mm)
+Pad dimensions (using manufacturer-recommended values):
+- Width: 0.9mm (terminal + extensions, adjusted for process)
+- Height: 0.95mm (body height + side extensions, adjusted)
+- Centre-to-centre span: 1.5mm
 
 IPC Name: RESC1608X55N
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,22 +4,9 @@ This document describes the architecture of the MCP server.
 
 ## Core Principle
 
-**The AI handles the intelligence. The tool handles the file I/O.**
+**The AI handles the intelligence. The tool handles file I/O.**
 
-```text
-┌─────────────────────────────────────────────────────────────────────────┐
-│  RESPONSIBILITY SPLIT                                                    │
-│                                                                         │
-│  AI (Claude, etc.)                    MCP Server (this tool)            │
-│  ─────────────────                    ──────────────────────            │
-│  • IPC-7351B calculations             • Read .PcbLib/.SchLib files      │
-│  • Package layout decisions           • Write .PcbLib/.SchLib files     │
-│  • Style choices                      • Primitive placement             │
-│  • Datasheet interpretation           • STEP model attachment           │
-│  • Design rule knowledge              • OLE document handling           │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
+See [VISION.md](VISION.md) for the full responsibility split and architectural rationale.
 
 This architecture means the AI can create **any footprint** — not just pre-programmed
 package types. The tool is package-agnostic.

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -125,7 +125,7 @@ Create a `.mcp.json` file in your Altium project's root directory:
     "mcpServers": {
         "altium": {
             "command": "C:\\path\\to\\altium-designer-mcp\\target\\release\\altium-designer-mcp.exe",
-            "args": ["C:\\Users\\YourName\\.altium-designer-mcp\\config.json"]
+            "args": ["%USERPROFILE%\\.altium-designer-mcp\\config.json"]
         }
     }
 }
@@ -164,7 +164,7 @@ You can also add the MCP server globally using the Claude Code CLI:
 **Windows (PowerShell):**
 
 ```powershell
-claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe -- C:\Users\YourName\.altium-designer-mcp\config.json
+claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe -- %USERPROFILE%\.altium-designer-mcp\config.json
 ```
 
 **Linux / macOS:**

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -125,7 +125,7 @@ Create a `.mcp.json` file in your Altium project's root directory:
     "mcpServers": {
         "altium": {
             "command": "C:\\path\\to\\altium-designer-mcp\\target\\release\\altium-designer-mcp.exe",
-            "args": []
+            "args": ["C:\\Users\\YourName\\.altium-designer-mcp\\config.json"]
         }
     }
 }
@@ -138,7 +138,7 @@ Create a `.mcp.json` file in your Altium project's root directory:
     "mcpServers": {
         "altium": {
             "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
-            "args": []
+            "args": ["/home/yourname/.altium-designer-mcp/config.json"]
         }
     }
 }
@@ -151,7 +151,7 @@ Create a `.mcp.json` file in your Altium project's root directory:
     "mcpServers": {
         "altium": {
             "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
-            "args": []
+            "args": ["/Users/yourname/.altium-designer-mcp/config.json"]
         }
     }
 }
@@ -164,13 +164,13 @@ You can also add the MCP server globally using the Claude Code CLI:
 **Windows (PowerShell):**
 
 ```powershell
-claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe
+claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe -- C:\Users\YourName\.altium-designer-mcp\config.json
 ```
 
 **Linux / macOS:**
 
 ```bash
-claude mcp add altium /path/to/altium-designer-mcp/target/release/altium-designer-mcp
+claude mcp add altium /path/to/altium-designer-mcp/target/release/altium-designer-mcp -- ~/.altium-designer-mcp/config.json
 ```
 
 To verify it was added:

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -1,0 +1,423 @@
+# Using altium-designer-mcp with Claude Code
+
+This guide explains how to set up and use the Altium Designer MCP server with Claude Code
+for AI-assisted component library creation.
+
+---
+
+## Overview
+
+Claude Code can use this MCP server to:
+
+- Read existing Altium libraries and analyse their structure
+- Create new footprints with IPC-7351B compliant land patterns
+- Create schematic symbols with proper pin definitions
+- Match the style of existing libraries
+- Generate entire component libraries from specifications
+
+**Note:** While Altium Designer only runs on Windows, you can use this MCP server on any
+platform to generate library files that can then be opened in Altium Designer on Windows.
+
+---
+
+## Installation
+
+### Prerequisites
+
+- [Rust 1.75+](https://rustup.rs/) (for building from source)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
+
+### Step 1: Clone and Build
+
+#### Windows (PowerShell)
+
+```powershell
+git clone https://github.com/embedded-society/altium-designer-mcp.git
+cd altium-designer-mcp
+cargo build --release
+```
+
+The binary will be at `target\release\altium-designer-mcp.exe`.
+
+#### Linux / macOS
+
+```bash
+git clone https://github.com/embedded-society/altium-designer-mcp.git
+cd altium-designer-mcp
+cargo build --release
+```
+
+The binary will be at `target/release/altium-designer-mcp`.
+
+### Step 2: Create Configuration File
+
+Create the configuration directory and file.
+
+#### Windows (PowerShell)
+
+```powershell
+mkdir $env:USERPROFILE\.altium-designer-mcp -ErrorAction SilentlyContinue
+```
+
+Create `%USERPROFILE%\.altium-designer-mcp\config.json`:
+
+```json
+{
+    "allowed_paths": [
+        "C:\\Users\\YourName\\Documents\\Altium\\Libraries"
+    ],
+    "logging": {
+        "level": "warn"
+    }
+}
+```
+
+#### Linux
+
+```bash
+mkdir -p ~/.altium-designer-mcp
+```
+
+Create `~/.altium-designer-mcp/config.json`:
+
+```json
+{
+    "allowed_paths": [
+        "/home/yourname/altium-libraries"
+    ],
+    "logging": {
+        "level": "warn"
+    }
+}
+```
+
+#### macOS
+
+```bash
+mkdir -p ~/.altium-designer-mcp
+```
+
+Create `~/.altium-designer-mcp/config.json`:
+
+```json
+{
+    "allowed_paths": [
+        "/Users/yourname/Documents/Altium/Libraries"
+    ],
+    "logging": {
+        "level": "warn"
+    }
+}
+```
+
+### Step 3: Configure Claude Code
+
+Add the MCP server to your Claude Code configuration.
+
+#### Windows
+
+Edit `%APPDATA%\Claude\claude_desktop_config.json` (or your Claude Code settings):
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "C:\\path\\to\\altium-designer-mcp\\target\\release\\altium-designer-mcp.exe",
+            "args": []
+        }
+    }
+}
+```
+
+Alternatively, using a relative path from your project:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "./altium-designer-mcp/target/release/altium-designer-mcp.exe",
+            "args": []
+        }
+    }
+}
+```
+
+#### Linux
+
+Edit `~/.config/claude-code/config.json` (or your Claude Code settings):
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "args": []
+        }
+    }
+}
+```
+
+#### macOS
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "args": []
+        }
+    }
+}
+```
+
+---
+
+## Using with Claude Code CLI
+
+### Starting Claude Code with the MCP
+
+Simply run Claude Code in your project directory:
+
+```bash
+claude
+```
+
+Claude Code will automatically load the MCP server from your configuration.
+
+### Verify MCP is Loaded
+
+Ask Claude Code:
+
+```
+What MCP tools do you have available?
+```
+
+You should see the Altium tools listed:
+- `read_pcblib`
+- `write_pcblib`
+- `read_schlib`
+- `write_schlib`
+- `list_components`
+- `extract_style`
+
+---
+
+## Example Workflows
+
+### 1. Create a Single Footprint
+
+```
+Create an IPC-7351B compliant 0603 chip resistor footprint and save it to
+./MyLibrary.PcbLib
+```
+
+Claude Code will:
+1. Calculate the land pattern using IPC-7351B
+2. Generate pad coordinates, silkscreen, and courtyard
+3. Call `write_pcblib` to create the file
+
+### 2. Create a Matching Schematic Symbol
+
+```
+Now create a matching schematic symbol for the 0603 resistor and save it to
+./MyLibrary.SchLib. Use designator "R?" and link it to the RESC1608X55N footprint.
+```
+
+### 3. Analyse an Existing Library
+
+```
+Read ./ExistingLibrary.PcbLib and describe the footprints it contains.
+What silkscreen style does it use?
+```
+
+Claude Code will:
+1. Call `read_pcblib` to read the library
+2. Analyse the primitives
+3. Describe the styling conventions
+
+### 4. Match an Existing Style
+
+```
+Extract the style from ./CompanyLibrary.PcbLib and create a new 0805 capacitor
+footprint that matches the same style conventions.
+```
+
+Claude Code will:
+1. Call `extract_style` to analyse the existing library
+2. Apply the same track widths, pad shapes, and layer usage
+3. Create a style-matched footprint
+
+### 5. Create a Complete Component Library
+
+```
+Create a chip resistor library with footprints and symbols for:
+- 0201, 0402, 0603, 0805, 1206, 2010, 2512
+
+Use IPC-7351B nominal density. Save to ./ChipResistors.PcbLib and
+./ChipResistors.SchLib
+```
+
+Claude Code will batch-create all components using IPC-7351B calculations.
+
+### 6. Create from Datasheet Specifications
+
+```
+Create a footprint for a QFN-24 package with:
+- Body: 4mm x 4mm
+- 24 pins, 0.5mm pitch
+- Thermal pad: 2.5mm x 2.5mm
+- Use IPC-7351B nominal density
+
+Save to ./ICs.PcbLib
+```
+
+---
+
+## Example Prompts
+
+### Basic Component Creation
+
+```
+Create an 0805 chip capacitor footprint with IPC-7351B nominal land pattern.
+```
+
+```
+Create a 2-pin polarised capacitor schematic symbol.
+```
+
+### Working with Existing Libraries
+
+```
+List all components in ./MyLibrary.PcbLib
+```
+
+```
+Read ./Passives.SchLib and show me the pin configuration for the RESISTOR symbol.
+```
+
+### Style Matching
+
+```
+Analyse the silkscreen style in ./ExistingLib.PcbLib - what line width does it use?
+```
+
+```
+Create a new footprint matching the style of ./CompanyStandard.PcbLib
+```
+
+### Batch Creation
+
+```
+Create a complete SMD inductor library with sizes: 0402, 0603, 0805, 1008, 1206
+```
+
+```
+Create schematic symbols for all footprints in ./Passives.PcbLib
+```
+
+---
+
+## Tips for Best Results
+
+### 1. Be Specific About Standards
+
+```
+Use IPC-7351B nominal density (not maximum or minimum)
+```
+
+### 2. Specify Layer Preferences
+
+```
+Put silkscreen on Top Overlay, courtyard on Top Courtyard layer
+```
+
+### 3. Request Style Analysis First
+
+```
+First analyse ./ExistingLib.PcbLib, then create new components matching that style
+```
+
+### 4. Provide Datasheet Details
+
+When creating custom packages, provide:
+- Body dimensions (L x W x H)
+- Pin pitch
+- Pin count and arrangement
+- Thermal pad dimensions (if applicable)
+
+### 5. Use Append Mode for Incremental Building
+
+```
+Add an 0402 resistor footprint to the existing ./Passives.PcbLib (append mode)
+```
+
+---
+
+## Troubleshooting
+
+### "Access denied" Error
+
+The file path is outside `allowed_paths`. Update your config.json to include the
+directory where you want to create libraries.
+
+### MCP Server Not Found
+
+Verify the path in your Claude Code configuration points to the correct binary:
+- Windows: `.exe` extension required
+- Check the path exists and is executable
+
+### Library Won't Open in Altium
+
+- Ensure you're using a recent version of Altium Designer (19+)
+- Check that the file was created successfully (non-zero file size)
+- Try opening with File > Open rather than drag-and-drop
+
+### Style Extraction Shows Unexpected Values
+
+The `extract_style` tool analyses all primitives in the library. If a library has
+mixed styles, you may see multiple values for each property.
+
+---
+
+## Platform-Specific Notes
+
+### Windows
+
+This is the primary platform since Altium Designer runs on Windows. You can:
+- Generate libraries directly in your Altium project folder
+- Use Windows paths with backslashes in config.json (escape them: `\\`)
+- Run Claude Code in PowerShell, CMD, or Windows Terminal
+
+### Linux
+
+Generate libraries on Linux and transfer to Windows for use in Altium:
+- Use a shared folder, cloud sync, or version control
+- File format is binary-compatible across platforms
+- Consider using Wine with Altium Designer (community-supported)
+
+### macOS
+
+Same approach as Linux:
+- Generate libraries and transfer to Windows
+- Use Apple Silicon or Intel Mac - both work
+- File format is binary-compatible
+
+---
+
+## Security Notes
+
+The MCP server validates all file paths against the `allowed_paths` configuration.
+This prevents the AI from accessing or modifying files outside designated directories.
+
+Always configure `allowed_paths` to include only the directories where you want
+to allow library operations.
+
+---
+
+## Next Steps
+
+- Read [AI_WORKFLOW.md](AI_WORKFLOW.md) for detailed IPC-7351B reference
+- See [ARCHITECTURE.md](ARCHITECTURE.md) for technical details
+- Check sample files in `scripts/` folder for examples

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -112,11 +112,13 @@ Create `~/.altium-designer-mcp/config.json`:
 
 ### Step 3: Configure Claude Code
 
-Add the MCP server to your Claude Code configuration.
+Claude Code uses a `.mcp.json` file in your project root to configure MCP servers.
+
+#### Option A: Project-Level Configuration (Recommended)
+
+Create a `.mcp.json` file in your Altium project's root directory:
 
 #### Windows
-
-Edit `%APPDATA%\Claude\claude_desktop_config.json` (or your Claude Code settings):
 
 ```json
 {
@@ -129,22 +131,7 @@ Edit `%APPDATA%\Claude\claude_desktop_config.json` (or your Claude Code settings
 }
 ```
 
-Alternatively, using a relative path from your project:
-
-```json
-{
-    "mcpServers": {
-        "altium": {
-            "command": "./altium-designer-mcp/target/release/altium-designer-mcp.exe",
-            "args": []
-        }
-    }
-}
-```
-
 #### Linux
-
-Edit `~/.config/claude-code/config.json` (or your Claude Code settings):
 
 ```json
 {
@@ -159,8 +146,6 @@ Edit `~/.config/claude-code/config.json` (or your Claude Code settings):
 
 #### macOS
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
-
 ```json
 {
     "mcpServers": {
@@ -172,19 +157,44 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
+#### Option B: Global Configuration via CLI
+
+You can also add the MCP server globally using the Claude Code CLI:
+
+**Windows (PowerShell):**
+
+```powershell
+claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe
+```
+
+**Linux / macOS:**
+
+```bash
+claude mcp add altium /path/to/altium-designer-mcp/target/release/altium-designer-mcp
+```
+
+To verify it was added:
+
+```bash
+claude mcp list
+```
+
 ---
 
 ## Using with Claude Code CLI
 
-### Starting Claude Code with the MCP
+### Starting Claude Code
 
-Simply run Claude Code in your project directory:
+Navigate to your Altium project directory and run:
 
 ```bash
 claude
 ```
 
-Claude Code will automatically load the MCP server from your configuration.
+Claude Code will automatically detect and load the MCP server from:
+
+1. The `.mcp.json` file in the current directory (if present)
+2. Your global MCP configuration
 
 ### Verify MCP is Loaded
 
@@ -192,6 +202,12 @@ Ask Claude Code:
 
 ```
 What MCP tools do you have available?
+```
+
+Or use the CLI command:
+
+```bash
+claude mcp list
 ```
 
 You should see the Altium tools listed:

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -211,6 +211,7 @@ claude mcp list
 ```
 
 You should see the Altium tools listed:
+
 - `read_pcblib`
 - `write_pcblib`
 - `read_schlib`
@@ -230,6 +231,7 @@ Create an IPC-7351B compliant 0603 chip resistor footprint and save it to
 ```
 
 Claude Code will:
+
 1. Calculate the land pattern using IPC-7351B
 2. Generate pad coordinates, silkscreen, and courtyard
 3. Call `write_pcblib` to create the file
@@ -249,6 +251,7 @@ What silkscreen style does it use?
 ```
 
 Claude Code will:
+
 1. Call `read_pcblib` to read the library
 2. Analyse the primitives
 3. Describe the styling conventions
@@ -261,6 +264,7 @@ footprint that matches the same style conventions.
 ```
 
 Claude Code will:
+
 1. Call `extract_style` to analyse the existing library
 2. Apply the same track widths, pad shapes, and layer usage
 3. Create a style-matched footprint
@@ -358,6 +362,7 @@ First analyse ./ExistingLib.PcbLib, then create new components matching that sty
 ### 4. Provide Datasheet Details
 
 When creating custom packages, provide:
+
 - Body dimensions (L x W x H)
 - Pin pitch
 - Pin count and arrangement
@@ -381,6 +386,7 @@ directory where you want to create libraries.
 ### MCP Server Not Found
 
 Verify the path in your Claude Code configuration points to the correct binary:
+
 - Windows: `.exe` extension required
 - Check the path exists and is executable
 
@@ -402,6 +408,7 @@ mixed styles, you may see multiple values for each property.
 ### Windows
 
 This is the primary platform since Altium Designer runs on Windows. You can:
+
 - Generate libraries directly in your Altium project folder
 - Use Windows paths with backslashes in config.json (escape them: `\\`)
 - Run Claude Code in PowerShell, CMD, or Windows Terminal
@@ -409,6 +416,7 @@ This is the primary platform since Altium Designer runs on Windows. You can:
 ### Linux
 
 Generate libraries on Linux and transfer to Windows for use in Altium:
+
 - Use a shared folder, cloud sync, or version control
 - File format is binary-compatible across platforms
 - Consider using Wine with Altium Designer (community-supported)
@@ -416,6 +424,7 @@ Generate libraries on Linux and transfer to Windows for use in Altium:
 ### macOS
 
 Same approach as Linux:
+
 - Generate libraries and transfer to Windows
 - Use Apple Silicon or Intel Mac - both work
 - File format is binary-compatible

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -78,7 +78,7 @@ The AI provides complete primitive definitions. The tool just writes them.
 
 - **Pad**: Position, size, shape, designator, layer
 - **Track**: Start/end points, width, layer
-- **Arc**: Center, radius, angles, width, layer
+- **Arc**: Centre, radius, angles, width, layer
 - **Region**: Vertices, layer
 - **Text**: Position, content, size, layer
 


### PR DESCRIPTION
## Description

This PR adds comprehensive Claude Code CLI documentation and consolidates duplicated content across the documentation.

### New Features
- **Claude Code Setup Guide** (`docs/CLAUDE_CODE_GUIDE.md`) — Complete step-by-step instructions for using the MCP server with Claude Code CLI on Windows, Linux, and macOS
- **Quick Start section** in README linking to the new guide

### Documentation Improvements
- Consolidated responsibility split documentation — now references `VISION.md` as the single source of truth (reduces duplication in `CLAUDE.md`, `AI_WORKFLOW.md`, and `ARCHITECTURE.md`)
- Clarified IPC-7351B calculation example in `AI_WORKFLOW.md`
- Added placeholder note to `CHANGELOG.md` for first release

### Housekeeping
- British English spelling corrections: `color` → `colour`, `Center` → `Centre`
- Fixed date in `SECURITY.md`: 2025 → 2026
- Added `.venv/**` to markdownlint ignore patterns

## Type of Change

- [x] Documentation update
- [x] Refactoring (no functional changes)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] Documentation changes only — no code changes to test
- [x] Markdownlint passes

## Code Quality

- [x] Documentation is updated
- [x] CHANGELOG.md is updated for user-facing changes
