### PR TITLE
Updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,13 +13,14 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [x] Core fields: x, y, diameter, hole_size, from_layer, to_layer, solder_mask_expansion
 - [ ] Advanced fields TODO: thermal relief settings, diameter stack mode (per-layer diameters)
 
-### WideStrings Stream - Not Implemented
+### WideStrings Stream - Implemented ✓
 
-- [ ] Parse `/WideStrings` stream during library read in `src/altium/pcblib/mod.rs`
-- [ ] Decode `ENCODEDTEXT{N}=...` format (comma-separated ASCII codes)
-- [ ] Store decoded strings in a lookup table
-- [ ] Update `parse_text()` in `src/altium/pcblib/reader.rs` to use WideStrings lookup (currently only `.Designator`/`.Comment` work, see line 540-561)
-- [ ] Write WideStrings stream when saving libraries
+- [x] Parse `/WideStrings` stream during library read in `src/altium/pcblib/mod.rs`
+- [x] Decode `ENCODEDTEXT{N}=...` format (comma-separated ASCII codes)
+- [x] Store decoded strings in a lookup table (`WideStrings` type in reader.rs)
+- [x] Update `parse_text()` in `src/altium/pcblib/reader.rs` to use WideStrings lookup
+- [x] Write WideStrings stream when saving libraries
+- [ ] TODO: Verify WideStringsIndex offset in geometry block (currently tries offsets 95-97)
 
 ### 3D Model Embedding - Not Implemented
 

--- a/TODO.md
+++ b/TODO.md
@@ -133,6 +133,7 @@ Add to `Layer` enum in `src/altium/pcblib/primitives.rs`:
 - [ ] Write flags to common header (writer.rs, currently hardcoded to 0x00)
 
 Flag bits to support:
+
 - [ ] `Locked` (0x0001)
 - [ ] `Polygon` (0x0002)
 - [ ] `KeepOut` (0x0004)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,181 @@
