### PR TITLE
Feature/pcb flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ glob = "0.3"
 # Zlib decompression (for embedded 3D models)
 flate2 = "1.0"
 
+# Bitflags for PCB primitive flags
+bitflags = { version = "2.6", features = ["serde"] }
+
 [dev-dependencies]
 # Async testing utilities
 tokio-test = "0.4"

--- a/TODO.md
+++ b/TODO.md
@@ -139,20 +139,22 @@ This document tracks implementation gaps between the documented PcbLib format (`
 - [x] `BottomPadMaster` (ID 84)
 - [x] `DRCDetailLayer` (ID 85)
 
-## PcbFlags - Not Exposed
+## PcbFlags - Implemented ✓
 
-- [ ] Add `PcbFlags` struct or bitflags to primitives
-- [ ] Add flags field to all primitives (Pad, Track, Arc, Region, Fill, Text)
-- [ ] Parse flags from common header bytes 1-2 (reader.rs)
-- [ ] Write flags to common header (writer.rs, currently hardcoded to 0x00)
+- [x] Add `PcbFlags` struct or bitflags to primitives
+- [x] Add flags field to all primitives (Pad, Track, Arc, Region, Fill, Text)
+- [x] Parse flags from common header bytes 1-2 (reader.rs)
+- [x] Write flags to common header (writer.rs)
 
-Flag bits to support:
+Flag bits supported:
 
-- [ ] `Locked` (0x0001)
-- [ ] `Polygon` (0x0002)
-- [ ] `KeepOut` (0x0004)
-- [ ] `TentingTop` (0x0008)
-- [ ] `TentingBottom` (0x0010)
+- [x] `LOCKED` (0x0001)
+- [x] `POLYGON` (0x0002)
+- [x] `KEEPOUT` (0x0004)
+- [x] `TENTING_TOP` (0x0008)
+- [x] `TENTING_BOTTOM` (0x0010)
+
+Note: Text primitive uses byte 1 for `TextKind` instead of flags, so flags are always empty for Text.
 
 ## OLE Streams - Partial Implementation
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -40,7 +40,8 @@ use serde::{Deserialize, Serialize};
 
 pub use primitives::{
     Arc, ComponentBody, EmbeddedModel, Fill, HoleShape, Layer, Model3D, Pad, PadShape,
-    PadStackMode, Region, StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via,
+    PadStackMode, PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track, Vertex,
+    Via,
 };
 
 use crate::altium::error::{AltiumError, AltiumResult};
@@ -879,6 +880,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::empty(),
         });
         original.add_text(Text {
             x: 1.5,
@@ -890,6 +892,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             justification: TextJustification::TopLeft,
+            flags: PcbFlags::empty(),
         });
 
         let data = writer::encode_data_stream(&original);
@@ -935,6 +938,7 @@ mod tests {
                 },
             ],
             layer: Layer::TopAssembly,
+            flags: PcbFlags::empty(),
         });
 
         // Add a rectangular region
@@ -976,6 +980,7 @@ mod tests {
             y2: 0.5,
             layer: Layer::BottomPaste,
             rotation: 45.0,
+            flags: PcbFlags::empty(),
         });
 
         let data = writer::encode_data_stream(&original);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1964,7 +1964,7 @@ impl McpServer {
 
     /// Parses a pad from JSON.
     fn parse_pad(json: &Value) -> Result<crate::altium::pcblib::Pad, String> {
-        use crate::altium::pcblib::{Layer, Pad, PadShape, PadStackMode};
+        use crate::altium::pcblib::{Layer, Pad, PadShape, PadStackMode, PcbFlags};
 
         let designator = json
             .get("designator")
@@ -2069,6 +2069,7 @@ impl McpServer {
             per_layer_shapes: None,
             per_layer_corner_radii: None,
             per_layer_offsets: None,
+            flags: PcbFlags::empty(),
         })
     }
 
@@ -2113,7 +2114,7 @@ impl McpServer {
 
     /// Parses an arc from JSON.
     fn parse_arc(json: &Value) -> Result<crate::altium::pcblib::Arc, String> {
-        use crate::altium::pcblib::{Arc, Layer};
+        use crate::altium::pcblib::{Arc, Layer, PcbFlags};
 
         let x = json
             .get("x")
@@ -2159,12 +2160,13 @@ impl McpServer {
             end_angle,
             width,
             layer,
+            flags: PcbFlags::empty(),
         })
     }
 
     /// Parses a region from JSON.
     fn parse_region(json: &Value) -> Option<crate::altium::pcblib::Region> {
-        use crate::altium::pcblib::{Layer, Region, Vertex};
+        use crate::altium::pcblib::{Layer, PcbFlags, Region, Vertex};
 
         let vertices_json = json.get("vertices").and_then(Value::as_array)?;
         let layer = json
@@ -2186,12 +2188,16 @@ impl McpServer {
             return None; // Need at least 3 vertices for a polygon
         }
 
-        Some(Region { vertices, layer })
+        Some(Region {
+            vertices,
+            layer,
+            flags: PcbFlags::empty(),
+        })
     }
 
     /// Parses text from JSON.
     fn parse_text(json: &Value) -> Option<crate::altium::pcblib::Text> {
-        use crate::altium::pcblib::{Layer, Text, TextJustification, TextKind};
+        use crate::altium::pcblib::{Layer, PcbFlags, Text, TextJustification, TextKind};
 
         let x = json.get("x").and_then(Value::as_f64)?;
         let y = json.get("y").and_then(Value::as_f64)?;
@@ -2214,6 +2220,7 @@ impl McpServer {
             kind: TextKind::Stroke,
             stroke_font: None,
             justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::empty(),
         })
     }
 


### PR DESCRIPTION
## Description

This PR implements PCB primitive flags parsing and writing, enabling proper handling of locked, keepout, and tenting properties for footprint elements.

### Changes

**New `PcbFlags` bitflags struct** in `primitives.rs`:
- `LOCKED` (0x0001) – Primitive is locked and cannot be moved/edited
- `POLYGON` (0x0002) – Primitive is part of a polygon pour
- `KEEPOUT` (0x0004) – Primitive defines a keep-out region
- `TENTING_TOP` (0x0008) – Top solder mask tenting enabled
- `TENTING_BOTTOM` (0x0010) – Bottom solder mask tenting enabled

**Updated primitives** – Added `flags` field to:
- `Pad`
- `Track`
- `Arc`
- `Region`
- `Fill`
- `Text` (always empty – byte 1 is used for `TextKind` in Text primitives)

**Reader updates** (`reader.rs`):
- New `read_flags()` helper function to parse flags from common header bytes 1-2
- All primitive parsers now extract and store flags

**Writer updates** (`writer.rs`):
- `write_common_header()` now accepts `PcbFlags` parameter
- Flags are properly serialised to bytes 1-2 of the common header

**Dependencies**:
- Added `bitflags = "2.6"` with `serde` feature for serialisation support

### Backwards Compatibility

This change is **backwards compatible**:
- Flags field defaults to empty (`PcbFlags::empty()`)
- Empty flags are skipped during JSON serialisation (`skip_serializing_if = "PcbFlags::is_empty"`)
- Existing code that doesn't specify flags will continue to work unchanged

## Related Issue

Implements the "PcbFlags - Not Exposed" item from TODO.md

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] Documentation updated if needed
- [x] TODO.md updated to mark feature as complete
