### PR TITLE
docs: update documentation for new primitives and fix British spelling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,8 +88,8 @@ src/
 
 The AI provides primitive definitions. The tool writes them.
 
-**Footprint**: Pads, tracks, arcs, regions, text
-**Symbol**: Pins, rectangles, lines, arcs, text
+**Footprint**: Pads, tracks, arcs, regions, text, fills, component bodies (3D models)
+**Symbol**: Pins, rectangles, lines, polylines, arcs, ellipses, labels
 
 ## Off Limits
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Returns statistics about track widths, pad shapes, pin lengths, colours, and lay
 | **Arc** | Arc or circle on any layer |
 | **Region** | Filled polygon (courtyard, copper pour) |
 | **Text** | Text string with font, size, position, layer |
+| **Fill** | Filled rectangle on any layer |
+| **ComponentBody** | 3D model reference (embedded STEP models) |
 
 ### Symbol Primitives (SchLib)
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -237,8 +237,9 @@ See `CONTRIBUTING.md` § Commit Messages for conventions and allowed types.
 - All dimensions in millimetres (mm)
 - Use `f64` for dimensional values
 - Document units in variable names or comments when not obvious
-- Primitive types: Pad, Track, Arc, Region, Text
+- Footprint primitives: Pad, Track, Arc, Region, Text, Fill, ComponentBody
+- Symbol primitives: Pin, Rectangle, Line, Polyline, Arc, Ellipse, Label
 
 ---
 
