### PR TITLE
feat(pcblib): add pad advanced features - hole shapes and mask expansion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,12 +34,32 @@ This document tracks implementation gaps between the documented PcbLib format (`
 
 ## Pad Advanced Features
 
-### Hole Shapes - Incomplete
+### Hole Shapes - Implemented ✓
 
-- [ ] Add `Square` and `Slot` variants to `PadShape` enum in `src/altium/pcblib/primitives.rs`
-- [ ] Update `pad_shape_from_id()` in `src/altium/pcblib/reader.rs` to handle IDs 0 (Round), 1 (Square), 2 (Slot)
-- [ ] Update `pad_shape_to_id()` in `src/altium/pcblib/writer.rs`
-- [ ] Note: These are hole shapes, separate from pad shapes
+- [x] Add `HoleShape` enum with `Round`, `Square`, `Slot` variants to `src/altium/pcblib/primitives.rs`
+- [x] Add `hole_shape: HoleShape` field to `Pad` struct
+- [x] Add `hole_shape_from_id()` in `src/altium/pcblib/reader.rs` to handle IDs 0 (Round), 1 (Square), 2 (Slot)
+- [x] Add `hole_shape_to_id()` in `src/altium/pcblib/writer.rs`
+- [x] Parse hole shape from geometry offset 61 in `parse_pad()`
+- [x] Write hole shape in `encode_pad_geometry()`
+- Note: Hole shapes are separate from pad shapes (copper outline)
+
+### Paste/Solder Mask Expansion - Implemented ✓
+
+- [x] Add `paste_mask_expansion: Option<f64>` field to `Pad`
+- [x] Add `solder_mask_expansion: Option<f64>` field to `Pad`
+- [x] Add `paste_mask_expansion_manual: bool` field
+- [x] Add `solder_mask_expansion_manual: bool` field
+- [x] Parse from geometry block offsets 86-93 and 101-102
+- [x] Write to geometry block in `encode_pad_geometry()`
+- [x] Add roundtrip tests for mask expansion
+
+### Corner Radius - Partial Implementation
+
+- [x] Add `corner_radius_percent: Option<u8>` field to `Pad` struct (0-100%)
+- [x] Parse corner radius from per-layer data (Block 5)
+- [ ] Write corner radius to per-layer data (not yet implemented)
+- Note: Percentage of smaller pad dimension, not absolute value
 
 ### Stack Modes - Not Implemented
 
@@ -56,22 +76,6 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [ ] Add per-layer offset-from-hole-center arrays (32 CoordPoints)
 - [ ] Parse Block 6 in `parse_pad()` when stack mode != Simple
 - [ ] Write Block 6 in `encode_pad()` when stack mode != Simple
-
-### Corner Radius - Not Exposed
-
-- [ ] Add `corner_radius_percent: Option<u8>` field to `Pad` struct (0-100%)
-- [ ] Parse corner radius from per-layer data
-- [ ] Write corner radius to per-layer data
-- [ ] Note: Percentage of smaller pad dimension, not absolute value
-
-### Paste/Solder Mask Expansion - Not Exposed
-
-- [ ] Add `paste_mask_expansion: Option<f64>` field to `Pad`
-- [ ] Add `solder_mask_expansion: Option<f64>` field to `Pad`
-- [ ] Add `paste_mask_expansion_manual: bool` field
-- [ ] Add `solder_mask_expansion_manual: bool` field
-- [ ] Parse from geometry block (currently ignored)
-- [ ] Write to geometry block (currently hardcoded to 0 in writer.rs line 253-261)
 
 ## Text Advanced Features
 
@@ -169,6 +173,7 @@ Flag bits to support:
 - [x] Add roundtrip tests for Via primitive
 - [x] Add tests for WideStrings parsing
 - [x] Add tests for 3D model parsing and embedding
+- [x] Add tests for pad hole shapes, mask expansion (basic features)
 - [ ] Add tests for advanced pad features (stack modes, per-layer data)
 - [ ] Add tests for all layer ID mappings
 - [ ] Add integration tests with real Altium library files

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -35,9 +35,40 @@ pub struct Pad {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hole_size: Option<f64>,
 
+    /// Hole shape for through-hole pads.
+    #[serde(default, skip_serializing_if = "is_default_hole_shape")]
+    pub hole_shape: HoleShape,
+
     /// Rotation angle in degrees.
     #[serde(default)]
     pub rotation: f64,
+
+    /// Paste mask expansion in mm. None uses design rules.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paste_mask_expansion: Option<f64>,
+
+    /// Solder mask expansion in mm. None uses design rules.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub solder_mask_expansion: Option<f64>,
+
+    /// Whether paste mask expansion is manually set.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub paste_mask_expansion_manual: bool,
+
+    /// Whether solder mask expansion is manually set.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub solder_mask_expansion_manual: bool,
+
+    /// Corner radius as percentage of smaller pad dimension (0-100).
+    /// Only applies to `RoundedRectangle` shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corner_radius_percent: Option<u8>,
+}
+
+/// Helper for serde to skip default hole shape in serialization.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires reference
+fn is_default_hole_shape(shape: &HoleShape) -> bool {
+    *shape == HoleShape::default()
 }
 
 impl Pad {
@@ -53,7 +84,13 @@ impl Pad {
             shape: PadShape::RoundedRectangle,
             layer: Layer::MultiLayer,
             hole_size: None,
+            hole_shape: HoleShape::Round,
             rotation: 0.0,
+            paste_mask_expansion: None,
+            solder_mask_expansion: None,
+            paste_mask_expansion_manual: false,
+            solder_mask_expansion_manual: false,
+            corner_radius_percent: None,
         }
     }
 
@@ -76,7 +113,13 @@ impl Pad {
             shape: PadShape::Round,
             layer: Layer::MultiLayer,
             hole_size: Some(hole_size),
+            hole_shape: HoleShape::Round,
             rotation: 0.0,
+            paste_mask_expansion: None,
+            solder_mask_expansion: None,
+            paste_mask_expansion_manual: false,
+            solder_mask_expansion_manual: false,
+            corner_radius_percent: None,
         }
     }
 }
@@ -94,6 +137,22 @@ pub enum PadShape {
     Round,
     /// Oval/oblong pad.
     Oval,
+}
+
+/// Hole shape types for through-hole pads.
+///
+/// This is separate from `PadShape` as it describes the drill hole shape,
+/// not the copper pad shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HoleShape {
+    /// Circular hole (most common).
+    #[default]
+    Round,
+    /// Square hole.
+    Square,
+    /// Slot (oblong) hole.
+    Slot,
 }
 
 /// A PCB via (vertical interconnect access).

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2013,6 +2013,36 @@ impl McpServer {
         let hole_size = json.get("hole_size").and_then(Value::as_f64);
         let rotation = json.get("rotation").and_then(Value::as_f64).unwrap_or(0.0);
 
+        // Parse optional hole shape
+        let hole_shape = json
+            .get("hole_shape")
+            .and_then(Value::as_str)
+            .map(|s| match s.to_lowercase().as_str() {
+                "square" => crate::altium::pcblib::HoleShape::Square,
+                "slot" => crate::altium::pcblib::HoleShape::Slot,
+                _ => crate::altium::pcblib::HoleShape::Round,
+            })
+            .unwrap_or_default();
+
+        // Parse optional mask expansion values
+        let paste_mask_expansion = json.get("paste_mask_expansion").and_then(Value::as_f64);
+        let solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
+        let paste_mask_expansion_manual = json
+            .get("paste_mask_expansion_manual")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let solder_mask_expansion_manual = json
+            .get("solder_mask_expansion_manual")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        // Parse optional corner radius
+        let corner_radius_percent = json
+            .get("corner_radius_percent")
+            .and_then(Value::as_u64)
+            .and_then(|v| u8::try_from(v).ok())
+            .filter(|&v| v <= 100);
+
         Ok(Pad {
             designator: designator.to_string(),
             x,
@@ -2022,7 +2052,13 @@ impl McpServer {
             shape,
             layer,
             hole_size,
+            hole_shape,
             rotation,
+            paste_mask_expansion,
+            solder_mask_expansion,
+            paste_mask_expansion_manual,
+            solder_mask_expansion_manual,
+            corner_radius_percent,
         })
     }
 


### PR DESCRIPTION
## Description

This PR extends the Pad primitive with advanced features for through-hole pad holes and mask expansions:

- **Hole Shapes**: Adds `HoleShape` enum (`Round`, `Square`, `Slot`) separate from the copper pad shape, enabling proper representation of different drill hole geometries
- **Mask Expansions**: Adds `paste_mask_expansion` and `solder_mask_expansion` fields with corresponding `_manual` flags for explicit control over mask sizing
- **Corner Radius**: Adds `corner_radius_percent` field (read-only for now) to support rounded rectangle pads

All features include full binary roundtrip support with documented geometry block offsets, and the MCP server has been updated to parse these new fields from JSON input.

## Related Issue

N/A - Feature enhancement

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

### Test Coverage
- `binary_roundtrip_pad_advanced_features` - Tests roundtrip encoding/decoding of hole shapes and mask expansions
- `test_hole_shape_from_id` - Unit tests for hole shape ID conversion (reader)
- `test_hole_shape_to_id` - Unit tests for hole shape ID conversion (writer)

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes

## Additional Notes

- Corner radius writing is not yet implemented (read-only) - tracked in TODO.md
- Geometry block offsets are now fully documented in both reader.rs and writer.rs for maintainability
