### PR TITLE
Feature/per layer pad data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,14 +70,14 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [x] Write stack mode in `encode_pad_geometry()` (writer.rs)
 - [x] Auto-upgrade to FullStack when corner_radius_percent is set
 
-### Per-Layer Pad Data - Not Implemented
+### Per-Layer Pad Data - Implemented ✓
 
-- [ ] Add per-layer size arrays to `Pad` struct (32 CoordPoints)
-- [ ] Add per-layer shape arrays (32 bytes)
-- [ ] Add per-layer corner radius percentages (32 bytes, 0-100)
-- [ ] Add per-layer offset-from-hole-center arrays (32 CoordPoints)
-- [ ] Parse Block 6 in `parse_pad()` when stack mode != Simple
-- [ ] Write Block 6 in `encode_pad()` when stack mode != Simple
+- [x] Add per-layer size arrays to `Pad` struct (32 CoordPoints)
+- [x] Add per-layer shape arrays (32 bytes)
+- [x] Add per-layer corner radius percentages (32 bytes, 0-100)
+- [x] Add per-layer offset-from-hole-center arrays (32 CoordPoints)
+- [x] Parse Block 5 in `parse_pad()` when stack mode != Simple
+- [x] Write Block 5 in `encode_pad()` when stack mode != Simple
 
 ## Text Advanced Features
 

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -67,6 +67,27 @@ pub struct Pad {
     /// Stack mode for per-layer pad geometry.
     #[serde(default)]
     pub stack_mode: PadStackMode,
+
+    /// Per-layer pad sizes in mm (width, height) for 32 layers.
+    /// Only used when `stack_mode` != `Simple`.
+    /// Index 0 = Top Layer, Index 1 = Bottom Layer, Index 2-31 = Mid Layers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_layer_sizes: Option<Vec<(f64, f64)>>,
+
+    /// Per-layer pad shapes for 32 layers.
+    /// Only used when `stack_mode` != `Simple`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_layer_shapes: Option<Vec<PadShape>>,
+
+    /// Per-layer corner radius percentages (0-100) for 32 layers.
+    /// Only used when `stack_mode` != `Simple`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_layer_corner_radii: Option<Vec<u8>>,
+
+    /// Per-layer offset from hole center in mm (x, y) for 32 layers.
+    /// Only used when `stack_mode` != `Simple`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_layer_offsets: Option<Vec<(f64, f64)>>,
 }
 
 /// Helper for serde to skip default hole shape in serialization.
@@ -96,6 +117,10 @@ impl Pad {
             solder_mask_expansion_manual: false,
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
+            per_layer_sizes: None,
+            per_layer_shapes: None,
+            per_layer_corner_radii: None,
+            per_layer_offsets: None,
         }
     }
 
@@ -126,6 +151,10 @@ impl Pad {
             solder_mask_expansion_manual: false,
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
+            per_layer_sizes: None,
+            per_layer_shapes: None,
+            per_layer_corner_radii: None,
+            per_layer_offsets: None,
         }
     }
 }

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -532,25 +532,30 @@ fn parse_pad(data: &[u8], offset: usize) -> Option<(Pad, usize)> {
     // - 32 corner radius percentages (1 byte each) = 32 bytes
     // - 32 offset entries (x, y as i32 pairs) = 256 bytes (optional)
     // Total: 320 bytes minimum, 576 bytes with offsets
-    let (corner_radius_percent, per_layer_sizes, per_layer_shapes, per_layer_corner_radii, per_layer_offsets) =
-        if stack_mode == PadStackMode::Simple {
-            // For Simple mode, extract corner radius if available (backwards compatibility)
-            let corner_radius = per_layer_data.and_then(|data| {
-                if data.len() > 288 {
-                    let radius = data[288];
-                    if radius > 0 && radius <= 100 {
-                        Some(radius)
-                    } else {
-                        None
-                    }
+    let (
+        corner_radius_percent,
+        per_layer_sizes,
+        per_layer_shapes,
+        per_layer_corner_radii,
+        per_layer_offsets,
+    ) = if stack_mode == PadStackMode::Simple {
+        // For Simple mode, extract corner radius if available (backwards compatibility)
+        let corner_radius = per_layer_data.and_then(|data| {
+            if data.len() > 288 {
+                let radius = data[288];
+                if radius > 0 && radius <= 100 {
+                    Some(radius)
                 } else {
                     None
                 }
-            });
-            (corner_radius, None, None, None, None)
-        } else {
-            parse_per_layer_data(per_layer_data)
-        };
+            } else {
+                None
+            }
+        });
+        (corner_radius, None, None, None, None)
+    } else {
+        parse_per_layer_data(per_layer_data)
+    };
 
     let pad = Pad {
         designator,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2065,6 +2065,10 @@ impl McpServer {
             solder_mask_expansion_manual,
             corner_radius_percent,
             stack_mode: PadStackMode::Simple,
+            per_layer_sizes: None,
+            per_layer_shapes: None,
+            per_layer_corner_radii: None,
+            per_layer_offsets: None,
         })
     }
 


### PR DESCRIPTION
## Description

Implements per-layer pad data support for Altium PcbLib files, enabling FullStack and TopMiddleBottom pad modes with independent geometry per layer.

### Changes

**Primitives (`primitives.rs`):**
- Added four new optional fields to `Pad` struct:
  - `per_layer_sizes`: Width/height pairs for 32 layers (in mm)
  - `per_layer_shapes`: Pad shapes for 32 layers
  - `per_layer_corner_radii`: Corner radius percentages (0-100) for 32 layers
  - `per_layer_offsets`: X/Y offsets from hole centre for 32 layers

**Reader (`reader.rs`):**
- Added `parse_per_layer_data()` function to parse Block 5 per-layer data
- Format: 320 bytes minimum (sizes + shapes + radii), 576 bytes with offsets
- Maintains backwards compatibility for Simple stack mode

**Writer (`writer.rs`):**
- Updated `encode_pad_per_layer_data()` to use per-layer fields when present
- Updated `encode_pad()` to write Block 5 when any per-layer data is present
- Falls back to uniform pad geometry when per-layer fields are not set

**Server (`server.rs`):**
- Initialised new per-layer fields to `None` in pad construction

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally

## Code Quality

- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes
