### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/tests/model_parsing.rs
+++ b/tests/model_parsing.rs
@@ -5,7 +5,8 @@ use altium_designer_mcp::altium::pcblib::PcbLib;
 #[test]
 #[ignore = "Requires sample.PcbLib with embedded 3D models"]
 fn test_model_parsing() {
-    let lib_path = std::env::var("ALTIUM_TEST_PCBLIB").unwrap_or_else(|_| "scripts/sample.PcbLib".to_string());
+    let lib_path =
+        std::env::var("ALTIUM_TEST_PCBLIB").unwrap_or_else(|_| "scripts/sample.PcbLib".to_string());
     let lib = PcbLib::read(&lib_path).expect("Failed to read sample.PcbLib");
 
     println!("\n=== Testing 3D Model Parsing ===\n");

--- a/tests/model_parsing.rs
+++ b/tests/model_parsing.rs
@@ -47,3 +47,15 @@ fn test_model_parsing() {
         }
     }
 }
+
+#[test]
+fn test_model_parsing_missing_file() {
+    // This test ensures that the PcbLib::read API behaves sensibly when the
+    // requested file is not present. It does not rely on any external files
+    // and therefore can run in CI/CD environments.
+    let result = PcbLib::read("nonexistent_sample.PcbLib");
+    assert!(
+        result.is_err(),
+        "PcbLib::read should fail when the input file does not exist"
+    );
+}

--- a/tests/model_parsing.rs
+++ b/tests/model_parsing.rs
@@ -5,7 +5,8 @@ use altium_designer_mcp::altium::pcblib::PcbLib;
 #[test]
 #[ignore = "Requires sample.PcbLib with embedded 3D models"]
 fn test_model_parsing() {
-    let lib = PcbLib::read("scripts/sample.PcbLib").expect("Failed to read sample.PcbLib");
+    let lib_path = std::env::var("ALTIUM_TEST_PCBLIB").unwrap_or_else(|_| "scripts/sample.PcbLib".to_string());
+    let lib = PcbLib::read(&lib_path).expect("Failed to read sample.PcbLib");
 
     println!("\n=== Testing 3D Model Parsing ===\n");
 


### PR DESCRIPTION
## Summary

Addresses code quality improvements for `tests/model_parsing.rs` based on [AI findings](https://github.com/embedded-society/altium-designer-mcp/security/quality/ai-findings).

## Changes

### Configurable test library path
Replaced the hardcoded path to `sample.PcbLib` with an environment variable lookup:
- Uses `ALTIUM_TEST_PCBLIB` environment variable when set
- Falls back to the original `scripts/sample.PcbLib` path
- Improves flexibility for CI/CD environments and different local setups

### Error handling test
Added `test_model_parsing_missing_file` to verify that `PcbLib::read()` correctly returns an error when the input file doesn't exist. This test runs without external dependencies, making it suitable for CI/CD environments.

## Testing
- New test validates error handling for missing files
- Existing functionality preserved with the default fallback path