### PR TITLE
refactor(altium): unify remaining shared helpers between PcbLib and SchLib (pt.5)

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -29,10 +29,12 @@ pub(crate) mod framing;
 pub mod pcblib;
 pub mod schlib;
 pub(crate) mod serde_round;
+pub(crate) mod text;
 
 pub use error::{AltiumError, AltiumResult};
 pub use pcblib::{Footprint, PcbLib};
 pub use schlib::{SchLib, Symbol};
+pub use text::TextJustification;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -267,6 +269,23 @@ pub(crate) fn parse_pipe_params(text: &str) -> std::collections::HashMap<String,
         }
     }
     map
+}
+
+/// Builds a stable-reorder ranking function from a desired name order.
+///
+/// The returned closure maps a name to its sort rank: its index in `new_order`,
+/// or `new_order.len()` for names not listed — so unlisted items sort after
+/// listed ones, keeping their original relative order under a stable sort.
+/// Shared by both libraries' `reorder` methods, which differ only in their
+/// backing collection (`IndexMap` vs `Vec`).
+pub(crate) fn order_ranker<'a>(new_order: &[&'a str]) -> impl Fn(&str) -> usize + 'a {
+    let order_map: std::collections::HashMap<&'a str, usize> = new_order
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (*name, i))
+        .collect();
+    let max_pos = new_order.len();
+    move |name: &str| order_map.get(name).copied().unwrap_or(max_pos)
 }
 
 #[cfg(test)]

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -535,60 +535,40 @@ impl PcbLib {
         cfb: &mut cfb::CompoundFile<F>,
         metadata: &mut LibraryMetadata,
     ) {
+        use crate::altium::{
+            bytes::read_u32_le,
+            framing::{read_block, read_pascal_string},
+        };
+
         let Some(data) = crate::altium::read_stream_opt(cfb, "/Library/Data") else {
             return;
         };
 
-        if data.len() < 8 {
+        // Skip the leading parameter block, then read the component count.
+        let Some((_, mut offset)) = read_block(&data, 0) else {
             return;
-        }
-
-        // Skip parameter block: [block_len:4][content]
-        let block_len = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
-        let mut offset = 4 + block_len;
-
-        if offset + 4 > data.len() {
+        };
+        let Some(comp_count) = read_u32_le(&data, offset) else {
             return;
-        }
-
-        // Read component count
-        let comp_count = u32::from_le_bytes([
-            data[offset],
-            data[offset + 1],
-            data[offset + 2],
-            data[offset + 3],
-        ]) as usize;
+        };
         offset += 4;
+        let comp_count = comp_count as usize;
 
         metadata.component_count = comp_count;
         metadata.component_names.clear();
 
-        // Read component names: [block_len:4][str_len:1][name]
+        // Read component names, each a WriteStringBlock wrapping a Pascal string:
+        // [block_len:4][str_len:1][name]. Stop gracefully at the first
+        // malformed/truncated entry, keeping whatever was parsed.
         for _ in 0..comp_count {
-            if offset + 4 > data.len() {
+            let Some((name_block, next)) = read_block(&data, offset) else {
                 break;
+            };
+            let (name, _) = read_pascal_string(name_block, 0);
+            if !name.is_empty() {
+                metadata.component_names.push(name);
             }
-
-            let name_block_len = u32::from_le_bytes([
-                data[offset],
-                data[offset + 1],
-                data[offset + 2],
-                data[offset + 3],
-            ]) as usize;
-            offset += 4;
-
-            if name_block_len == 0 || offset + name_block_len > data.len() {
-                break;
-            }
-
-            let str_len = data[offset] as usize;
-            if str_len < name_block_len && offset + 1 + str_len <= data.len() {
-                if let Ok(name) = std::str::from_utf8(&data[offset + 1..offset + 1 + str_len]) {
-                    metadata.component_names.push(name.to_string());
-                }
-            }
-
-            offset += name_block_len;
+            offset = next;
         }
 
         tracing::debug!(
@@ -773,20 +753,16 @@ impl PcbLib {
         };
 
         if let Ok(text) = String::from_utf8(text_data.to_vec()) {
-            for pair in text.split('|') {
-                if let Some((key, value)) = pair.split_once('=') {
-                    match key.to_uppercase().as_str() {
-                        // Use PATTERN as the canonical name since OLE storage names
-                        // are limited to 31 characters
-                        "PATTERN" if !value.is_empty() => {
-                            footprint.name = value.to_string();
-                        }
-                        "DESCRIPTION" => {
-                            footprint.description = value.to_string();
-                        }
-                        _ => {}
-                    }
+            let params = crate::altium::parse_pipe_params(&text);
+            // Use PATTERN as the canonical name since OLE storage names are
+            // limited to 31 characters; DESCRIPTION is free text.
+            if let Some(pattern) = params.get("pattern") {
+                if !pattern.is_empty() {
+                    footprint.name.clone_from(pattern);
                 }
+            }
+            if let Some(description) = params.get("description") {
+                footprint.description.clone_from(description);
             }
         }
     }
@@ -1115,15 +1091,12 @@ impl PcbLib {
         #[allow(clippy::cast_possible_truncation)]
         data.extend_from_slice(&(self.footprints.len() as u32).to_le_bytes());
 
-        // Component names as WriteStringBlock: [block_len:4][str_len:1][string]
+        // Component names as WriteStringBlock: [block_len:4][str_len:1][string].
+        // The read-side mirror is `read_library_data`.
         for ole_name in ole_names {
-            let name_bytes = ole_name.as_bytes();
-            #[allow(clippy::cast_possible_truncation)]
-            {
-                data.extend_from_slice(&((name_bytes.len() + 1) as u32).to_le_bytes());
-                data.push(name_bytes.len() as u8);
-            }
-            data.extend_from_slice(name_bytes);
+            let mut name_block = Vec::new();
+            crate::altium::framing::write_pascal_string(&mut name_block, ole_name.as_bytes());
+            crate::altium::framing::write_block(&mut data, &name_block);
         }
 
         // Write Library/Data
@@ -1137,13 +1110,12 @@ impl PcbLib {
 
     /// Wraps a parameter string as an Altium C-string block:
     /// `[block_len:4][text + \x00]` where `block_len` includes the terminator.
+    ///
+    /// Thin owned-`Vec` wrapper around the shared
+    /// [`crate::altium::framing::write_cstring_param_block`] frame.
     fn param_block(text: &str) -> Vec<u8> {
-        let bytes = text.as_bytes();
-        let mut v = Vec::with_capacity(4 + bytes.len() + 1);
-        #[allow(clippy::cast_possible_truncation)]
-        v.extend_from_slice(&((bytes.len() + 1) as u32).to_le_bytes());
-        v.extend_from_slice(bytes);
-        v.push(0x00);
+        let mut v = Vec::new();
+        crate::altium::framing::write_cstring_param_block(&mut v, text.as_bytes());
         v
     }
 
@@ -1441,21 +1413,10 @@ impl PcbLib {
     ///
     /// Returns the new order of footprint names.
     pub fn reorder(&mut self, new_order: &[&str]) -> Vec<String> {
-        // Build a position map for the desired order
-        let order_map: std::collections::HashMap<&str, usize> = new_order
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (*name, i))
-            .collect();
-
-        // Sort footprints: those in order_map come first (by their position),
-        // then those not in the map (preserving relative order via stable sort)
-        let max_pos = new_order.len();
-        self.footprints.sort_by(|a, b| {
-            let pos_a = order_map.get(a.name.as_str()).copied().unwrap_or(max_pos);
-            let pos_b = order_map.get(b.name.as_str()).copied().unwrap_or(max_pos);
-            pos_a.cmp(&pos_b)
-        });
+        // Stable-sort footprints into the desired order; footprints not listed
+        // in `new_order` keep their relative order at the end.
+        let rank = crate::altium::order_ranker(new_order);
+        self.footprints.sort_by_key(|a| rank(a.name.as_str()));
 
         self.names()
     }

--- a/src/altium/pcblib/primitives.rs
+++ b/src/altium/pcblib/primitives.rs
@@ -708,34 +708,10 @@ pub enum StrokeFont {
     Serif,
 }
 
-/// Text justification (alignment).
-///
-/// Specifies how text is aligned relative to its anchor point.
-/// The 9 positions form a 3x3 grid combining vertical (Bottom/Middle/Top)
-/// and horizontal (Left/Centre/Right) alignment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TextJustification {
-    /// Bottom-left aligned.
-    BottomLeft,
-    /// Bottom-centre aligned.
-    BottomCenter,
-    /// Bottom-right aligned.
-    BottomRight,
-    /// Middle-left aligned.
-    MiddleLeft,
-    /// Middle-centre aligned.
-    #[default]
-    MiddleCenter,
-    /// Middle-right aligned.
-    MiddleRight,
-    /// Top-left aligned.
-    TopLeft,
-    /// Top-centre aligned.
-    TopCenter,
-    /// Top-right aligned.
-    TopRight,
-}
+/// Text justification (alignment). Shared with `SchLib`; the canonical
+/// definition is [`crate::altium::TextJustification`]. `PcbLib` text defaults to
+/// `MiddleCenter` (this enum's `Default`).
+pub use crate::altium::TextJustification;
 
 /// A text string on a layer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -250,21 +250,11 @@ impl SchLib {
     ///
     /// Returns the new order of symbol names.
     pub fn reorder(&mut self, new_order: &[&str]) -> Vec<String> {
-        // Build a position map for the desired order
-        let order_map: std::collections::HashMap<&str, usize> = new_order
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (*name, i))
-            .collect();
-
-        // Sort symbols: those in order_map come first (by their position),
-        // then those not in the map (preserving relative order via stable sort)
-        let max_pos = new_order.len();
-        self.symbols.sort_by(|a_key, _, b_key, _| {
-            let pos_a = order_map.get(a_key.as_str()).copied().unwrap_or(max_pos);
-            let pos_b = order_map.get(b_key.as_str()).copied().unwrap_or(max_pos);
-            pos_a.cmp(&pos_b)
-        });
+        // Stable-sort symbols into the desired order; symbols not listed in
+        // `new_order` keep their relative order at the end.
+        let rank = crate::altium::order_ranker(new_order);
+        self.symbols
+            .sort_by(|a_key, _, b_key, _| rank(a_key.as_str()).cmp(&rank(b_key.as_str())));
 
         self.names()
     }
@@ -525,14 +515,10 @@ struct FileHeader {
 ///
 /// Returns an error if the file is not a valid `SchLib` (wrong file type).
 fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<FileHeader> {
-    let mut stream = cfb
-        .open_stream("/FileHeader")
-        .map_err(|_| AltiumError::missing_stream("FileHeader"))?;
-
-    let mut data = Vec::new();
-    stream
-        .read_to_end(&mut data)
-        .map_err(|_| AltiumError::parse_error(0, "Failed to read FileHeader"))?;
+    // A `SchLib` without a readable FileHeader is invalid, so map the shared
+    // optional read onto a hard error.
+    let data = crate::altium::read_stream_opt(&mut *cfb, "/FileHeader")
+        .ok_or_else(|| AltiumError::missing_stream("FileHeader"))?;
 
     // Parse header: [length:4 LE][pipe-delimited key=value pairs]
     if data.len() < 4 {

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -769,7 +769,7 @@ pub struct Label {
     #[serde(default)]
     pub color: u32,
     /// Text justification.
-    #[serde(default)]
+    #[serde(default = "default_justification")]
     pub justification: TextJustification,
     /// Rotation in degrees.
     #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
@@ -804,7 +804,7 @@ pub struct Text {
     #[serde(default)]
     pub color: u32,
     /// Text justification.
-    #[serde(default)]
+    #[serde(default = "default_justification")]
     pub justification: TextJustification,
     /// Rotation in degrees.
     #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
@@ -824,29 +824,15 @@ const fn default_font_id() -> u8 {
     1
 }
 
-/// Text justification.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TextJustification {
-    /// Bottom-left aligned.
-    #[default]
-    BottomLeft,
-    /// Bottom-centre aligned.
-    BottomCenter,
-    /// Bottom-right aligned.
-    BottomRight,
-    /// Middle-left aligned.
-    MiddleLeft,
-    /// Middle-centre aligned.
-    MiddleCenter,
-    /// Middle-right aligned.
-    MiddleRight,
-    /// Top-left aligned.
-    TopLeft,
-    /// Top-centre aligned.
-    TopCenter,
-    /// Top-right aligned.
-    TopRight,
+/// Text justification. Shared with `PcbLib`; the canonical definition is
+/// [`crate::altium::TextJustification`].
+pub use crate::altium::TextJustification;
+
+/// `SchLib`'s per-field default justification. Unlike `PcbLib` (which defaults
+/// to `MiddleCenter`, the shared enum's `Default`), `SchLib` text/labels default
+/// to `BottomLeft`, so the `justification` fields set this explicitly.
+const fn default_justification() -> TextJustification {
+    TextJustification::BottomLeft
 }
 
 /// A component parameter (e.g., Value, Part Number).

--- a/src/altium/text.rs
+++ b/src/altium/text.rs
@@ -1,0 +1,36 @@
+//! Shared text/alignment types used by both `PcbLib` and `SchLib`.
+
+use serde::{Deserialize, Serialize};
+
+/// Text justification within a 3x3 anchor grid, combining vertical
+/// (Bottom/Middle/Top) and horizontal (Left/Centre/Right) alignment.
+///
+/// Shared by `SchLib` labels/text and `PcbLib` layer text — the serde
+/// representation (`snake_case` strings) is identical across both formats. The
+/// *default* differs per format (`SchLib` → `BottomLeft`, `PcbLib` →
+/// `MiddleCenter`), so each `justification` field sets its own
+/// `#[serde(default = ...)]` rather than relying on this enum's `Default`; the
+/// enum-level default below matches `PcbLib` and is what `default()` returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TextJustification {
+    /// Bottom-left aligned.
+    BottomLeft,
+    /// Bottom-centre aligned.
+    BottomCenter,
+    /// Bottom-right aligned.
+    BottomRight,
+    /// Middle-left aligned.
+    MiddleLeft,
+    /// Middle-centre aligned.
+    #[default]
+    MiddleCenter,
+    /// Middle-right aligned.
+    MiddleRight,
+    /// Top-left aligned.
+    TopLeft,
+    /// Top-centre aligned.
+    TopCenter,
+    /// Top-right aligned.
+    TopRight,
+}


### PR DESCRIPTION
## What

Continues the `unify-altium` series, removing the last genuine cross-module duplication between `altium/schlib` and `altium/pcblib` that a discovery pass turned up. **No format/byte changes** — purely routing duplicated logic through the existing shared layer.

Crucially, this deliberately leaves alone everything that only *looks* parallel but is genuinely format-specific (the record-dispatch loops, geometric structs, coordinate/colour serialisation, container CRUD, the uppercase NUL-trimming pipe parsers) — SchLib is ASCII grid-units, PcbLib is binary internal-units, and forcing those together would be a leaky abstraction.

## Changes

- **`TextJustification`** — was defined identically in both `primitives` modules; moved to a new shared `altium::text` module and re-exported from both. The per-format default genuinely differs (SchLib `BottomLeft`, PcbLib `MiddleCenter`), so each `justification` field now sets its own `#[serde(default = ...)]` rather than relying on the enum's `Default`. **Observable behaviour is unchanged.**
- **`order_ranker`** — extracted the near-identical ranking logic shared by both `reorder()` methods into one helper (each keeps its own `sort_by`/`sort_by_key` for its backing collection).
- **pcblib `param_block`** — was a verbatim copy of `framing::write_cstring_param_block`; now a thin wrapper around it.
- **pcblib `/Library/Data`** — the `WriteStringBlock` reader (`read_library_data`) and writer now go through `framing::read_block`/`write_block`/`*_pascal_string` + `bytes::read_u32_le` instead of inline `from_le_bytes` + manual bounds maths (graceful break-on-malformed preserved).
- **pcblib `parse_parameters`** — routed through the shared `parse_pipe_params` (as SchLib already does).
- **SchLib FileHeader read** — routed through the shared `read_stream_opt` (as PcbLib already does), preserving the hard "missing FileHeader" error.

Net: **−36 lines**.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass (221 unit + 69 integration + 10 doc-tests + others), including round-trip and byte-level format tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)