### PR TITLE
feat(pcblib): 596-byte pad size/shape block — hole shapes + corner radius (#68 follow-up)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -2265,17 +2265,12 @@ mod tests {
 
         assert_eq!(decoded.pads.len(), 3);
 
-        // Mask expansion (main-block fields) round-trips for every pad.
-        //
-        // NOTE: non-round hole SHAPES (Square/Slot) live in the 596-byte
-        // size/shape block at offset 262, which simple from-scratch pads do not
-        // emit, so hole_shape currently reads back as Round. (The old writer put
-        // it at main-block offset 61, which Altium treats as reserved, so it
-        // never actually reached Altium either.) Full hole-shape support is a
-        // follow-up; see the size/shape-block work.
+        // Non-round hole shapes now round-trip via the 596-byte size/shape block
+        // (hole type at offset 262), alongside the main-block mask-expansion.
 
-        // Pad 1: solder mask expansion
+        // Pad 1: Square hole + solder mask expansion
         assert_eq!(decoded.pads[0].designator, "1");
+        assert_eq!(decoded.pads[0].hole_shape, HoleShape::Square);
         assert!(decoded.pads[0].solder_mask_expansion.is_some());
         assert!(approx_eq(
             decoded.pads[0].solder_mask_expansion.unwrap(),
@@ -2284,8 +2279,9 @@ mod tests {
         ));
         assert!(decoded.pads[0].solder_mask_expansion_manual);
 
-        // Pad 2: paste mask expansion
+        // Pad 2: Slot hole + paste mask expansion
         assert_eq!(decoded.pads[1].designator, "2");
+        assert_eq!(decoded.pads[1].hole_shape, HoleShape::Slot);
         assert!(decoded.pads[1].paste_mask_expansion.is_some());
         assert!(approx_eq(
             decoded.pads[1].paste_mask_expansion.unwrap(),
@@ -2294,7 +2290,7 @@ mod tests {
         ));
         assert!(decoded.pads[1].paste_mask_expansion_manual);
 
-        // Pad 3: Default round hole
+        // Pad 3: Default round hole (empty Block 5)
         assert_eq!(decoded.pads[2].designator, "3");
         assert_eq!(decoded.pads[2].hole_shape, HoleShape::Round);
     }
@@ -2344,11 +2340,11 @@ mod tests {
         pad_with_radius.stack_mode = PadStackMode::FullStack;
         original.add_pad(pad_with_radius);
 
-        // Default RoundedRectangle SMD pad: stays a Simple pad (shape id 9, empty
-        // size/shape block). Altium applies its default corner radius on display;
-        // we do not store one. Precise corner radius requires FullStack (above).
-        let pad_default_radius = Pad::smd("2", 2.54, 0.0, 1.5, 0.8);
-        original.add_pad(pad_default_radius);
+        // Simple SMD pad with an EXPLICIT corner radius: now round-trips via the
+        // 596-byte size/shape block (no FullStack needed).
+        let mut pad_simple_radius = Pad::smd("2", 2.54, 0.0, 1.5, 0.8);
+        pad_simple_radius.corner_radius_percent = Some(30);
+        original.add_pad(pad_simple_radius);
 
         // Rectangle pad (no corner radius needed)
         let mut pad_no_radius = Pad::smd("3", 5.08, 0.0, 1.5, 0.8);
@@ -2365,11 +2361,10 @@ mod tests {
         assert_eq!(decoded.pads[0].corner_radius_percent, Some(25));
         assert_eq!(decoded.pads[0].stack_mode, PadStackMode::FullStack);
 
-        // Default RoundedRectangle SMD pad stays Simple with no stored radius;
-        // the shape itself still round-trips (shape id 9).
-        assert_eq!(decoded.pads[1].shape, PadShape::RoundedRectangle);
-        assert_eq!(decoded.pads[1].corner_radius_percent, None);
+        // Simple pad's explicit corner radius round-trips without FullStack.
+        assert_eq!(decoded.pads[1].corner_radius_percent, Some(30));
         assert_eq!(decoded.pads[1].stack_mode, PadStackMode::Simple);
+        assert_eq!(decoded.pads[1].shape, PadShape::RoundedRectangle);
 
         // Rectangle pad has no corner radius
         assert_eq!(decoded.pads[2].corner_radius_percent, None);

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -924,12 +924,12 @@ fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         0.0
     };
 
-    // Hole shape - offset 61
-    let hole_shape = if geometry.len() > 61 {
-        hole_shape_from_id(geometry[61])
-    } else {
-        HoleShape::Round
-    };
+    // Hole shape comes from the 596-byte size/shape block (offset 262) when
+    // present; a plain simple pad (empty Block 5) has a round hole. Main-block
+    // offset 61 is reserved in Altium's layout, so it is not used here.
+    let hole_shape = per_layer_data
+        .filter(|d| d.len() >= 596)
+        .map_or(HoleShape::Round, |d| hole_shape_from_id(d[262]));
 
     // Stack mode - offset 62
     let stack_mode = if geometry.len() > 62 {
@@ -976,18 +976,17 @@ fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         per_layer_corner_radii,
         per_layer_offsets,
     ) = if stack_mode == PadStackMode::Simple {
-        // For Simple mode, extract corner radius if available (backwards compatibility)
+        // Corner radius from the size/shape block: offset 564 in the canonical
+        // 596-byte layout, or offset 288 in the legacy block (back-compat).
         let corner_radius = per_layer_data.and_then(|data| {
-            if data.len() > 288 {
-                let radius = data[288];
-                if radius > 0 && radius <= 100 {
-                    Some(radius)
-                } else {
-                    None
-                }
+            let radius = if data.len() >= 596 {
+                data[564]
+            } else if data.len() > 288 {
+                data[288]
             } else {
-                None
-            }
+                return None;
+            };
+            (radius > 0 && radius <= 100).then_some(radius)
         });
         (corner_radius, None, None, None, None)
     } else {

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -14,8 +14,8 @@
 //! ```
 
 use super::primitives::{
-    Arc, ComponentBody, Fill, Layer, Pad, PadShape, PadStackMode, PcbFlags, Region, StrokeFont,
-    Text, TextKind, Track, Via, ViaStackMode,
+    Arc, ComponentBody, Fill, HoleShape, Layer, Pad, PadShape, PadStackMode, PcbFlags, Region,
+    StrokeFont, Text, TextKind, Track, Via, ViaStackMode,
 };
 use super::Footprint;
 
@@ -426,23 +426,85 @@ fn encode_pad(data: &mut Vec<u8>, pad: &Pad) -> crate::altium::error::AltiumResu
     let geometry = encode_pad_geometry(pad);
     write_block(data, &geometry);
 
-    // Block 5: size/shape (full-stack) data. A simple pad keeps stack mode
-    // Simple and writes an EMPTY block; RoundedRectangle is conveyed by shape
-    // id 9 in the main block. Only genuine per-layer data populates Block 5.
+    // Block 5: the size/shape block. Three cases:
+    //  - genuine per-layer (full-stack) data  -> legacy per-layer block;
+    //  - a non-round hole or an explicit corner radius on a simple pad
+    //    -> the canonical 596-byte size/shape block (carries hole type @262 and
+    //       the rounded-rect corner radius @564, which the main block cannot);
+    //  - otherwise (plain simple pad) -> EMPTY block (matches Altium).
     let needs_per_layer_data = pad.stack_mode != PadStackMode::Simple
         || pad.per_layer_sizes.is_some()
         || pad.per_layer_shapes.is_some()
         || pad.per_layer_corner_radii.is_some()
         || pad.per_layer_offsets.is_some();
+    let needs_size_shape =
+        pad.hole_shape != HoleShape::Round || pad.corner_radius_percent.is_some();
 
     if needs_per_layer_data {
-        let per_layer_data = encode_pad_per_layer_data(pad);
-        write_block(data, &per_layer_data);
+        write_block(data, &encode_pad_per_layer_data(pad));
+    } else if needs_size_shape {
+        write_block(data, &encode_pad_size_shape_block(pad));
     } else {
         write_block(data, &[]);
     }
 
     Ok(())
+}
+
+/// Converts our `HoleShape` enum to the Altium hole-type id.
+const fn hole_shape_to_id(shape: HoleShape) -> u8 {
+    match shape {
+        HoleShape::Round => 0,
+        HoleShape::Square => 1,
+        HoleShape::Slot => 2,
+    }
+}
+
+/// Encodes the canonical 596-byte pad size/shape block (Block 5) for a simple
+/// pad that needs a non-round hole or an explicit corner radius. Layout matches
+/// `AltiumSharp` `WritePad` (values uniform across layers); the reader pairs
+/// with this via [`super::reader`] when the block is >= 596 bytes.
+fn encode_pad_size_shape_block(pad: &Pad) -> Vec<u8> {
+    let mut b = Vec::with_capacity(596);
+    let w = from_mm(pad.width);
+    let h = from_mm(pad.height);
+    let shape_id = pad_shape_to_id(pad.shape);
+    let radius = pad
+        .corner_radius_percent
+        .unwrap_or(if pad.shape == PadShape::RoundedRectangle {
+            50
+        } else {
+            0
+        });
+
+    for _ in 0..29 {
+        write_i32(&mut b, w); // 0-115: internal-layer X sizes
+    }
+    for _ in 0..29 {
+        write_i32(&mut b, h); // 116-231: internal-layer Y sizes
+    }
+    for _ in 0..29 {
+        b.push(shape_id); // 232-260: internal-layer shapes
+    }
+    b.push(0); // 261: reserved
+    b.push(hole_shape_to_id(pad.hole_shape)); // 262: hole type
+    write_i32(&mut b, 0); // 263-266: hole slot length (not modelled)
+    write_f64(&mut b, 0.0); // 267-274: hole rotation
+    for _ in 0..32 {
+        write_i32(&mut b, 0); // 275-402: per-layer X offsets
+    }
+    for _ in 0..32 {
+        write_i32(&mut b, 0); // 403-530: per-layer Y offsets
+    }
+    b.push(u8::from(pad.shape == PadShape::RoundedRectangle)); // 531: has-rounded-rect
+    for _ in 0..32 {
+        b.push(shape_id); // 532-563: per-layer shapes
+    }
+    for _ in 0..32 {
+        b.push(radius); // 564-595: per-layer corner radii (%)
+    }
+    debug_assert_eq!(b.len(), 596);
+    b
 }
 
 /// Total length of the pad main geometry block (`SubRecord-5`) in a `PcbLib`:


### PR DESCRIPTION
First of the documented #68 follow-ups: non-round hole shapes (Square/Slot) and an explicit rounded-rectangle corner radius on **simple pads**.

## Problem
Simple pads emitted an empty Block 5, so `hole_shape` (Square/Slot) and `corner_radius_percent` were dropped — Altium fell back to a round hole / default corner.

## Fix
Emit the canonical **596-byte size/shape block** (AltiumSharp `WritePad` layout) when a pad has a non-round hole **or** an explicit corner radius:
- hole type `@262`, has-rounded-rect `@531`, per-layer corner radii `@564`.
- Plain round-hole pads still emit an **empty** Block 5 — the verified #68 default output is unchanged (no regression).
- The legacy full-stack/per-layer path is left untouched (size-discriminated).

Reader pairs with it: `hole_shape` now comes from Block 5 `@262` (main-block offset 61 is reserved in Altium's layout), corner radius from `@564`.

## Verified
End-to-end via the oracle: `hole_shape="square"` → `holeType@262=1`; `corner_radius_percent=30` → `@564=30`; **pyaltiumlib 0 warnings**. Round-trip assertions restored (advanced-features + corner-radius tests). Standard oracle **13/13, 0 regressions**; clippy `-D` + full suite + E2E green.

## Remaining follow-ups
- Slot **length** isn't modelled separately (HoleSlotLength written as 0) — minor.
- 3D `component_body`/STEP byte-audit — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)