### PR TITLE
refactor(altium): unify PcbLib/SchLib shared low-level helpers

### DIFF
--- a/src/altium/bytes.rs
+++ b/src/altium/bytes.rs
@@ -1,0 +1,69 @@
+//! Shared bounds-checked little-endian scalar readers.
+//!
+//! Both the `PcbLib` and `SchLib` readers walk byte buffers at explicit
+//! offsets; these helpers replace the byte-identical `read_*` functions each
+//! had defined locally. Every reader returns `None` past the end of the slice
+//! rather than panicking, so callers can use `?`.
+
+/// Reads a little-endian `u16` at `offset`, or `None` if out of bounds.
+pub fn read_u16_le(data: &[u8], offset: usize) -> Option<u16> {
+    data.get(offset..offset + 2)?
+        .try_into()
+        .ok()
+        .map(u16::from_le_bytes)
+}
+
+/// Reads a little-endian `u32` at `offset`, or `None` if out of bounds.
+pub fn read_u32_le(data: &[u8], offset: usize) -> Option<u32> {
+    data.get(offset..offset + 4)?
+        .try_into()
+        .ok()
+        .map(u32::from_le_bytes)
+}
+
+/// Reads a little-endian `i16` at `offset`, or `None` if out of bounds.
+pub fn read_i16_le(data: &[u8], offset: usize) -> Option<i16> {
+    data.get(offset..offset + 2)?
+        .try_into()
+        .ok()
+        .map(i16::from_le_bytes)
+}
+
+/// Reads a little-endian `i32` at `offset`, or `None` if out of bounds.
+pub fn read_i32_le(data: &[u8], offset: usize) -> Option<i32> {
+    data.get(offset..offset + 4)?
+        .try_into()
+        .ok()
+        .map(i32::from_le_bytes)
+}
+
+/// Reads a little-endian IEEE-754 `f64` at `offset`, or `None` if out of bounds.
+pub fn read_f64_le(data: &[u8], offset: usize) -> Option<f64> {
+    data.get(offset..offset + 8)?
+        .try_into()
+        .ok()
+        .map(f64::from_le_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_little_endian_values() {
+        let d = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        assert_eq!(read_u16_le(&d, 0), Some(0x0201));
+        assert_eq!(read_u32_le(&d, 0), Some(0x0403_0201));
+        assert_eq!(read_i16_le(&d, 0), Some(0x0201));
+        assert_eq!(read_i32_le(&d, 0), Some(0x0403_0201));
+        assert_eq!(read_f64_le(&d, 0), Some(f64::from_le_bytes(d)));
+    }
+
+    #[test]
+    fn out_of_bounds_is_none() {
+        let d = [0x01, 0x02];
+        assert_eq!(read_u32_le(&d, 0), None);
+        assert_eq!(read_u16_le(&d, 1), None);
+        assert_eq!(read_f64_le(&d, 0), None);
+    }
+}

--- a/src/altium/framing.rs
+++ b/src/altium/framing.rs
@@ -1,0 +1,78 @@
+//! Shared low-level byte framing for Altium library streams.
+//!
+//! Both the `PcbLib` (binary) and `SchLib` (ASCII-record) writers frame data
+//! with the same handful of length-prefixed primitives. They live here so the
+//! two formats share one implementation of each frame instead of copy-pasting
+//! the exact byte layout (which previously drifted and caused issue #68's
+//! "Data does not end with 0x00").
+//!
+//! The per-format record *shape* (`PcbLib`'s binary sub-blocks vs `SchLib`'s
+//! `|KEY=VALUE|` text records) stays in each module — only these byte frames
+//! are shared.
+
+/// Appends a length-prefixed binary block: `[u32 LE length][bytes]`.
+///
+/// This is the frame for every `PcbLib` primitive sub-block.
+pub fn write_block(data: &mut Vec<u8>, block: &[u8]) {
+    #[allow(clippy::cast_possible_truncation)]
+    data.extend_from_slice(&(block.len() as u32).to_le_bytes());
+    data.extend_from_slice(block);
+}
+
+/// Appends Altium's C-string parameter block: `[u32 LE length][bytes][0x00]`,
+/// where the length **includes** the trailing null terminator.
+///
+/// This is the canonical `WriteCStringParameterBlock` frame used for parameter
+/// and header blocks in both formats. Centralising it guarantees the
+/// length-includes-null / trailing-`0x00` invariant that Altium requires
+/// (omitting it was issue #68's "Data does not end with 0x00"). Callers that
+/// hold text encode it first, e.g. `&crate::altium::encode_windows1252(s)`.
+pub fn write_cstring_param_block(data: &mut Vec<u8>, text_bytes: &[u8]) {
+    #[allow(clippy::cast_possible_truncation)]
+    data.extend_from_slice(&((text_bytes.len() + 1) as u32).to_le_bytes());
+    data.extend_from_slice(text_bytes);
+    data.push(0x00);
+}
+
+/// Appends a Pascal short string: `[u8 length][bytes]`.
+///
+/// The caller is responsible for validating that `bytes.len() <= 255` (each
+/// call site produces its own field-named error); in debug builds an overflow
+/// is asserted.
+pub fn write_pascal_string(record: &mut Vec<u8>, bytes: &[u8]) {
+    debug_assert!(bytes.len() <= 255, "Pascal short string exceeds 255 bytes");
+    #[allow(clippy::cast_possible_truncation)]
+    record.push(bytes.len() as u8);
+    record.extend_from_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_is_length_prefixed() {
+        let mut out = Vec::new();
+        write_block(&mut out, &[0x01, 0x02, 0x03]);
+        assert_eq!(out, vec![0x03, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn cstring_param_block_length_includes_null() {
+        let mut out = Vec::new();
+        write_cstring_param_block(&mut out, b"|K=V");
+        // length = 4 bytes + 1 null = 5
+        assert_eq!(
+            out,
+            vec![0x05, 0x00, 0x00, 0x00, b'|', b'K', b'=', b'V', 0x00]
+        );
+        assert_eq!(*out.last().unwrap(), 0x00);
+    }
+
+    #[test]
+    fn pascal_string_has_u8_length() {
+        let mut out = Vec::new();
+        write_pascal_string(&mut out, b"R1");
+        assert_eq!(out, vec![0x02, b'R', b'1']);
+    }
+}

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -24,6 +24,7 @@
 //! - Style choices
 
 pub mod error;
+pub(crate) mod framing;
 pub mod pcblib;
 pub mod schlib;
 

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -23,10 +23,12 @@
 //! - Package layout decisions
 //! - Style choices
 
+pub(crate) mod bytes;
 pub mod error;
 pub(crate) mod framing;
 pub mod pcblib;
 pub mod schlib;
+pub(crate) mod serde_round;
 
 pub use error::{AltiumError, AltiumResult};
 pub use pcblib::{Footprint, PcbLib};

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -39,100 +39,7 @@
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
-/// Custom serialisation for coordinate values to avoid floating-point precision artifacts.
-///
-/// Rounds values to 6 decimal places (1 nanometre precision) to prevent output like
-/// `-0.750001` instead of `-0.75`.
-mod coord_serde {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    /// Rounds a coordinate value to 6 decimal places.
-    #[inline]
-    fn round_coord(value: f64) -> f64 {
-        (value * 1_000_000.0).round() / 1_000_000.0
-    }
-
-    /// Serialises an f64 coordinate with rounding.
-    #[allow(clippy::trivially_copy_pass_by_ref)] // serde requires &T signature
-    pub fn serialize<S: Serializer>(value: &f64, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_f64(round_coord(*value))
-    }
-
-    /// Serialises an optional f64 coordinate with rounding.
-    pub mod option {
-        use super::{round_coord, Deserialize, Deserializer, Serializer};
-
-        #[allow(clippy::ref_option)] // serde requires &Option<T> signature
-        pub fn serialize<S: Serializer>(
-            value: &Option<f64>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error> {
-            match value {
-                Some(v) => serializer.serialize_some(&round_coord(*v)),
-                None => serializer.serialize_none(),
-            }
-        }
-
-        pub fn deserialize<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<Option<f64>, D::Error> {
-            Option::<f64>::deserialize(deserializer)
-        }
-    }
-
-    /// Serialises a Vec of (f64, f64) coordinate tuples with rounding.
-    pub mod vec_tuple {
-        use super::{round_coord, Deserialize, Deserializer, Serialize, Serializer};
-
-        #[allow(clippy::ref_option)] // serde requires &Option<T> signature
-        pub fn serialize<S: Serializer>(
-            value: &Option<Vec<(f64, f64)>>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error> {
-            match value {
-                Some(v) => {
-                    let rounded: Vec<(f64, f64)> = v
-                        .iter()
-                        .map(|(a, b)| (round_coord(*a), round_coord(*b)))
-                        .collect();
-                    rounded.serialize(serializer)
-                }
-                None => serializer.serialize_none(),
-            }
-        }
-
-        pub fn deserialize<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<Option<Vec<(f64, f64)>>, D::Error> {
-            Option::<Vec<(f64, f64)>>::deserialize(deserializer)
-        }
-    }
-
-    /// Serialises a Vec of f64 coordinates with rounding.
-    pub mod vec_f64 {
-        use super::{round_coord, Deserialize, Deserializer, Serialize, Serializer};
-
-        #[allow(clippy::ref_option)] // serde requires &Option<T> signature
-        pub fn serialize<S: Serializer>(
-            value: &Option<Vec<f64>>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error> {
-            match value {
-                Some(v) => {
-                    let rounded: Vec<f64> = v.iter().map(|x| round_coord(*x)).collect();
-                    rounded.serialize(serializer)
-                }
-                None => serializer.serialize_none(),
-            }
-        }
-
-        pub fn deserialize<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<Option<Vec<f64>>, D::Error> {
-            Option::<Vec<f64>>::deserialize(deserializer)
-        }
-    }
-}
+// Coordinate rounding on serialization is shared (crate::altium::serde_round).
 
 bitflags! {
     /// Flags for PCB primitives stored in the common header (bytes 1-2).
@@ -188,19 +95,19 @@ pub struct Pad {
     pub designator: String,
 
     /// X position in mm (from footprint origin).
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x: f64,
 
     /// Y position in mm (from footprint origin).
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y: f64,
 
     /// Pad width in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
 
     /// Pad height in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub height: f64,
 
     /// Pad shape.
@@ -215,7 +122,7 @@ pub struct Pad {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::option"
+        with = "crate::altium::serde_round::option"
     )]
     pub hole_size: Option<f64>,
 
@@ -224,14 +131,14 @@ pub struct Pad {
     pub hole_shape: HoleShape,
 
     /// Rotation angle in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
 
     /// Paste mask expansion in mm. None uses design rules.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::option"
+        with = "crate::altium::serde_round::option"
     )]
     pub paste_mask_expansion: Option<f64>,
 
@@ -239,7 +146,7 @@ pub struct Pad {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::option"
+        with = "crate::altium::serde_round::option"
     )]
     pub solder_mask_expansion: Option<f64>,
 
@@ -266,7 +173,7 @@ pub struct Pad {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::vec_tuple"
+        with = "crate::altium::serde_round::vec_tuple"
     )]
     pub per_layer_sizes: Option<Vec<(f64, f64)>>,
 
@@ -285,7 +192,7 @@ pub struct Pad {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::vec_tuple"
+        with = "crate::altium::serde_round::vec_tuple"
     )]
     pub per_layer_offsets: Option<Vec<(f64, f64)>>,
 
@@ -439,19 +346,19 @@ pub enum ViaStackMode {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Via {
     /// X position in mm (from footprint origin).
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x: f64,
 
     /// Y position in mm (from footprint origin).
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y: f64,
 
     /// Via diameter (annular ring outer diameter) in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub diameter: f64,
 
     /// Hole diameter in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub hole_size: f64,
 
     /// Starting layer for the via.
@@ -463,7 +370,7 @@ pub struct Via {
     pub to_layer: Layer,
 
     /// Solder mask expansion in mm (negative = tented).
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub solder_mask_expansion: f64,
 
     /// Whether solder mask expansion is manually set.
@@ -474,7 +381,7 @@ pub struct Via {
     /// Thermal relief air gap width in mm (default: 0.254mm = 10 mils).
     #[serde(
         default = "default_thermal_relief_gap",
-        serialize_with = "coord_serde::serialize"
+        serialize_with = "crate::altium::serde_round::serialize"
     )]
     pub thermal_relief_gap: f64,
 
@@ -485,7 +392,7 @@ pub struct Via {
     /// Thermal relief conductor width in mm (default: 0.254mm = 10 mils).
     #[serde(
         default = "default_thermal_relief_width",
-        serialize_with = "coord_serde::serialize"
+        serialize_with = "crate::altium::serde_round::serialize"
     )]
     pub thermal_relief_width: f64,
 
@@ -499,7 +406,7 @@ pub struct Via {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "coord_serde::vec_f64"
+        with = "crate::altium::serde_round::vec_f64"
     )]
     pub per_layer_diameters: Option<Vec<f64>>,
 
@@ -600,19 +507,19 @@ impl Via {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Track {
     /// Start X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x1: f64,
     /// Start Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y1: f64,
     /// End X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x2: f64,
     /// End Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y2: f64,
     /// Line width in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
     /// Layer the track is on.
     pub layer: Layer,
@@ -678,22 +585,22 @@ impl Track {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Arc {
     /// Centre X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x: f64,
     /// Centre Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y: f64,
     /// Radius in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub radius: f64,
     /// Start angle in degrees (0 = right, counter-clockwise).
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub start_angle: f64,
     /// End angle in degrees.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub end_angle: f64,
     /// Line width in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
     /// Layer the arc is on.
     pub layer: Layer,
@@ -760,10 +667,10 @@ impl Region {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Vertex {
     /// X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x: f64,
     /// Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y: f64,
 }
 
@@ -834,20 +741,20 @@ pub enum TextJustification {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Text {
     /// X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x: f64,
     /// Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y: f64,
     /// Text content.
     pub text: String,
     /// Text height in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub height: f64,
     /// Layer the text is on.
     pub layer: Layer,
     /// Rotation angle in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
     /// Text rendering kind (Stroke, TrueType, or `BarCode`).
     #[serde(default)]
@@ -870,21 +777,21 @@ pub struct Text {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fill {
     /// First corner X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x1: f64,
     /// First corner Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y1: f64,
     /// Second corner X position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub x2: f64,
     /// Second corner Y position in mm.
-    #[serde(serialize_with = "coord_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y2: f64,
     /// Layer the fill is on.
     pub layer: Layer,
     /// Rotation angle in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
@@ -934,16 +841,16 @@ pub struct Model3D {
     /// Path to the STEP file.
     pub filepath: String,
     /// X offset from footprint origin in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub x_offset: f64,
     /// Y offset from footprint origin in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub y_offset: f64,
     /// Z offset from board surface in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub z_offset: f64,
     /// Rotation around Z axis in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
 }
 
@@ -1016,27 +923,27 @@ pub struct ComponentBody {
     pub embedded: bool,
 
     /// Rotation around X axis in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation_x: f64,
 
     /// Rotation around Y axis in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation_y: f64,
 
     /// Rotation around Z axis in degrees.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation_z: f64,
 
     /// Z offset (standoff from board) in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub z_offset: f64,
 
     /// Overall height in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub overall_height: f64,
 
     /// Standoff height in mm.
-    #[serde(default, serialize_with = "coord_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub standoff_height: f64,
 
     /// Layer the body outline is on.

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -31,6 +31,10 @@ use super::primitives::{
     StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via, ViaStackMode,
 };
 use super::Footprint;
+use crate::altium::bytes::{
+    read_f64_le as read_f64, read_i32_le as read_i32, read_u16_le as read_u16,
+    read_u32_le as read_u32,
+};
 use crate::altium::error::AltiumError;
 
 /// Result type for internal parse functions.
@@ -354,49 +358,6 @@ fn to_mm(internal: i32) -> f64 {
     let raw = f64::from(internal) * INTERNAL_UNITS_TO_MM;
     // Round to 6 decimal places (1nm = 0.000001mm) to avoid precision artifacts
     (raw * 1_000_000.0).round() / 1_000_000.0
-}
-
-/// Reads a 4-byte little-endian unsigned integer.
-fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
-    if offset + 4 > data.len() {
-        return None;
-    }
-    Some(u32::from_le_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-    ]))
-}
-
-/// Reads a 4-byte little-endian signed integer.
-fn read_i32(data: &[u8], offset: usize) -> Option<i32> {
-    if offset + 4 > data.len() {
-        return None;
-    }
-    Some(i32::from_le_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-    ]))
-}
-
-/// Reads an 8-byte little-endian double (IEEE 754).
-fn read_f64(data: &[u8], offset: usize) -> Option<f64> {
-    if offset + 8 > data.len() {
-        return None;
-    }
-    Some(f64::from_le_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-        data[offset + 4],
-        data[offset + 5],
-        data[offset + 6],
-        data[offset + 7],
-    ]))
 }
 
 /// Reads a length-prefixed block from data.
@@ -1632,14 +1593,6 @@ fn extract_text_from_block(block: &[u8], wide_strings: Option<&WideStrings>) -> 
 
     // No text content found
     String::new()
-}
-
-/// Reads a 2-byte little-endian unsigned integer.
-fn read_u16(data: &[u8], offset: usize) -> Option<u16> {
-    if offset + 2 > data.len() {
-        return None;
-    }
-    Some(u16::from_le_bytes([data[offset], data[offset + 1]]))
 }
 
 /// Finds an ASCII pattern within a block (for special text like ".Designator").

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -44,14 +44,12 @@ fn write_f64(data: &mut Vec<u8>, value: f64) {
     data.extend_from_slice(&value.to_le_bytes());
 }
 
-/// Writes a length-prefixed block.
-#[allow(clippy::cast_possible_truncation)] // Blocks are always small
-fn write_block(data: &mut Vec<u8>, block: &[u8]) {
-    write_u32(data, block.len() as u32);
-    data.extend_from_slice(block);
-}
+// Shared byte frames live in crate::altium::framing so PcbLib and SchLib use
+// one implementation each (see that module).
+use crate::altium::framing::{write_block, write_cstring_param_block, write_pascal_string};
 
-/// Writes a length-prefixed string block.
+/// Writes a length-prefixed string block: outer `[u32 len]` wrapping a Pascal
+/// short string `[u8 len][bytes]`.
 ///
 /// # Errors
 ///
@@ -78,9 +76,7 @@ fn write_string_block(
     }
 
     let mut block = Vec::with_capacity(1 + bytes.len());
-    #[allow(clippy::cast_possible_truncation)] // Validated above
-    block.push(bytes.len() as u8);
-    block.extend_from_slice(&bytes);
+    write_pascal_string(&mut block, &bytes);
     write_block(data, &block);
     Ok(())
 }
@@ -968,12 +964,8 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     // Unknown bytes (5 bytes)
     block.extend_from_slice(&[0x00; 5]);
 
-    // Parameter block is a C-string: length INCLUDES the null terminator
-    // (matching Altium WriteCStringParameterBlock), else Altium/pyaltiumlib
-    // report "Data does not end with 0x00".
-    write_u32(&mut block, (params_bytes.len() + 1) as u32);
-    block.extend_from_slice(params_bytes);
-    block.push(0x00);
+    // C-string parameter block (length includes the null terminator).
+    write_cstring_param_block(&mut block, params_bytes);
 
     // Vertex count
     write_u32(&mut block, vertex_count as u32);
@@ -1073,16 +1065,9 @@ fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
     // Zeros (5 bytes)
     block.extend_from_slice(&[0x00; 5]);
 
-    // Build parameter string
+    // Parameter string as a C-string block (length includes the null).
     let param_str = build_component_body_params(body);
-
-    // Parameter string length including null terminator (4 bytes)
-    let param_len = param_str.len() + 1; // +1 for null
-    write_u32(&mut block, param_len as u32);
-
-    // Parameter string (null-terminated)
-    block.extend_from_slice(param_str.as_bytes());
-    block.push(0x00); // Null terminator
+    write_cstring_param_block(&mut block, param_str.as_bytes());
 
     // No outline vertices (4 bytes = count of 0)
     write_u32(&mut block, 0);
@@ -1226,14 +1211,8 @@ pub fn encode_model_data_stream(models: &[EmbeddedModel]) -> Vec<u8> {
             "|EMBED=TRUE|MODELSOURCE=Undefined|ID={}|ROTX=0.000|ROTY=0.000|ROTZ=0.000|DZ=0|CHECKSUM=0|NAME={}",
             model.id, model.name
         );
-        let record_bytes = record.as_bytes();
-
-        // Block length includes null terminator
-        output.extend_from_slice(&((record_bytes.len() + 1) as u32).to_le_bytes());
-
-        // Write record content + null terminator
-        output.extend_from_slice(record_bytes);
-        output.push(0x00);
+        // C-string parameter block (length includes the null terminator).
+        write_cstring_param_block(&mut output, record.as_bytes());
     }
 
     output
@@ -1382,14 +1361,8 @@ fn encode_unique_id_record(
 ) {
     let record =
         format!("|PRIMITIVEINDEX={index}|PRIMITIVEOBJECTID={primitive_type}|UNIQUEID={unique_id}");
-    let record_bytes = record.as_bytes();
-
-    // Write block length (includes null terminator)
-    write_u32(data, (record_bytes.len() + 1) as u32);
-
-    // Write record content + null terminator
-    data.extend_from_slice(record_bytes);
-    data.push(0x00);
+    // C-string parameter block (length includes the null terminator).
+    write_cstring_param_block(data, record.as_bytes());
 }
 
 // =============================================================================
@@ -1459,15 +1432,10 @@ pub fn encode_component_wide_strings(footprint: &Footprint) -> Vec<u8> {
         let _ = write!(content, "ENCODEDTEXT{index}={encoded}|");
     }
 
-    // Block format: [block_len:4][content + \x00]
+    // Block format: [block_len:4][content + \x00] (length includes the null).
     let content_bytes = content.as_bytes();
-    let block_len = content_bytes.len() + 1; // +1 for null terminator
-
-    let mut data = Vec::with_capacity(4 + block_len);
-    #[allow(clippy::cast_possible_truncation)]
-    write_u32(&mut data, block_len as u32);
-    data.extend_from_slice(content_bytes);
-    data.push(0x00); // Null terminator
+    let mut data = Vec::with_capacity(4 + content_bytes.len() + 1);
+    write_cstring_param_block(&mut data, content_bytes);
 
     data
 }

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -5,24 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Custom serialisation for floating-point values to avoid precision artifacts.
-///
-/// Rounds values to 6 decimal places to prevent output like `359.999999` instead of `360.0`.
-mod float_serde {
-    use serde::Serializer;
-
-    /// Rounds a floating-point value to 6 decimal places.
-    #[inline]
-    fn round_float(value: f64) -> f64 {
-        (value * 1_000_000.0).round() / 1_000_000.0
-    }
-
-    /// Serialises an f64 with rounding.
-    #[allow(clippy::trivially_copy_pass_by_ref)] // serde requires &T signature
-    pub fn serialize<S: Serializer>(value: &f64, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_f64(round_float(*value))
-    }
-}
+// Float rounding on serialization is shared (crate::altium::serde_round).
 
 /// A schematic symbol pin.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -500,12 +483,12 @@ pub struct Arc {
     /// Radius.
     pub radius: i32,
     /// Start angle in degrees (0 = right, counter-clockwise).
-    #[serde(default, serialize_with = "float_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub start_angle: f64,
     /// End angle in degrees.
     #[serde(
         default = "default_end_angle",
-        serialize_with = "float_serde::serialize"
+        serialize_with = "crate::altium::serde_round::serialize"
     )]
     pub end_angle: f64,
     /// Line width.
@@ -714,18 +697,18 @@ pub struct EllipticalArc {
     /// Centre Y coordinate.
     pub y: i32,
     /// Primary radius (horizontal).
-    #[serde(serialize_with = "float_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub radius: f64,
     /// Secondary radius (vertical).
-    #[serde(serialize_with = "float_serde::serialize")]
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub secondary_radius: f64,
     /// Start angle in degrees (0 = right, counter-clockwise).
-    #[serde(default, serialize_with = "float_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub start_angle: f64,
     /// End angle in degrees.
     #[serde(
         default = "default_end_angle",
-        serialize_with = "float_serde::serialize"
+        serialize_with = "crate::altium::serde_round::serialize"
     )]
     pub end_angle: f64,
     /// Line width.
