### PR TITLE
Fix for Empty except

### DIFF
--- a/scripts/analyze_pcblib.py
+++ b/scripts/analyze_pcblib.py
@@ -444,8 +444,12 @@ def parse_component_body_params(block: bytes) -> dict:
                     # Clean up null bytes
                     val = val.rstrip('\x00')
                     params[key] = val
-    except Exception:
-        pass
+    except Exception as e:
+        # Keep returning an empty parameter dict on failure, but make the error visible.
+        print(
+            f"      Warning: failed to parse ComponentBody parameters: {e}",
+            file=sys.stderr,
+        )
     return params
 
 


### PR DESCRIPTION
## Summary

Replaces the bare `except Exception: pass` in `parse_component_body_params()` with proper error logging.

## Changes

- Captures the exception and prints a warning message to `stderr`
- Maintains existing behaviour (function still returns `{}` on error, no crash)
- Makes failures visible for debugging whilst preserving graceful degradation

## Why

Empty `except` blocks silently swallow errors, making debugging difficult. This fix follows Python best practices by logging meaningful diagnostics without changing the function's contract.

---
*Suggested fix powered by Copilot Autofix*