### PR TITLE
Fix/3d step model persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ bitflags = { version = "2.6", features = ["serde"] }
 # Character encoding (for Windows-1252 in legacy Altium files)
 encoding_rs = "0.8"
 
+# UUID generation (for 3D model GUIDs)
+uuid = { version = "1.11", features = ["v4"] }
+
 [dev-dependencies]
 # Async testing utilities
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ encoding_rs = "0.8"
 # UUID generation (for 3D model GUIDs)
 uuid = { version = "1.11", features = ["v4"] }
 
+# Regex for pattern matching (batch_update symbol filter)
+regex = "1.11"
+
 [dev-dependencies]
 # Async testing utilities
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ Returns:
 
 ### `batch_update`
 
-Perform batch updates across all components in an Altium PcbLib file. Supports updating track widths
-and renaming layers library-wide.
+Perform batch updates across all components in an Altium library file. Supports PcbLib
+operations (track width updates, layer renames) and SchLib operations (parameter updates).
 
 ```json
 {
@@ -344,18 +344,24 @@ and renaming layers library-wide.
 
 | Parameter | Description |
 |-----------|-------------|
-| `filepath` | Path to the PcbLib file |
-| `operation` | One of: `update_track_width`, `rename_layer` |
+| `filepath` | Path to the PcbLib or SchLib file |
+| `operation` | One of: `update_track_width`, `rename_layer`, `update_parameters` |
 | `parameters` | Operation-specific parameters |
 
-**Operations:**
+**PcbLib Operations:**
 
 | Operation | Parameters | Description |
 |-----------|------------|-------------|
 | `update_track_width` | `from_width`, `to_width`, `tolerance` | Update all tracks matching `from_width` (±tolerance) to `to_width` |
 | `rename_layer` | `from_layer`, `to_layer` | Change all primitives from one layer to another |
 
-**Example: Rename layer**
+**SchLib Operations:**
+
+| Operation | Parameters | Description |
+|-----------|------------|-------------|
+| `update_parameters` | `param_name`, `param_value`, `symbol_filter`?, `add_if_missing`? | Update parameter values across symbols |
+
+**Example: Rename layer (PcbLib)**
 
 ```json
 {
@@ -372,6 +378,31 @@ and renaming layers library-wide.
 ```
 
 Layer names accept both spaced format (`Top Layer`) and camelCase (`TopLayer`).
+
+**Example: Update parameters across symbols (SchLib)**
+
+```json
+{
+    "name": "batch_update",
+    "arguments": {
+        "filepath": "./MySymbols.SchLib",
+        "operation": "update_parameters",
+        "parameters": {
+            "param_name": "Manufacturer",
+            "param_value": "Acme Corp",
+            "symbol_filter": "^RES.*",
+            "add_if_missing": true
+        }
+    }
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `param_name` | Name of the parameter to update |
+| `param_value` | New value for the parameter |
+| `symbol_filter` | Optional regex to filter which symbols to update |
+| `add_if_missing` | If true, add the parameter to symbols that don't have it (default: false) |
 
 ### `copy_component`
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # TODO
 
-## Future Enhancements
-
-- [ ] **Bulk parameter update**: Set parameters across multiple symbols at once
-
 ## Known Limitations
 
 - **Floating-point precision**: Minor artifacts from mm↔mils conversion (cosmetic, doesn't affect functionality)

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,5 @@
 # TODO
 
-## Bugs
-
-- [ ] **3D STEP model not persisted**: `step_model` parameter in `write_pcblib` is accepted but data is not stored.
-      Read returns `model_3d: null`. Needs implementation of ComponentBody3D records for writing and parsing.
-
 ## Future Enhancements
 
 - [ ] **Bulk parameter update**: Set parameters across multiple symbols at once

--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,17 @@
 # TODO
 
+## Bugs
+
+- [ ] **3D STEP model not persisted**: `step_model` parameter in `write_pcblib` is accepted but data is not stored.
+      Read returns `model_3d: null`. Needs implementation of ComponentBody3D records for writing and parsing.
+
 ## Future Enhancements
 
-- [x] Add `render_symbol` tool for ASCII rendering of schematic symbols (parallel to `render_footprint`)
-- [x] Improve error messages with more descriptive failure reasons
-- [x] Add integration tests with real Altium library files (requires sample .PcbLib/.SchLib files)
+- [ ] **Bulk parameter update**: Set parameters across multiple symbols at once
 
-## Testing Gaps
+## To Investigate
 
-- [x] Verify `append: true` mode works correctly for `write_pcblib` and `write_schlib`
-- [x] Test multi-part schematic symbols (e.g., dual op-amps)
-- [x] Test 3D model attachment (`step_model` parameter)
-- [x] Stress test pagination (`limit`/`offset`) with large libraries
-
-## Documentation
-
-- [x] Clarify pin 1 indicator usage in `write_pcblib` (rectangular vs round pad shape)
-
----
+- [ ] **Pad layer defaults**: Created pads default to "Multi-Layer" instead of "Top Layer" for SMD components — verify if this is intentional behaviour or a bug
 
 ## Known Limitations
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,6 @@
 
 - [ ] **Bulk parameter update**: Set parameters across multiple symbols at once
 
-## To Investigate
-
-- [ ] **Pad layer defaults**: Created pads default to "Multi-Layer" instead of "Top Layer" for SMD components — verify if this is intentional behaviour or a bug
-
 ## Known Limitations
 
 - **Floating-point precision**: Minor artifacts from mm↔mils conversion (cosmetic, doesn't affect functionality)

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -278,6 +278,35 @@ The AI provides complete primitive definitions. The tool writes them.
 }
 ```
 
+### step_model (3D Model Attachment)
+
+To attach a STEP 3D model to a footprint, include the `step_model` property:
+
+```json
+{
+    "name": "RESC1608X55N",
+    "description": "Chip resistor with 3D model",
+    "pads": [...],
+    "step_model": {
+        "filepath": "./models/RESC1608X55.step",
+        "x_offset": 0,
+        "y_offset": 0,
+        "z_offset": 0,
+        "rotation": 0
+    }
+}
+```
+
+| Property | Description |
+|----------|-------------|
+| `filepath` | Path to the .step file (will be embedded in the library) |
+| `x_offset` | X offset in mm (default: 0) |
+| `y_offset` | Y offset in mm (default: 0) |
+| `z_offset` | Z offset in mm (default: 0) |
+| `rotation` | Z rotation in degrees (default: 0) |
+
+The STEP file is read from disk and embedded in the PcbLib file during write.
+
 ---
 
 ## Standard Altium Layers
@@ -581,12 +610,43 @@ Use `batch_update` to perform library-wide updates efficiently:
 }
 ```
 
-**Supported operations:**
+**PcbLib operations:**
 
 | Operation | Description |
 |-----------|-------------|
 | `update_track_width` | Change track widths matching a value (with tolerance) |
 | `rename_layer` | Move primitives from one layer to another |
+
+**SchLib operations:**
+
+| Operation | Description |
+|-----------|-------------|
+| `update_parameters` | Set parameter values across multiple symbols |
+
+**Example: Update parameters across symbols (SchLib)**
+
+```json
+{
+    "name": "batch_update",
+    "arguments": {
+        "filepath": "./MyLibrary.SchLib",
+        "operation": "update_parameters",
+        "parameters": {
+            "param_name": "Manufacturer",
+            "param_value": "Texas Instruments",
+            "symbol_filter": "^LM.*",
+            "add_if_missing": true
+        }
+    }
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `param_name` | Name of the parameter to update |
+| `param_value` | New value to set |
+| `symbol_filter` | Optional regex to filter which symbols to update |
+| `add_if_missing` | If true, add the parameter to symbols that don't have it (default: false) |
 
 ### Copying Components
 

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -180,7 +180,7 @@ You should see the Altium tools listed:
 
 **Batch Operations:**
 
-- `batch_update` — Perform library-wide updates (track widths, layer renaming)
+- `batch_update` — Perform library-wide updates (PcbLib: track widths, layer renaming; SchLib: parameter updates)
 
 **SchLib Tools:**
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -765,7 +765,10 @@ impl PcbLib {
                 // Extract filename from path
                 let filename = std::path::Path::new(&model_3d.filepath)
                     .file_name()
-                    .map_or_else(|| "model.step".to_string(), |n| n.to_string_lossy().to_string());
+                    .map_or_else(
+                        || "model.step".to_string(),
+                        |n| n.to_string_lossy().to_string(),
+                    );
 
                 // Create EmbeddedModel
                 let embedded_model = EmbeddedModel::new(&guid, &filename, step_data);

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -186,7 +186,7 @@ fn is_default_hole_shape(shape: &HoleShape) -> bool {
 }
 
 impl Pad {
-    /// Creates a new SMD pad.
+    /// Creates a new SMD pad on the top layer.
     #[must_use]
     pub fn smd(designator: impl Into<String>, x: f64, y: f64, width: f64, height: f64) -> Self {
         Self {
@@ -196,7 +196,7 @@ impl Pad {
             width,
             height,
             shape: PadShape::RoundedRectangle,
-            layer: Layer::MultiLayer,
+            layer: Layer::TopLayer,
             hole_size: None,
             hole_shape: HoleShape::Round,
             rotation: 0.0,

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -157,6 +157,11 @@ impl SchLib {
         self.symbols.iter()
     }
 
+    /// Returns a mutable iterator over all symbols.
+    pub fn symbols_mut(&mut self) -> impl Iterator<Item = &mut Symbol> {
+        self.symbols.values_mut()
+    }
+
     /// Returns the number of symbols in the library.
     #[must_use]
     pub fn len(&self) -> usize {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3969,11 +3969,7 @@ impl McpServer {
     }
 
     /// Performs batch updates on a `PcbLib` file.
-    fn batch_update_pcblib(
-        filepath: &str,
-        operation: &str,
-        parameters: &Value,
-    ) -> ToolCallResult {
+    fn batch_update_pcblib(filepath: &str, operation: &str, parameters: &Value) -> ToolCallResult {
         use crate::altium::PcbLib;
 
         // Read the library
@@ -3995,11 +3991,7 @@ impl McpServer {
     }
 
     /// Performs batch updates on a `SchLib` file.
-    fn batch_update_schlib(
-        filepath: &str,
-        operation: &str,
-        parameters: &Value,
-    ) -> ToolCallResult {
+    fn batch_update_schlib(filepath: &str, operation: &str, parameters: &Value) -> ToolCallResult {
         use crate::altium::schlib::SchLib;
 
         // Read the library

--- a/tests/sample_library_integration.rs
+++ b/tests/sample_library_integration.rs
@@ -111,7 +111,7 @@ fn test_pcblib_roundtrip() {
         return;
     }
 
-    let original = PcbLib::read(path).expect("Failed to read original PcbLib");
+    let mut original = PcbLib::read(path).expect("Failed to read original PcbLib");
     let original_count = original.len();
 
     // Write to temp file

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -957,7 +957,7 @@ fn test_model_3d_persistence() {
     let pcblib_path = temp_dir.path().join("model_3d_test.PcbLib");
 
     // Create a minimal STEP file (valid header but empty content)
-    let step_content = br#"ISO-10303-21;
+    let step_content = br"ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION(('Test STEP file'), '2;1');
 FILE_NAME('test_model.step', '2024-01-01T00:00:00', (''), (''), '', '', '');
@@ -966,7 +966,7 @@ ENDSEC;
 DATA;
 ENDSEC;
 END-ISO-10303-21;
-"#;
+";
 
     {
         let mut step_file = File::create(&step_path).expect("Failed to create STEP file");


### PR DESCRIPTION
## Description

Fix 3D STEP model persistence and add SchLib batch parameter updates.

### 3D Model Persistence Fix

The `step_model` parameter in `write_pcblib` was being accepted but not persisted to the file. This PR implements the full roundtrip:

**Write path:**
- Convert `Model3D` to `ComponentBody` primitive
- Read STEP file from disk and create `EmbeddedModel`
- Generate GUID for the model and write to `/Library/Models/`

**Read path:**
- Parse model names from `/Library/Models/Data` stream
- Populate `model_3d` from `component_bodies` for backward compatibility

### SMD Pad Layer Fix

Fixed `Pad::smd()` to use `TopLayer` instead of `MultiLayer`. SMD pads should be on a single copper layer, not multi-layer which is for through-hole pads.

### SchLib Batch Parameter Updates

Extended `batch_update` tool to support SchLib files with a new `update_parameters` operation:
- Set parameter values across multiple symbols
- Optional regex filtering via `symbol_filter`
- `add_if_missing` option to create parameters if not present

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes

## New Dependencies

- `uuid` v1.11 - for generating GUIDs for 3D models
- `regex` v1.11 - for symbol filtering in batch updates

## Additional Notes

The `PcbLib::write()` signature changed from `&self` to `&mut self` to support the 3D model conversion. This is technically a breaking change for the Rust API but not for the MCP tool interface.