+# TODO
+
+This document tracks implementation gaps between the documented PcbLib format (`docs/PCBLIB_FORMAT.md`) and the Rust codebase.
+
+## Primitives
+
+### Via (0x03) - Not Implemented
+
+- [ ] Add `Via` struct to `src/altium/pcblib/primitives.rs`
+- [ ] Implement `parse_via()` in `src/altium/pcblib/reader.rs` (currently skipped at line 265-274)
+- [ ] Implement `encode_via()` in `src/altium/pcblib/writer.rs`
+- [ ] Add `vias: Vec<Via>` field to `Footprint` struct in `src/altium/pcblib/mod.rs`
+- [ ] Fields needed: x, y, diameter, hole_size, from_layer, to_layer, thermal relief settings, solder mask expansion, diameter stack mode
+
+### WideStrings Stream - Not Implemented
+
+- [ ] Parse `/WideStrings` stream during library read in `src/altium/pcblib/mod.rs`
+- [ ] Decode `ENCODEDTEXT{N}=...` format (comma-separated ASCII codes)
+- [ ] Store decoded strings in a lookup table
+- [ ] Update `parse_text()` in `src/altium/pcblib/reader.rs` to use WideStrings lookup (currently only `.Designator`/`.Comment` work, see line 540-561)
+- [ ] Write WideStrings stream when saving libraries
+
+### 3D Model Embedding - Not Implemented
+
+- [ ] Parse `/Library/Models/Header` stream for model count
+- [ ] Parse `/Library/Models/Data` stream for GUID-to-index mapping
+- [ ] Extract zlib-compressed STEP files from `/Library/Models/{N}` streams
+- [ ] Add model embedding support when writing libraries
+- [ ] Link `ComponentBody.model_id` to actual embedded model data
+
+## Pad Advanced Features
+
+### Hole Shapes - Incomplete
+
+- [ ] Add `Square` and `Slot` variants to `PadShape` enum in `src/altium/pcblib/primitives.rs`
+- [ ] Update `pad_shape_from_id()` in `src/altium/pcblib/reader.rs` to handle IDs 0 (Round), 1 (Square), 2 (Slot)
+- [ ] Update `pad_shape_to_id()` in `src/altium/pcblib/writer.rs`
+- [ ] Note: These are hole shapes, separate from pad shapes
+
+### Stack Modes - Not Implemented
+
+- [ ] Add `stack_mode: PadStackMode` field to `Pad` struct
+- [ ] Create `PadStackMode` enum: `Simple`, `TopMiddleBottom`, `FullStack`
+- [ ] Parse stack mode byte at geometry offset 62 in `parse_pad()` (reader.rs)
+- [ ] Write stack mode in `encode_pad_geometry()` (writer.rs, currently hardcoded to 0)
+
+### Per-Layer Pad Data - Not Implemented
+
+- [ ] Add per-layer size arrays to `Pad` struct (32 CoordPoints)
+- [ ] Add per-layer shape arrays (32 bytes)
+- [ ] Add per-layer corner radius percentages (32 bytes, 0-100)
+- [ ] Add per-layer offset-from-hole-center arrays (32 CoordPoints)
+- [ ] Parse Block 6 in `parse_pad()` when stack mode != Simple
+- [ ] Write Block 6 in `encode_pad()` when stack mode != Simple
+
+### Corner Radius - Not Exposed
+
+- [ ] Add `corner_radius_percent: Option<u8>` field to `Pad` struct (0-100%)
+- [ ] Parse corner radius from per-layer data
+- [ ] Write corner radius to per-layer data
+- [ ] Note: Percentage of smaller pad dimension, not absolute value
+
+### Paste/Solder Mask Expansion - Not Exposed
+
+- [ ] Add `paste_mask_expansion: Option<f64>` field to `Pad`
+- [ ] Add `solder_mask_expansion: Option<f64>` field to `Pad`
+- [ ] Add `paste_mask_expansion_manual: bool` field
+- [ ] Add `solder_mask_expansion_manual: bool` field
+- [ ] Parse from geometry block (currently ignored)
+- [ ] Write to geometry block (currently hardcoded to 0 in writer.rs line 253-261)
+
+## Text Advanced Features
+
+### Text Kinds - Not Differentiated
+
+- [ ] Add `TextKind` enum: `Stroke`, `TrueType`, `BarCode`
+- [ ] Add `kind: TextKind` field to `Text` struct
+- [ ] Parse text kind from geometry block
+- [ ] Write text kind to geometry block
+
+### Stroke Font IDs - Not Exposed
+
+- [ ] Add `StrokeFont` enum: `Default`, `SansSerif`, `Serif`
+- [ ] Add `stroke_font: Option<StrokeFont>` field to `Text`
+- [ ] Parse stroke font ID (bytes 25-26 in geometry block)
+- [ ] Write stroke font ID
+
+### Text Justification - Not Exposed
+
+- [ ] Add `TextJustification` enum with 9 positions (BottomRight, BottomCenter, etc.)
+- [ ] Add `justification: TextJustification` field to `Text`
+- [ ] Parse justification from geometry block
+- [ ] Write justification (currently hardcoded to 4 in writer.rs line 391)
+
+## Layers - Incomplete Coverage
+
+### Missing Layer Variants
+
+Add to `Layer` enum in `src/altium/pcblib/primitives.rs`:
+
+- [ ] Mid layers: `MidLayer1` through `MidLayer30` (IDs 2-31)
+- [ ] Internal planes: `InternalPlane1` through `InternalPlane16` (IDs 39-54)
+- [ ] `DrillGuide` (ID 55)
+- [ ] `DrillDrawing` (ID 73)
+- [ ] Mechanical 3-12, 14, 16 (IDs 59-68, 70, 72) - currently some are aliased incorrectly
+
+### Missing Special Layers
+
+- [ ] `ConnectLayer` (ID 75)
+- [ ] `BackgroundLayer` (ID 76)
+- [ ] `DRCErrorLayer` (ID 77)
+- [ ] `HighlightLayer` (ID 78)
+- [ ] `GridColor1` (ID 79)
+- [ ] `GridColor10` (ID 80)
+- [ ] `PadHoleLayer` (ID 81)
+- [ ] `ViaHoleLayer` (ID 82)
+- [ ] `TopPadMaster` (ID 83)
+- [ ] `BottomPadMaster` (ID 84)
+- [ ] `DRCDetailLayer` (ID 85)
+
+### Layer Mapping Fixes
+
+- [ ] Fix `layer_from_id()` in reader.rs (line 130-156) - many IDs incorrectly default to MultiLayer
+- [ ] Fix `layer_to_id()` in writer.rs (line 70-94) - incomplete mapping
+
+## PcbFlags - Not Exposed
+
+- [ ] Add `PcbFlags` struct or bitflags to primitives
+- [ ] Add flags field to all primitives (Pad, Track, Arc, Region, Fill, Text)
+- [ ] Parse flags from common header bytes 1-2 (reader.rs)
+- [ ] Write flags to common header (writer.rs, currently hardcoded to 0x00)
+
+Flag bits to support:
+- [ ] `Locked` (0x0001)
+- [ ] `Polygon` (0x0002)
+- [ ] `KeepOut` (0x0004)
+- [ ] `TentingTop` (0x0008)
+- [ ] `TentingBottom` (0x0010)
+
+## OLE Streams - Partial Implementation
+
+### Storage Stream
+
+- [ ] Parse `UniqueIdPrimitiveInformation` mappings from `/Storage` stream
+- [ ] Use mappings to link primitives to unique IDs
+
+### FileHeader Improvements
+
+- [ ] Parse `CompCount` field (number of components)
+- [ ] Parse `LibRef{N}` fields (component names by index)
+- [ ] Parse `CompDescr{N}` fields (component descriptions)
+- [ ] Write complete FileHeader with all fields (currently minimal in mod.rs line 364-367)
+
+## Code Quality
+
+### Error Handling
+
+- [ ] Return `Result` from `parse_pad()`, `parse_track()`, etc. instead of `Option`
+- [ ] Add specific error types for parse failures
+- [ ] Improve error messages with offset information
+
+### Testing
+
+- [ ] Add roundtrip tests for Via primitive (once implemented)
+- [ ] Add tests for WideStrings parsing
+- [ ] Add tests for advanced pad features (stack modes, per-layer data)
+- [ ] Add tests for all layer ID mappings
+- [ ] Add integration tests with real Altium library files
+
+### Documentation
+
+- [ ] Add doc comments to all public types in primitives.rs
+- [ ] Document coordinate system in primitives.rs module docs
+- [ ] Add examples to Pad, Track, Arc struct docs
+
+## Low Priority / Future
+
+- [ ] Support reading/writing SchLib files (separate module exists but may need similar review)
+- [ ] Support component variants (board-level feature, not library)
+- [ ] Support net information (board-level feature, not library)
+- [ ] Optimize binary parsing with zero-copy where possible

