### PR TITLE
fix(pcblib): correct 3D ComponentBody record + Models/Data byte format

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1050,6 +1050,7 @@ impl PcbLib {
                     overall_height: 0.0, // Could be calculated from STEP, but not implemented
                     standoff_height: 0.0,
                     layer: Layer::Top3DBody,
+                    outline: Vec::new(), // Synthesised from the footprint extent on write
                     unique_id: None,
                 };
 
@@ -2010,7 +2011,7 @@ mod tests {
 
         let mut original = Footprint::new("ROUNDTRIP_COMPONENT_BODY");
 
-        // Add a ComponentBody with typical values
+        // Add a ComponentBody with typical values and an explicit outline.
         let body = ComponentBody {
             model_id: "{TEST-GUID-1234-5678-ABCDEFGH}".to_string(),
             model_name: "TEST_MODEL.step".to_string(),
@@ -2022,6 +2023,7 @@ mod tests {
             overall_height: 1.0,  // mm
             standoff_height: 0.1, // mm
             layer: Layer::Top3DBody,
+            outline: vec![(-2.0, 1.0), (-2.0, -1.0), (2.0, -1.0), (2.0, 1.0)],
             unique_id: None,
         };
         original.add_component_body(body);
@@ -2044,6 +2046,92 @@ mod tests {
         assert!(approx_eq(body.overall_height, 1.0, 0.01));
         assert!(approx_eq(body.standoff_height, 0.1, 0.01));
         assert_eq!(body.layer, Layer::Top3DBody);
+
+        // The explicit outline round-trips (4 vertices, in mm).
+        assert_eq!(body.outline.len(), 4);
+        assert!(approx_eq(body.outline[0].0, -2.0, 0.001));
+        assert!(approx_eq(body.outline[0].1, 1.0, 0.001));
+        assert!(approx_eq(body.outline[2].0, 2.0, 0.001));
+        assert!(approx_eq(body.outline[2].1, -1.0, 0.001));
+    }
+
+    #[test]
+    fn component_body_emits_single_block_with_outline() {
+        // A footprint with two bodies must not emit stray empty blocks between
+        // them (Altium reads exactly one block per body; trailing zero bytes are
+        // mis-read as a bogus object-id-0 primitive — the #68 class of bug).
+        let mut fp = Footprint::new("TWO_BODIES");
+        fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.6, 0.5));
+        fp.add_pad(Pad::smd("2", 1.0, 0.0, 0.6, 0.5));
+        for i in 0..2 {
+            fp.add_component_body(ComponentBody {
+                model_id: format!("{{GUID-{i}}}"),
+                model_name: format!("M{i}.step"),
+                embedded: true,
+                rotation_x: 0.0,
+                rotation_y: 0.0,
+                rotation_z: 0.0,
+                z_offset: 0.0,
+                overall_height: 1.0,
+                standoff_height: 0.0,
+                layer: Layer::Top3DBody,
+                outline: Vec::new(), // exercise the synthesised-bbox fallback
+                unique_id: None,
+            });
+        }
+
+        let data = writer::encode_data_stream(&fp).expect("encoding should succeed");
+        let mut decoded = Footprint::new("TWO_BODIES");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        // Both bodies survive (no desync from stray blocks), and each gets a
+        // non-degenerate synthesised outline (the pad bounding box).
+        assert_eq!(decoded.component_bodies.len(), 2);
+        for body in &decoded.component_bodies {
+            assert_eq!(body.outline.len(), 4, "body must have a non-empty outline");
+        }
+
+        // Byte-level: a body must be EXACTLY one size-prefixed block (as Altium
+        // writes). This catches the stray empty blocks regardless of whether our
+        // own reader tolerates them. Build a one-body footprint and walk it.
+        let mut single = Footprint::new("ONE_BODY");
+        single.add_component_body(ComponentBody::new("{G}", "M.step"));
+        let d = writer::encode_data_stream(&single).expect("encoding should succeed");
+        let name_len = u32::from_le_bytes(d[0..4].try_into().unwrap()) as usize;
+        let mut off = 4 + name_len;
+        assert_eq!(d[off], 0x0C, "expected ComponentBody object id");
+        off += 1;
+        let block_len = u32::from_le_bytes(d[off..off + 4].try_into().unwrap()) as usize;
+        off += 4 + block_len;
+        assert_eq!(
+            off,
+            d.len(),
+            "ComponentBody must be a single block with no trailing empty blocks"
+        );
+
+        // The body param block carries the full key set Altium emits.
+        let s = String::from_utf8_lossy(&d);
+        assert!(s.contains("IDENTIFIER="), "missing IDENTIFIER key");
+        assert!(s.contains("TEXTURE="), "missing TEXTURE key");
+        assert_eq!(
+            s.matches("ARCRESOLUTION=").count(),
+            2,
+            "Altium emits ARCRESOLUTION twice"
+        );
+    }
+
+    #[test]
+    fn models_data_record_has_no_leading_pipe() {
+        // AltiumSharp and every BODY_3D golden start the record at EMBED= with no
+        // leading pipe; the u32 length prefix is followed directly by 'E'.
+        let models = vec![EmbeddedModel::new("{GUID}", "part.step", Vec::new())];
+        let stream = writer::encode_model_data_stream(&models);
+        // [u32 len][record + NUL]; first record byte (offset 4) must be 'E', not '|'.
+        assert_eq!(stream[4], b'E', "Models/Data record must start at EMBED=");
+        assert_ne!(
+            stream[4], b'|',
+            "Models/Data record must not have a leading pipe"
+        );
     }
 
     #[test]

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -950,6 +950,14 @@ pub struct ComponentBody {
     #[serde(default)]
     pub layer: Layer,
 
+    /// 2D outline of the body in the footprint plane, as `(x, y)` vertices in mm.
+    ///
+    /// Altium stores a closed polygon giving the body's 2D extent. When this is
+    /// empty the writer synthesises a bounding box from the footprint, since
+    /// Altium needs a non-degenerate outline to place and render the body.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outline: Vec<(f64, f64)>,
+
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -970,6 +978,7 @@ impl ComponentBody {
             overall_height: 0.0,
             standoff_height: 0.0,
             layer: Layer::Top3DBody,
+            outline: Vec::new(),
             unique_id: None,
         }
     }

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -1809,28 +1809,17 @@ fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
 /// Parses a `ComponentBody` primitive (3D model reference).
 /// Returns the parsed `ComponentBody` and the new offset on success.
 ///
