### PR TITLE
Add comprehensive input validation for PcbLib and SchLib writers

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -866,7 +866,10 @@ impl McpServer {
         }
 
         // Validate footprint names
+        // OLE storage names are limited to 31 characters and cannot contain certain chars
+        #[allow(clippy::items_after_statements)]
         const MAX_OLE_NAME_LEN: usize = 31;
+        #[allow(clippy::items_after_statements)]
         const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
         for name in &new_names {
             if name.is_empty() {
@@ -874,18 +877,15 @@ impl McpServer {
             }
             if name.len() > MAX_OLE_NAME_LEN {
                 return ToolCallResult::error(format!(
-                    "Footprint name '{}' is too long ({} characters). \
-                     Maximum length is {} characters due to OLE storage format limitations.",
-                    name,
+                    "Footprint name '{name}' is too long ({} characters). \
+                     Maximum length is {MAX_OLE_NAME_LEN} characters due to OLE storage format limitations.",
                     name.len(),
-                    MAX_OLE_NAME_LEN
                 ));
             }
             if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
                 return ToolCallResult::error(format!(
-                    "Footprint name '{}' contains invalid character '{}'. \
+                    "Footprint name '{name}' contains invalid character '{c}'. \
                      Names cannot contain: / \\ : * ? \" < > |",
-                    name, c
                 ));
             }
         }
@@ -1120,7 +1120,10 @@ impl McpServer {
         }
 
         // Validate symbol names
+        // OLE storage names are limited to 31 characters and cannot contain certain chars
+        #[allow(clippy::items_after_statements)]
         const MAX_OLE_NAME_LEN: usize = 31;
