### PR TITLE
chore(deps): clear js-yaml/markdown-it DoS advisories via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -430,10 +430,20 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -477,25 +487,45 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -534,6 +564,7 @@
             "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "globby": "16.2.0",
                 "js-yaml": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
     },
     "devDependencies": {
         "markdownlint-cli2": "^0.22.1"
+    },
+    "comment:overrides": "Force patched transitive deps of markdownlint-cli2 to clear Dependabot DoS advisories (dev-tooling only; not shipped in the Rust binary).",
+    "overrides": {
+        "js-yaml": ">=4.2.0",
+        "markdown-it": ">=14.2.0"
     }
 }


### PR DESCRIPTION
Clears the last 2 open Dependabot advisories — both **DoS in transitive dev-dependencies** of `markdownlint-cli2` (the markdown linter used in CI). Neither is part of the shipped Rust binary.

- **js-yaml** 4.1.1 → **4.2.0** (quadratic-complexity DoS in merge-key handling)
- **markdown-it** 14.1.1 → **14.2.0** (quadratic-complexity DoS in the smartquotes rule)

Fixed with npm `overrides` in `package.json` (regenerated `package-lock.json`), since these are transitive and not directly declared.

Verification: `npm audit` → **0 vulnerabilities**; `markdownlint-cli2` still runs clean.

(The picomatch high+medium advisories were already cleared by #66; smol-toml by the markdownlint-cli2 0.22.1 bump in #69.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)