### PR TITLE
docs(mcp): add description for write_schlib append parameter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 | Feature | Why It Helps |
 |---------|--------------|
-| Append mode for `write_schlib` | PcbLib has it, SchLib should too for consistency |
 | `search_components` with regex/glob across multiple libraries | Finding components without knowing exact library |
 | `get_component` (single component by name without full read) | Faster than read + filter for large libraries |
 | `reorder_components` | Control component order in library (some teams care about this) |

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -854,7 +854,10 @@ impl McpServer {
                                 "required": ["name", "pins"]
                             }
                         },
-                        "append": { "type": "boolean" }
+                        "append": {
+                            "type": "boolean",
+                            "description": "If true, append to existing file; if false, create new file"
+                        }
                     },
                     "required": ["filepath", "symbols"]
                 }),


### PR DESCRIPTION
The `write_schlib` tool already supports append mode, but the tool definition was missing a description for the `append` parameter. This adds the description to match `write_pcblib`'s documentation style.

Also removes the completed TODO item for SchLib append mode since the feature is already implemented.

## Description

This PR improves documentation consistency between the PcbLib and SchLib writers:
- Adds missing `append` parameter description to `write_schlib` tool definition
- Removes the obsolete TODO entry for "Append mode for `write_schlib`" since this feature already exists

## Type of Change

- [x] Documentation update

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes (N/A - internal docs only)