-/// `ComponentBody` has 3 blocks:
-/// - Block 0: Properties (layer, parameters as key=value string)
-/// - Block 1: Usually empty
-/// - Block 2: Usually empty
+/// A `ComponentBody` is a single size-prefixed block (matching `AltiumSharp` and
+/// the `BODY_3D` golden libraries): the layer/flags header, a C-string
+/// parameter block, then the 2D outline polygon — all within the one block.
 fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<ComponentBody> {
-    let mut current = offset;
-
-    // Block 0: Properties with parameter string (required)
-    let (block0, next) = read_block(data, current).ok_or_else(|| {
-        AltiumError::parse_error(offset, "failed to read ComponentBody block 0 (properties)")
+    // The single block holds the header, parameters and outline.
+    let (block0, current) = read_block(data, offset).ok_or_else(|| {
+        AltiumError::parse_error(offset, "failed to read ComponentBody block (properties)")
     })?;
-    current = next;
 
-    // Block 1: Usually empty (optional - may not exist at end of file)
-    if let Some((_, next)) = read_block(data, current) {
-        current = next;
-
-        // Block 2: Usually empty (optional)
-        if let Some((_, next)) = read_block(data, current) {
-            current = next;
-        }
-    }
+    // Parse the outline polygon that follows the parameter block.
+    let outline = parse_component_body_outline(block0);
 
     // Parse block 0 to extract parameters
     // Format: [header bytes][parameter_string]
@@ -1881,10 +1870,43 @@ fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<ComponentBody
         overall_height,
         standoff_height,
         layer,
+        outline,
         unique_id: None,
     };
 
     Ok((body, current))
+}
+
+/// Parses the 2D outline polygon from a `ComponentBody` block.
+///
+/// Layout within the block: an 18-byte layer/flags header, the C-string
+/// parameter block (`[u32 len incl. NUL][bytes][NUL]`), then `[u32 count]`
+/// followed by `count` `(f64 x, f64 y)` vertices in Altium internal units.
+/// Returns the vertices in mm, or empty if the block is malformed/truncated.
+fn parse_component_body_outline(block0: &[u8]) -> Vec<(f64, f64)> {
+    const HEADER_LEN: usize = 18;
+
+    // Skip the header + the C-string parameter block (its u32 prefix already
+    // counts the bytes-plus-NUL that follow it).
+    let Some(param_len) = read_u32(block0, HEADER_LEN) else {
+        return Vec::new();
+    };
+    let mut off = HEADER_LEN + 4 + param_len as usize;
+
+    let Some(count) = read_u32(block0, off) else {
+        return Vec::new();
+    };
+    off += 4;
+
+    let mut outline = Vec::new();
+    for _ in 0..count {
+        let (Some(x), Some(y)) = (read_f64(block0, off), read_f64(block0, off + 8)) else {
+            break;
+        };
+        off += 16;
+        outline.push((x * INTERNAL_UNITS_TO_MM, y * INTERNAL_UNITS_TO_MM));
+    }
+    outline
 }
 
 /// Parses key=value parameters from a `ComponentBody` block string.

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -315,7 +315,8 @@ pub fn encode_data_stream(footprint: &Footprint) -> crate::altium::error::Altium
 
     for body in &footprint.component_bodies {
         data.push(0x0C); // ComponentBody record type
-        encode_component_body(&mut data, body);
+        let outline = resolve_body_outline(body, footprint);
+        encode_component_body(&mut data, body, &outline);
     }
 
     // No end marker: Altium reads exactly the primitive count from the component
@@ -1026,13 +1027,15 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
 }
 
 /// Encodes a `ComponentBody` primitive (3D model reference).
-fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody) {
-    let block = encode_component_body_block(body);
+///
+/// Altium writes exactly ONE size-prefixed block per body (verified against
+/// `AltiumSharp` and the `BODY_3D`/`BODY_3D_STEP` golden libraries) — the outline
+/// lives inside that block. Emitting extra empty blocks would be read back as a
+/// bogus object-id-0 primitive and desynchronise the record stream (the same
+/// class of bug as the trailing-`0x00` end marker removed for #68).
+fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody, outline: &[(f64, f64)]) {
+    let block = encode_component_body_block(body, outline);
     write_block(data, &block);
-
-    // Blocks 1 and 2 are optional/empty
-    write_block(data, &[]);
-    write_block(data, &[]);
 }
 
 /// Encodes the `ComponentBody` block 0.
@@ -1045,11 +1048,11 @@ fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody) {
 /// [zeros:5]                    // Zeros
 /// [param_len:4]                // Parameter string length (including null)
 /// [param_string:param_len]     // Key=value pairs separated by |
-/// [vertex_count:4]             // Outline vertex count (usually 0 or 4)
-/// [vertices...]                // Optional outline vertices
+/// [vertex_count:4]             // Outline vertex count
+/// [vertices...]                // Outline vertices: f64 x, f64 y (internal units)
 /// ```
-#[allow(clippy::cast_possible_truncation)] // Parameter strings are always small
-fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
+#[allow(clippy::cast_possible_truncation)] // Parameter strings + outlines are always small
+fn encode_component_body_block(body: &ComponentBody, outline: &[(f64, f64)]) -> Vec<u8> {
     let mut block = Vec::with_capacity(128);
 
     // Layer ID (1 byte)
@@ -1069,10 +1072,54 @@ fn encode_component_body_block(body: &ComponentBody) -> Vec<u8> {
     let param_str = build_component_body_params(body);
     write_cstring_param_block(&mut block, param_str.as_bytes());
 
-    // No outline vertices (4 bytes = count of 0)
-    write_u32(&mut block, 0);
+    // Outline polygon: vertex count then (f64 x, f64 y) per vertex, in Altium
+    // internal units (1 mil = 10000). Altium needs a non-empty outline to place
+    // and render the body.
+    write_u32(&mut block, outline.len() as u32);
+    for &(x, y) in outline {
+        write_f64(&mut block, x * MM_TO_INTERNAL_UNITS);
+        write_f64(&mut block, y * MM_TO_INTERNAL_UNITS);
+    }
 
     block
+}
+
+/// Resolves the outline to write for a `ComponentBody`.
+///
+/// Uses the body's explicit outline when present (e.g. preserved from a file we
+/// read); otherwise synthesises a rectangle from the footprint's pad extent so
+/// the body is never written with a degenerate (empty) outline. Falls back to a
+/// ±1 mm square when the footprint has no pads. Vertices are wound to match
+/// Altium's convention: top-left, bottom-left, bottom-right, top-right.
+fn resolve_body_outline(body: &ComponentBody, footprint: &Footprint) -> Vec<(f64, f64)> {
+    if !body.outline.is_empty() {
+        return body.outline.clone();
+    }
+
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    for pad in &footprint.pads {
+        min_x = min_x.min(pad.x - pad.width / 2.0);
+        max_x = max_x.max(pad.x + pad.width / 2.0);
+        min_y = min_y.min(pad.y - pad.height / 2.0);
+        max_y = max_y.max(pad.y + pad.height / 2.0);
+    }
+    if !min_x.is_finite() {
+        // No pads to bound — use a small default square.
+        min_x = -1.0;
+        min_y = -1.0;
+        max_x = 1.0;
+        max_y = 1.0;
+    }
+
+    vec![
+        (min_x, max_y),
+        (min_x, min_y),
+        (max_x, min_y),
+        (max_x, max_y),
+    ]
 }
 
 /// Builds the parameter string for a `ComponentBody`.
@@ -1103,8 +1150,13 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         mm_to_mil(body.overall_height)
     ));
     params.push("BODYPROJECTION=0".to_string());
+    // Altium repeats ARCRESOLUTION after BODYPROJECTION (verbatim shape from the
+    // BODY_3D golden files).
+    params.push("ARCRESOLUTION=0.5mil".to_string());
     params.push("BODYCOLOR3D=8421504".to_string());
     params.push("BODYOPACITY3D=1.000".to_string());
