### PR TITLE
feat(mcp): add get_component tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,57 @@ and `.SchLib` (symbols) files.
 }
 ```
 
+### `get_component`
+
+Get a single component by name from an Altium library. Returns the full component data
+(footprint or symbol) without needing to read and filter the entire library. Supports both
+`.PcbLib` (footprints) and `.SchLib` (symbols) files.
+
+```json
+{
+    "name": "get_component",
+    "arguments": {
+        "filepath": "./MyLibrary.PcbLib",
+        "component_name": "SOIC-8"
+    }
+}
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `filepath` | Path to the Altium library file (.PcbLib or .SchLib) |
+| `component_name` | Exact name of the component to retrieve |
+
+**Example Response (PcbLib):**
+
+```json
+{
+    "status": "success",
+    "filepath": "./MyLibrary.PcbLib",
+    "component_name": "SOIC-8",
+    "type": "PcbLib",
+    "component": {
+        "name": "SOIC-8",
+        "description": "8-pin SOIC package",
+        "pads": [...],
+        "tracks": [...]
+    },
+    "message": "Retrieved footprint 'SOIC-8' from './MyLibrary.PcbLib'"
+}
+```
+
+**Error Response (component not found):**
+
+```json
+{
+    "isError": true,
+    "content": [{
+        "type": "text",
+        "text": "Component 'SOIC-99' not found in library. Available components: SOIC-8, SOIC-14, SOIC-16 ... and 5 more"
+    }]
+}
+```
+
 ### `render_footprint`
 
 Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks,

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 | Feature | Why It Helps |
 |---------|--------------|
-| `get_component` (single component by name without full read) | Faster than read + filter for large libraries |
 | `reorder_components` | Control component order in library (some teams care about this) |
 | `update_component` (in-place replace) | Currently must delete + write or rewrite entire library |
 

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -939,6 +939,54 @@ Use `search_components` to find components across multiple libraries using glob 
 - Search for components by part number prefix (e.g., `LM78*`)
 - Audit libraries for naming consistency
 
+### Getting a Single Component
+
+Use `get_component` to retrieve a single component by exact name:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ GET COMPONENT WORKFLOW                                                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  GET FOOTPRINT FROM PCBLIB                                                  │
+│  AI calls: get_component {                                                  │
+│      filepath: "./MyLibrary.PcbLib",                                        │
+│      component_name: "SOIC-8"                                               │
+│  }                                                                          │
+│                                                                             │
+│  GET SYMBOL FROM SCHLIB                                                     │
+│  AI calls: get_component {                                                  │
+│      filepath: "./Components.SchLib",                                       │
+│      component_name: "LM7805"                                               │
+│  }                                                                          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Example Response:**
+
+```json
+{
+    "status": "success",
+    "filepath": "./MyLibrary.PcbLib",
+    "component_name": "SOIC-8",
+    "type": "PcbLib",
+    "component": {
+        "name": "SOIC-8",
+        "description": "8-pin SOIC package",
+        "pads": [...],
+        "tracks": [...]
+    },
+    "message": "Retrieved footprint 'SOIC-8' from './MyLibrary.PcbLib'"
+}
+```
+
+**Common use cases:**
+
+- Retrieve a specific component for inspection or modification
+- Get component data for comparison with another library
+- Extract component details for documentation
+
 ### Previewing Footprints
 
 Use `render_footprint` to generate an ASCII art visualisation for quick preview:

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -178,6 +178,7 @@ You should see the Altium tools listed:
 - `copy_component_cross_library` — Copy a component from one library to another
 - `merge_libraries` — Merge multiple libraries into one
 - `search_components` — Search for components across multiple libraries
+- `get_component` — Get a single component by name from a library
 - `validate_library` — Check a library for common issues
 - `export_library` — Export library to JSON or CSV format
 - `import_library` — Import components from JSON data (inverse of export_library)


### PR DESCRIPTION
Retrieve a single component by exact name from an Altium library. Returns full component data (footprint or symbol) with helpful error messages listing available components if not found.

## Description

Adds the `get_component` MCP tool for retrieving a single component by name from `.PcbLib` or `.SchLib` files. This is more efficient than reading the entire library and filtering when you only need one specific component.

Key features:
- Exact name matching for precise component retrieval
- Supports both PcbLib (footprints) and SchLib (symbols)
- Helpful error messages that list available components when the requested one isn't found
- Returns full component data including all primitives (pads, tracks, pins, etc.)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass (`cargo test`)

## Code Quality

- [x] CI checks pass (build, test, clippy, fmt)
- [x] Documentation updated if needed
- [x] CHANGELOG.md updated for user-facing changes