-*Last updated: 2026-01-17*
+*Last updated: 2026-01-18*

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -341,6 +341,36 @@ The AI provides complete primitive definitions. The tool writes them.
 }
 ```
 
+### Fill
+
+```json
+{
+    "x1": -0.8,
+    "y1": -0.4,
+    "x2": 0.8,
+    "y2": 0.4,
+    "layer": "Top Assembly",
+    "rotation": 0
+}
+```
+
+### ComponentBody
+
+```json
+{
+    "model_id": "GUID-HERE",
+    "model_name": "RESC1608X55.step",
+    "embedded": true,
+    "rotation_x": 0,
+    "rotation_y": 0,
+    "rotation_z": 0,
+    "z_offset": 0,
+    "overall_height": 0.55,
+    "standoff_height": 0,
+    "layer": "Top 3D Body"
+}
+```
+
 ---
 
 ## Standard Altium Layers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,8 @@ The AI provides complete primitive definitions. The tool writes them.
 | **Arc** | x, y, radius, start_angle, end_angle, width, layer |
 | **Region** | vertices[], layer |
 | **Text** | x, y, text, height, layer, rotation |
+| **Fill** | x1, y1, x2, y2, layer, rotation |
+| **ComponentBody** | model_id, model_name, embedded, rotation_x/y/z, z_offset, overall_height, standoff_height, layer |
 | **Model3D** | filepath, x_offset, y_offset, z_offset, rotation |
 
 ### Standard Altium Layers

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -194,39 +194,95 @@ All primitives start with a common header:
 | 2 | 1 | More flags |
 | 3-12 | 10 | Padding (0xFF) |
 
-## Not Yet Implemented
-
-The following primitives are recognized but not yet parsed:
-
 ### Text (0x05)
 
-Text strings (designator, comment, free text). Format details unknown.
+Text has 2 blocks:
 
-- Uses 1 block
-- Contains layer, position, font info, and string content
+**Block 0 (Geometry):**
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Layer ID |
+| 1-12 | 12 | Flags and padding |
+| 13-16 | 4 | X position (internal units) |
+| 17-20 | 4 | Y position |
+| 21-24 | 4 | Height |
+| 25-26 | 2 | Font style flags |
+| 27-34 | 8 | Rotation (double, degrees) |
+| 35+ | var | Font name and additional data |
+
+**Block 1 (Content):**
+
+Length-prefixed string with text content, or reference to `WideStrings` stream.
+
+Special text values:
+
+| Value | Meaning |
+|-------|---------|
+| `.Designator` | Pad/component designator |
+| `.Comment` | Component comment |
 
 ### Fill (0x06)
 
-Filled rectangles. Format details unknown.
+Filled rectangle, single block:
 
-- Uses 1 block
-- Contains layer and corner coordinates
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Layer ID |
+| 1-12 | 12 | Flags and padding |
+| 13-16 | 4 | X1 (first corner) |
+| 17-20 | 4 | Y1 |
+| 21-24 | 4 | X2 (second corner) |
+| 25-28 | 4 | Y2 |
+| 29-36 | 8 | Rotation (double, degrees) |
 
 ### Region (0x0B)
 
-Filled polygons (courtyard, copper pour). Format details unknown.
+Filled polygon with 2 blocks:
 
-- Uses 2 blocks
-- Contains layer and vertex list
-- Used for complex outlines
+**Block 0 (Properties):**
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Layer ID |
+| 1-12 | 12 | Flags and padding |
+| 13-17 | 5 | Unknown |
+| 18-21 | 4 | Parameter string length |
+| 22+ | var | Parameter string (ASCII key=value) |
+| 22+len | 4 | Vertex count |
+| 26+len | 16×N | Vertices (N pairs of doubles) |
+
+**Block 1:** Usually empty.
+
+**Vertex format:**
+
+| Offset | Size | Field |
+|--------|------|-------|
+| 0-7 | 8 | X coordinate (double, internal units) |
+| 8-15 | 8 | Y coordinate (double, internal units) |
 
 ### ComponentBody (0x0C)
 
-3D model reference. Links to embedded STEP models.
+3D model reference with 3 blocks:
 
-- Uses 3 blocks
-- References model data in `/Library/Models/N` streams
-- Model metadata in `/Library/Models/Data` stream
+**Block 0 (Properties):**
+
+Contains pipe-delimited key=value parameters:
+
+| Key | Description |
+|-----|-------------|
+| `V7_LAYER` | Layer (e.g., "MECHANICAL6") |
+| `MODELID` | Model GUID |
+| `MODEL.NAME` | Model filename |
+| `MODEL.EMBED` | TRUE if embedded |
+| `MODEL.3D.ROTX` | X rotation (degrees) |
+| `MODEL.3D.ROTY` | Y rotation (degrees) |
+| `MODEL.3D.ROTZ` | Z rotation (degrees) |
+| `MODEL.3D.DZ` | Z offset (e.g., "15.748mil") |
+| `STANDOFFHEIGHT` | Standoff height |
+| `OVERALLHEIGHT` | Overall height |
+
+**Block 1 and 2:** Usually empty.
 
 ### 3D Model Storage
 

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -131,9 +131,9 @@ impl Track {
 /// An arc or circle on a layer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Arc {
-    /// Center X position in mm.
+    /// Centre X position in mm.
     pub x: f64,
-    /// Center Y position in mm.
+    /// Centre Y position in mm.
     pub y: f64,
     /// Radius in mm.
     pub radius: f64,
@@ -247,7 +247,7 @@ impl Fill {
         }
     }
 
-    /// Creates a Fill from center position and dimensions.
+    /// Creates a Fill from centre position and dimensions.
     #[must_use]
     pub fn from_center(x: f64, y: f64, width: f64, height: f64, layer: Layer) -> Self {
         let half_w = width / 2.0;

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -417,7 +417,7 @@ fn parse_arc(data: &[u8], offset: usize) -> Option<(Arc, usize)> {
     let layer_id = block[0];
     let layer = layer_from_id(layer_id);
 
-    // Center coordinates (X, Y) - offsets 13-20
+    // Centre coordinates (X, Y) - offsets 13-20
     let x = to_mm(read_i32(block, 13)?);
     let y = to_mm(read_i32(block, 17)?);
 

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -297,7 +297,7 @@ fn encode_arc(data: &mut Vec<u8>, arc: &Arc) {
     // Common header (13 bytes)
     write_common_header(&mut block, arc.layer);
 
-    // Center coordinates (X, Y) - offsets 13-20
+    // Centre coordinates (X, Y) - offsets 13-20
     write_i32(&mut block, from_mm(arc.x));
     write_i32(&mut block, from_mm(arc.y));
 

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -197,10 +197,10 @@ pub struct Rectangle {
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
-    /// Line color (BGR format).
+    /// Line colour (BGR format).
     #[serde(default)]
     pub line_color: u32,
-    /// Fill color (BGR format).
+    /// Fill colour (BGR format).
     #[serde(default)]
     pub fill_color: u32,
     /// Whether the rectangle is filled.
@@ -247,7 +247,7 @@ pub struct Line {
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
-    /// Line color (BGR format).
+    /// Line colour (BGR format).
     #[serde(default)]
     pub color: u32,
     /// Owner part ID.
@@ -279,7 +279,7 @@ pub struct Polyline {
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
-    /// Line color (BGR format).
+    /// Line colour (BGR format).
     #[serde(default)]
     pub color: u32,
     /// Owner part ID.
@@ -290,9 +290,9 @@ pub struct Polyline {
 /// An arc or circle.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Arc {
-    /// Center X coordinate.
+    /// Centre X coordinate.
     pub x: i32,
-    /// Center Y coordinate.
+    /// Centre Y coordinate.
     pub y: i32,
     /// Radius.
     pub radius: i32,
@@ -305,7 +305,7 @@ pub struct Arc {
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
-    /// Line color (BGR format).
+    /// Line colour (BGR format).
     #[serde(default)]
     pub color: u32,
     /// Owner part ID.
@@ -320,9 +320,9 @@ const fn default_end_angle() -> f64 {
 /// An ellipse.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Ellipse {
-    /// Center X coordinate.
+    /// Centre X coordinate.
     pub x: i32,
-    /// Center Y coordinate.
+    /// Centre Y coordinate.
     pub y: i32,
     /// X radius (horizontal).
     pub radius_x: i32,
@@ -331,10 +331,10 @@ pub struct Ellipse {
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
-    /// Line color (BGR format).
+    /// Line colour (BGR format).
     #[serde(default)]
     pub line_color: u32,
-    /// Fill color (BGR format).
+    /// Fill colour (BGR format).
     #[serde(default)]
     pub fill_color: u32,
     /// Whether the ellipse is filled.
@@ -381,7 +381,7 @@ pub struct Label {
     /// Font ID (1-based index into library fonts).
     #[serde(default = "default_font_id")]
     pub font_id: u8,
-    /// Text color (BGR format).
+    /// Text colour (BGR format).
     #[serde(default)]
     pub color: u32,
     /// Text justification.
@@ -406,19 +406,19 @@ pub enum TextJustification {
     /// Bottom-left aligned.
     #[default]
     BottomLeft,
-    /// Bottom-center aligned.
+    /// Bottom-centre aligned.
     BottomCenter,
     /// Bottom-right aligned.
     BottomRight,
     /// Middle-left aligned.
     MiddleLeft,
-    /// Middle-center aligned.
+    /// Middle-centre aligned.
     MiddleCenter,
     /// Middle-right aligned.
     MiddleRight,
     /// Top-left aligned.
     TopLeft,
-    /// Top-center aligned.
+    /// Top-centre aligned.
     TopCenter,
     /// Top-right aligned.
     TopRight,
@@ -438,7 +438,7 @@ pub struct Parameter {
     /// Font ID.
     #[serde(default = "default_font_id")]
     pub font_id: u8,
-    /// Text color (BGR format).
+    /// Text colour (BGR format).
     #[serde(default)]
     pub color: u32,
     /// Whether the parameter is hidden.

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -245,7 +245,7 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     let y = i32::from(read_i16_signed(data, offset).unwrap_or(0));
     offset += 2;
 
-    // color (4 bytes)
+    // colour (4 bytes)
     offset += 4;
 
     // name: [length:1][string]

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -97,7 +97,7 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) {
     record.extend_from_slice(&x.to_le_bytes());
     record.extend_from_slice(&y.to_le_bytes());
 
-    // Color (4 bytes) - default black
+    // Colour (4 bytes) - default black
     record.extend_from_slice(&0u32.to_le_bytes());
 
     // Name: [length:1][string]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1642,7 +1642,7 @@ impl McpServer {
                 let mut line_widths: Vec<u8> = Vec::new();
                 // Pin lengths
                 let mut pin_lengths: Vec<i32> = Vec::new();
-                // Colors used
+                // Colours used
                 let mut line_colors: HashMap<String, usize> = HashMap::new();
                 let mut fill_colors: HashMap<String, usize> = HashMap::new();
                 // Rectangle stats


### PR DESCRIPTION
## Summary

Comprehensive documentation update adding support for Fill and ComponentBody primitives, plus British English spelling fixes in code comments.

## Changes

### Documentation Updates
- Add **Fill** and **ComponentBody** to primitive type lists in README, ARCHITECTURE, AI_WORKFLOW, STYLE, and CLAUDE.md
- Document **Text**, **Fill**, **Region**, and **ComponentBody** binary formats in PCBLIB_FORMAT.md (previously marked as "Not Yet Implemented")
- Add JSON examples for Fill and ComponentBody primitives in AI_WORKFLOW.md

### Code Comment Improvements
- Fix British spelling throughout codebase:
  - `color` → `colour`
  - `center` → `centre`
- Affects: `primitives.rs` (pcblib and schlib), `reader.rs`, `writer.rs`, `server.rs`

### Miscellaneous
- Update STYLE.md date to 2026-01-18

## Type of Change

- [x] Documentation update
- [x] Refactoring (no functional changes)

## Files Changed

13 files across documentation and source code comments (no functional code changes)