### PR TITLE
Improve error handling in parse functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,11 +172,14 @@ Note: Text primitive uses byte 1 for `TextKind` instead of flags, so flags are a
 
 ## Code Quality
 
-### Error Handling
+### Error Handling - Implemented ✓
 
-- [ ] Return `Result` from `parse_pad()`, `parse_track()`, etc. instead of `Option`
-- [ ] Add specific error types for parse failures
-- [ ] Improve error messages with offset information
+- [x] Return `Result` from `parse_pad()`, `parse_track()`, etc. instead of `Option`
+- [x] Add specific error types for parse failures
+- [x] Improve error messages with offset information
+
+Note: All parse functions now return `ParseResult<T>` which is `Result<(T, usize), AltiumError>`.
+Error messages include the primitive type, block number, and byte offset where parsing failed.
 
 ### Testing
 


### PR DESCRIPTION
Refactor all parse functions in `reader.rs` to return `Result<(T, usize), AltiumError>` instead of `Option`. Error messages now include the primitive type, block number, and byte offset where parsing failed, making it significantly easier to diagnose issues with corrupted or malformed library files.

## Description

This PR introduces a new `ParseResult<T>` type alias and updates all internal parse functions to use proper error handling with descriptive error messages. Key changes include:

- **New type alias**: `type ParseResult<T> = Result<(T, usize), AltiumError>` for consistent return types
- **Updated parse functions**: `parse_pad`, `parse_track`, `parse_arc`, `parse_text`, `parse_region`, `parse_fill`, `parse_component_body`, and `parse_via` now return `ParseResult<T>`
- **Descriptive error messages**: Each failure point now reports:
  - The primitive type being parsed (e.g., "Pad", "Track", "Arc")
  - The specific block or field that failed (e.g., "block 0 (designator)", "x coordinate")
  - The byte offset where the failure occurred
- **Improved caller code**: `parse_data_stream` now uses `match` expressions instead of `if let` for cleaner error handling and better logging via `tracing::debug!`

### Example error messages

Before:
```
Failed to parse Pad at offset 0x1234
```

After:
```
Failed to parse Pad: Parse error at offset 0x1234: failed to read Pad block 4 (geometry)
```

## Related Issue

Implements the error handling improvements outlined in TODO.md under "Code Quality → Error Handling".

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [ ] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [ ] CHANGELOG.md updated for user-facing changes

## Additional Notes

This is an internal refactoring that does not affect the public API. The `ParseResult` type is private to the `reader` module. External callers continue to receive the same `AltiumError` types they did before, but with richer context in the error messages.

The error handling now gracefully distinguishes between:
- Missing or truncated blocks (e.g., "failed to read Pad block 0")
- Blocks that are too short (e.g., "Pad geometry block too short: 40 bytes, expected at least 52")
- Failed field reads within valid blocks (e.g., "failed to read Pad x coordinate")