@@ -789,7 +772,7 @@ pub struct Label {
     #[serde(default)]
     pub justification: TextJustification,
     /// Rotation in degrees.
-    #[serde(default, serialize_with = "float_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
     /// Whether the label is mirrored horizontally.
     #[serde(default)]
@@ -824,7 +807,7 @@ pub struct Text {
     #[serde(default)]
     pub justification: TextJustification,
     /// Rotation in degrees.
-    #[serde(default, serialize_with = "float_serde::serialize")]
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
     /// Whether the text is mirrored horizontally.
     #[serde(default)]

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -22,6 +22,9 @@ use super::primitives::{
     TextJustification,
 };
 use super::Symbol;
+use crate::altium::bytes::{
+    read_i16_le as read_i16, read_i32_le as read_i32, read_u32_le as read_u32,
+};
 use std::collections::HashMap;
 
 /// Parses primitives from a `SchLib` Data stream.
@@ -927,39 +930,7 @@ const fn justification_from_id(id: u8) -> TextJustification {
     }
 }
 
-/// Reads a 4-byte little-endian signed integer.
-fn read_i32(data: &[u8], offset: usize) -> Option<i32> {
-    if offset + 4 > data.len() {
-        return None;
-    }
-    Some(i32::from_le_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-    ]))
-}
-
-/// Reads a 2-byte little-endian signed integer.
-fn read_i16(data: &[u8], offset: usize) -> Option<i16> {
-    if offset + 2 > data.len() {
-        return None;
-    }
-    Some(i16::from_le_bytes([data[offset], data[offset + 1]]))
-}
-
-/// Reads a 4-byte little-endian unsigned integer.
-fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
-    if offset + 4 > data.len() {
-        return None;
-    }
-    Some(u32::from_le_bytes([
-        data[offset],
-        data[offset + 1],
-        data[offset + 2],
-        data[offset + 3],
-    ]))
-}
+// Bounds-checked little-endian scalar readers are shared (crate::altium::bytes).
 
 #[cfg(test)]
 mod tests {

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -24,6 +24,7 @@ use super::primitives::{
     Polyline, Rectangle, RoundRect, Text, TextJustification,
 };
 use super::Symbol;
+use crate::altium::framing::{write_cstring_param_block, write_pascal_string};
 
 /// Writes a record frame to the output: Altium's `[u24 length LE][u8 flags]`
 /// header followed by the payload. `flags` is 0 for a text record and 1 for a
@@ -177,10 +178,10 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.push(pin.symbol_outside.to_id());
 
     // Description: Pascal short string [length:1][string]
-    let desc_bytes = crate::altium::encode_windows1252(&pin.description);
-    #[allow(clippy::cast_possible_truncation)] // length validated above
-    record.push(desc_bytes.len() as u8);
-    record.extend_from_slice(&desc_bytes);
+    write_pascal_string(
+        &mut record,
+        &crate::altium::encode_windows1252(&pin.description),
+    );
 
     // Formal type (1 byte) - 0x01 for a normal pin (matches Altium's output).
     record.push(0x01);
@@ -228,16 +229,13 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.extend_from_slice(&pin.colour.to_le_bytes());
 
     // Name: [length:1][string]
-    let name_bytes = crate::altium::encode_windows1252(&pin.name);
-    #[allow(clippy::cast_possible_truncation)] // length validated above
-    record.push(name_bytes.len() as u8);
-    record.extend_from_slice(&name_bytes);
+    write_pascal_string(&mut record, &crate::altium::encode_windows1252(&pin.name));
 
     // Designator: [length:1][string]
-    let desig_bytes = crate::altium::encode_windows1252(&pin.designator);
-    #[allow(clippy::cast_possible_truncation)] // length validated above
-    record.push(desig_bytes.len() as u8);
-    record.extend_from_slice(&desig_bytes);
+    write_pascal_string(
+        &mut record,
+        &crate::altium::encode_windows1252(&pin.designator),
+    );
 
     // Pin swap-id tail (Pascal short strings), matching Altium's output:
     //   SwapIdGroup = "" , PartAndSequence = "|&|" , DefaultValue = "".
@@ -768,11 +766,7 @@ pub fn encode_file_header(symbols: &[&Symbol], ole_names: &[String]) -> Vec<u8> 
     // WriteCStringParameterBlockRaw). Omitting it is issue #68's "Data does not
     // end with 0x00".
     let mut data = Vec::with_capacity(4 + text_bytes.len() + 1);
-    #[allow(clippy::cast_possible_truncation)]
-    let length = (text_bytes.len() + 1) as u32;
-    data.extend_from_slice(&length.to_le_bytes());
-    data.extend_from_slice(text_bytes);
-    data.push(0x00);
+    write_cstring_param_block(&mut data, text_bytes);
 
     data
 }