+        #[allow(clippy::items_after_statements)]
         const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
         for name in &new_names {
             if name.is_empty() {
@@ -1128,18 +1131,15 @@ impl McpServer {
             }
             if name.len() > MAX_OLE_NAME_LEN {
                 return ToolCallResult::error(format!(
-                    "Symbol name '{}' is too long ({} characters). \
-                     Maximum length is {} characters due to OLE storage format limitations.",
-                    name,
+                    "Symbol name '{name}' is too long ({} characters). \
+                     Maximum length is {MAX_OLE_NAME_LEN} characters due to OLE storage format limitations.",
                     name.len(),
-                    MAX_OLE_NAME_LEN
                 ));
             }
             if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
                 return ToolCallResult::error(format!(
-                    "Symbol name '{}' contains invalid character '{}'. \
+                    "Symbol name '{name}' contains invalid character '{c}'. \
                      Names cannot contain: / \\ : * ? \" < > |",
-                    name, c
                 ));
             }
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1677,7 +1677,9 @@ impl McpServer {
     /// Validates that a coordinate is within the safe range for Altium internal units.
     fn validate_coordinate(value: f64, field_name: &str) -> Result<(), String> {
         if !value.is_finite() {
-            return Err(format!("{field_name} must be a finite number, got: {value}"));
+            return Err(format!(
+                "{field_name} must be a finite number, got: {value}"
+            ));
         }
         if value.abs() > Self::MAX_COORDINATE_MM {
             return Err(format!(
@@ -1757,22 +1759,35 @@ impl McpServer {
     }
 
     /// Validates all coordinates in a symbol before writing.
-    fn validate_symbol_coordinates(
-        symbol: &crate::altium::schlib::Symbol,
-    ) -> Result<(), String> {
+    fn validate_symbol_coordinates(symbol: &crate::altium::schlib::Symbol) -> Result<(), String> {
         let name = &symbol.name;
 
         for (i, pin) in symbol.pins.iter().enumerate() {
             Self::validate_schlib_coordinate(pin.x, &format!("Symbol '{name}' pin {i} x"))?;
             Self::validate_schlib_coordinate(pin.y, &format!("Symbol '{name}' pin {i} y"))?;
-            Self::validate_schlib_coordinate(pin.length, &format!("Symbol '{name}' pin {i} length"))?;
+            Self::validate_schlib_coordinate(
+                pin.length,
+                &format!("Symbol '{name}' pin {i} length"),
+            )?;
         }
 
         for (i, rect) in symbol.rectangles.iter().enumerate() {
-            Self::validate_schlib_coordinate(rect.x1, &format!("Symbol '{name}' rectangle {i} x1"))?;
-            Self::validate_schlib_coordinate(rect.y1, &format!("Symbol '{name}' rectangle {i} y1"))?;
-            Self::validate_schlib_coordinate(rect.x2, &format!("Symbol '{name}' rectangle {i} x2"))?;
-            Self::validate_schlib_coordinate(rect.y2, &format!("Symbol '{name}' rectangle {i} y2"))?;
+            Self::validate_schlib_coordinate(
+                rect.x1,
+                &format!("Symbol '{name}' rectangle {i} x1"),
+            )?;
+            Self::validate_schlib_coordinate(
+                rect.y1,
+                &format!("Symbol '{name}' rectangle {i} y1"),
+            )?;
+            Self::validate_schlib_coordinate(
+                rect.x2,
+                &format!("Symbol '{name}' rectangle {i} x2"),
+            )?;
+            Self::validate_schlib_coordinate(
+                rect.y2,
+                &format!("Symbol '{name}' rectangle {i} y2"),
+            )?;
         }
 
         for (i, line) in symbol.lines.iter().enumerate() {
@@ -1798,7 +1813,10 @@ impl McpServer {
         for (i, arc) in symbol.arcs.iter().enumerate() {
             Self::validate_schlib_coordinate(arc.x, &format!("Symbol '{name}' arc {i} x"))?;
             Self::validate_schlib_coordinate(arc.y, &format!("Symbol '{name}' arc {i} y"))?;
-            Self::validate_schlib_coordinate(arc.radius, &format!("Symbol '{name}' arc {i} radius"))?;
+            Self::validate_schlib_coordinate(
+                arc.radius,
+                &format!("Symbol '{name}' arc {i} radius"),
+            )?;
         }
 
         for (i, ellipse) in symbol.ellipses.iter().enumerate() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -865,11 +865,13 @@ impl McpServer {
             }
         }
 
-        // Validate name lengths (OLE storage names are limited to 31 characters)
-        // While we store the full name in the Parameters stream, the storage name
-        // must still fit within this limit
+        // Validate footprint names
         const MAX_OLE_NAME_LEN: usize = 31;
+        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
         for name in &new_names {
+            if name.is_empty() {
+                return ToolCallResult::error("Footprint name cannot be empty");
+            }
             if name.len() > MAX_OLE_NAME_LEN {
                 return ToolCallResult::error(format!(
                     "Footprint name '{}' is too long ({} characters). \
@@ -877,6 +879,13 @@ impl McpServer {
                     name,
                     name.len(),
                     MAX_OLE_NAME_LEN
+                ));
+            }
+            if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
+                return ToolCallResult::error(format!(
+                    "Footprint name '{}' contains invalid character '{}'. \
+                     Names cannot contain: / \\ : * ? \" < > |",
+                    name, c
                 ));
             }
         }
@@ -1110,9 +1119,13 @@ impl McpServer {
             }
         }
 
-        // Validate name lengths (OLE storage names are limited to 31 characters)
+        // Validate symbol names
         const MAX_OLE_NAME_LEN: usize = 31;
+        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
         for name in &new_names {
+            if name.is_empty() {
+                return ToolCallResult::error("Symbol name cannot be empty");
+            }
             if name.len() > MAX_OLE_NAME_LEN {
                 return ToolCallResult::error(format!(
                     "Symbol name '{}' is too long ({} characters). \
@@ -1120,6 +1133,13 @@ impl McpServer {
                     name,
                     name.len(),
                     MAX_OLE_NAME_LEN
+                ));
+            }
+            if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
+                return ToolCallResult::error(format!(
+                    "Symbol name '{}' contains invalid character '{}'. \
+                     Names cannot contain: / \\ : * ? \" < > |",
+                    name, c
                 ));
             }
         }


### PR DESCRIPTION
## Summary

Add comprehensive input validation to prevent silent data corruption and panics when writing PcbLib and SchLib files. This addresses several edge cases related to OLE storage format limitations.

## Changes

### Footprint Name Handling
- Read full footprint name from `PATTERN` field in Parameters stream (OLE storage names are limited to 31 characters)
- Add documentation explaining the Parameters stream parsing

### Name Validation (PcbLib & SchLib)
- Reject empty component names with clear error messages
- Validate name length (max 31 bytes due to OLE storage limitations)
- Reject names containing invalid characters (`/ \ : * ? " < > |`)
- Add duplicate symbol check in `write_schlib` to match `write_pcblib` behaviour

### Coordinate Validation
- **PcbLib**: Validate all coordinates within ±5000 mm to prevent i32 overflow when converting to internal units
- **SchLib**: Validate all coordinates within ±32000 to prevent i16 overflow in binary writer
- Validate against NaN and Infinity values
- Clear error messages identifying the exact field that failed validation

## Bugs Prevented

1. Panic when writing footprints with names longer than 31 characters
2. Silent data corruption when coordinates exceed i32/i16 range
3. Cryptic OLE errors from invalid characters in names
4. Duplicate symbols overwriting each other in append mode

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)