### PR TITLE
feat: implement ComponentBody primitive (0x0C) read/write support

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -767,8 +767,8 @@ mod tests {
             rotation_x: 0.0,
             rotation_y: 0.0,
             rotation_z: 45.0,
-            z_offset: 0.5, // mm
-            overall_height: 1.0, // mm
+            z_offset: 0.5,        // mm
+            overall_height: 1.0,  // mm
             standoff_height: 0.1, // mm
             layer: Layer::Top3DBody,
         };

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -263,7 +263,7 @@ impl Fill {
     }
 }
 
-/// A 3D model reference.
+/// A 3D model reference (simple version for programmatic creation).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Model3D {
     /// Path to the STEP file.
@@ -280,6 +280,71 @@ pub struct Model3D {
     /// Rotation around Z axis in degrees.
     #[serde(default)]
     pub rotation: f64,
+}
+
+/// A 3D component body primitive (record type 0x0C).
+///
+/// This represents an embedded 3D model in the footprint. The model data
+/// is stored in `/Library/Models/N` streams and referenced by GUID.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentBody {
+    /// Model identifier (GUID) referencing `/Library/Models/Data`.
+    pub model_id: String,
+
+    /// Model filename (e.g., "RESC1005X04L.step").
+    #[serde(default)]
+    pub model_name: String,
+
+    /// Whether the model is embedded in the library.
+    #[serde(default)]
+    pub embedded: bool,
+
+    /// Rotation around X axis in degrees.
+    #[serde(default)]
+    pub rotation_x: f64,
+
+    /// Rotation around Y axis in degrees.
+    #[serde(default)]
+    pub rotation_y: f64,
+
+    /// Rotation around Z axis in degrees.
+    #[serde(default)]
+    pub rotation_z: f64,
+
+    /// Z offset (standoff from board) in mm.
+    #[serde(default)]
+    pub z_offset: f64,
+
+    /// Overall height in mm.
+    #[serde(default)]
+    pub overall_height: f64,
+
+    /// Standoff height in mm.
+    #[serde(default)]
+    pub standoff_height: f64,
+
+    /// Layer the body outline is on.
+    #[serde(default)]
+    pub layer: Layer,
+}
+
+impl ComponentBody {
+    /// Creates a new `ComponentBody` with the given model ID.
+    #[must_use]
+    pub fn new(model_id: impl Into<String>, model_name: impl Into<String>) -> Self {
+        Self {
+            model_id: model_id.into(),
+            model_name: model_name.into(),
+            embedded: true,
+            rotation_x: 0.0,
+            rotation_y: 0.0,
+            rotation_z: 0.0,
+            z_offset: 0.0,
+            overall_height: 0.0,
+            standoff_height: 0.0,
+            layer: Layer::Top3DBody,
+        }
+    }
 }
 
 /// Altium layer identifiers.

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -829,9 +829,8 @@ fn parse_component_body_params(s: &str) -> std::collections::HashMap<String, Str
 
 /// Parses a value in mils (e.g., "15.748mil") to mm.
 fn parse_mil_value(s: Option<&str>) -> f64 {
-    let s = match s {
-        Some(s) => s,
-        None => return 0.0,
+    let Some(s) = s else {
+        return 0.0;
     };
 
     // Remove "mil" suffix if present

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -13,7 +13,7 @@
 //! [0x00]                                       // End marker
 //! ```
 
-use super::primitives::{Arc, Fill, Layer, Pad, PadShape, Region, Text, Track};
+use super::primitives::{Arc, ComponentBody, Fill, Layer, Pad, PadShape, Region, Text, Track};
 use super::Footprint;
 
 /// Conversion factor from millimetres to Altium internal units.
@@ -154,6 +154,11 @@ pub fn encode_data_stream(footprint: &Footprint) -> Vec<u8> {
     for fill in &footprint.fills {
         data.push(0x06); // Fill record type
         encode_fill(&mut data, fill);
+    }
+
+    for body in &footprint.component_bodies {
+        data.push(0x0C); // ComponentBody record type
+        encode_component_body(&mut data, body);
     }
 
     // End marker
@@ -500,6 +505,126 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
     block.extend_from_slice(&[0x00; 13]);
 
     block
+}
+
+/// Encodes a `ComponentBody` primitive (3D model reference).
+fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody) {
+    let block = encode_component_body_block(body);
+    write_block(data, &block);
+
+    // Blocks 1 and 2 are optional/empty
+    write_block(data, &[]);
+    write_block(data, &[]);
+}
+
+/// Encodes the `ComponentBody` block 0.
+///
+/// Format:
+/// ```text
+/// [layer:1]                    // Layer ID (e.g., 62 for Top 3D Body)
+/// [record_type:2]              // Record type (0x0C, 0x00)
+/// [ff_padding:10]              // 0xFF padding
+/// [zeros:5]                    // Zeros
+/// [param_len:4]                // Parameter string length (including null)
+/// [param_string:param_len]     // Key=value pairs separated by |
+/// [vertex_count:4]             // Outline vertex count (usually 0 or 4)
+/// [vertices...]                // Optional outline vertices
+/// ```
+fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
+    let mut block = Vec::with_capacity(128);
+
+    // Layer ID (1 byte)
+    block.push(layer_to_id(body.layer));
+
+    // Record type marker (2 bytes): 0x0C 0x00
+    block.push(0x0C);
+    block.push(0x00);
+
+    // 0xFF padding (10 bytes)
+    block.extend_from_slice(&[0xFF; 10]);
+
+    // Zeros (5 bytes)
+    block.extend_from_slice(&[0x00; 5]);
+
+    // Build parameter string
+    let param_str = build_component_body_params(body);
+
+    // Parameter string length including null terminator (4 bytes)
+    let param_len = param_str.len() + 1; // +1 for null
+    write_u32(&mut block, param_len as u32);
+
+    // Parameter string (null-terminated)
+    block.extend_from_slice(param_str.as_bytes());
+    block.push(0x00); // Null terminator
+
+    // No outline vertices (4 bytes = count of 0)
+    write_u32(&mut block, 0);
+
+    block
+}
+
+/// Builds the parameter string for a `ComponentBody`.
+fn build_component_body_params(body: &ComponentBody) -> String {
+    let mut params = Vec::new();
+
+    // V7_LAYER
+    let layer_name = match body.layer {
+        Layer::Top3DBody => "MECHANICAL6",
+        Layer::Bottom3DBody => "MECHANICAL7",
+        _ => "MECHANICAL6",
+    };
+    params.push(format!("V7_LAYER={layer_name}"));
+
+    // Standard parameters
+    params.push("NAME= ".to_string());
+    params.push("KIND=0".to_string());
+    params.push("SUBPOLYINDEX=-1".to_string());
+    params.push("UNIONINDEX=0".to_string());
+    params.push("ARCRESOLUTION=0.5mil".to_string());
+    params.push("ISSHAPEBASED=FALSE".to_string());
+    params.push("CAVITYHEIGHT=0mil".to_string());
+    params.push(format!(
+        "STANDOFFHEIGHT={}mil",
+        mm_to_mil(body.standoff_height)
+    ));
+    params.push(format!(
+        "OVERALLHEIGHT={}mil",
+        mm_to_mil(body.overall_height)
+    ));
+    params.push("BODYPROJECTION=0".to_string());
+    params.push("ARCRESOLUTION=0.5mil".to_string());
+    params.push("BODYCOLOR3D=8421504".to_string());
+    params.push("BODYOPACITY3D=1.000".to_string());
+    params.push("TEXTURECENTERX=0mil".to_string());
+    params.push("TEXTURECENTERY=0mil".to_string());
+    params.push("TEXTURESIZEX=0mil".to_string());
+    params.push("TEXTURESIZEY=0mil".to_string());
+    params.push("TEXTUREROTATION= 0.00000000000000E+0000".to_string());
+
+    // Model reference
+    params.push(format!("MODELID={}", body.model_id));
+    params.push("MODEL.CHECKSUM=0".to_string());
+    params.push(format!(
+        "MODEL.EMBED={}",
+        if body.embedded { "TRUE" } else { "FALSE" }
+    ));
+    params.push(format!("MODEL.NAME={}", body.model_name));
+    params.push("MODEL.2D.X=0mil".to_string());
+    params.push("MODEL.2D.Y=0mil".to_string());
+    params.push("MODEL.2D.ROTATION=0.000".to_string());
+    params.push(format!("MODEL.3D.ROTX={:.3}", body.rotation_x));
+    params.push(format!("MODEL.3D.ROTY={:.3}", body.rotation_y));
+    params.push(format!("MODEL.3D.ROTZ={:.3}", body.rotation_z));
+    params.push(format!("MODEL.3D.DZ={}mil", mm_to_mil(body.z_offset)));
+    params.push("MODEL.MODELTYPE=1".to_string());
+    params.push("MODEL.MODELSOURCE=Undefined".to_string());
+
+    params.join("|")
+}
+
+/// Converts mm to mils for parameter strings.
+fn mm_to_mil(mm: f64) -> f64 {
+    mm / 0.0254
 }
 
 #[cfg(test)]

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -530,6 +530,7 @@ fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody) {
 /// [vertex_count:4]             // Outline vertex count (usually 0 or 4)
 /// [vertices...]                // Optional outline vertices
 /// ```
+#[allow(clippy::cast_possible_truncation)] // Parameter strings are always small
 fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
     let mut block = Vec::with_capacity(128);
 
@@ -567,9 +568,8 @@ fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
 fn build_component_body_params(body: &ComponentBody) -> String {
     let mut params = Vec::new();
 
-    // V7_LAYER
+    // V7_LAYER (Top3DBody is MECHANICAL6, Bottom3DBody is MECHANICAL7)
     let layer_name = match body.layer {
-        Layer::Top3DBody => "MECHANICAL6",
         Layer::Bottom3DBody => "MECHANICAL7",
         _ => "MECHANICAL6",
     };

--- a/tests/component_body_parsing.rs
+++ b/tests/component_body_parsing.rs
@@ -1,0 +1,42 @@
+//! Test for ComponentBody primitive parsing.
+
+use altium_designer_mcp::altium::pcblib::PcbLib;
+
+#[test]
+#[ignore = "Requires sample.PcbLib with ComponentBody records"]
+fn test_component_body_parsing() {
+    let lib = PcbLib::read("scripts/sample.PcbLib").expect("Failed to read sample.PcbLib");
+
+    println!("\n=== Testing ComponentBody Parsing ===\n");
+
+    let mut total_bodies = 0;
+    for fp in lib.footprints() {
+        if !fp.component_bodies.is_empty() {
+            println!("Footprint: {}", fp.name);
+            println!("  ComponentBodies: {}", fp.component_bodies.len());
+            total_bodies += fp.component_bodies.len();
+
+            for (i, body) in fp.component_bodies.iter().enumerate() {
+                println!("    Body[{i}]:");
+                println!("      model_id: {}", body.model_id);
+                println!("      model_name: {}", body.model_name);
+                println!("      embedded: {}", body.embedded);
+                println!(
+                    "      rotation: ({:.3}, {:.3}, {:.3})",
+                    body.rotation_x, body.rotation_y, body.rotation_z
+                );
+                println!("      z_offset: {:.4} mm", body.z_offset);
+                println!("      overall_height: {:.4} mm", body.overall_height);
+                println!("      standoff_height: {:.4} mm", body.standoff_height);
+                println!("      layer: {:?}", body.layer);
+            }
+            println!();
+        }
+    }
+
+    println!("Total component bodies found: {total_bodies}");
+    assert!(
+        total_bodies > 0,
+        "Expected at least one component body in sample.PcbLib"
+    );
+}

--- a/tests/component_body_parsing.rs
+++ b/tests/component_body_parsing.rs
@@ -1,4 +1,4 @@
-//! Test for ComponentBody primitive parsing.
+//! Test for `ComponentBody` primitive parsing.
 
 use altium_designer_mcp::altium::pcblib::PcbLib;
 


### PR DESCRIPTION
Implements full read/write support for the ComponentBody primitive (record type 0x0C), which handles 3D model references in PcbLib files. This completes all primitives planned in IMPLEMENTATION_PLAN.md.

## Changes

### Core Implementation
- Add `ComponentBody` struct to `primitives.rs` with fields for model GUID, filename, rotation, heights, and layer
- Implement reader in `reader.rs` to parse parameter strings containing model metadata (MODELID, MODEL.NAME, rotations, heights)
- Implement writer in `writer.rs` to generate properly formatted parameter strings
- Add `component_bodies` vector to `Footprint` struct with `add_component_body()` helper method

### Binary Format Details
- ComponentBody uses 3 blocks (block 0 contains parameters, blocks 1-2 are optional/empty)
- Parameters are stored as pipe-separated key=value strings starting with `V7_LAYER=`
- Heights/offsets stored in mils, converted to/from mm internally

### Testing
- Round-trip unit test verifies all fields survive encode/decode cycle
- Integration test for parsing real PcbLib files with 3D models (ignored by default)

### Documentation
- Updated IMPLEMENTATION_PLAN.md to reflect completed status
- Updated analysis script with improved ComponentBody and Fill parsing

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] Round-trip test verifies encode/decode preserves all values
- [x] Integration test available for real-world PcbLib files