### PR TITLE
Update copyright year to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Licence
 
-Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/altium-designer-mcp>.
+Copyright (C) 2026 Matej Gomboc <https://github.com/MatejGomboc/altium-designer-mcp>.
 
 GNU General Public License v3.0 — see [LICENCE](LICENCE).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> ExitCode {
 
     // Display GPL license notice (required by GPLv3 Section 5d)
     eprintln!(
-        "altium-designer-mcp {}  Copyright (C) 2025  Embedded Society",
+        "altium-designer-mcp {}  Copyright (C) 2026  Embedded Society",
         env!("CARGO_PKG_VERSION")
     );
     eprintln!("This program comes with ABSOLUTELY NO WARRANTY.");


### PR DESCRIPTION
## Description

Updates the copyright year from 2025 to 2026 in all relevant files for the new year.

### Files Changed
- `README.md` - Updated copyright notice in the Licence section
- `src/main.rs` - Updated copyright notice in the GPL license display (required by GPLv3 Section 5d)

## Type of Change

- [x] Documentation update

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed

## Additional Notes

Routine annual maintenance to keep copyright notices current.