### PR TITLE
feat(mcp): add search_components tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,58 @@ type (all PcbLib or all SchLib). Components are copied from each source into the
 }
 ```
 
+### `search_components`
+
+Search for components across multiple Altium libraries using regex or glob patterns. Returns
+matching component names with their source library paths. Supports both `.PcbLib` (footprints)
+and `.SchLib` (symbols) files.
+
+```json
+{
+    "name": "search_components",
+    "arguments": {
+        "filepaths": [
+            "./Resistors.PcbLib",
+            "./Capacitors.PcbLib",
+            "./ICs.PcbLib"
+        ],
+        "pattern": "SOIC-*",
+        "pattern_type": "glob"
+    }
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `filepaths` | Array of library file paths to search (.PcbLib or .SchLib) |
+| `pattern` | Search pattern to match component names |
+| `pattern_type` | Pattern type: `glob` (wildcards like `*` and `?`) or `regex`. Default: `glob` |
+
+**Glob Patterns:**
+
+- `*` matches any number of characters
+- `?` matches a single character
+- Search is case-insensitive
+
+**Example Response:**
+
+```json
+{
+    "status": "success",
+    "pattern": "SOIC-*",
+    "pattern_type": "glob",
+    "libraries_searched": 3,
+    "components_searched": 150,
+    "matches_found": 5,
+    "matches": [
+        { "name": "SOIC-8", "library": "./ICs.PcbLib", "type": "PcbLib" },
+        { "name": "SOIC-14", "library": "./ICs.PcbLib", "type": "PcbLib" },
+        { "name": "SOIC-16", "library": "./ICs.PcbLib", "type": "PcbLib" }
+    ],
+    "message": "Found 5 matches for 'SOIC-*' across 3 libraries (150 components searched)"
+}
+```
+
 ### `render_footprint`
 
 Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks,

--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,6 @@
 
 | Feature | Why It Helps |
 |---------|--------------|
-| Append mode for `write_schlib` | PcbLib has it, SchLib should too for consistency |
-| `search_components` with regex/glob across multiple libraries | Finding components without knowing exact library |
 | `get_component` (single component by name without full read) | Faster than read + filter for large libraries |
 | `reorder_components` | Control component order in library (some teams care about this) |
 | `update_component` (in-place replace) | Currently must delete + write or rewrite entire library |

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -883,6 +883,62 @@ Use `merge_libraries` to combine multiple libraries into one:
 - Create backup/archive libraries from multiple sources
 - Merge team member contributions into a shared library
 
+### Searching Components
+
+Use `search_components` to find components across multiple libraries using glob or regex patterns:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ COMPONENT SEARCH WORKFLOW                                                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  GLOB PATTERN SEARCH                                                        │
+│  AI calls: search_components {                                              │
+│      filepaths: [                                                           │
+│          "./Resistors.PcbLib",                                              │
+│          "./Capacitors.PcbLib",                                             │
+│          "./ICs.PcbLib"                                                     │
+│      ],                                                                     │
+│      pattern: "SOIC-*",                                                     │
+│      pattern_type: "glob"                                                   │
+│  }                                                                          │
+│                                                                             │
+│  REGEX PATTERN SEARCH                                                       │
+│  AI calls: search_components {                                              │
+│      filepaths: ["./Components.SchLib"],                                    │
+│      pattern: "LM78[0-9]{2}",                                               │
+│      pattern_type: "regex"                                                  │
+│  }                                                                          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Example Response:**
+
+```json
+{
+    "status": "success",
+    "pattern": "SOIC-*",
+    "pattern_type": "glob",
+    "libraries_searched": 3,
+    "components_searched": 150,
+    "matches_found": 5,
+    "matches": [
+        { "name": "SOIC-8", "library": "./ICs.PcbLib", "type": "PcbLib" },
+        { "name": "SOIC-14", "library": "./ICs.PcbLib", "type": "PcbLib" },
+        { "name": "SOIC-16", "library": "./ICs.PcbLib", "type": "PcbLib" }
+    ],
+    "message": "Found 5 matches for 'SOIC-*' across 3 libraries (150 components searched)"
+}
+```
+
+**Common use cases:**
+
+- Find all footprint variants (e.g., `RES_0402*` for all 0402 resistor sizes)
+- Locate components matching a package type (e.g., `*QFN*`)
+- Search for components by part number prefix (e.g., `LM78*`)
+- Audit libraries for naming consistency
+
 ### Previewing Footprints
 
 Use `render_footprint` to generate an ASCII art visualisation for quick preview:

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -177,6 +177,7 @@ You should see the Altium tools listed:
 - `rename_component` — Rename a component within a library
 - `copy_component_cross_library` — Copy a component from one library to another
 - `merge_libraries` — Merge multiple libraries into one
+- `search_components` — Search for components across multiple libraries
 - `validate_library` — Check a library for common issues
 - `export_library` — Export library to JSON or CSV format
 - `import_library` — Import components from JSON data (inverse of export_library)


### PR DESCRIPTION
Add a new `search_components` MCP tool that enables searching for components across multiple Altium libraries using glob or regex patterns. Returns matching component names with their source library paths.

## Description

This PR implements the `search_components` tool which allows users to:
- Search for components across multiple `.PcbLib` and `.SchLib` files simultaneously
- Use glob patterns (e.g., `SOIC-*`, `*QFN*`) for simple wildcard matching
- Use regex patterns for more complex searches (e.g., `LM78[0-9]{2}`)
- Get structured results with component names, source library paths, and library types

Key implementation details:
- Case-insensitive matching for both glob and regex patterns
- Glob patterns converted to regex internally using `glob_to_regex()` helper
- Graceful error handling with partial results when some libraries fail to read
- Comprehensive response with statistics (libraries searched, components searched, matches found)

## Related Issue

Implements feature from TODO.md: "search_components with regex/glob across multiple libraries"

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

Added tests:
- `test_pcblib_search_glob` - glob pattern matching in PcbLib
- `test_pcblib_search_regex` - regex pattern matching in PcbLib  
- `test_pcblib_search_multiple_libraries` - searching across multiple PcbLib files
- `test_schlib_search` - searching in SchLib files

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes

## Documentation Updates

- README.md: Added tool documentation with examples
- AI_WORKFLOW.md: Added search workflow section with use cases
- CLAUDE_CODE_GUIDE.md: Added tool to available tools list
- TODO.md: Removed completed feature from the list