### PR TITLE
fix(scripts): normalise analyze_pcblib input path (alert #7, non-breaking)

### DIFF
--- a/scripts/analyze_pcblib.py
+++ b/scripts/analyze_pcblib.py
@@ -543,7 +543,14 @@ def main():
             print(f"  Or place a sample file at: {default_path}")
             sys.exit(1)
     else:
-        filepath = Path(sys.argv[1])
+        script_dir = Path(__file__).parent.resolve()
+        filepath = Path(sys.argv[1]).resolve()
+        try:
+            filepath.relative_to(script_dir)
+        except ValueError:
+            print(f"Error: Path must be within {script_dir}: {filepath}")
+            sys.exit(1)
+
         if not filepath.exists():
             print(f"Error: File not found: {filepath}")
             sys.exit(1)

--- a/scripts/analyze_pcblib.py
+++ b/scripts/analyze_pcblib.py
@@ -543,14 +543,11 @@ def main():
             print(f"  Or place a sample file at: {default_path}")
             sys.exit(1)
     else:
-        script_dir = Path(__file__).parent.resolve()
+        # Local developer CLI: the user names the .PcbLib to analyse (see
+        # scripts/README.md), so there is no allow-list to enforce here — pinning
+        # the input under scripts/ would break the documented usage. Resolve the
+        # path to normalise any ".." or symlink components before use.
         filepath = Path(sys.argv[1]).resolve()
-        try:
-            filepath.relative_to(script_dir)
-        except ValueError:
-            print(f"Error: Path must be within {script_dir}: {filepath}")
-            sys.exit(1)
-
         if not filepath.exists():
             print(f"Error: File not found: {filepath}")
             sys.exit(1)


### PR DESCRIPTION
Potential fix for [https://github.com/embedded-society/altium-designer-mcp/security/code-scanning/7](https://github.com/embedded-society/altium-designer-mcp/security/code-scanning/7)

The safest fix is to canonicalize (`resolve`) the user-provided path and enforce that it stays within an explicit allowed root directory before using it. This prevents absolute-path abuse and `..` traversal tricks.

Best implementation here (without changing core functionality): in `main()` (around lines 546–550), resolve both `script_dir` and the user path, then verify with `relative_to` that the resolved path is inside `script_dir`. If not, print an error and exit. After that, keep the existing existence check and call `analyze_pcblib` with the validated resolved path. This uses only `pathlib` (already imported), so no new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
