### PR TITLE
refactor(step): checked usize conversion for pagination params

### DIFF
--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -43,11 +43,11 @@ impl McpServer {
         let limit = arguments
             .get("limit")
             .and_then(Value::as_u64)
-            .map(|v| v as usize);
+            .map(|v| usize::try_from(v).unwrap_or(usize::MAX));
         let offset = arguments
             .get("offset")
             .and_then(Value::as_u64)
-            .map_or(0, |v| v as usize);
+            .map_or(0, |v| usize::try_from(v).unwrap_or(usize::MAX));
 
         // Read the library
         let library = match PcbLib::open(filepath) {


### PR DESCRIPTION
## What

Addresses the two GitHub **AI findings** on `step.rs` pagination parsing (surfaced when the file was re-scanned after #96).

Replaces the `v as usize` casts for the `limit`/`offset` arguments with `usize::try_from(v).unwrap_or(usize::MAX)`. A client-supplied `u64` can no longer silently truncate on a 32-bit target; an out-of-range value now saturates instead of wrapping. No behavioural change on the 64-bit build targets.

## Triage of the remaining AI findings (not in this PR)

The other four findings were verified and are **dismissed** (rationale captured for the UI):

- **`reader.rs` indexing offset** — already documented; the suggested `if has_zero_index { 0 } else { 1 }` rewrite would *fail CI* (`clippy::bool_to_int_with_if` flags it and suggests exactly the current `usize::from(!has_zero_index)`).
- **`reader.rs` decompression cap (256→64 MiB)** — intentionally kept. Decompression is already bomb-safe via the bounded `.take(max + 1)` reader, so this is threshold tuning, not a vuln; 256 MiB avoids silently skipping unusually large legitimate models.
- **`writer.rs` "no end marker" assertion** — ⚠️ the suggestion (write a trailing `0x00`) would reintroduce issue #68.
- **`schlib/reader.rs` part_count fallback** — `unwrap_or(2)` is correct (Altium stores `count + 1`; decodes to `1`). The suggested `unwrap_or(1)` is a behavioural no-op.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all suites pass (221 unit + 69 integration + 10 doc-tests, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)