### PR TITLE
Add special layer support (IDs 75-85)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,19 +125,19 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [x] Mechanical 1-16 (IDs 57-72)
 - [x] Mechanical 2-7 aliased to component layers (TopAssembly, BottomAssembly, etc.)
 
-### Missing Special Layers
+### Special Layers - Implemented ✓
 
-- [ ] `ConnectLayer` (ID 75)
-- [ ] `BackgroundLayer` (ID 76)
-- [ ] `DRCErrorLayer` (ID 77)
-- [ ] `HighlightLayer` (ID 78)
-- [ ] `GridColor1` (ID 79)
-- [ ] `GridColor10` (ID 80)
-- [ ] `PadHoleLayer` (ID 81)
-- [ ] `ViaHoleLayer` (ID 82)
-- [ ] `TopPadMaster` (ID 83)
-- [ ] `BottomPadMaster` (ID 84)
-- [ ] `DRCDetailLayer` (ID 85)
+- [x] `ConnectLayer` (ID 75)
+- [x] `BackgroundLayer` (ID 76)
+- [x] `DRCErrorLayer` (ID 77)
+- [x] `HighlightLayer` (ID 78)
+- [x] `GridColor1` (ID 79)
+- [x] `GridColor10` (ID 80)
+- [x] `PadHoleLayer` (ID 81)
+- [x] `ViaHoleLayer` (ID 82)
+- [x] `TopPadMaster` (ID 83)
+- [x] `BottomPadMaster` (ID 84)
+- [x] `DRCDetailLayer` (ID 85)
 
 ## PcbFlags - Not Exposed
 

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -989,8 +989,43 @@ pub enum Layer {
     #[serde(rename = "Mechanical 16", alias = "Mechanical16")]
     Mechanical16,
 
+    // Special layers (IDs 75-85)
+    /// Connect layer (ID 75).
+    #[serde(rename = "Connect Layer", alias = "ConnectLayer")]
+    ConnectLayer,
+    /// Background layer (ID 76).
+    #[serde(rename = "Background Layer", alias = "BackgroundLayer")]
+    BackgroundLayer,
+    /// DRC error layer (ID 77).
+    #[serde(rename = "DRC Error Layer", alias = "DRCErrorLayer")]
+    DRCErrorLayer,
+    /// Highlight layer (ID 78).
+    #[serde(rename = "Highlight Layer", alias = "HighlightLayer")]
+    HighlightLayer,
+    /// Grid color 1 layer (ID 79).
+    #[serde(rename = "Grid Color 1", alias = "GridColor1")]
+    GridColor1,
+    /// Grid color 10 layer (ID 80).
+    #[serde(rename = "Grid Color 10", alias = "GridColor10")]
+    GridColor10,
+    /// Pad hole layer (ID 81).
+    #[serde(rename = "Pad Hole Layer", alias = "PadHoleLayer")]
+    PadHoleLayer,
+    /// Via hole layer (ID 82).
+    #[serde(rename = "Via Hole Layer", alias = "ViaHoleLayer")]
+    ViaHoleLayer,
+    /// Top pad master layer (ID 83).
+    #[serde(rename = "Top Pad Master", alias = "TopPadMaster")]
+    TopPadMaster,
+    /// Bottom pad master layer (ID 84).
+    #[serde(rename = "Bottom Pad Master", alias = "BottomPadMaster")]
+    BottomPadMaster,
+    /// DRC detail layer (ID 85).
+    #[serde(rename = "DRC Detail Layer", alias = "DRCDetailLayer")]
+    DRCDetailLayer,
+
     // Keep-out
-    /// Keep-out layer.
+    /// Keep-out layer (ID 56).
     #[serde(rename = "Keep-Out Layer", alias = "KeepOut")]
     KeepOut,
 }
@@ -1079,6 +1114,17 @@ impl Layer {
             Self::Mechanical14 => "Mechanical 14",
             Self::Mechanical15 => "Mechanical 15",
             Self::Mechanical16 => "Mechanical 16",
+            Self::ConnectLayer => "Connect Layer",
+            Self::BackgroundLayer => "Background Layer",
+            Self::DRCErrorLayer => "DRC Error Layer",
+            Self::HighlightLayer => "Highlight Layer",
+            Self::GridColor1 => "Grid Color 1",
+            Self::GridColor10 => "Grid Color 10",
+            Self::PadHoleLayer => "Pad Hole Layer",
+            Self::ViaHoleLayer => "Via Hole Layer",
+            Self::TopPadMaster => "Top Pad Master",
+            Self::BottomPadMaster => "Bottom Pad Master",
+            Self::DRCDetailLayer => "DRC Detail Layer",
             Self::KeepOut => "Keep-Out Layer",
         }
     }