--- a/TODO.md
+++ b/TODO.md
@@ -4,13 +4,14 @@ This document tracks implementation gaps between the documented PcbLib format (`
 
 ## Primitives
 
-### Via (0x03) - Not Implemented
+### Via (0x03) - Implemented ✓
 
-- [ ] Add `Via` struct to `src/altium/pcblib/primitives.rs`
-- [ ] Implement `parse_via()` in `src/altium/pcblib/reader.rs` (currently skipped at line 265-274)
-- [ ] Implement `encode_via()` in `src/altium/pcblib/writer.rs`
-- [ ] Add `vias: Vec<Via>` field to `Footprint` struct in `src/altium/pcblib/mod.rs`
-- [ ] Fields needed: x, y, diameter, hole_size, from_layer, to_layer, thermal relief settings, solder mask expansion, diameter stack mode
+- [x] Add `Via` struct to `src/altium/pcblib/primitives.rs`
+- [x] Implement `parse_via()` in `src/altium/pcblib/reader.rs`
+- [x] Implement `encode_via()` in `src/altium/pcblib/writer.rs`
+- [x] Add `vias: Vec<Via>` field to `Footprint` struct in `src/altium/pcblib/mod.rs`
+- [x] Core fields: x, y, diameter, hole_size, from_layer, to_layer, solder_mask_expansion
+- [ ] Advanced fields TODO: thermal relief settings, diameter stack mode (per-layer diameters)
 
 ### WideStrings Stream - Not Implemented
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -261,7 +261,7 @@ impl PcbLib {
         Ok(library)
     }
 
-    /// Reads the WideStrings stream if present.
+    /// Reads the `WideStrings` stream if present.
     fn read_wide_strings<F: std::io::Read + std::io::Seek>(
         cfb: &mut cfb::CompoundFile<F>,
     ) -> reader::WideStrings {

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -233,7 +233,12 @@ impl PcbLib {
 
                 if !component_name.is_empty() && !is_internal {
                     // Read the component data
-                    match Self::read_footprint(&mut cfb, &entry_path, &component_name, &wide_strings) {
+                    match Self::read_footprint(
+                        &mut cfb,
+                        &entry_path,
+                        &component_name,
+                        &wide_strings,
+                    ) {
                         Ok(footprint) => library.footprints.push(footprint),
                         Err(e) => {
                             tracing::warn!(
@@ -342,7 +347,11 @@ impl PcbLib {
     ///
     /// The Data stream contains binary records for each primitive (pads, tracks, arcs, etc.).
     /// See the [`reader`] module for format details.
-    fn parse_primitives(footprint: &mut Footprint, data: &[u8], wide_strings: &reader::WideStrings) {
+    fn parse_primitives(
+        footprint: &mut Footprint,
+        data: &[u8],
+        wide_strings: &reader::WideStrings,
+    ) {
         reader::parse_data_stream(footprint, data, Some(wide_strings));
     }
 

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -136,7 +136,7 @@ impl Via {
     ///
     /// By default, vias span from top to bottom layer.
     #[must_use]
-    pub fn new(x: f64, y: f64, diameter: f64, hole_size: f64) -> Self {
+    pub const fn new(x: f64, y: f64, diameter: f64, hole_size: f64) -> Self {
         Self {
             x,
             y,
@@ -151,7 +151,7 @@ impl Via {
 
     /// Creates a blind via (connects outer layer to inner layer).
     #[must_use]
-    pub fn blind(x: f64, y: f64, diameter: f64, hole_size: f64, from: Layer, to: Layer) -> Self {
+    pub const fn blind(x: f64, y: f64, diameter: f64, hole_size: f64, from: Layer, to: Layer) -> Self {
         Self {
             x,
             y,

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -96,6 +96,75 @@ pub enum PadShape {
     Oval,
 }
 
+/// A PCB via (vertical interconnect access).
+///
+/// Vias connect traces between different copper layers. They have a drill hole
+/// and copper annular rings on the connected layers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Via {
+    /// X position in mm (from footprint origin).
+    pub x: f64,
+
+    /// Y position in mm (from footprint origin).
+    pub y: f64,
+
+    /// Via diameter (annular ring outer diameter) in mm.
+    pub diameter: f64,
+
+    /// Hole diameter in mm.
+    pub hole_size: f64,
+
+    /// Starting layer for the via.
+    #[serde(default)]
+    pub from_layer: Layer,
+
+    /// Ending layer for the via.
+    #[serde(default)]
+    pub to_layer: Layer,
+
+    /// Solder mask expansion in mm (negative = tented).
+    #[serde(default)]
+    pub solder_mask_expansion: f64,
+
+    /// Whether solder mask expansion is manually set.
+    #[serde(default)]
+    pub solder_mask_expansion_manual: bool,
+}
+
+impl Via {
+    /// Creates a new via with default settings.
+    ///
+    /// By default, vias span from top to bottom layer.
+    #[must_use]
+    pub fn new(x: f64, y: f64, diameter: f64, hole_size: f64) -> Self {
+        Self {
+            x,
+            y,
+            diameter,
+            hole_size,
+            from_layer: Layer::TopLayer,
+            to_layer: Layer::BottomLayer,
+            solder_mask_expansion: 0.0,
+            solder_mask_expansion_manual: false,
+        }
+    }
+
+    /// Creates a blind via (connects outer layer to inner layer).
+    #[must_use]
+    pub fn blind(x: f64, y: f64, diameter: f64, hole_size: f64, from: Layer, to: Layer) -> Self {
+        Self {
+            x,
+            y,
+            diameter,
+            hole_size,
+            from_layer: from,
+            to_layer: to,
+            solder_mask_expansion: 0.0,
+            solder_mask_expansion_manual: false,
+        }
+    }
+}
+
 /// A track (line segment) on a layer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Track {

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -151,7 +151,14 @@ impl Via {
 
     /// Creates a blind via (connects outer layer to inner layer).
     #[must_use]
-    pub const fn blind(x: f64, y: f64, diameter: f64, hole_size: f64, from: Layer, to: Layer) -> Self {
+    pub const fn blind(
+        x: f64,
+        y: f64,
+        diameter: f64,
+        hole_size: f64,
+        from: Layer,
+        to: Layer,
+    ) -> Self {
         Self {
             x,
             y,

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -31,7 +31,7 @@ use super::primitives::{
 };
 use super::Footprint;
 
-/// A lookup table for WideStrings text content.
+/// A lookup table for `WideStrings` text content.
 ///
 /// Maps index (e.g., 0, 1, 2) to decoded text content.
 /// The `/WideStrings` stream stores text as `|ENCODEDTEXT{N}=c1,c2,c3,...|`
@@ -55,12 +55,9 @@ pub fn parse_wide_strings(data: &[u8]) -> WideStrings {
     let mut strings = WideStrings::new();
 
     // WideStrings is pipe-delimited key=value pairs
-    let text = match String::from_utf8(data.to_vec()) {
-        Ok(s) => s,
-        Err(_) => {
-            tracing::debug!("WideStrings stream is not valid UTF-8");
-            return strings;
-        }
+    let Ok(text) = String::from_utf8(data.to_vec()) else {
+        tracing::debug!("WideStrings stream is not valid UTF-8");
+        return strings;
     };
 
     for pair in text.split('|') {
@@ -242,7 +239,7 @@ const fn pad_shape_from_id(id: u8) -> PadShape {
 ///
 /// * `footprint` - The footprint to populate with parsed primitives
 /// * `data` - The raw Data stream bytes
-/// * `wide_strings` - Optional WideStrings lookup for text content
+/// * `wide_strings` - Optional `WideStrings` lookup for text content
 pub fn parse_data_stream(
     footprint: &mut Footprint,
     data: &[u8],
@@ -706,9 +703,9 @@ fn parse_text(
     Some((text, current))
 }
 
-/// Resolves text content, looking up WideStrings if needed.
+/// Resolves text content, looking up `WideStrings` if needed.
 ///
-/// If the content looks like a WideStrings index (numeric), attempts to look it up.
+/// If the content looks like a `WideStrings` index (numeric), attempts to look it up.
 /// Otherwise returns the content as-is.
 fn resolve_text_content(content: &str, wide_strings: Option<&WideStrings>) -> String {
     // Special text values are returned as-is
@@ -734,12 +731,12 @@ fn resolve_text_content(content: &str, wide_strings: Option<&WideStrings>) -> St
 ///
 /// Text content may be:
 /// - Special inline text like `.Designator` or `.Comment`
-/// - A WideStrings index that needs to be looked up
+/// - A `WideStrings` index that needs to be looked up
 ///
 /// # Arguments
 ///
 /// * `block` - The geometry block data
-/// * `wide_strings` - Optional WideStrings lookup table
+/// * `wide_strings` - Optional `WideStrings` lookup table
 ///
 /// # Returns
 ///

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -243,7 +243,11 @@ const fn pad_shape_from_id(id: u8) -> PadShape {
 /// * `footprint` - The footprint to populate with parsed primitives
 /// * `data` - The raw Data stream bytes
 /// * `wide_strings` - Optional WideStrings lookup for text content
-pub fn parse_data_stream(footprint: &mut Footprint, data: &[u8], wide_strings: Option<&WideStrings>) {
+pub fn parse_data_stream(
+    footprint: &mut Footprint,
+    data: &[u8],
+    wide_strings: Option<&WideStrings>,
+) {
     if data.len() < 5 {
         tracing::warn!("Data stream too short");
         return;
@@ -634,7 +638,11 @@ fn parse_arc(data: &[u8], offset: usize) -> Option<(Arc, usize)> {
 /// [font_name:varies]            // Font name in UTF-16 (null-terminated)
 /// [text_content:varies]         // Text content in UTF-16 or reference
 /// ```
-fn parse_text(data: &[u8], offset: usize, wide_strings: Option<&WideStrings>) -> Option<(Text, usize)> {
+fn parse_text(
+    data: &[u8],
+    offset: usize,
+    wide_strings: Option<&WideStrings>,
+) -> Option<(Text, usize)> {
     // Text has 2 blocks:
     // - Block 0: Geometry/metadata (layer, position, height, rotation, font, etc.)
     // - Block 1: Text content (length-prefixed string, or reference to WideStrings)

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -13,7 +13,7 @@
 //! [0x00]                                       // End marker
 //! ```
 
-use super::primitives::{Arc, ComponentBody, Fill, Layer, Pad, PadShape, Region, Text, Track};
+use super::primitives::{Arc, ComponentBody, Fill, Layer, Pad, PadShape, Region, Text, Track, Via};
 use super::Footprint;
 
 /// Conversion factor from millimetres to Altium internal units.
@@ -134,6 +134,11 @@ pub fn encode_data_stream(footprint: &Footprint) -> Vec<u8> {
     for pad in &footprint.pads {
         data.push(0x02); // Pad record type
         encode_pad(&mut data, pad);
+    }
+
+    for via in &footprint.vias {
+        data.push(0x03); // Via record type
+        encode_via(&mut data, via);
     }
 
     for track in &footprint.tracks {
@@ -265,6 +270,102 @@ fn encode_pad_geometry(pad: &Pad) -> Vec<u8> {
 
     // Jumper ID
     block.extend_from_slice(&[0u8; 2]);
+
+    block
+}
+
+/// Encodes a Via primitive.
+///
+/// Via has 6 blocks (similar to Pad):
+/// - Block 0: Name/designator (empty for vias)
+/// - Block 1: Layer stack data (empty)
+/// - Block 2: Marker string ("|&|0")
+/// - Block 3: Net/connectivity data (empty)
+/// - Block 4: Geometry data
+/// - Block 5: Per-layer data (empty for simple vias)
+fn encode_via(data: &mut Vec<u8>, via: &Via) {
+    // Block 0: Name/designator (empty for vias)
+    write_block(data, &[0u8; 1]); // Single null byte for empty string
+
+    // Block 1: Layer stack data (empty)
+    write_block(data, &[]);
+
+    // Block 2: "|&|0" marker string
+    write_string_block(data, "|&|0");
+
+    // Block 3: Net/connectivity data (empty for library vias)
+    write_block(data, &[]);
+
+    // Block 4: Geometry data
+    let geometry = encode_via_geometry(via);
+    write_block(data, &geometry);
+
+    // Block 5: Per-layer data (empty for simple vias)
+    write_block(data, &[]);
+}
+
+/// Encodes the geometry block for a via.
+///
+/// # Format
+///
+/// ```text
+/// [layer:1]                 // Layer ID (typically MultiLayer = 74)
+/// [flags:12]                // Flags and padding
+/// [x:4 i32]                 // X position
+/// [y:4 i32]                 // Y position
+/// [diameter:4 i32]          // Via diameter
+/// [hole_size:4 i32]         // Hole diameter
+/// [from_layer:1]            // Starting layer ID
+/// [to_layer:1]              // Ending layer ID
+/// [thermal_gap:4 i32]       // Thermal relief air gap width
+/// [thermal_count:1]         // Thermal relief conductors count
+/// [thermal_width:4 i32]     // Thermal relief conductors width
+/// [solder_expansion:4 i32]  // Solder mask expansion
+/// [solder_manual:1]         // Solder mask expansion manual flag
+/// [stack_mode:1]            // Diameter stack mode (0 = Simple)
+/// ```
+fn encode_via_geometry(via: &Via) -> Vec<u8> {
+    let mut block = Vec::with_capacity(64);
+
+    // Common header (13 bytes) - use MultiLayer for vias
+    write_common_header(&mut block, Layer::MultiLayer);
+
+    // Location (X, Y) - offsets 13-20
+    write_i32(&mut block, from_mm(via.x));
+    write_i32(&mut block, from_mm(via.y));
+
+    // Diameter - offset 21
+    write_i32(&mut block, from_mm(via.diameter));
+
+    // Hole size - offset 25
+    write_i32(&mut block, from_mm(via.hole_size));
+
+    // From/To layers - offsets 29-30
+    block.push(layer_to_id(via.from_layer));
+    block.push(layer_to_id(via.to_layer));
+
+    // Thermal relief air gap width - offset 31 (default: 10 mils = 0.254mm)
+    write_i32(&mut block, from_mm(0.254));
+
+    // Thermal relief conductors count - offset 35 (default: 4)
+    block.push(4);
+
+    // Thermal relief conductors width - offset 36 (default: 10 mils = 0.254mm)
+    write_i32(&mut block, from_mm(0.254));
+
+    // Solder mask expansion - offset 40
+    write_i32(&mut block, from_mm(via.solder_mask_expansion));
+
+    // Solder mask expansion manual flag - offset 44
+    block.push(u8::from(via.solder_mask_expansion_manual));
+
+    // Diameter stack mode - offset 45 (0 = Simple)
+    block.push(0x00);
+
+    // Pad to minimum expected size
+    while block.len() < 46 {
+        block.push(0x00);
+    }
 
     block
 }

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -16,7 +16,7 @@
 use super::primitives::{Arc, ComponentBody, Fill, Layer, Pad, PadShape, Region, Text, Track, Via};
 use super::Footprint;
 
-/// Encodes text content for the WideStrings stream.
+/// Encodes text content for the `WideStrings` stream.
 ///
 /// # Format
 ///
@@ -32,8 +32,10 @@ use super::Footprint;
 ///
 /// # Returns
 ///
-/// Encoded WideStrings stream content as bytes.
+/// Encoded `WideStrings` stream content as bytes.
 pub fn encode_wide_strings(texts: &[&str]) -> Vec<u8> {
+    use std::fmt::Write;
+
     let mut output = String::new();
 
     for (index, text) in texts.iter().enumerate() {
@@ -49,7 +51,7 @@ pub fn encode_wide_strings(texts: &[&str]) -> Vec<u8> {
             .collect::<Vec<_>>()
             .join(",");
 
-        output.push_str(&format!("|ENCODEDTEXT{index}={encoded}"));
+        let _ = write!(output, "|ENCODEDTEXT{index}={encoded}");
     }
 
     if !output.is_empty() {
@@ -59,7 +61,7 @@ pub fn encode_wide_strings(texts: &[&str]) -> Vec<u8> {
     output.into_bytes()
 }
 
-/// Collects all text content from footprints that needs to be stored in WideStrings.
+/// Collects all text content from footprints that needs to be stored in `WideStrings`.
 ///
 /// Returns a vector of unique text strings (excluding special values like `.Designator`).
 pub fn collect_wide_strings_content(footprints: &[Footprint]) -> Vec<String> {


### PR DESCRIPTION
## Description

Implement two major features for PcbLib file handling:

### Via Primitive Support (0x03)
- Add `Via` struct with position, diameter, hole size, from/to layers, and solder mask expansion
- Implement `parse_via()` for reading vias from binary format  
- Implement `encode_via()` for writing vias to binary format
- Add `vias: Vec<Via>` field to `Footprint` struct with `add_via()` method
- Support for through-hole and blind/buried vias

### WideStrings Stream Support
- Parse `/WideStrings` stream during library read (contains text content as ASCII-encoded entries)
- Decode `ENCODEDTEXT{N}=c1,c2,c3,...` format (comma-separated ASCII codes)
- Resolve text primitive content from WideStrings lookup when available
- Write WideStrings stream when saving libraries with text content
- Collect and deduplicate text content from all footprints

### Documentation
- Add comprehensive `TODO.md` tracking implementation gaps between PCBLIB_FORMAT.md and the Rust codebase

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

### New Tests Added
- `binary_roundtrip_via` - Via encoding/decoding roundtrip
- `binary_roundtrip_mixed_with_vias` - Mixed primitives including vias
- `test_parse_wide_strings` - WideStrings stream parsing
- `test_encode_wide_strings` - WideStrings stream encoding
- `test_collect_wide_strings_content` - Text content collection

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
