### PR TITLE
Fix for Except block handles 'BaseException'

### DIFF
--- a/scripts/analyze_pcblib.py
+++ b/scripts/analyze_pcblib.py
@@ -51,7 +51,7 @@ def parse_string_block(data: bytes, offset: int) -> tuple[str, int]:
             try:
                 s = data[offset + 5 : offset + 5 + str_len].decode("ascii")
                 return s, offset + 4 + block_len
-            except:
+            except Exception:
                 pass
 
     return "", offset + 4 + block_len


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `scripts/analyze_pcblib.py` to avoid catching `KeyboardInterrupt`, `SystemExit`, and other process-control exceptions.

This follows Python best practices and ensures the programme can be interrupted or exited normally, whilst still handling decode errors gracefully.