+    params.push("IDENTIFIER=".to_string());
+    params.push("TEXTURE=".to_string());
     params.push("TEXTURECENTERX=0mil".to_string());
     params.push("TEXTURECENTERY=0mil".to_string());
     params.push("TEXTURESIZEX=0mil".to_string());
@@ -1206,9 +1258,10 @@ pub fn encode_model_data_stream(models: &[EmbeddedModel]) -> Vec<u8> {
     let mut output = Vec::new();
 
     for model in models {
-        // Build the record content (leading pipe, pipe-delimited parameters)
+        // Pipe-delimited parameters, NO leading pipe (matches AltiumSharp's
+        // string.Join and every BODY_3D golden, whose record starts at EMBED=).
         let record = format!(
-            "|EMBED=TRUE|MODELSOURCE=Undefined|ID={}|ROTX=0.000|ROTY=0.000|ROTZ=0.000|DZ=0|CHECKSUM=0|NAME={}",
+            "EMBED=TRUE|MODELSOURCE=Undefined|ID={}|ROTX=0.000|ROTY=0.000|ROTZ=0.000|DZ=0|CHECKSUM=0|NAME={}",
             model.id, model.name
         );
         // C-string parameter block (length includes the null terminator).

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -363,6 +363,7 @@ impl McpServer {
                             overall_height: 0.0,
                             standoff_height: 0.0,
                             layer: Layer::Top3DBody,
+                            outline: Vec::new(),
                             unique_id: None,
                         });
                     }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -780,6 +780,7 @@ fn test_component_body_roundtrip() {
         overall_height: 0.35,
         standoff_height: 0.0,
         layer: Layer::TopLayer,
+        outline: Vec::new(),
         unique_id: None,
     };
     fp.component_bodies.push(body);
@@ -824,6 +825,7 @@ fn test_component_body_with_rotation() {
         overall_height: 1.75,
         standoff_height: 0.0,
         layer: Layer::TopLayer,
+        outline: Vec::new(),
         unique_id: None,
     };
     fp.component_bodies.push(body);
@@ -2516,6 +2518,7 @@ fn test_component_body_external_model_reference() {
         overall_height: 1.0,
         standoff_height: 0.0,
         layer: Layer::Top3DBody,
+        outline: Vec::new(),
         unique_id: None,
     };
     fp.component_bodies.push(body);


### PR DESCRIPTION
A byte-level audit of our embedded-3D-model output against **AltiumSharp** and the **BODY_3D / BODY_3D_STEP** golden libraries (dumped with `olefile`) found four format errors. Two would stop Altium opening footprints that contain 3D bodies.

## Fixes

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | **critical** | We wrote **3 blocks** per `ComponentBody` (one + two empty). Altium writes **exactly one**; the trailing zero bytes are read back as a bogus object-id-0 primitive and desync the record stream for any footprint with >1 body (the #68 trailing-`0x00` class of bug). | Emit a single block. Reader reads a single block. |
| 2 | **critical** | Zero-vertex **outline** hardcoded; every golden body has a 2D polygon. | `ComponentBody.outline` field (mm); writer synthesises the pad bounding box when unset so the body is never degenerate; reader parses it back. |
| 3 | major | `Library/Models/Data` record began with a leading `\|`; AltiumSharp/goldens start at `EMBED=`. | Drop the leading pipe. |
| 4 | minor | Missing `IDENTIFIER=` / `TEXTURE=` keys and the duplicate `ARCRESOLUTION` Altium emits. | Add them, matching the golden key set/order. |

The 18-byte common header and the no-leading-pipe body param string were already byte-identical to AltiumSharp — those are unchanged.

## Independently verified
The reference structure was confirmed directly from the golden bytes: `BODY_3D/Data` is **one** block (objid 12, size 774 = 18 header + 688 param + 4 + 64 outline), ending at stream end with a **4-vertex** outline (±100×±50 mil).

## Tests
`cargo build` · `clippy -D` · full suite **219 lib + all integration green** · **oracle 13/13 (0 regressions)** · E2E 25/25. New byte-level unit tests assert: single-block framing (catches stray blocks regardless of our own reader's tolerance), outline round-trip, the body param key set, and the no-leading-pipe `Models/Data` record.

## Deliberately deferred
Fidelity-only, not openability — we only emit STEP bodies, where the current values are correct/golden-validated:
- `MODELTYPE`/`EXTRUDED` branching (we never emit extruded primitive bodies; `MODELTYPE=1` is right for STEP).
- Position-weighted model `CHECKSUM` (`0` is explicitly valid per the `BODY_3D_STEP_CHECKSUM0` golden; a mismatch would be worse than a consistent 0).
- `V7_LAYER` MECHANICAL1 convention (ours stays consistent with the header layer byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)