### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/tests/component_body_parsing.rs
+++ b/tests/component_body_parsing.rs
@@ -16,8 +16,8 @@ fn test_component_body_parsing() {
             println!("  ComponentBodies: {}", fp.component_bodies.len());
             total_bodies += fp.component_bodies.len();
 
-            for (i, body) in fp.component_bodies.iter().enumerate() {
-                println!("    Body[{i}]:");
+            for (body_index, body) in fp.component_bodies.iter().enumerate() {
+                println!("    Body[{body_index}]:");
                 println!("      model_id: {}", body.model_id);
                 println!("      model_name: {}", body.model_name);
                 println!("      embedded: {}", body.embedded);


### PR DESCRIPTION
## Summary

Improves code readability in the component body parsing test by using a more descriptive loop variable name.

## Changes

- Renamed loop variable `i` to `body_index` in `tests/component_body_parsing.rs`
- Updated the corresponding `println!` statement to use the new variable name

## Rationale

Using descriptive variable names like `body_index` instead of single-letter names like `i` improves code clarity and maintainability, especially when the variable represents something specific (in this case, the index of a component body in the iteration).

---
_Generated from [AI code quality findings](https://github.com/embedded-society/altium-designer-mcp/security/quality/ai-findings)._