### PR TITLE
fix(security): close two path-traversal gaps in STEP-model handling

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -970,6 +970,13 @@ impl PcbLib {
             if let Some(ref model_3d) = footprint.model_3d {
                 let path = std::path::Path::new(&model_3d.filepath);
 
+                // Only ever surface the bare file name in logs/errors, never the
+                // caller's full path (sanitisation rule).
+                let display_name = path.file_name().map_or_else(
+                    || "<model>".to_string(),
+                    |n| n.to_string_lossy().into_owned(),
+                );
+
                 // Check if the filepath looks like an explicit path (has directory components)
                 // vs just a model name (which gets set during read from ComponentBody)
                 let is_explicit_path = path.parent().is_some_and(|p| !p.as_os_str().is_empty());
@@ -981,7 +988,7 @@ impl PcbLib {
                     tracing::trace!(
                         footprint = %footprint.name,
                         component_bodies = footprint.component_bodies.len(),
-                        filepath = %model_3d.filepath,
+                        model = %display_name,
                         "Skipping model_3d - footprint already has ComponentBody and filepath is not explicit"
                     );
                     continue;
@@ -994,7 +1001,7 @@ impl PcbLib {
                     if !footprint.component_bodies.is_empty() {
                         tracing::trace!(
                             footprint = %footprint.name,
-                            filepath = %model_3d.filepath,
+                            model = %display_name,
                             "Skipping model_3d - file not found but ComponentBody exists"
                         );
                         continue;
@@ -1006,7 +1013,7 @@ impl PcbLib {
                         message: format!(
                             "STEP file not found for footprint '{}': '{}'. \
                              Provide a valid path or use embed: false for external reference.",
-                            footprint.name, model_3d.filepath
+                            footprint.name, display_name
                         ),
                     });
                 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1461,6 +1461,82 @@ mod tests {
     }
 
     #[test]
+    fn write_pcblib_rejects_embed_source_outside_allowlist() {
+        // GAP A regression: an embedded step_model.filepath is read from disk at
+        // save time (prepare_3d_models_for_writing -> std::fs::read). A caller
+        // must not be able to embed a file from outside the configured
+        // allow-list (arbitrary file read / exfiltration into the library).
+        let allowed = test_temp_dir();
+        let outside = test_temp_dir(); // a different dir, NOT on the allow-list
+        let secret = outside.path().join("secret.step");
+        std::fs::write(&secret, b"TOP SECRET").expect("write secret");
+
+        let server = create_test_server(allowed.path());
+        let lib_path = allowed.path().join("out.PcbLib");
+        let args = json!({
+            "filepath": lib_path.to_string_lossy(),
+            "footprints": [{
+                "name": "FP1",
+                "pads": [{"designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0}],
+                "step_model": {"filepath": secret.to_string_lossy(), "embed": true}
+            }]
+        });
+
+        let result = server.call_write_pcblib(&args);
+        assert!(
+            result.is_error,
+            "embedding a file outside the allow-list must be rejected"
+        );
+        let msg = get_result_text(&result).to_lowercase();
+        assert!(
+            msg.contains("denied") || msg.contains("outside"),
+            "expected an access-denied error, got: {msg}"
+        );
+        // No library should have been written, and the secret never surfaces.
+        assert!(
+            !lib_path.exists(),
+            "library must not be written on rejection"
+        );
+        assert!(!msg.contains("top secret"));
+    }
+
+    #[test]
+    fn extract_all_step_models_sanitises_malicious_model_name() {
+        // GAP B regression: model.name comes from inside a (caller-supplied)
+        // library. A crafted name must not escape the output directory via
+        // Path::join with ".." or an absolute path.
+        use crate::altium::pcblib::EmbeddedModel;
+
+        let temp = test_temp_dir();
+        let server = create_test_server(temp.path());
+        let out_dir = temp.path().join("out");
+
+        let models_owned = [
+            EmbeddedModel::new("{A}", "../ESCAPED.step", b"DATA".to_vec()),
+            EmbeddedModel::new("{B}", "..", b"DATA".to_vec()),
+        ];
+        let models: Vec<&EmbeddedModel> = models_owned.iter().collect();
+
+        let result =
+            server.extract_all_step_models("lib.PcbLib", Some(&out_dir.to_string_lossy()), &models);
+        assert!(
+            !result.is_error,
+            "extract_all reports per-model errors as partial success, not a hard error"
+        );
+
+        // "../ESCAPED.step" must be reduced to a bare filename inside out_dir,
+        // never written to out_dir's parent; ".." has no file component (skipped).
+        assert!(
+            !temp.path().join("ESCAPED.step").exists(),
+            "model name escaped the output directory"
+        );
+        assert!(
+            out_dir.join("ESCAPED.step").exists(),
+            "sanitised model should be written inside out_dir"
+        );
+    }
+
+    #[test]
     fn write_pcblib_append_mode() {
         let temp = test_temp_dir();
         let lib_path = temp.path().join("append_test.PcbLib");

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -322,6 +322,16 @@ impl McpServer {
                         .unwrap_or(true);
 
                     if embed {
+                        // The embed source is read from disk at save time
+                        // (prepare_3d_models_for_writing -> std::fs::read), far from
+                        // this handler. Validate it against the allow-list now so a
+                        // caller cannot embed an arbitrary file (e.g. "../../etc/passwd")
+                        // into the library. External references (embed=false) are only
+                        // stored as a string and never read, so they are not gated here.
+                        if let Err(e) = self.validate_path(model_path) {
+                            return ToolCallResult::error(e);
+                        }
+
                         // Embedded model - use Model3D which will read the file on save
                         footprint.model_3d = Some(Model3D {
                             filepath: model_path.to_string(),

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -122,7 +122,7 @@ impl McpServer {
             }
             "extract_all" => {
                 // Extract all models to output directory
-                Self::extract_all_step_models(filepath, output_path, &models)
+                self.extract_all_step_models(filepath, output_path, &models)
             }
             "extract_by_footprint" => {
                 // Extract models used by a specific footprint
@@ -131,7 +131,7 @@ impl McpServer {
                         "Missing required parameter 'footprint_name' for extract_by_footprint mode",
                     );
                 };
-                Self::extract_step_by_footprint(filepath, output_path, &library, &models, fp_name)
+                self.extract_step_by_footprint(filepath, output_path, &library, &models, fp_name)
             }
             _ => {
                 // Default "auto" mode - original behaviour
@@ -219,6 +219,7 @@ impl McpServer {
 
     /// Extracts all STEP models to an output directory.
     pub(crate) fn extract_all_step_models(
+        &self,
         filepath: &str,
         output_path: Option<&str>,
         models: &[&crate::altium::pcblib::EmbeddedModel],
@@ -239,7 +240,27 @@ impl McpServer {
         let mut errors: Vec<Value> = Vec::new();
 
         for model in models {
-            let output_file = out_dir.join(&model.name);
+            // model.name comes from inside the (caller-supplied) library. Reduce
+            // it to a bare filename so a crafted name cannot use an absolute path
+            // or ".." segments to escape out_dir via Path::join, then re-validate
+            // the resolved path against the allow-list (defence in depth).
+            let Some(safe_name) = std::path::Path::new(&model.name).file_name() else {
+                errors.push(json!({
+                    "id": model.id,
+                    "name": model.name,
+                    "error": "model name has no usable file component; skipped",
+                }));
+                continue;
+            };
+            let output_file = out_dir.join(safe_name);
+            if let Err(e) = self.validate_path(&output_file.to_string_lossy()) {
+                errors.push(json!({
+                    "id": model.id,
+                    "name": model.name,
+                    "error": e,
+                }));
+                continue;
+            }
             match std::fs::write(&output_file, &model.data) {
                 Ok(()) => {
                     extracted.push(json!({
@@ -274,6 +295,7 @@ impl McpServer {
 
     /// Extracts STEP models used by a specific footprint.
     pub(crate) fn extract_step_by_footprint(
+        &self,
         filepath: &str,
         output_path: Option<&str>,
         library: &crate::altium::PcbLib,
@@ -355,7 +377,7 @@ impl McpServer {
             Self::extract_model_output(filepath, output_path, matching_models[0])
         } else if let Some(out_dir) = output_path {
             // Multiple models - extract to directory
-            Self::extract_all_step_models(filepath, Some(out_dir), &matching_models)
+            self.extract_all_step_models(filepath, Some(out_dir), &matching_models)
         } else {
             // Multiple models, no output - return info
             let model_info: Vec<Value> = matching_models


### PR DESCRIPTION
A path-traversal (CWE-22) audit of **every** MCP filesystem sink found two real, confirmed gaps — both in the STEP-model code paths. All other ~40 caller-controlled sinks already validate via `validate_path` before access, and `validate_path` itself is correct (fail-closed allow-list, canonicalises to resolve `..`/symlinks, `starts_with`).

## GAP A — arbitrary file read (HIGH)
`write_pcblib` validated only the library `filepath`, **not** a footprint's `step_model.filepath`. With `embed: true`, that path is read from disk at save time (`prepare_3d_models_for_writing` → `std::fs::read`), so a caller could embed any server-readable file — e.g. `"../../../etc/passwd"` — into the output `.PcbLib` (arbitrary read / exfiltration + a file-existence oracle).

**Fix:** validate the embed source against the allow-list at the handler, before it is stored into `Model3D`. External references (`embed: false`) are only stored as a string and never read by us, so they stay ungated — validating them would break legitimate out-of-tree references with no security benefit.

## GAP B — arbitrary file write (HIGH)
`extract_all_step_models` built the output path as `out_dir.join(model.name)`, where `model.name` comes from inside the **caller-supplied** library. `Path::join` discards the base when the joined segment is absolute (`/etc/cron.d/x`), and `..` segments climb above `out_dir`; the result was never re-validated → write outside the allow-list.

**Fix:** reduce `model.name` to a bare filename (`Path::file_name`; skip-with-error if none) so it cannot escape, then re-validate the resolved path against the allow-list (defence in depth). `extract_all_step_models` / `extract_step_by_footprint` are now `&self`.

## Path-leak hardening
`prepare_3d_models_for_writing`'s "STEP file not found" **client error** and its tracing now surface only the bare file name, never the caller's full path (sanitisation rule).

## Tests / verification
- New regression tests: `write_pcblib_rejects_embed_source_outside_allowlist` (GAP A) and `extract_all_step_models_sanitises_malicious_model_name` (GAP B).
- `clippy -D warnings` clean · full suite **221 lib + integration green** · **oracle 13/13 (0 regressions)** · E2E 25/25.

## Follow-up (not in this PR)
The audit's systemic suggestion — a validate-then-IO choke point (e.g. `write_file`/`open_pcblib` helpers, or a validation closure threaded into the altium layer) so a new unvalidated sink is hard to add — is worth a separate refactor. The per-handler pattern is correct everywhere now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)