--- a/src/altium/serde_round.rs
+++ b/src/altium/serde_round.rs
@@ -1,0 +1,91 @@
+//! Shared serde helper that rounds `f64` values to 6 decimal places on
+//! serialization.
+//!
+//! Both `PcbLib` (mm coordinates) and `SchLib` (rotation/angle fields) round
+//! float JSON output identically; this is the single implementation they share
+//! (it previously lived as duplicate `coord_serde`/`float_serde` modules). The
+//! rounding is unchanged, so serialized output is bit-identical.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Rounds a value to 6 decimal places.
+#[inline]
+fn round(value: f64) -> f64 {
+    (value * 1_000_000.0).round() / 1_000_000.0
+}
+
+/// Serialises an f64 with rounding.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires &T signature
+pub fn serialize<S: Serializer>(value: &f64, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_f64(round(*value))
+}
+
+/// Serialises an optional f64 with rounding.
+pub mod option {
+    use super::{round, Deserialize, Deserializer, Serializer};
+
+    #[allow(clippy::ref_option)] // serde requires &Option<T> signature
+    pub fn serialize<S: Serializer>(value: &Option<f64>, serializer: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => serializer.serialize_some(&round(*v)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<f64>, D::Error> {
+        Option::<f64>::deserialize(deserializer)
+    }
+}
+
+/// Serialises a `Vec` of (f64, f64) tuples with rounding.
+pub mod vec_tuple {
+    use super::{round, Deserialize, Deserializer, Serialize, Serializer};
+
+    #[allow(clippy::ref_option)] // serde requires &Option<T> signature
+    pub fn serialize<S: Serializer>(
+        value: &Option<Vec<(f64, f64)>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => {
+                let rounded: Vec<(f64, f64)> =
+                    v.iter().map(|(a, b)| (round(*a), round(*b))).collect();
+                rounded.serialize(serializer)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Vec<(f64, f64)>>, D::Error> {
+        Option::<Vec<(f64, f64)>>::deserialize(deserializer)
+    }
+}
+
+/// Serialises a `Vec` of f64 with rounding.
+pub mod vec_f64 {
+    use super::{round, Deserialize, Deserializer, Serialize, Serializer};
+
+    #[allow(clippy::ref_option)] // serde requires &Option<T> signature
+    pub fn serialize<S: Serializer>(
+        value: &Option<Vec<f64>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => {
+                let rounded: Vec<f64> = v.iter().map(|x| round(*x)).collect();
+                rounded.serialize(serializer)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Vec<f64>>, D::Error> {
+        Option::<Vec<f64>>::deserialize(deserializer)
+    }
+}


### PR DESCRIPTION
Deep-unification of the PcbLib and SchLib modules (your request), driven by a 4-agent analysis of both module trees. This PR unifies the **shared low-level layer**; every change is a pure refactor with **no emitted/decoded byte changes** (oracle 13/13, round-trip + full suite green throughout).

**Stacked on #89.**

## What's shared now (`crate::altium::*`)
| Module | Replaces | Both formats used it as |
|---|---|---|
| `framing` | `write_block` + ~7 inline C-string/`pascal` copies | length-prefixed write frames (incl. the #68-critical `[len-incl-null][bytes]0x00`) |
| `bytes` | byte-identical `read_u16/u32/i16/i32/f64` in both readers | bounds-checked LE scalar reads |
| `serde_round` | `pcblib::coord_serde` + `schlib::float_serde` (51 + 9 sites) | 6-dp float rounding on serialize |
| *(existing)* `encode/decode_windows1252` | — | on-disk string encoding |

## Left divergent (by design — genuine binary-vs-text format differences)
- The **outer record frame**: PcbLib `[u32 len][bytes]` sub-blocks vs SchLib `[u24 len][u8 flags]` records — different on-disk layouts, both hand-tuned for #68.
- Per-primitive encoders: PcbLib `encode_*(&mut Vec)->Result` (binary) vs SchLib `encode_*(...)->String` (ASCII records).
- Per-format dispatch loops, geometry parsers, and the model/3D streams.

## Still to come (noted, not in this PR)
- **OLE plumbing + public API** (area C): shared `create_ole`/`open_ole`/`read_stream`/`write_stream` + a consistent `save`/`write`/`open`/`read` surface on both types. It touches the #68-tuned `mod.rs` write paths, so it deserves its own careful pass.
- 3D `component_body`/STEP byte-audit (separate follow-up).

## Verification
`cargo build` · `clippy -D` · full suite · Python E2E 25/25 · **oracle 13/13, 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)