### PR TITLE
refactor(altium): unify OLE read/save plumbing + param parsing + PcbLib units/flags (pt.4)

### DIFF
--- a/src/altium/framing.rs
+++ b/src/altium/framing.rs
@@ -46,6 +46,42 @@ pub fn write_pascal_string(record: &mut Vec<u8>, bytes: &[u8]) {
     record.extend_from_slice(bytes);
 }
 
+/// Reads a length-prefixed binary block written by [`write_block`]:
+/// `[u32 LE length][bytes]`.
+///
+/// Returns the inner slice and the offset just past it, or `None` if the
+/// length prefix or payload runs past the end of `data`. Imposes **no** size
+/// cap — callers that need a sanity limit apply it themselves.
+#[must_use]
+pub fn read_block(data: &[u8], offset: usize) -> Option<(&[u8], usize)> {
+    let len = crate::altium::bytes::read_u32_le(data, offset)? as usize;
+    let end = offset + 4 + len;
+    if end > data.len() {
+        return None;
+    }
+    Some((&data[offset + 4..end], end))
+}
+
+/// Reads a Pascal short string written by [`write_pascal_string`]:
+/// `[u8 length][win1252 bytes]` at `offset`.
+///
+/// Returns the decoded string and the offset just past the field
+/// (`offset + 1 + length`). A length byte that is missing or whose bytes run
+/// out of bounds yields an empty string; the offset still advances past the
+/// declared length so callers stepping through fixed records stay aligned.
+#[must_use]
+pub fn read_pascal_string(data: &[u8], offset: usize) -> (String, usize) {
+    let len = data.get(offset).copied().unwrap_or(0) as usize;
+    let start = offset + 1;
+    let end = start + len;
+    let s = if len > 0 && end <= data.len() {
+        crate::altium::decode_windows1252(&data[start..end])
+    } else {
+        String::new()
+    };
+    (s, end)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -189,6 +189,86 @@ pub(crate) fn write_stream<F: std::io::Read + std::io::Write + std::io::Seek>(
     Ok(())
 }
 
+/// Opens the OLE stream at `path` and reads it fully into a `Vec`.
+///
+/// Returns `None` if the stream is absent or cannot be opened/read — the
+/// read-side counterpart of [`write_stream`]. `path` is an internal OLE path,
+/// not a filesystem path.
+pub(crate) fn read_stream_opt<F, P>(cfb: &mut cfb::CompoundFile<F>, path: P) -> Option<Vec<u8>>
+where
+    F: std::io::Read + std::io::Seek,
+    P: AsRef<std::path::Path>,
+{
+    let path = path.as_ref();
+    if !cfb.is_stream(path) {
+        return None;
+    }
+    let mut stream = cfb.open_stream(path).ok()?;
+    let mut data = Vec::new();
+    std::io::Read::read_to_end(&mut stream, &mut data).ok()?;
+    Some(data)
+}
+
+/// Creates an OLE storage at `path`, wrapping failures as `invalid_ole`.
+///
+/// The storage-creation mirror of [`write_stream`]. `path` is an internal OLE
+/// path. Callers that must guard against an already-existing storage check
+/// `cfb.exists(path)` themselves.
+pub(crate) fn create_storage<F: std::io::Read + std::io::Write + std::io::Seek>(
+    cfb: &mut cfb::CompoundFile<F>,
+    path: &str,
+) -> AltiumResult<()> {
+    cfb.create_storage(path)
+        .map_err(|e| AltiumError::invalid_ole(format!("Failed to create storage {path}: {e}")))?;
+    Ok(())
+}
+
+/// Writes a library to `path` atomically.
+///
+/// Serialises into a sibling temp file (named with `tmp_ext`) via `write`, then
+/// renames it over the destination, so a failed or partial write never clobbers
+/// an existing file. The temp file is removed on any failure. Shared by both
+/// library writers — they differ only in the temp extension and whether
+/// serialisation needs `&mut self`, both captured by `write`.
+pub(crate) fn save_atomic(
+    path: &std::path::Path,
+    tmp_ext: &str,
+    write: impl FnOnce(std::fs::File) -> AltiumResult<()>,
+) -> AltiumResult<()> {
+    // Temp file in the same directory ensures the rename stays on one filesystem.
+    let temp_path = path.with_extension(tmp_ext);
+
+    let file =
+        std::fs::File::create(&temp_path).map_err(|e| AltiumError::file_write(&temp_path, e))?;
+
+    // Attempt to write; clean up the temp file on failure.
+    if let Err(e) = write(file) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(e);
+    }
+
+    // Atomically rename the temp file over the target (overwrites existing).
+    std::fs::rename(&temp_path, path).map_err(|e| {
+        let _ = std::fs::remove_file(&temp_path);
+        AltiumError::file_write(path, e)
+    })?;
+
+    Ok(())
+}
+
+/// Parses a pipe-delimited `KEY=VALUE` parameter string into a map, lowercasing
+/// keys (values kept verbatim). Segments that are empty or lack `=` are skipped;
+/// duplicate keys keep the last value. Used by `SchLib`'s text/property records.
+pub(crate) fn parse_pipe_params(text: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for part in text.split('|') {
+        if let Some((key, value)) = part.split_once('=') {
+            map.insert(key.to_lowercase(), value.to_string());
+        }
+    }
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/altium/pcblib/flags.rs
+++ b/src/altium/pcblib/flags.rs
@@ -1,0 +1,17 @@
+//! Altium `PcbLib` primitive flag-word bits (common-header bytes 1–2).
+//!
+//! Shared by the writer's `encode_altium_flags` and the reader's `read_flags`
+//! so the bit values are defined once instead of copied into both. These are
+//! `PcbLib`-specific — `SchLib` pins use a different, unrelated 8-bit flag
+//! table, so they intentionally do not live in `crate::altium`.
+
+/// `FlagUnlocked` — set unless the primitive is locked.
+pub(super) const ALT_FLAG_UNLOCKED: u16 = 0x0004;
+/// `FlagSaved` — always set on a saved primitive (writer-side only).
+pub(super) const ALT_FLAG_SAVED: u16 = 0x0008;
+/// Solder-mask tenting on the top layer.
+pub(super) const ALT_FLAG_TENTING_TOP: u16 = 0x0020;
+/// Solder-mask tenting on the bottom layer.
+pub(super) const ALT_FLAG_TENTING_BOTTOM: u16 = 0x0040;
+/// Keepout primitive.
+pub(super) const ALT_FLAG_KEEPOUT: u16 = 0x0200;

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -32,8 +32,10 @@
 //!
 //! Record types: Arc(1), Pad(2), Via(3), Track(4), Text(5), Fill(6), Region(11), ComponentBody(12)
 
+mod flags;
 pub mod primitives;
 mod reader;
+mod units;
 mod writer;
 
 use serde::{Deserialize, Serialize};
@@ -437,19 +439,9 @@ impl PcbLib {
     ) -> AltiumResult<LibraryMetadata> {
         let mut metadata = LibraryMetadata::default();
 
-        let header_path = std::path::Path::new("/FileHeader");
-        if !cfb.is_stream(header_path) {
-            return Ok(metadata);
-        }
-
-        let Ok(mut stream) = cfb.open_stream(header_path) else {
+        let Some(data) = crate::altium::read_stream_opt(cfb, "/FileHeader") else {
             return Ok(metadata);
         };
-
-        let mut data = Vec::new();
-        if std::io::Read::read_to_end(&mut stream, &mut data).is_err() {
-            return Ok(metadata);
-        }
 
         // Try binary version string format first:
         // [string_len:4 LE u32][string_len:1 u8][string_data]
@@ -543,19 +535,9 @@ impl PcbLib {
         cfb: &mut cfb::CompoundFile<F>,
         metadata: &mut LibraryMetadata,
     ) {
-        let data_path = std::path::Path::new("/Library/Data");
-        if !cfb.is_stream(data_path) {
-            return;
-        }
-
-        let Ok(mut stream) = cfb.open_stream(data_path) else {
+        let Some(data) = crate::altium::read_stream_opt(cfb, "/Library/Data") else {
             return;
         };
-
-        let mut data = Vec::new();
-        if std::io::Read::read_to_end(&mut stream, &mut data).is_err() {
-            return;
-        }
 
         if data.len() < 8 {
             return;
@@ -628,19 +610,9 @@ impl PcbLib {
     /// similar to other Altium streams. Known fields:
     /// - `UNIQUEIDPRIMITIVEINFORMATION{N}`: Primitive unique ID mappings
     fn read_storage_stream<F: std::io::Read + std::io::Seek>(cfb: &mut cfb::CompoundFile<F>) {
-        let storage_path = std::path::Path::new("/Storage");
-        if !cfb.is_stream(storage_path) {
-            return;
-        }
-
-        let Ok(mut stream) = cfb.open_stream(storage_path) else {
+        let Some(data) = crate::altium::read_stream_opt(cfb, "/Storage") else {
             return;
         };
-
-        let mut data = Vec::new();
-        if std::io::Read::read_to_end(&mut stream, &mut data).is_err() {
-            return;
-        }
 
         // Storage stream is typically ASCII text with pipe-delimited key=value pairs
         if let Ok(text) = String::from_utf8(data) {
@@ -659,14 +631,8 @@ impl PcbLib {
     fn read_wide_strings<F: std::io::Read + std::io::Seek>(
         cfb: &mut cfb::CompoundFile<F>,
     ) -> reader::WideStrings {
-        let wide_strings_path = std::path::Path::new("/WideStrings");
-        if cfb.is_stream(wide_strings_path) {
-            if let Ok(mut stream) = cfb.open_stream(wide_strings_path) {
-                let mut data = Vec::new();
-                if std::io::Read::read_to_end(&mut stream, &mut data).is_ok() {
-                    return reader::parse_wide_strings(&data);
-                }
-            }
+        if let Some(data) = crate::altium::read_stream_opt(cfb, "/WideStrings") {
+            return reader::parse_wide_strings(&data);
         }
         reader::WideStrings::new()
     }
@@ -688,32 +654,13 @@ impl PcbLib {
 
         // Read Header to get model count
         let header_path = models_storage.join("Header");
-        let model_count = cfb
-            .is_stream(&header_path)
-            .then(|| {
-                cfb.open_stream(&header_path).ok().and_then(|mut stream| {
-                    let mut data = Vec::new();
-                    std::io::Read::read_to_end(&mut stream, &mut data)
-                        .ok()
-                        .map(|_| reader::parse_model_header_stream(&data))
-                })
-            })
-            .flatten()
-            .unwrap_or(0);
+        let model_count = crate::altium::read_stream_opt(cfb, &header_path)
+            .map_or(0, |data| reader::parse_model_header_stream(&data));
 
         // Read Data stream to get GUID-to-index mapping
         let data_path = models_storage.join("Data");
-        let model_index = cfb
-            .is_stream(&data_path)
-            .then(|| {
-                cfb.open_stream(&data_path).ok().and_then(|mut stream| {
-                    let mut data = Vec::new();
-                    std::io::Read::read_to_end(&mut stream, &mut data)
-                        .ok()
-                        .map(|_| reader::parse_model_data_stream(&data))
-                })
-            })
-            .flatten()
+        let model_index = crate::altium::read_stream_opt(cfb, &data_path)
+            .map(|data| reader::parse_model_data_stream(&data))
             .unwrap_or_default();
 
         if model_index.is_empty() {
@@ -739,18 +686,13 @@ impl PcbLib {
         // Model streams are numbered 0, 1, 2, ...
         for idx in 0..max_index {
             let stream_path = models_storage.join(idx.to_string());
-            if cfb.is_stream(&stream_path) {
-                if let Ok(mut stream) = cfb.open_stream(&stream_path) {
-                    let mut data = Vec::new();
-                    if std::io::Read::read_to_end(&mut stream, &mut data).is_ok() {
-                        tracing::trace!(
-                            index = idx,
-                            size = data.len(),
-                            "Read compressed model stream"
-                        );
-                        model_data.push((idx, data));
-                    }
-                }
+            if let Some(data) = crate::altium::read_stream_opt(cfb, &stream_path) {
+                tracing::trace!(
+                    index = idx,
+                    size = data.len(),
+                    "Read compressed model stream"
+                );
+                model_data.push((idx, data));
             }
             // Don't break early - indices might not be sequential
         }
@@ -771,13 +713,8 @@ impl PcbLib {
 
         // Read parameters if present
         let params_path = storage_path.join("Parameters");
-        if cfb.is_stream(&params_path) {
-            if let Ok(mut stream) = cfb.open_stream(&params_path) {
-                let mut params_data = Vec::new();
-                if std::io::Read::read_to_end(&mut stream, &mut params_data).is_ok() {
-                    Self::parse_parameters(&mut footprint, &params_data);
-                }
-            }
+        if let Some(params_data) = crate::altium::read_stream_opt(cfb, &params_path) {
+            Self::parse_parameters(&mut footprint, &params_data);
         }
 
         // Read Data stream (contains primitives)
@@ -796,14 +733,9 @@ impl PcbLib {
 
         // Read UniqueIDPrimitiveInformation stream if present (contains unique IDs for primitives)
         let unique_id_path = storage_path.join("UniqueIDPrimitiveInformation/Data");
-        if cfb.is_stream(&unique_id_path) {
-            if let Ok(mut stream) = cfb.open_stream(&unique_id_path) {
-                let mut uid_data = Vec::new();
-                if std::io::Read::read_to_end(&mut stream, &mut uid_data).is_ok() {
-                    let unique_ids = reader::parse_unique_id_stream(&uid_data);
-                    reader::apply_unique_ids(&mut footprint, &unique_ids);
-                }
-            }
+        if let Some(uid_data) = crate::altium::read_stream_opt(cfb, &unique_id_path) {
+            let unique_ids = reader::parse_unique_id_stream(&uid_data);
+            reader::apply_unique_ids(&mut footprint, &unique_ids);
         }
 
         Ok(footprint)
@@ -880,28 +812,7 @@ impl PcbLib {
     ///
     /// Returns an error if the file cannot be written.
     pub fn save(&mut self, path: impl AsRef<std::path::Path>) -> AltiumResult<()> {
-        let path = path.as_ref();
-
-        // Create temp file path in the same directory (ensures same filesystem for rename)
-        let temp_path = path.with_extension("pcblib.tmp");
-
-        // Write to temp file
-        let file = std::fs::File::create(&temp_path)
-            .map_err(|e| AltiumError::file_write(&temp_path, e))?;
-
-        // Attempt to write; clean up temp file on failure
-        if let Err(e) = self.write(file) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(e);
-        }
-
-        // Atomically rename temp file to target (overwrites existing)
-        std::fs::rename(&temp_path, path).map_err(|e| {
-            let _ = std::fs::remove_file(&temp_path);
-            AltiumError::file_write(path, e)
-        })?;
-
-        Ok(())
+        crate::altium::save_atomic(path.as_ref(), "pcblib.tmp", |file| self.write(file))
     }
 
     /// Writes the library to any writer implementing `Read + Write + Seek`.
@@ -1090,15 +1001,11 @@ impl PcbLib {
 
         // Create /Library storage if it doesn't exist
         if !cfb.exists("/Library") {
-            cfb.create_storage("/Library").map_err(|e| {
-                AltiumError::invalid_ole(format!("Failed to create Library storage: {e}"))
-            })?;
+            crate::altium::create_storage(cfb, "/Library")?;
         }
 
         // Create /Library/Models storage
-        cfb.create_storage("/Library/Models").map_err(|e| {
-            AltiumError::invalid_ole(format!("Failed to create Models storage: {e}"))
-        })?;
+        crate::altium::create_storage(cfb, "/Library/Models")?;
 
         // Write Header stream
         let header_data = writer::encode_model_header_stream(self.models.len());
@@ -1186,9 +1093,7 @@ impl PcbLib {
         ole_names: &[String],
     ) -> AltiumResult<()> {
         // Create /Library storage
-        cfb.create_storage("/Library").map_err(|e| {
-            AltiumError::invalid_ole(format!("Failed to create Library storage: {e}"))
-        })?;
+        crate::altium::create_storage(cfb, "/Library")?;
 
         // Write Library/Header (record count = 1)
         crate::altium::write_stream(cfb, "/Library/Header", &1u32.to_le_bytes())?;
@@ -1243,8 +1148,7 @@ impl PcbLib {
         header_count: u32,
         data: &[u8],
     ) -> AltiumResult<()> {
-        cfb.create_storage(path)
-            .map_err(|e| AltiumError::invalid_ole(format!("Failed to create {path}: {e}")))?;
+        crate::altium::create_storage(cfb, path)?;
         crate::altium::write_stream(cfb, &format!("{path}/Header"), &header_count.to_le_bytes())?;
         crate::altium::write_stream(cfb, &format!("{path}/Data"), data)?;
         Ok(())
@@ -1378,8 +1282,7 @@ impl PcbLib {
         let storage_path = format!("/{ole_name}");
 
         // Create storage for the footprint
-        cfb.create_storage(&storage_path)
-            .map_err(|e| AltiumError::invalid_ole(format!("Failed to create storage: {e}")))?;
+        crate::altium::create_storage(cfb, &storage_path)?;
 
         // Write Header stream (4-byte primitive count)
         let header_data = writer::encode_component_header(footprint);
@@ -1415,11 +1318,7 @@ impl PcbLib {
         if let Some(uid_data) = writer::encode_unique_id_stream(footprint) {
             // Create UniqueIDPrimitiveInformation storage
             let uid_storage_path = format!("{storage_path}/UniqueIDPrimitiveInformation");
-            cfb.create_storage(&uid_storage_path).map_err(|e| {
-                AltiumError::invalid_ole(format!(
-                    "Failed to create UniqueIDPrimitiveInformation storage: {e}"
-                ))
-            })?;
+            crate::altium::create_storage(cfb, &uid_storage_path)?;
 
             // Write Header + Data streams.
             let uid_header_data = writer::encode_unique_id_header(footprint);

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -362,28 +362,22 @@ fn to_mm(internal: i32) -> f64 {
 
 /// Reads a length-prefixed block from data.
 /// Returns the block data and the new offset.
+///
+/// Wraps the shared [`crate::altium::framing::read_block`] frame with a
+/// `PcbLib`-side 100 kB sanity cap to reject corrupt/oversized length prefixes.
 fn read_block(data: &[u8], offset: usize) -> Option<(&[u8], usize)> {
-    let block_len = read_u32(data, offset)? as usize;
-    if block_len > 100_000 || offset + 4 + block_len > data.len() {
+    let (block, next) = crate::altium::framing::read_block(data, offset)?;
+    if block.len() > 100_000 {
         return None;
     }
-    Some((
-        &data[offset + 4..offset + 4 + block_len],
-        offset + 4 + block_len,
-    ))
+    Some((block, next))
 }
 
 /// Reads a length-prefixed string from block data.
 fn read_string_from_block(block: &[u8]) -> String {
-    if block.is_empty() {
-        return String::new();
-    }
-    let str_len = block[0] as usize;
-    if str_len + 1 > block.len() {
-        return String::new();
-    }
-    // Altium stores strings as Windows-1252 (pairs with `write_string_block`).
-    crate::altium::decode_windows1252(&block[1..=str_len])
+    // Pascal short string at the start of the block; Altium stores strings as
+    // Windows-1252 (pairs with `write_string_block`).
+    crate::altium::framing::read_pascal_string(block, 0).0
 }
 
 const ALT_FLAG_UNLOCKED: u16 = 0x0004;

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -348,17 +348,9 @@ pub fn apply_unique_ids(footprint: &mut Footprint, unique_ids: &UniqueIdMap) {
     );
 }
 
-/// Conversion factor from Altium internal units to millimetres.
-/// Internal units: 10000 = 1 mil = 0.0254 mm
-const INTERNAL_UNITS_TO_MM: f64 = 0.0254 / 10000.0;
-
-/// Converts Altium internal units to millimetres.
-/// Rounds to 6 decimal places (1nm resolution) to avoid floating-point noise.
-fn to_mm(internal: i32) -> f64 {
-    let raw = f64::from(internal) * INTERNAL_UNITS_TO_MM;
-    // Round to 6 decimal places (1nm = 0.000001mm) to avoid precision artifacts
-    (raw * 1_000_000.0).round() / 1_000_000.0
-}
+// Unit conversions live in `super::units` so the writer and reader share one
+// definition of the PcbLib scale (10000 = 1 mil = 0.0254 mm).
+use super::units::{to_mm, INTERNAL_UNITS_TO_MM, MM_PER_MIL};
 
 /// Reads a length-prefixed block from data.
 /// Returns the block data and the new offset.
@@ -380,10 +372,10 @@ fn read_string_from_block(block: &[u8]) -> String {
     crate::altium::framing::read_pascal_string(block, 0).0
 }
 
-const ALT_FLAG_UNLOCKED: u16 = 0x0004;
-const ALT_FLAG_TENTING_TOP: u16 = 0x0020;
-const ALT_FLAG_TENTING_BOTTOM: u16 = 0x0040;
-const ALT_FLAG_KEEPOUT: u16 = 0x0200;
+// Flag bits shared with the writer via `super::flags`.
+use super::flags::{
+    ALT_FLAG_KEEPOUT, ALT_FLAG_TENTING_BOTTOM, ALT_FLAG_TENTING_TOP, ALT_FLAG_UNLOCKED,
+};
 
 /// Reads PCB flags from the common header bytes 1-2.
 ///
@@ -1930,7 +1922,7 @@ fn parse_mil_value(s: Option<&str>) -> f64 {
 
     // Remove "mil" suffix if present
     let numeric = s.trim_end_matches("mil").trim();
-    numeric.parse::<f64>().map_or(0.0, |v| v * 0.0254) // Convert mils to mm
+    numeric.parse::<f64>().map_or(0.0, |v| v * MM_PER_MIL) // Convert mils to mm
 }
 
 /// Parses `V7_LAYER` string (e.g., "MECHANICAL6") to Layer enum.

--- a/src/altium/pcblib/units.rs
+++ b/src/altium/pcblib/units.rs
@@ -1,0 +1,35 @@
+//! `PcbLib` coordinate and unit conversions.
+//!
+//! Altium `PcbLib` internal units: `10000 = 1 mil = 0.0254 mm`. Centralising the
+//! scale here gives the writer and reader a single source of truth instead of
+//! each hard-coding `0.0254`/`10000`. These helpers are `PcbLib`-specific —
+//! `SchLib` stores coordinates as ASCII decimals in raw grid units and must
+//! NEVER be routed through them.
+
+/// One mil in millimetres.
+pub(super) const MM_PER_MIL: f64 = 0.0254;
+
+/// Conversion factor from millimetres to Altium internal units (`10000 = 1 mil`).
+pub(super) const MM_TO_INTERNAL_UNITS: f64 = 10000.0 / MM_PER_MIL;
+
+/// Conversion factor from Altium internal units to millimetres.
+pub(super) const INTERNAL_UNITS_TO_MM: f64 = MM_PER_MIL / 10000.0;
+
+/// Converts millimetres to Altium internal units (rounded to the nearest unit).
+#[allow(clippy::cast_possible_truncation)] // Intentional: PCB coordinates fit in i32
+pub(super) fn from_mm(mm: f64) -> i32 {
+    (mm * MM_TO_INTERNAL_UNITS).round() as i32
+}
+
+/// Converts Altium internal units to millimetres.
+///
+/// Rounds to 6 decimal places (1 nm resolution) to avoid floating-point noise.
+pub(super) fn to_mm(internal: i32) -> f64 {
+    let raw = f64::from(internal) * INTERNAL_UNITS_TO_MM;
+    (raw * 1_000_000.0).round() / 1_000_000.0
+}
+
+/// Converts millimetres to mils (for parameter strings).
+pub(super) fn mm_to_mil(mm: f64) -> f64 {
+    mm / MM_PER_MIL
+}

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -19,15 +19,7 @@ use super::primitives::{
 };
 use super::Footprint;
 
-/// Conversion factor from millimetres to Altium internal units.
-/// Internal units: 10000 = 1 mil = 0.0254 mm
-const MM_TO_INTERNAL_UNITS: f64 = 10000.0 / 0.0254;
-
-/// Converts millimetres to Altium internal units.
-#[allow(clippy::cast_possible_truncation)] // Intentional: PCB coordinates fit in i32
-fn from_mm(mm: f64) -> i32 {
-    (mm * MM_TO_INTERNAL_UNITS).round() as i32
-}
+use super::units::{from_mm, mm_to_mil, MM_TO_INTERNAL_UNITS};
 
 /// Writes a 4-byte little-endian unsigned integer.
 fn write_u32(data: &mut Vec<u8>, value: u32) {
@@ -224,12 +216,11 @@ const fn pad_shape_to_id(shape: PadShape) -> u8 {
 // them is a follow-up. Offset 61 of the main block is reserved (0x00).
 
 // Altium primitive flag bits (PcbBinaryConstants), distinct from our internal
-// `PcbFlags` bit layout.
-const ALT_FLAG_UNLOCKED: u16 = 0x0004;
-const ALT_FLAG_SAVED: u16 = 0x0008;
-const ALT_FLAG_TENTING_TOP: u16 = 0x0020;
-const ALT_FLAG_TENTING_BOTTOM: u16 = 0x0040;
-const ALT_FLAG_KEEPOUT: u16 = 0x0200;
+// `PcbFlags` bit layout — shared with the reader via `super::flags`.
+use super::flags::{
+    ALT_FLAG_KEEPOUT, ALT_FLAG_SAVED, ALT_FLAG_TENTING_BOTTOM, ALT_FLAG_TENTING_TOP,
+    ALT_FLAG_UNLOCKED,
+};
 
 /// Encodes our internal `PcbFlags` into Altium's on-disk flag word.
 ///
@@ -1182,11 +1173,6 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     params.push("MODEL.MODELSOURCE=Undefined".to_string());
 
     params.join("|")
-}
-
-/// Converts mm to mils for parameter strings.
-fn mm_to_mil(mm: f64) -> f64 {
-    mm / 0.0254
 }
 
 // =============================================================================

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -278,28 +278,7 @@ impl SchLib {
     ///
     /// Returns an error if the file cannot be written.
     pub fn save(&self, path: impl AsRef<Path>) -> AltiumResult<()> {
-        let path = path.as_ref();
-
-        // Create temp file path in the same directory (ensures same filesystem for rename)
-        let temp_path = path.with_extension("schlib.tmp");
-
-        // Write to temp file
-        let file = std::fs::File::create(&temp_path)
-            .map_err(|e| AltiumError::file_write(&temp_path, e))?;
-
-        // Attempt to write; clean up temp file on failure
-        if let Err(e) = self.write(file) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(e);
-        }
-
-        // Atomically rename temp file to target (overwrites existing)
-        std::fs::rename(&temp_path, path).map_err(|e| {
-            let _ = std::fs::remove_file(&temp_path);
-            AltiumError::file_write(path, e)
-        })?;
-
-        Ok(())
+        crate::altium::save_atomic(path.as_ref(), "schlib.tmp", |file| self.write(file))
     }
 
     /// Writes the library to any writer implementing `Read + Write + Seek`.
@@ -323,9 +302,7 @@ impl SchLib {
 
         // One Data stream per symbol, under its own storage.
         for (symbol, ole_name) in symbols.iter().zip(ole_names.iter()) {
-            cfb.create_storage(format!("/{ole_name}")).map_err(|e| {
-                AltiumError::invalid_ole(format!("Failed to create storage /{ole_name}: {e}"))
-            })?;
+            crate::altium::create_storage(&mut cfb, &format!("/{ole_name}"))?;
             let data = writer::encode_data_stream(symbol)?;
             crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/Data"), &data)?;
         }
@@ -571,13 +548,7 @@ fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<F
     // padding) before splitting so values don't carry a stray '\0'.
     let text = String::from_utf8_lossy(&data[4..4 + length]);
     let text = text.trim_end_matches('\u{0}');
-    let mut props: HashMap<String, String> = HashMap::new();
-
-    for part in text.split('|') {
-        if let Some((key, value)) = part.split_once('=') {
-            props.insert(key.to_lowercase(), value.to_string());
-        }
-    }
+    let props = crate::altium::parse_pipe_params(text);
 
     // Validate file type - must be a Schematic Library
     if let Some(header) = props.get("header") {

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -280,14 +280,8 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     offset += 4;
 
     // description: Pascal short string [length:1][string]
-    let desc_len = data.get(offset).copied().unwrap_or(0) as usize;
-    offset += 1;
-    let description = if desc_len > 0 && offset + desc_len <= data.len() {
-        crate::altium::decode_windows1252(&data[offset..offset + desc_len])
-    } else {
-        String::new()
-    };
-    offset += desc_len;
+    let (description, next) = crate::altium::framing::read_pascal_string(data, offset);
+    offset = next;
 
     // formal_type (1 byte) - unused
     offset += 1;
@@ -322,23 +316,11 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     offset += 4;
 
     // name: [length:1][string]
-    let name_len = data.get(offset).copied().unwrap_or(0) as usize;
-    offset += 1;
-    let name = if name_len > 0 && offset + name_len <= data.len() {
-        crate::altium::decode_windows1252(&data[offset..offset + name_len])
-    } else {
-        String::new()
-    };
-    offset += name_len;
+    let (name, next) = crate::altium::framing::read_pascal_string(data, offset);
+    offset = next;
 
     // designator: [length:1][string]
-    let desig_len = data.get(offset).copied().unwrap_or(0) as usize;
-    offset += 1;
-    let designator = if desig_len > 0 && offset + desig_len <= data.len() {
-        crate::altium::decode_windows1252(&data[offset..offset + desig_len])
-    } else {
-        String::new()
-    };
+    let (designator, _) = crate::altium::framing::read_pascal_string(data, offset);
 
     Some(Pin {
         name,

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -237,17 +237,10 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
     }
 }
 
-/// Parses pipe-delimited key=value properties.
+/// Parses pipe-delimited key=value properties (shared with the rest of the
+/// crate via [`crate::altium::parse_pipe_params`]).
 fn parse_properties(text: &str) -> HashMap<String, String> {
-    let mut props = HashMap::new();
-
-    for part in text.split('|') {
-        if let Some((key, value)) = part.split_once('=') {
-            props.insert(key.to_lowercase(), value.to_string());
-        }
-    }
-
-    props
+    crate::altium::parse_pipe_params(text)
 }
 
 /// Parses a binary pin record.


### PR DESCRIPTION
Continues the PcbLib/SchLib de-duplication (pt.4), from a 6-dimension dedup audit that distinguished genuinely-safe shared plumbing from format-divergent code that must stay separate. **All byte-safe** — no emitted/parsed byte changes (oracle 13/13, round-trip + full suite + E2E green).

## Shared into `crate::altium` / `framing`
| Helper | What it replaces |
|--------|------------------|
| `framing::read_block` / `read_pascal_string` | read-side inverses of `write_block`/`write_pascal_string`; PcbLib `read_block`/`read_string_from_block` + SchLib's 3 pin Pascal-string reads |
| `read_stream_opt` | 9 hand-rolled `is_stream`+`open_stream`+`read_to_end` blocks in PcbLib (mirror of `write_stream`) |
| `save_atomic` | the temp-write+rename+cleanup dance duplicated verbatim by `PcbLib::save` and `SchLib::save` |
| `create_storage` | create-storage error wrapper; 6 PcbLib + 1 SchLib sites |
| `parse_pipe_params` | the lowercase `\|KEY=VALUE\|` → map parser SchLib had in two places |

## PcbLib-internal (writer ↔ reader copy-paste)
- **`pcblib::units`** — single source for the `10000 = 1 mil = 0.0254 mm` scale (`MM_TO_INTERNAL_UNITS`/`INTERNAL_UNITS_TO_MM`/`MM_PER_MIL` + `from_mm`/`to_mm`/`mm_to_mil`), previously hard-coded in both writer and reader.
- **`pcblib::flags`** — the `ALT_FLAG_*` bit values, previously declared in both the encoder and decoder.

## Left divergent by design
Per-record `|KEY=VALUE|` builders (disjoint key sets, leading-pipe policy), FileHeader layouts, record-dispatch loops, coordinate encodings, and enum↔id tables are the on-disk byte contract and stay per-module. SchLib coordinates/flags are deliberately **not** routed through the PcbLib `units`/`flags` helpers (different scale and bit table). The `?`-propagating footprint `Data` stream keeps its distinct error semantics rather than using the silent `read_stream_opt`.

## Verification
`cargo build` · `clippy -D warnings` · full suite · **oracle 13/13 (0 regressions)** · E2E 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)