### PR TITLE
refactor: address GitHub AI code-quality findings

### DIFF
--- a/src/altium/pcblib/units.rs
+++ b/src/altium/pcblib/units.rs
@@ -15,6 +15,10 @@ pub(super) const MM_TO_INTERNAL_UNITS: f64 = 10000.0 / MM_PER_MIL;
 /// Conversion factor from Altium internal units to millimetres.
 pub(super) const INTERNAL_UNITS_TO_MM: f64 = MM_PER_MIL / 10000.0;
 
+/// Multiplier for rounding millimetres to 6 decimal places (1 nm resolution),
+/// used to strip floating-point noise from converted coordinates.
+pub(super) const MM_ROUNDING_MULTIPLIER: f64 = 1_000_000.0;
+
 /// Converts millimetres to Altium internal units (rounded to the nearest unit).
 #[allow(clippy::cast_possible_truncation)] // Intentional: PCB coordinates fit in i32
 pub(super) fn from_mm(mm: f64) -> i32 {
@@ -26,7 +30,7 @@ pub(super) fn from_mm(mm: f64) -> i32 {
 /// Rounds to 6 decimal places (1 nm resolution) to avoid floating-point noise.
 pub(super) fn to_mm(internal: i32) -> f64 {
     let raw = f64::from(internal) * INTERNAL_UNITS_TO_MM;
-    (raw * 1_000_000.0).round() / 1_000_000.0
+    (raw * MM_ROUNDING_MULTIPLIER).round() / MM_ROUNDING_MULTIPLIER
 }
 
 /// Converts millimetres to mils (for parameter strings).

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -325,9 +325,14 @@ impl McpServer {
         // From model_3d reference (if it points to an embedded model)
         if let Some(ref m3d) = footprint.model_3d {
             if !m3d.filepath.is_empty() {
-                // Try to match by name
+                // Match by filename: m3d.filepath may carry path components,
+                // whereas the embedded model name is a bare filename.
+                let m3d_name = std::path::Path::new(&m3d.filepath)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(m3d.filepath.as_str());
                 for model in models {
-                    if model.name.eq_ignore_ascii_case(&m3d.filepath) {
+                    if model.name.eq_ignore_ascii_case(m3d_name) {
                         model_ids.insert(model.id.to_lowercase());
                     }
                 }


### PR DESCRIPTION
## What

Addresses the GitHub **Code quality → AI findings** (Preview) suggestions. Each finding was verified against the actual code before acting; only the two that are genuine, safe improvements are applied here.

### Applied
- **`units.rs`** — extract the repeated `1_000_000.0` rounding literal in `to_mm()` into a named `MM_ROUNDING_MULTIPLIER` constant, so the multiply/divide pair can't drift apart. Behaviour-preserving.
- **`step.rs`** — when resolving `model_3d` references, match on the **file-name component** of `m3d.filepath` rather than the raw string, via `Path::file_name()`. Defensive hardening against path-qualified references in malformed/third-party files; the normal case (already a bare filename) is unchanged.

### Deliberately NOT applied (verified false positives)
- **`writer.rs` "no end marker" assertion** — ⚠️ the finding's suggestion (write a trailing `0x00` end marker) would **reintroduce issue #68** (Altium mis-reads a trailing `0x00` as an object-id-0 record and fails to open the file). The trailing `0x00` is just the empty final block's length prefix; test and implementation already agree. Left as-is.
- **`schlib/reader.rs` part_count fallback** — `unwrap_or(2)` is correct: Altium stores `part_count + 1`, so `2` is the on-disk encoding of a single-part symbol and decodes to `1` via `saturating_sub(1).max(1)`. The suggested `unwrap_or(1)` is a behavioural no-op with worse clarity.
- **`pcblib/reader.rs` indexing offset** — the explanatory comment already exists, and the suggested rewrite (`if has_zero_index { 0 } else { 1 }`) would trip `clippy::bool_to_int_with_if`; the current `usize::from(!has_zero_index)` is the idiomatic form.

### Pending
- One of the two `reader.rs` findings was not captured in the source screenshots, so it is not triaged here.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 69 tests + 10 doc-tests pass (incl. `test_step_model_extraction_to_file`, `test_step_model_lookup_by_name_and_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)