### PR TITLE
feat(mcp): add merge_libraries tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,57 @@ components between projects.
 - If the target file exists, the component will be added to it
 - If a component with the same name already exists in the target, an error is returned
 
+### `merge_libraries`
+
+Merge multiple Altium libraries into a single library. All source libraries must be the same
+type (all PcbLib or all SchLib). Components are copied from each source into the target library.
+
+```json
+{
+    "name": "merge_libraries",
+    "arguments": {
+        "source_filepaths": [
+            "./LibraryA.PcbLib",
+            "./LibraryB.PcbLib",
+            "./LibraryC.PcbLib"
+        ],
+        "target_filepath": "./MergedLibrary.PcbLib",
+        "on_duplicate": "skip"
+    }
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_filepaths` | Array of paths to source library files (.PcbLib or .SchLib) |
+| `target_filepath` | Path to the target library file (will be created or appended to) |
+| `on_duplicate` | How to handle duplicate names: `skip` (ignore), `error` (fail), `rename` (auto-suffix). Default: `error` |
+
+**Behaviour:**
+
+- If the target file does not exist, it will be created
+- If the target file exists, components will be appended to it
+- Duplicate handling options:
+    - `error`: Fail immediately if a duplicate is found (default)
+    - `skip`: Silently ignore duplicates, keeping the first occurrence
+    - `rename`: Auto-rename duplicates with `_1`, `_2`, etc. suffixes
+
+**Example Response:**
+
+```json
+{
+    "status": "success",
+    "target_filepath": "./MergedLibrary.PcbLib",
+    "file_type": "PcbLib",
+    "sources_count": 3,
+    "merged_count": 45,
+    "skipped_count": 2,
+    "renamed_count": 0,
+    "final_count": 45,
+    "message": "Merged 45 components from 3 sources into './MergedLibrary.PcbLib' (total: 45)"
+}
+```
+
 ### `render_footprint`
 
 Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks,

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,5 @@
 # TODO
 
-## Missing Features (Would Unblock Workflows)
-
-| Feature | Current Workaround | Impact |
-|---------|-------------------|--------|
-| `merge_libraries` | Manual component-by-component | Common need when combining projects |
-
 ## Nice-to-Haves (Quality of Life)
 
 | Feature | Why It Helps |

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -825,6 +825,64 @@ Use `copy_component_cross_library` to copy components from one library to anothe
 - Create project-specific libraries from master libraries
 - Migrate components during library reorganisation
 
+### Merging Libraries
+
+Use `merge_libraries` to combine multiple libraries into one:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ LIBRARY MERGE WORKFLOW                                                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  MERGE MULTIPLE LIBRARIES                                                   │
+│  AI calls: merge_libraries {                                                │
+│      source_filepaths: [                                                    │
+│          "./ResistorLib.PcbLib",                                            │
+│          "./CapacitorLib.PcbLib",                                           │
+│          "./ConnectorLib.PcbLib"                                            │
+│      ],                                                                     │
+│      target_filepath: "./MasterLib.PcbLib",                                 │
+│      on_duplicate: "skip"                                                   │
+│  }                                                                          │
+│                                                                             │
+│  MERGE WITH AUTO-RENAME FOR DUPLICATES                                      │
+│  AI calls: merge_libraries {                                                │
+│      source_filepaths: ["./LibA.SchLib", "./LibB.SchLib"],                  │
+│      target_filepath: "./Combined.SchLib",                                  │
+│      on_duplicate: "rename"                                                 │
+│  }                                                                          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Example Response:**
+
+```json
+{
+    "status": "success",
+    "target_filepath": "./MasterLib.PcbLib",
+    "file_type": "PcbLib",
+    "sources_count": 3,
+    "merged_count": 150,
+    "skipped_count": 5,
+    "renamed_count": 0,
+    "final_count": 150,
+    "sources": [
+        { "source": "./ResistorLib.PcbLib", "merged": 50, "skipped": 0, "renamed": 0 },
+        { "source": "./CapacitorLib.PcbLib", "merged": 60, "skipped": 3, "renamed": 0 },
+        { "source": "./ConnectorLib.PcbLib", "merged": 40, "skipped": 2, "renamed": 0 }
+    ],
+    "message": "Merged 150 components from 3 sources into './MasterLib.PcbLib' (total: 150)"
+}
+```
+
+**Common use cases:**
+
+- Consolidate project libraries into a master library
+- Combine vendor-specific libraries into a unified library
+- Create backup/archive libraries from multiple sources
+- Merge team member contributions into a shared library
+
 ### Previewing Footprints
 
 Use `render_footprint` to generate an ASCII art visualisation for quick preview:

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -176,6 +176,7 @@ You should see the Altium tools listed:
 - `copy_component` — Duplicate a component within a library
 - `rename_component` — Rename a component within a library
 - `copy_component_cross_library` — Copy a component from one library to another
+- `merge_libraries` — Merge multiple libraries into one
 - `validate_library` — Check a library for common issues
 - `export_library` — Export library to JSON or CSV format
 - `import_library` — Import components from JSON data (inverse of export_library)


### PR DESCRIPTION
Add tool to merge multiple Altium libraries into a single library. All source libraries must be the same type (all PcbLib or all SchLib).

**Features:**
- Merges footprints from multiple PcbLib files
- Merges symbols from multiple SchLib files
- Configurable duplicate handling: `skip`, `error`, or `rename`
- Creates target file if it doesn't exist
- Appends to existing target file if it exists
- Reports per-source merge statistics

## Description

Implements the `merge_libraries` MCP tool which addresses a common workflow need when combining component libraries from multiple projects or team members. This removes the need for manual component-by-component copying.

## Related Issue

Closes the `merge_libraries` item in TODO.md (Missing Features section).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

Includes tests for:
- Basic PcbLib merge
- Basic SchLib merge  
- Duplicate handling with `skip` strategy
- Duplicate handling with `rename` strategy

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes

## Documentation Updates

- README.md: Added `merge_libraries` tool documentation
- TODO.md: Removed `merge_libraries` from missing features
- docs/AI_WORKFLOW.md: Added library merge workflow section
- docs/CLAUDE_CODE_GUIDE.md: Added tool to available tools list
