### PR TITLE
Add corner radius write support for Pad per-layer data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,11 +54,12 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [x] Write to geometry block in `encode_pad_geometry()`
 - [x] Add roundtrip tests for mask expansion
 
-### Corner Radius - Partial Implementation
+### Corner Radius - Implemented ✓
 
 - [x] Add `corner_radius_percent: Option<u8>` field to `Pad` struct (0-100%)
 - [x] Parse corner radius from per-layer data (Block 5)
-- [ ] Write corner radius to per-layer data (not yet implemented)
+- [x] Write corner radius to per-layer data (Block 5, offset 288)
+- [x] Set stack mode to FullStack (2) when corner radius is specified
 - Note: Percentage of smaller pad dimension, not absolute value
 
 ### Stack Modes - Not Implemented

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -205,7 +205,6 @@ pub struct Via {
     pub solder_mask_expansion_manual: bool,
 
     // Thermal relief settings (for polygon pours)
-
     /// Thermal relief air gap width in mm (default: 0.254mm = 10 mils).
     #[serde(default = "default_thermal_relief_gap")]
     pub thermal_relief_gap: f64,
@@ -219,29 +218,28 @@ pub struct Via {
     pub thermal_relief_width: f64,
 
     // Diameter stack mode
-
-    /// Diameter stack mode (Simple, TopMiddleBottom, or FullStack).
+    /// Diameter stack mode (`Simple`, `TopMiddleBottom`, or `FullStack`).
     #[serde(default)]
     pub diameter_stack_mode: ViaStackMode,
 
-    /// Per-layer diameters in mm (32 layers). Only used when stack_mode != Simple.
+    /// Per-layer diameters in mm (32 layers). Only used when `stack_mode` != `Simple`.
     /// Index 0 = Top Layer, Index 1 = Bottom Layer, Index 2-31 = Mid Layers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub per_layer_diameters: Option<Vec<f64>>,
 }
 
 /// Default thermal relief gap (10 mils = 0.254mm).
-fn default_thermal_relief_gap() -> f64 {
+const fn default_thermal_relief_gap() -> f64 {
     0.254
 }
 
 /// Default thermal relief conductor count.
-fn default_thermal_relief_conductors() -> u8 {
+const fn default_thermal_relief_conductors() -> u8 {
     4
 }
 
 /// Default thermal relief conductor width (10 mils = 0.254mm).
-fn default_thermal_relief_width() -> f64 {
+const fn default_thermal_relief_width() -> f64 {
     0.254
 }
 
@@ -261,9 +259,9 @@ impl Via {
             to_layer: Layer::BottomLayer,
             solder_mask_expansion: 0.0,
             solder_mask_expansion_manual: false,
-            thermal_relief_gap: 0.254,       // 10 mils
+            thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
-            thermal_relief_width: 0.254,     // 10 mils
+            thermal_relief_width: 0.254, // 10 mils
             diameter_stack_mode: ViaStackMode::Simple,
             per_layer_diameters: None,
         }
@@ -288,9 +286,9 @@ impl Via {
             to_layer: to,
             solder_mask_expansion: 0.0,
             solder_mask_expansion_manual: false,
-            thermal_relief_gap: 0.254,       // 10 mils
+            thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
-            thermal_relief_width: 0.254,     // 10 mils
+            thermal_relief_width: 0.254, // 10 mils
             diameter_stack_mode: ViaStackMode::Simple,
             per_layer_diameters: None,
         }

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -665,20 +665,21 @@ fn parse_via(data: &[u8], offset: usize) -> Option<(Via, usize)> {
     };
 
     // Per-layer diameters - offset 46+ (32 × 4 bytes = 128 bytes)
-    let per_layer_diameters = if diameter_stack_mode != ViaStackMode::Simple && geometry.len() > 45 + 128 {
-        let mut diameters = Vec::with_capacity(32);
-        for i in 0..32 {
-            let offset = 46 + (i * 4);
-            if let Some(val) = read_i32(geometry, offset) {
-                diameters.push(to_mm(val));
-            } else {
-                diameters.push(diameter); // Fallback to main diameter
+    let per_layer_diameters =
+        if diameter_stack_mode != ViaStackMode::Simple && geometry.len() > 45 + 128 {
+            let mut diameters = Vec::with_capacity(32);
+            for i in 0..32 {
+                let offset = 46 + (i * 4);
+                if let Some(val) = read_i32(geometry, offset) {
+                    diameters.push(to_mm(val));
+                } else {
+                    diameters.push(diameter); // Fallback to main diameter
+                }
             }
-        }
-        Some(diameters)
-    } else {
-        None
-    };
+            Some(diameters)
+        } else {
+            None
+        };
 
     let via = Via {
         x,
@@ -700,12 +701,11 @@ fn parse_via(data: &[u8], offset: usize) -> Option<(Via, usize)> {
 }
 
 /// Converts a via stack mode ID to `ViaStackMode`.
-fn via_stack_mode_from_id(id: u8) -> ViaStackMode {
+const fn via_stack_mode_from_id(id: u8) -> ViaStackMode {
     match id {
-        0 => ViaStackMode::Simple,
         1 => ViaStackMode::TopMiddleBottom,
         2 => ViaStackMode::FullStack,
-        _ => ViaStackMode::Simple, // Default fallback
+        _ => ViaStackMode::Simple, // 0 and any unknown value default to Simple
     }
 }
 


### PR DESCRIPTION
Implements write support for pad corner radius by encoding per-layer data (Block 5) in the PcbLib format.

## Changes

- Create `encode_pad_per_layer_data()` to generate Block 5 data structure:
  - 32 size entries (`CoordPoint`, 8 bytes each) = 256 bytes
  - 32 shape entries (1 byte each) = 32 bytes  
  - 32 corner radius percentages (1 byte each, 0-100) = 32 bytes
  - Total: 320 bytes per pad
- Update `encode_pad_geometry()` to set stack mode to `FullStack` (2) when `corner_radius_percent` is present
- Update `encode_pad()` to write per-layer data when corner radius is set
- Apply `cargo fmt` formatting fixes to `primitives.rs` and `reader.rs`
- Mark several functions as `const` where applicable

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed