### PR TITLE
feat(schlib): write Altium-readable SchLib files (#68 SchLib path)

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -349,6 +349,25 @@ impl SchLib {
             })?;
         }
 
+        // Write the root Storage stream (Altium's icon/image storage). It is
+        // always present; for a library with no embedded images it is just the
+        // header parameter block.
+        {
+            let header = b"|HEADER=Icon storage";
+            let mut storage = Vec::with_capacity(4 + header.len() + 1);
+            #[allow(clippy::cast_possible_truncation)]
+            storage.extend_from_slice(&((header.len() + 1) as u32).to_le_bytes());
+            storage.extend_from_slice(header);
+            storage.push(0x00);
+
+            let mut stream = cfb
+                .create_stream("/Storage")
+                .map_err(|e| AltiumError::invalid_ole(format!("Failed to create Storage: {e}")))?;
+            stream
+                .write_all(&storage)
+                .map_err(|e| AltiumError::invalid_ole(format!("Failed to write Storage: {e}")))?;
+        }
+
         cfb.flush()
             .map_err(|e| AltiumError::invalid_ole(format!("Failed to flush OLE file: {e}")))?;
 
@@ -602,7 +621,10 @@ fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<F
         return Err(AltiumError::parse_error(4, "FileHeader truncated"));
     }
 
+    // The block is a C-string; drop the trailing null terminator (and any
+    // padding) before splitting so values don't carry a stray '\0'.
     let text = String::from_utf8_lossy(&data[4..4 + length]);
