### PR TITLE
style: fix line length violations exceeding 170 chars

### DIFF
--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -145,7 +145,9 @@ fn encode_component_header(symbol: &Symbol) -> String {
 /// Encodes a rectangle record.
 fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
     format!(
-        "|RECORD=14|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}|LineWidth={}|Color={}|AreaColor={}|IsSolid=T|UniqueID={}|",
+        "|RECORD=14|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
+         |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
+         |LineWidth={}|Color={}|AreaColor={}|IsSolid=T|UniqueID={}|",
         index,
         rect.owner_part_id,
         rect.x1,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -652,7 +652,11 @@ impl McpServer {
                                                 "y": { "type": "number", "description": "Y position in mm" },
                                                 "width": { "type": "number", "description": "Pad width in mm" },
                                                 "height": { "type": "number", "description": "Pad height in mm" },
-                                                "shape": { "type": "string", "enum": ["rectangle", "rounded_rectangle", "round", "oval"], "description": "Pad shape. Note: read_pcblib returns 'round', write accepts 'round' or 'circle'" },
+                                                "shape": {
+                                                    "type": "string",
+                                                    "enum": ["rectangle", "rounded_rectangle", "round", "oval"],
+                                                    "description": "Pad shape (round/circle are equivalent)"
+                                                },
                                                 "layer": { "type": "string", "description": "Layer name (default: multi-layer for SMD)" },
                                                 "hole_size": { "type": "number", "description": "Hole diameter for through-hole pads (mm)" }
                                             },


### PR DESCRIPTION
Break long lines in `encode_rectangle` format string and JSON schema definition to comply with STYLE.md max line length of 170 characters.

## Description

This PR fixes line length violations in two files:
- `src/altium/schlib/writer.rs`: Breaks the long format string in `encode_rectangle()` using line continuation
- `src/mcp/server.rs`: Reformats the "shape" property JSON schema into a multi-line structure and simplifies the description

## Type of Change

- [x] Refactoring (no functional changes)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Code Quality

- [x] Code compiles without warnings (`cargo build`)
- [x] Clippy passes (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)