@@ -1166,6 +1212,17 @@ impl Layer {
             "Mechanical 14" => Some(Self::Mechanical14),
             "Mechanical 15" => Some(Self::Mechanical15),
             "Mechanical 16" => Some(Self::Mechanical16),
+            "Connect Layer" => Some(Self::ConnectLayer),
+            "Background Layer" => Some(Self::BackgroundLayer),
+            "DRC Error Layer" => Some(Self::DRCErrorLayer),
+            "Highlight Layer" => Some(Self::HighlightLayer),
+            "Grid Color 1" => Some(Self::GridColor1),
+            "Grid Color 10" => Some(Self::GridColor10),
+            "Pad Hole Layer" => Some(Self::PadHoleLayer),
+            "Via Hole Layer" => Some(Self::ViaHoleLayer),
+            "Top Pad Master" => Some(Self::TopPadMaster),
+            "Bottom Pad Master" => Some(Self::BottomPadMaster),
+            "DRC Detail Layer" => Some(Self::DRCDetailLayer),
             "Keep-Out Layer" => Some(Self::KeepOut),
             _ => None,
         }

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -277,7 +277,19 @@ const fn layer_from_id(id: u8) -> Layer {
         72 => Layer::Mechanical16,
         // Drill drawing
         73 => Layer::DrillDrawing,
-        // 74 = Multi-Layer and all other unknown layers
+        // Special layers (IDs 75-85)
+        75 => Layer::ConnectLayer,
+        76 => Layer::BackgroundLayer,
+        77 => Layer::DRCErrorLayer,
+        78 => Layer::HighlightLayer,
+        79 => Layer::GridColor1,
+        80 => Layer::GridColor10,
+        81 => Layer::PadHoleLayer,
+        82 => Layer::ViaHoleLayer,
+        83 => Layer::TopPadMaster,
+        84 => Layer::BottomPadMaster,
+        85 => Layer::DRCDetailLayer,
+        // Unknown layers default to MultiLayer
         _ => Layer::MultiLayer,
     }
 }

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -213,6 +213,18 @@ const fn layer_to_id(layer: Layer) -> u8 {
         Layer::Mechanical14 => 70,
         Layer::Mechanical15 => 71,
         Layer::Mechanical16 => 72,
+        // Special layers (IDs 75-85)
+        Layer::ConnectLayer => 75,
+        Layer::BackgroundLayer => 76,
+        Layer::DRCErrorLayer => 77,
+        Layer::HighlightLayer => 78,
+        Layer::GridColor1 => 79,
+        Layer::GridColor10 => 80,
+        Layer::PadHoleLayer => 81,
+        Layer::ViaHoleLayer => 82,
+        Layer::TopPadMaster => 83,
+        Layer::BottomPadMaster => 84,
+        Layer::DRCDetailLayer => 85,
         Layer::MultiLayer => 74,
     }
 }


### PR DESCRIPTION
This PR extends the `Layer` enum with support for Altium Designer's special layers (IDs 75-85), improving compatibility when reading and writing PcbLib files that utilise these layers.

## Summary of Changes

**New Layer Variants Added:**
- `ConnectLayer` (ID 75) — Used for net connectivity visualisation
- `BackgroundLayer` (ID 76) — Background display layer
- `DRCErrorLayer` (ID 77) — Design Rule Check error markers
- `HighlightLayer` (ID 78) — Highlighted object display
- `GridColor1` (ID 79) — Primary grid colour layer
- `GridColor10` (ID 80) — Secondary grid colour layer  
- `PadHoleLayer` (ID 81) — Pad hole visualisation
- `ViaHoleLayer` (ID 82) — Via hole visualisation
- `TopPadMaster` (ID 83) — Top pad master layer
- `BottomPadMaster` (ID 84) — Bottom pad master layer
- `DRCDetailLayer` (ID 85) — Detailed DRC information

**Implementation Details:**
- Extended the `Layer` enum in `primitives.rs` with proper serde attributes for serialisation/deserialisation
- Added doc comments with layer IDs for each new variant
- Updated `layer_from_id()` in `reader.rs` for correct ID-to-layer mapping when reading PcbLib files
- Updated `layer_to_id()` in `writer.rs` for correct layer-to-ID mapping when writing PcbLib files
- Extended `as_str()` method with human-readable layer names
- Extended `parse()` method to handle parsing of new layer name strings
- Updated `TODO.md` to reflect implementation status

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [ ] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [ ] CHANGELOG.md updated for user-facing changes

## Additional Notes

These special layers are primarily used for display and DRC purposes within Altium Designer. While they may not be commonly encountered in component library footprints, supporting them ensures complete compatibility when processing PcbLib files that reference these layers.