### PR TITLE
Fix for Empty except

### DIFF
--- a/scripts/analyze_schlib.py
+++ b/scripts/analyze_schlib.py
@@ -21,9 +21,10 @@ def parse_properties(data: bytes) -> dict:
             if '=' in part:
                 key, value = part.split('=', 1)
                 props[key] = value
+        return props
     except Exception:
-        pass
-    return props
+        # Invalid or unexpectedly formatted property data is ignored; return any props parsed so far.
+        return props
 
 
 def parse_binary_pin(data: bytes) -> dict:


### PR DESCRIPTION
## Summary

Fixes CodeQL warning about empty `except` block in `parse_properties()` function.

## Changes

- Moves `return props` into the `try` block for explicit normal-flow return
- Adds explanatory comment in `except` block clarifying that malformed property data is intentionally ignored
- Explicitly returns `props` from the `except` block to satisfy CodeQL whilst preserving existing behaviour

## Impact

No functional change — the function continues to return any successfully parsed properties, gracefully handling malformed input. The code is now more explicit about its intent.