### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/tests/component_body_parsing.rs
+++ b/tests/component_body_parsing.rs
@@ -9,12 +9,12 @@ fn test_component_body_parsing() {
 
     println!("\n=== Testing ComponentBody Parsing ===\n");
 
-    let mut total_bodies = 0;
+    let mut total_component_bodies_count = 0;
     for fp in lib.footprints() {
         if !fp.component_bodies.is_empty() {
             println!("Footprint: {}", fp.name);
             println!("  ComponentBodies: {}", fp.component_bodies.len());
-            total_bodies += fp.component_bodies.len();
+            total_component_bodies_count += fp.component_bodies.len();
 
             for (body_index, body) in fp.component_bodies.iter().enumerate() {
                 println!("    Body[{body_index}]:");
@@ -34,9 +34,9 @@ fn test_component_body_parsing() {
         }
     }
 
-    println!("Total component bodies found: {total_bodies}");
+    println!("Total component bodies found: {total_component_bodies_count}");
     assert!(
-        total_bodies > 0,
+        total_component_bodies_count > 0,
         "Expected at least one component body in sample.PcbLib"
     );
 }


### PR DESCRIPTION
## Summary

Improves code quality in the component body parsing test by renaming a variable for better clarity.

## Changes

- Renamed `total_bodies` → `total_component_bodies_count` in `tests/component_body_parsing.rs`

This makes the variable name more descriptive and specific about what it's counting, improving code readability.

---

_This PR applies 1/3 suggestions from code quality [AI findings](https://github.com/embedded-society/altium-designer-mcp/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._