+    let text = text.trim_end_matches('\u{0}');
     let mut props: HashMap<String, String> = HashMap::new();
 
     for part in text.split('|') {

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -273,15 +273,18 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     let symbol_outside = PinSymbol::from_id(data.get(offset + 3).copied().unwrap_or(0));
     offset += 4;
 
-    // description: [length:1][unknown:1][string]
+    // description: Pascal short string [length:1][string]
     let desc_len = data.get(offset).copied().unwrap_or(0) as usize;
-    offset += 2; // length + unknown byte
+    offset += 1;
     let description = if desc_len > 0 && offset + desc_len <= data.len() {
         String::from_utf8_lossy(&data[offset..offset + desc_len]).to_string()
     } else {
         String::new()
     };
     offset += desc_len;
+
+    // formal_type (1 byte) - unused
+    offset += 1;
 
     // electrical_type (1 byte)
     let electrical_type = data.get(offset).copied().unwrap_or(4);

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -8,8 +8,12 @@
 //! ```text
 //! [RecordLength:2 LE][RecordType:2 BE][data:RecordLength]
 //! ...
-//! [0x00 0x00]  // End marker (length = 0)
 //! ```
+//!
+//! The 4-byte record header is equivalent to Altium's single 32-bit
+//! little-endian size word whose high byte is a flag (0x00 text, 0x01 pin).
+//! Records run until the stream is exhausted — there is NO end-of-stream
+//! marker (a trailing 0x0000 would be mis-read as a zero-length record).
 //!
 //! Record types:
 //! - `0x0000`: Text record (pipe-delimited key=value pairs)
@@ -139,12 +143,14 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.push(pin.symbol_inside.to_id());
     record.push(pin.symbol_outside.to_id());
 
-    // Description: [length:1][unknown:1][string]
+    // Description: Pascal short string [length:1][string]
     let desc_bytes = pin.description.as_bytes();
     #[allow(clippy::cast_possible_truncation)]
     record.push(desc_bytes.len() as u8);
-    record.push(0x00); // Unknown byte
     record.extend_from_slice(desc_bytes);
+
+    // Formal type (1 byte) - 0 for from-scratch pins
+    record.push(0x00);
 
     // Electrical type (1 byte)
     record.push(pin.electrical_type.to_id());
@@ -200,6 +206,12 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.push(desig_bytes.len() as u8);
     record.extend_from_slice(desig_bytes);
 
+    // SwapIdGroup, PartAndSequence, DefaultValue: three empty Pascal short
+    // strings that Altium always writes at the tail of a pin record.
+    record.push(0);
+    record.push(0);
+    record.push(0);
+
     // Header: [length:2 LE][type:2 BE]
     #[allow(clippy::cast_possible_truncation)]
     let record_length = record.len() as u16;
@@ -222,7 +234,9 @@ fn encode_component_header(symbol: &Symbol) -> String {
         "IndexInSheet=-1".to_string(),
         "OwnerPartId=-1".to_string(),
         format!("CurrentPartId={}", symbol.current_part_id),
+        "LibraryPath=*".to_string(),
         format!("SourceLibraryName={}", symbol.source_library_name),
+        "SheetPartFileName=*".to_string(),
         format!("TargetFileName={}", symbol.target_file_name),
         format!("AllPinCount={}", symbol.pins.len()),
         "AreaColor=11599871".to_string(), // Light yellow fill
@@ -230,7 +244,8 @@ fn encode_component_header(symbol: &Symbol) -> String {
         format!("PartIDLocked={part_id_locked}"),
     ];
 
-    format!("|{}|", parts.join("|"))
+    // Leading pipe, NO trailing pipe (matches Altium's ParametersToString).
+    format!("|{}", parts.join("|"))
 }
 
 /// Encodes a rectangle record.
@@ -239,7 +254,7 @@ fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
     format!(
         "|RECORD=14|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
          |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
-         |LineWidth={}|Color={}|AreaColor={}|IsSolid=T|Transparent={}|UniqueID={}|",
+         |LineWidth={}|Color={}|AreaColor={}|IsSolid=T|Transparent={}|UniqueID={}",
         index,
         rect.owner_part_id,
         rect.x1,
@@ -257,7 +272,7 @@ fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
 /// Encodes a line record.
 fn encode_line(line: &Line, index: usize) -> String {
     format!(
-        "|RECORD=13|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}|LineWidth={}|Color={}|UniqueID={}|",
+        "|RECORD=13|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}|LineWidth={}|Color={}|UniqueID={}",
         index,
         line.owner_part_id,
         line.x1,
@@ -274,7 +289,7 @@ fn encode_line(line: &Line, index: usize) -> String {
 fn encode_parameter(param: &Parameter, index: usize) -> String {
     let hidden = if param.hidden { "T" } else { "F" };
     format!(
-        "|RECORD=41|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|IsHidden={}|ReadOnlyState={}|ParamType={}|Text={}|Name={}|UniqueID={}|",
+        "|RECORD=41|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|IsHidden={}|ReadOnlyState={}|ParamType={}|Text={}|Name={}|UniqueID={}",
         index,
         param.owner_part_id,
         param.x,
@@ -293,7 +308,7 @@ fn encode_parameter(param: &Parameter, index: usize) -> String {
 /// Encodes a designator record.
 fn encode_designator(designator: &str) -> String {
     format!(
-        "|RECORD=34|IndexInSheet=-1|OwnerPartId=-1|Location.Y=-6|Color=8388608|FontID=1|Text={}|Name=Designator|ReadOnlyState=1|UniqueID={}|",
+        "|RECORD=34|IndexInSheet=-1|OwnerPartId=-1|Location.Y=-6|Color=8388608|FontID=1|Text={}|Name=Designator|ReadOnlyState=1|UniqueID={}",
         designator,
         generate_unique_id()
     )
@@ -321,7 +336,7 @@ fn encode_polyline(polyline: &Polyline, index: usize) -> String {
 
     parts.push(format!("UniqueID={}", generate_unique_id()));
 
-    format!("|{}|", parts.join("|"))
+    format!("|{}", parts.join("|"))
 }
 
 /// Encodes a polygon record.
@@ -346,13 +361,13 @@ fn encode_polygon(polygon: &Polygon, index: usize) -> String {
 
     parts.push(format!("UniqueID={}", generate_unique_id()));
 
-    format!("|{}|", parts.join("|"))
+    format!("|{}", parts.join("|"))
 }
 
 /// Encodes an arc record.
 fn encode_arc(arc: &Arc, index: usize) -> String {
     format!(
-        "|RECORD=12|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|StartAngle={}|EndAngle={}|LineWidth={}|Color={}|UniqueID={}|",
+        "|RECORD=12|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|StartAngle={}|EndAngle={}|LineWidth={}|Color={}|UniqueID={}",
         index,
         arc.owner_part_id,
         arc.x,
@@ -369,7 +384,7 @@ fn encode_arc(arc: &Arc, index: usize) -> String {
 /// Encodes a Bezier curve record.
 fn encode_bezier(bezier: &Bezier, index: usize) -> String {
     format!(
-        "|RECORD=5|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|LineWidth={}|Color={}|LocationCount=4|X1={}|Y1={}|X2={}|Y2={}|X3={}|Y3={}|X4={}|Y4={}|UniqueID={}|",
+        "|RECORD=5|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|LineWidth={}|Color={}|LocationCount=4|X1={}|Y1={}|X2={}|Y2={}|X3={}|Y3={}|X4={}|Y4={}|UniqueID={}",
         index,
         bezier.owner_part_id,
         bezier.line_width,
@@ -390,7 +405,7 @@ fn encode_bezier(bezier: &Bezier, index: usize) -> String {
 fn encode_ellipse(ellipse: &Ellipse, index: usize) -> String {
     let is_solid = if ellipse.filled { "T" } else { "F" };
     format!(
-        "|RECORD=8|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|SecondaryRadius={}|LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}|",
+        "|RECORD=8|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|SecondaryRadius={}|LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}",
         index,
         ellipse.owner_part_id,
         ellipse.x,
@@ -412,7 +427,7 @@ fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
         "|RECORD=10|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
          |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
          |CornerXRadius={}|CornerYRadius={}\
-         |LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}|",
+         |LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}",
         index,
         round_rect.owner_part_id,
         round_rect.x1,
@@ -446,7 +461,7 @@ fn encode_elliptical_arc(arc: &EllipticalArc, index: usize) -> String {
          |Radius={}|Radius_Frac={}\
          |SecondaryRadius={}|SecondaryRadius_Frac={}\
          |StartAngle={}|EndAngle={}\
-         |LineWidth={}|Color={}|UniqueID={}|",
+         |LineWidth={}|Color={}|UniqueID={}",
         index,
         arc.owner_part_id,
         arc.x,
@@ -471,7 +486,7 @@ fn encode_label(label: &Label, index: usize) -> String {
     let is_mirrored = if label.is_mirrored { "T" } else { "F" };
     let is_hidden = if label.is_hidden { "T" } else { "F" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}|IsMirrored={}|IsHidden={}|Text={}|UniqueID={}|",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}|IsMirrored={}|IsHidden={}|Text={}|UniqueID={}",
         index,
         label.owner_part_id,
         label.x,
@@ -495,7 +510,7 @@ fn encode_text(text: &Text, index: usize) -> String {
     let is_mirrored = if text.is_mirrored { "T" } else { "F" };
     let is_hidden = if text.is_hidden { "T" } else { "F" };
     format!(
-        "|RECORD=3|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}|IsMirrored={}|IsHidden={}|Text={}|UniqueID={}|",
+        "|RECORD=3|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}|IsMirrored={}|IsHidden={}|Text={}|UniqueID={}",
         index,
         text.owner_part_id,
         text.x,
@@ -526,15 +541,16 @@ const fn justification_to_id(justification: TextJustification) -> u8 {
     }
 }
 
-/// Encodes an implementation list record (start of model list).
+/// Encodes an implementation list record (start of model list). Altium always
+/// writes this record, even when a symbol has no footprint models.
 fn encode_implementation_list() -> String {
-    "|RECORD=44|OwnerIndex=0|".to_string()
+    "|RECORD=44".to_string()
 }
 
 /// Encodes a footprint model record.
 fn encode_footprint_model(model: &FootprintModel, owner_index: usize) -> String {
     format!(
-        "|RECORD=45|OwnerIndex={}|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=0|UniqueID={}|",
+        "|RECORD=45|OwnerIndex={}|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=0|UniqueID={}",
         owner_index,
         model.description,
         model.name,
@@ -656,20 +672,17 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
         write_text_record(&mut data, &record);
     }
 
-    // 16. Implementation list (if we have footprints)
-    if !symbol.footprints.is_empty() {
-        let impl_list = encode_implementation_list();
-        write_text_record(&mut data, &impl_list);
-
-        // Footprint models
-        for (i, model) in symbol.footprints.iter().enumerate() {
-            let record = encode_footprint_model(model, i);
-            write_text_record(&mut data, &record);
-        }
+    // 16. Implementation list — Altium always writes RECORD=44, then a model
+    // record per footprint.
+    write_text_record(&mut data, &encode_implementation_list());
+    for (i, model) in symbol.footprints.iter().enumerate() {
+        let record = encode_footprint_model(model, i);
+        write_text_record(&mut data, &record);
     }
 
-    // End marker: length = 0
-    data.extend_from_slice(&0u16.to_le_bytes());
+    // No end-of-stream sentinel: Altium reads records until the stream is
+    // exhausted, and a trailing 0x0000 is mis-framed as a zero-length record
+    // (issue #68, "Data does not end with 0x00").
 
     Ok(data)
 }
@@ -716,15 +729,19 @@ pub fn encode_file_header(symbols: &[&Symbol], ole_names: &[String]) -> Vec<u8> 
         parts.push(format!("PartCount{}={}", i, symbol.part_count + 1));
     }
 
-    let text = format!("|{}|", parts.join("|"));
+    let text = format!("|{}", parts.join("|"));
     let text_bytes = text.as_bytes();
 
-    // Format: [length:4 LE][text]
-    let mut data = Vec::with_capacity(4 + text_bytes.len());
+    // Format: [length:4 LE][text + 0x00]. The block is a C-string: it MUST be
+    // null-terminated and the length MUST include the terminator (matches Altium
+    // WriteCStringParameterBlockRaw). Omitting it is issue #68's "Data does not
+    // end with 0x00".
+    let mut data = Vec::with_capacity(4 + text_bytes.len() + 1);
     #[allow(clippy::cast_possible_truncation)]
-    let length = text_bytes.len() as u32;
+    let length = (text_bytes.len() + 1) as u32;
     data.extend_from_slice(&length.to_le_bytes());
     data.extend_from_slice(text_bytes);
+    data.push(0x00);
 
     data
 }
@@ -760,10 +777,12 @@ mod tests {
         // Should have content
         assert!(!data.is_empty());
 
-        // Should end with 0x00 0x00
-        let len = data.len();
-        assert_eq!(data[len - 2], 0x00);
-        assert_eq!(data[len - 1], 0x00);
+        // No end-of-stream sentinel; the stream ends with the last text record's
+        // null terminator (the always-present RECORD=44 implementation list).
+        assert_eq!(*data.last().unwrap(), 0x00);
+        let text = String::from_utf8_lossy(&data);
+        assert!(text.contains("RECORD=1"), "component record present");
+        assert!(text.contains("RECORD=44"), "implementation list present");
     }
 
     #[test]

--- a/tests/integration/test_altium_readability.py
+++ b/tests/integration/test_altium_readability.py
@@ -36,9 +36,8 @@ from mcp_client import McpTestClient, find_binary  # noqa: E402
 # as the corresponding fix makes the check pass (the harness will nag if you
 # forget). Keep this list as the living scoreboard for #68.
 KNOWN_FAILURES = {
-    # PcbLib writer fixes have landed; only the SchLib path remains (next PR).
-    "schlib:no_parser_warnings",
-    "schlib:has_Storage",
+    # Both PcbLib and SchLib writer fixes have landed (#68). The harness is now
+    # fully strict: any failure here is a regression.
 }
 
 WARN_TOKENS = ("Failed", "does not end", "Error", "map value", "Unknown record")


### PR DESCRIPTION
Final piece of the #68 series: makes generated **SchLib** files openable in Altium Designer 24. With this, **the entire #68 readability oracle is green** (13/13, harness now fully strict).

> **Stacked on #86 → #83.** Diff currently includes those commits; merge in order (#83, #86, this) and the overlap disappears.

## Verification

pyaltiumlib oracle (independent Altium reader). Before: `Data does not end with 0x00` + missing `Storage`. After: **all SchLib checks pass, 0 regressions.**

## What was wrong (and is now fixed)

| Area | Before | After |
|------|--------|-------|
| **FileHeader block** | not null-terminated; length excluded NUL | proper C-string (`[len incl. NUL][text][0x00]`) — this *was* the "does not end with 0x00" |
| **Binary pin record** | stray `0x00` after desc len; missing FormalType byte; missing 3 trailing Pascal strings | exact Altium layout (reader updated to match) |
| **Data stream** | spurious `0x0000` end-sentinel | none (records run to EOF) |
| **RECORD=44** | only when footprints present | always emitted (`\|RECORD=44`), as Altium does |
| **/Storage stream** | absent | `\|HEADER=Icon storage` |
| **RECORD=1** | missing `LibraryPath`/`SheetPartFileName` | added |
| **Param records** | trailing pipe | leading-pipe / no-trailing-pipe (matches Altium) |

The pin conglomerate's orientation bits already matched Altium's enum — no change needed there. Round-trip + writer tests updated to the corrected contract.

## Checks
`cargo build` · `clippy --all-targets --all-features -D warnings` · `fmt` · full suite (206 lib + integration/property/perf/doctests) · Python E2E 25/25 · **Altium oracle 13/13** — all green.

## #68 status
Both PcbLib (#86) and SchLib (this) paths now produce pyaltiumlib-clean, reference-parity files. Per the agreed acceptance bar, #68 is **fixed pending final confirmation in real Altium Designer 24** (no Altium available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)