### PR TITLE
fix: resolve 10 verified correctness & security bugs

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -104,21 +104,15 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
     let sanitized = name.replace('/', "_");
     let name = sanitized.as_str();
 
-    if name.len() <= MAX_OLE_NAME_LEN && !used_names.contains(name) {
+    // The OLE/CFB limit is 31 UTF-16 code units — not bytes or chars. Measure
+    // it correctly so supplementary-plane characters (2 units each) cannot slip
+    // a name past the limit and make the whole save fail.
+    if utf16_len(name) <= MAX_OLE_NAME_LEN && !used_names.contains(name) {
         return name.to_string();
     }
 
-    // Need to truncate - use format: "{prefix}~{suffix}"
-    let max_prefix_len = MAX_OLE_NAME_LEN - SUFFIX_LEN;
-
-    // Truncate to max prefix length, respecting char boundaries
-    let prefix: String = name.chars().take(max_prefix_len).collect();
-    let prefix = if prefix.len() > max_prefix_len {
-        // If multi-byte chars, truncate further
-        prefix.chars().take(max_prefix_len - 1).collect()
-    } else {
-        prefix
-    };
+    // Truncate, leaving room for a "~NNN" suffix, measuring in UTF-16 units.
+    let prefix = truncate_utf16(name, MAX_OLE_NAME_LEN - SUFFIX_LEN);
 
     // Find a unique suffix
     for i in 1..1000 {
@@ -128,15 +122,36 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
         }
     }
 
-    // Fallback: use hash-based suffix (extremely unlikely to reach here)
+    // Fallback: use hash-based suffix (extremely unlikely to reach here). Drop
+    // one more *char* (never a byte) so we stay within the limit without
+    // slicing on a non-char boundary.
     let mut hasher = DefaultHasher::new();
     name.hash(&mut hasher);
     let hash = hasher.finish();
-    format!(
-        "{}~{:03X}",
-        &prefix[..prefix.len().saturating_sub(1)],
-        hash & 0xFFF
-    )
+    let mut short = prefix;
+    short.pop();
+    format!("{short}~{:03X}", hash & 0xFFF)
+}
+
+/// Length of `s` in UTF-16 code units — the unit OLE/CFB storage names are
+/// limited to. Supplementary-plane characters count as two.
+fn utf16_len(s: &str) -> usize {
+    s.chars().map(char::len_utf16).sum()
+}
+
+/// Truncates `s` to at most `max_units` UTF-16 code units, on a char boundary.
+fn truncate_utf16(s: &str, max_units: usize) -> String {
+    let mut out = String::new();
+    let mut units = 0;
+    for ch in s.chars() {
+        let w = ch.len_utf16();
+        if units + w > max_units {
+            break;
+        }
+        out.push(ch);
+        units += w;
+    }
+    out
 }
 
 /// Generates collision-free OLE storage names for an ordered list of component
@@ -349,6 +364,33 @@ mod tests {
         let result = generate_ole_name(name, &used);
         assert!(result.len() <= MAX_OLE_NAME_LEN);
         assert!(result.starts_with("VERY_LONG_COMPONENT_NAME_TH"));
+        assert!(result.contains('~'));
+    }
+
+    #[test]
+    fn ole_name_respects_utf16_limit_for_non_bmp() {
+        // Supplementary-plane chars are 2 UTF-16 units each. cfb rejects names
+        // over 31 UTF-16 code units, so a 20-emoji name must still fit.
+        let used = HashSet::new();
+        let name = "\u{1F600}".repeat(20); // 20 chars = 40 UTF-16 units
+        let result = generate_ole_name(&name, &used);
+        assert!(
+            result.encode_utf16().count() <= MAX_OLE_NAME_LEN,
+            "got {} UTF-16 units",
+            result.encode_utf16().count()
+        );
+    }
+
+    #[test]
+    fn ole_name_hash_fallback_handles_multibyte_prefix_without_panicking() {
+        // A long all-multibyte name forces truncation; exhausting the 999
+        // numeric suffixes drives the hash fallback, which previously panicked
+        // by byte-slicing inside a multi-byte char.
+        let name = "\u{00B5}".repeat(32); // 'µ': 1 UTF-16 unit each, 32 > 31
+        let prefix = "\u{00B5}".repeat(MAX_OLE_NAME_LEN - SUFFIX_LEN);
+        let used: HashSet<String> = (1..1000).map(|i| format!("{prefix}~{i:03}")).collect();
+        let result = generate_ole_name(&name, &used);
+        assert!(result.encode_utf16().count() <= MAX_OLE_NAME_LEN);
         assert!(result.contains('~'));
     }
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -651,17 +651,23 @@ impl PcbLib {
         // Read compressed model streams
         let mut model_data: Vec<(usize, Vec<u8>)> = Vec::new();
 
-        // Determine max index: use header count if available, otherwise use model_index size
-        let max_index = if model_count > 0 {
-            model_count
-        } else {
-            // Fall back to max index from model_index + 1
-            model_index
-                .values()
-                .map(|(idx, _)| *idx + 1)
-                .max()
-                .unwrap_or(0)
-        };
+        // Bound the scan by the indices actually present in the parsed Data
+        // index. The Header count (`model_count`) comes straight from the
+        // untrusted /Library/Models/Header stream and is uncapped, so it must
+        // never drive the loop — a crafted count would otherwise force an
+        // unbounded stream scan (DoS). Treat it as advisory only.
+        let max_index = model_index
+            .values()
+            .map(|(idx, _)| idx.saturating_add(1))
+            .max()
+            .unwrap_or(0);
+        if model_count != max_index {
+            tracing::debug!(
+                header_count = model_count,
+                indexed = max_index,
+                "Model Header count disagrees with parsed index; using the index"
+            );
+        }
 
         // Model streams are numbered 0, 1, 2, ...
         for idx in 0..max_index {
@@ -905,15 +911,26 @@ impl PcbLib {
                     });
                 }
 
-                // If we have component_bodies but user explicitly set a path that exists,
-                // they want to re-embed. Clear the old component_bodies first.
+                // If we have component_bodies but the user explicitly set a path
+                // that exists, they want to re-embed. Clear the old
+                // component_bodies first — and drop the embedded models those
+                // bodies referenced, so they don't linger in self.models as
+                // orphans (which previously bloated the library on every save).
                 if !footprint.component_bodies.is_empty() {
                     tracing::debug!(
                         footprint = %footprint.name,
                         old_bodies = footprint.component_bodies.len(),
                         "Clearing old ComponentBodies for re-embedding from new path"
                     );
+                    let stale: std::collections::HashSet<String> = footprint
+                        .component_bodies
+                        .iter()
+                        .filter(|cb| cb.embedded)
+                        .map(|cb| cb.model_id.to_lowercase())
+                        .collect();
                     footprint.component_bodies.clear();
+                    self.models
+                        .retain(|m| !stale.contains(&m.id.to_lowercase()));
                 }
 
                 // Read the STEP file

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -120,39 +120,28 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
         });
     }
 
-    // Validate that string lengths fit in u8 range (binary pin format limitation)
-    if pin.name.len() > MAX_STRING_LEN {
-        return Err(AltiumError::InvalidParameter {
-            name: "pin.name".to_string(),
-            message: format!(
-                "Pin '{}' name length {} exceeds maximum of {} bytes",
-                pin.designator,
-                pin.name.len(),
-                MAX_STRING_LEN
-            ),
-        });
-    }
-    if pin.designator.len() > MAX_STRING_LEN {
-        return Err(AltiumError::InvalidParameter {
-            name: "pin.designator".to_string(),
-            message: format!(
-                "Pin designator '{}' length {} exceeds maximum of {} bytes",
-                pin.designator,
-                pin.designator.len(),
-                MAX_STRING_LEN
-            ),
-        });
-    }
-    if pin.description.len() > MAX_STRING_LEN {
-        return Err(AltiumError::InvalidParameter {
-            name: "pin.description".to_string(),
-            message: format!(
-                "Pin '{}' description length {} exceeds maximum of {} bytes",
-                pin.designator,
-                pin.description.len(),
-                MAX_STRING_LEN
-            ),
-        });
+    // Strings are stored as Windows-1252 Pascal short strings; validate the
+    // ENCODED byte length (what the u8 length prefix actually holds), not the
+    // UTF-8 String length — otherwise non-ASCII text is wrongly rejected even
+    // though it fits in 255 encoded bytes.
+    let name = crate::altium::encode_windows1252(&pin.name);
+    let designator = crate::altium::encode_windows1252(&pin.designator);
+    let description = crate::altium::encode_windows1252(&pin.description);
+    for (bytes, field) in [
+        (&name, "name"),
+        (&designator, "designator"),
+        (&description, "description"),
+    ] {
+        if bytes.len() > MAX_STRING_LEN {
+            return Err(AltiumError::InvalidParameter {
+                name: format!("pin.{field}"),
+                message: format!(
+                    "Pin '{}' {field} length {} exceeds maximum of {MAX_STRING_LEN} bytes",
+                    pin.designator,
+                    bytes.len(),
+                ),
+            });
+        }
     }
 
     let mut record = Vec::with_capacity(64);
@@ -164,6 +153,15 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.push(0x00);
 
     // Owner part ID (2 bytes)
+    if pin.owner_part_id < I16_MIN || pin.owner_part_id > I16_MAX {
+        return Err(AltiumError::InvalidParameter {
+            name: "pin.owner_part_id".to_string(),
+            message: format!(
+                "Pin '{}' owner_part_id {} exceeds i16 range (±32767)",
+                pin.designator, pin.owner_part_id
+            ),
+        });
+    }
     #[allow(clippy::cast_possible_truncation)]
     let owner_part = pin.owner_part_id as i16;
     record.extend_from_slice(&owner_part.to_le_bytes());
@@ -178,10 +176,7 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.push(pin.symbol_outside.to_id());
 
     // Description: Pascal short string [length:1][string]
-    write_pascal_string(
-        &mut record,
-        &crate::altium::encode_windows1252(&pin.description),
-    );
+    write_pascal_string(&mut record, &description);
 
     // Formal type (1 byte) - 0x01 for a normal pin (matches Altium's output).
     record.push(0x01);
@@ -229,13 +224,10 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     record.extend_from_slice(&pin.colour.to_le_bytes());
 
     // Name: [length:1][string]
-    write_pascal_string(&mut record, &crate::altium::encode_windows1252(&pin.name));
+    write_pascal_string(&mut record, &name);
 
     // Designator: [length:1][string]
-    write_pascal_string(
-        &mut record,
-        &crate::altium::encode_windows1252(&pin.designator),
-    );
+    write_pascal_string(&mut record, &designator);
 
     // Pin swap-id tail (Pascal short strings), matching Altium's output:
     //   SwapIdGroup = "" , PartAndSequence = "|&|" , DefaultValue = "".

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1019,6 +1019,10 @@ mod tests {
         assert!(McpServer::validate_schlib_coordinate(-32000, "x").is_ok());
         assert!(McpServer::validate_schlib_coordinate(32001, "x").is_err());
         assert!(McpServer::validate_schlib_coordinate(-32001, "x").is_err());
+        // Extremes must be rejected without panicking: `value.abs()` overflowed
+        // on i32::MIN (panic in debug, wrap-negative bypass in release).
+        assert!(McpServer::validate_schlib_coordinate(i32::MIN, "x").is_err());
+        assert!(McpServer::validate_schlib_coordinate(i32::MAX, "x").is_err());
     }
 
     #[test]

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -82,6 +82,7 @@ impl McpServer {
         let original_count = library.len();
         let mut results: Vec<Value> = Vec::with_capacity(names.len());
         let mut deleted_count = 0;
+        let mut seen = std::collections::HashSet::new();
 
         // Check which components exist (for dry_run) or remove them
         for name in names {
@@ -92,7 +93,11 @@ impl McpServer {
                         "name": name,
                         "status": "would_delete"
                     }));
-                    deleted_count += 1;
+                    // Count each distinct existing name once so duplicate names
+                    // can't over-count (which underflowed remaining_count).
+                    if seen.insert(*name) {
+                        deleted_count += 1;
+                    }
                 } else {
                     results.push(json!({
                         "name": name,
@@ -151,7 +156,7 @@ impl McpServer {
             "dry_run": dry_run,
             "original_count": original_count,
             "deleted_count": deleted_count,
-            "remaining_count": if dry_run { original_count - deleted_count } else { library.len() },
+            "remaining_count": if dry_run { original_count.saturating_sub(deleted_count) } else { library.len() },
             "orphaned_models_removed": orphaned_models_removed,
             "results": results,
         });
@@ -190,6 +195,7 @@ impl McpServer {
         let original_count = library.len();
         let mut results: Vec<Value> = Vec::with_capacity(names.len());
         let mut deleted_count = 0;
+        let mut seen = std::collections::HashSet::new();
 
         // Check which components exist (for dry_run) or remove them
         for name in names {
@@ -200,7 +206,11 @@ impl McpServer {
                         "name": name,
                         "status": "would_delete"
                     }));
-                    deleted_count += 1;
+                    // Count each distinct existing name once so duplicate names
+                    // can't over-count (which underflowed remaining_count).
+                    if seen.insert(*name) {
+                        deleted_count += 1;
+                    }
                 } else {
                     results.push(json!({
                         "name": name,
@@ -252,7 +262,7 @@ impl McpServer {
             "dry_run": dry_run,
             "original_count": original_count,
             "deleted_count": deleted_count,
-            "remaining_count": if dry_run { original_count - deleted_count } else { library.len() },
+            "remaining_count": if dry_run { original_count.saturating_sub(deleted_count) } else { library.len() },
             "results": results,
         });
 

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -608,8 +608,24 @@ impl McpServer {
             pad.shape = new_shape;
         }
 
+        // Reject invalid geometry the create path enforces — update bypassed it,
+        // and out-of-range values would silently saturate in from_mm() on save.
+        if pad.width <= 0.0 || pad.height <= 0.0 {
+            return ToolCallResult::error(format!(
+                "Pad '{designator}': width and height must be positive"
+            ));
+        }
+        if pad.hole_size.is_some_and(|h| h < 0.0) {
+            return ToolCallResult::error(format!("Pad '{designator}': hole_size must be >= 0"));
+        }
+
         if changes.is_empty() {
             return ToolCallResult::error("No valid updates specified");
+        }
+
+        // Coordinate range check over the whole footprint (matches the write path).
+        if let Err(e) = Self::validate_footprint_coordinates(footprint) {
+            return ToolCallResult::error(e);
         }
 
         // Save if not dry run
@@ -1028,6 +1044,35 @@ impl McpServer {
 
         if changes.is_empty() {
             return ToolCallResult::error("No valid updates specified for this primitive type");
+        }
+
+        // Re-validate after the in-place edits: update bypassed the create-path
+        // checks, so an out-of-range coordinate would silently saturate in
+        // from_mm() and a non-positive dimension would write a degenerate shape.
+        if let Err(e) = Self::validate_footprint_coordinates(footprint) {
+            return ToolCallResult::error(e);
+        }
+        let dim_err = match primitive_type {
+            "track" => {
+                (footprint.tracks[index].width <= 0.0).then_some("track width must be positive")
+            }
+            "arc" => {
+                let a = &footprint.arcs[index];
+                if a.radius <= 0.0 {
+                    Some("arc radius must be positive")
+                } else if a.width < 0.0 {
+                    Some("arc width must be >= 0")
+                } else {
+                    None
+                }
+            }
+            "text" => {
+                (footprint.text[index].height <= 0.0).then_some("text height must be positive")
+            }
+            _ => None,
+        };
+        if let Some(msg) = dim_err {
+            return ToolCallResult::error(format!("Primitive {index} ({primitive_type}): {msg}"));
         }
 
         // Save if not dry run

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -7,6 +7,16 @@ use serde_json::Value;
 
 use crate::mcp::server::McpServer;
 
+/// Reads a JSON integer field as `i32`, returning `None` if it is missing, not
+/// an integer, or outside `i32` range — so an out-of-range value is rejected
+/// rather than silently wrapped (`as i32`), which previously let an absurd input
+/// land as a small in-range coordinate that bypassed range validation.
+fn json_i32(json: &Value, field: &str) -> Option<i32> {
+    json.get(field)
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+}
+
 impl McpServer {
     // ==================== Primitive Parsing Helpers ====================
 
@@ -317,9 +327,9 @@ impl McpServer {
             .get("name")
             .and_then(Value::as_str)
             .unwrap_or(designator);
-        let x = json.get("x").and_then(Value::as_i64)? as i32;
-        let y = json.get("y").and_then(Value::as_i64)? as i32;
-        let length = json.get("length").and_then(Value::as_i64).unwrap_or(10) as i32;
+        let x = json_i32(json, "x")?;
+        let y = json_i32(json, "y")?;
+        let length = json_i32(json, "length").unwrap_or(10);
 
         let orientation =
             json.get("orientation")
@@ -354,10 +364,7 @@ impl McpServer {
             .get("show_designator")
             .and_then(Value::as_bool)
             .unwrap_or(true);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         // Helper to parse PinSymbol from string
         let parse_pin_symbol = |s: &str| -> PinSymbol {
@@ -431,10 +438,10 @@ impl McpServer {
     pub(crate) fn parse_schlib_rectangle(json: &Value) -> Option<crate::altium::schlib::Rectangle> {
         use crate::altium::schlib::Rectangle;
 
-        let x1 = json.get("x1").and_then(Value::as_i64)? as i32;
-        let y1 = json.get("y1").and_then(Value::as_i64)? as i32;
-        let x2 = json.get("x2").and_then(Value::as_i64)? as i32;
-        let y2 = json.get("y2").and_then(Value::as_i64)? as i32;
+        let x1 = json_i32(json, "x1")?;
+        let y1 = json_i32(json, "y1")?;
+        let x2 = json_i32(json, "x2")?;
+        let y2 = json_i32(json, "y2")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let line_color = json
@@ -446,10 +453,7 @@ impl McpServer {
             .and_then(Value::as_u64)
             .unwrap_or(0xFF_FF_B0) as u32;
         let filled = json.get("filled").and_then(Value::as_bool).unwrap_or(true);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Rectangle {
             x1,
@@ -470,20 +474,17 @@ impl McpServer {
     pub(crate) fn parse_schlib_line(json: &Value) -> Option<crate::altium::schlib::Line> {
         use crate::altium::schlib::Line;
 
-        let x1 = json.get("x1").and_then(Value::as_i64)? as i32;
-        let y1 = json.get("y1").and_then(Value::as_i64)? as i32;
-        let x2 = json.get("x2").and_then(Value::as_i64)? as i32;
-        let y2 = json.get("y2").and_then(Value::as_i64)? as i32;
+        let x1 = json_i32(json, "x1")?;
+        let y1 = json_i32(json, "y1")?;
+        let x2 = json_i32(json, "x2")?;
+        let y2 = json_i32(json, "y2")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let color = json
             .get("color")
             .and_then(Value::as_u64)
             .unwrap_or(0x00_00_80) as u32;
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Line {
             x1,
@@ -508,18 +509,15 @@ impl McpServer {
             .unwrap_or("*")
             .to_string();
 
-        let x = json.get("x").and_then(Value::as_i64).unwrap_or(0) as i32;
-        let y = json.get("y").and_then(Value::as_i64).unwrap_or(0) as i32;
+        let x = json_i32(json, "x").unwrap_or(0);
+        let y = json_i32(json, "y").unwrap_or(0);
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;
         let color = json
             .get("color")
             .and_then(Value::as_u64)
             .unwrap_or(0x80_00_00) as u32;
         let hidden = json.get("hidden").and_then(Value::as_bool).unwrap_or(false);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Parameter {
             name: name.to_string(),
@@ -549,8 +547,8 @@ impl McpServer {
         let points: Vec<(i32, i32)> = points_json
             .iter()
             .filter_map(|p| {
-                let x = p.get("x").and_then(Value::as_i64)? as i32;
-                let y = p.get("y").and_then(Value::as_i64)? as i32;
+                let x = json_i32(p, "x")?;
+                let y = json_i32(p, "y")?;
                 Some((x, y))
             })
             .collect();
@@ -564,10 +562,7 @@ impl McpServer {
             .get("color")
             .and_then(Value::as_u64)
             .unwrap_or(0x00_00_80) as u32;
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Polyline {
             points,
@@ -586,9 +581,9 @@ impl McpServer {
     pub(crate) fn parse_schlib_arc(json: &Value) -> Option<crate::altium::schlib::Arc> {
         use crate::altium::schlib::Arc;
 
-        let x = json.get("x").and_then(Value::as_i64)? as i32;
-        let y = json.get("y").and_then(Value::as_i64)? as i32;
-        let radius = json.get("radius").and_then(Value::as_i64)? as i32;
+        let x = json_i32(json, "x")?;
+        let y = json_i32(json, "y")?;
+        let radius = json_i32(json, "radius")?;
         let start_angle = json
             .get("start_angle")
             .and_then(Value::as_f64)
@@ -602,10 +597,7 @@ impl McpServer {
             .get("color")
             .and_then(Value::as_u64)
             .unwrap_or(0x00_00_80) as u32;
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Arc {
             x,
@@ -624,10 +616,10 @@ impl McpServer {
     pub(crate) fn parse_schlib_ellipse(json: &Value) -> Option<crate::altium::schlib::Ellipse> {
         use crate::altium::schlib::Ellipse;
 
-        let x = json.get("x").and_then(Value::as_i64)? as i32;
-        let y = json.get("y").and_then(Value::as_i64)? as i32;
-        let radius_x = json.get("radius_x").and_then(Value::as_i64)? as i32;
-        let radius_y = json.get("radius_y").and_then(Value::as_i64)? as i32;
+        let x = json_i32(json, "x")?;
+        let y = json_i32(json, "y")?;
+        let radius_x = json_i32(json, "radius_x")?;
+        let radius_y = json_i32(json, "radius_y")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let line_color = json
@@ -639,10 +631,7 @@ impl McpServer {
             .and_then(Value::as_u64)
             .unwrap_or(0xFF_FF_B0) as u32;
         let filled = json.get("filled").and_then(Value::as_bool).unwrap_or(true);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Ellipse {
             x,
@@ -662,8 +651,8 @@ impl McpServer {
     pub(crate) fn parse_schlib_label(json: &Value) -> Option<crate::altium::schlib::Label> {
         use crate::altium::schlib::{Label, TextJustification};
 
-        let x = json.get("x").and_then(Value::as_i64)? as i32;
-        let y = json.get("y").and_then(Value::as_i64)? as i32;
+        let x = json_i32(json, "x")?;
+        let y = json_i32(json, "y")?;
         let text = json.get("text").and_then(Value::as_str)?.to_string();
 
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;
@@ -681,10 +670,7 @@ impl McpServer {
             .or_else(|| json.get("hidden"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         let justification = json.get("justification").and_then(Value::as_str).map_or(
             TextJustification::BottomLeft,
@@ -724,8 +710,8 @@ impl McpServer {
     pub(crate) fn parse_schlib_text(json: &Value) -> Option<crate::altium::schlib::Text> {
         use crate::altium::schlib::{Text, TextJustification};
 
-        let x = json.get("x").and_then(Value::as_i64)? as i32;
-        let y = json.get("y").and_then(Value::as_i64)? as i32;
+        let x = json_i32(json, "x")?;
+        let y = json_i32(json, "y")?;
         let text = json.get("text").and_then(Value::as_str)?.to_string();
 
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;
@@ -743,10 +729,7 @@ impl McpServer {
             .or_else(|| json.get("hidden"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let owner_part_id = json
-            .get("owner_part_id")
-            .and_then(Value::as_i64)
-            .unwrap_or(1) as i32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         let justification = json.get("justification").and_then(Value::as_str).map_or(
             TextJustification::BottomLeft,

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -172,8 +172,12 @@ impl McpServer {
         // Helper to convert coordinates
         let to_canvas = |x: f64, y: f64| -> (usize, usize) {
             let cx = ((x - min_x) * actual_scale_x).round() as usize;
-            let cy =
-                canvas_height.saturating_sub(1) - ((y - min_y) * actual_scale_y).round() as usize;
+            // Clamp the scaled offset before subtracting: a point outside the
+            // bounding box (e.g. the origin crosshair) would otherwise underflow
+            // — a panic in debug builds — instead of clamping to the edge.
+            let dy = (((y - min_y) * actual_scale_y).round() as usize)
+                .min(canvas_height.saturating_sub(1));
+            let cy = canvas_height.saturating_sub(1) - dy;
             (cx.min(canvas_width - 1), cy.min(canvas_height - 1))
         };
 
@@ -527,8 +531,11 @@ impl McpServer {
         // Helper to convert schematic coordinates to canvas coordinates
         let to_canvas = |x: i32, y: i32| -> (usize, usize) {
             let cx = (f64::from(x - min_x) * actual_scale_x).round() as usize;
-            let cy = canvas_height.saturating_sub(1)
-                - (f64::from(y - min_y) * actual_scale_y).round() as usize;
+            // Clamp before subtracting so an out-of-bbox point (e.g. the origin
+            // crosshair) clamps to the edge instead of underflowing (debug panic).
+            let dy = ((f64::from(y - min_y) * actual_scale_y).round() as usize)
+                .min(canvas_height.saturating_sub(1));
+            let cy = canvas_height.saturating_sub(1) - dy;
             (cx.min(canvas_width - 1), cy.min(canvas_height - 1))
         };
 

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -120,7 +120,10 @@ impl McpServer {
 
     /// Validates that a `SchLib` coordinate is within the safe range for i16.
     pub(crate) fn validate_schlib_coordinate(value: i32, field_name: &str) -> Result<(), String> {
-        if value.abs() > Self::MAX_SCHLIB_COORDINATE {
+        // Direct bound check, not `value.abs()`: `i32::MIN.abs()` overflows
+        // (panics in debug, wraps negative in release — silently passing the
+        // check), so a crafted coordinate could panic or bypass validation.
+        if !(-Self::MAX_SCHLIB_COORDINATE..=Self::MAX_SCHLIB_COORDINATE).contains(&value) {
             return Err(format!(
                 "{field_name} value {value} exceeds the maximum safe range of ±{} units",
                 Self::MAX_SCHLIB_COORDINATE


### PR DESCRIPTION
## Summary

An exhaustive, **adversarially-verified** bug hunt (6 parallel finders → independent skeptic verification per finding) surfaced 11 candidates; **10 were confirmed** and 1 was correctly rejected as intentional. All are real and most are reachable from untrusted input (MCP request args or malicious library files). This PR fixes all 10, with regression tests where cheap and the full suite green.

## Fixes (by severity)

**High**
- **Unbounded model-stream loop (DoS)** — `read_models` used the untrusted `/Library/Models/Header` count as the loop bound; now bounded by the indices actually present.
- **`usize` underflow → panic** — duplicate names in a `delete_component` dry-run over-counted, underflowing `remaining_count` (debug panic / release wrap). Dedup + `saturating_sub`.

**Medium**
- **OLE name truncation ignored UTF-16 width** — non-BMP names exceeded cfb's 31-code-unit limit and failed the *entire* save. Now measured in UTF-16 units.
- **`update_pad` / `update_primitive` skipped validation** — out-of-range geometry silently saturated in `from_mm()` and wrote corrupt bytes with a "success" status. Now re-validates (and rejects non-positive dimensions), in dry-run too.
- **`i32::MIN.abs()` overflow** — `validate_schlib_coordinate` panicked (debug) / bypassed the range check (release) on crafted coords. Now a range check; plus a checked `json_i32` parse helper so out-of-`i32` JSON integers are rejected, not wrapped.

**Low**
- **Orphaned embedded model** — re-embedding from a new path left the old model in `self.models`, bloating the library each save. Now dropped.
- **`owner_part_id` i32→i16 truncation** — unchecked; now range-validated like the other pin coords.
- **OLE-name hash fallback** sliced a `String` on a non-char boundary → panic on multi-byte prefixes. Now drops a char.
- **Render `to_canvas` underflow** — an origin outside the bbox underflowed (debug panic) and mis-placed the crosshair. Now clamps before subtracting.

## Behaviour changes (intentional)
- SchLib now validates the **encoded** (Windows-1252) pin-string length, so non-ASCII names that fit in 255 bytes are accepted (previously wrongly rejected).
- Out-of-range coordinates/dimensions in `update_*` and out-of-`i32` JSON integers are now **rejected** instead of silently saturating/wrapping.

## Not a bug (verifier-rejected)
- A claimed "WideStrings index collision" replacing numeric Text content — confirmed to be correct, intentional behaviour. Not changed.

## Follow-up
Non-coordinate `as u8` casts (e.g. `font_id`) weren't in scope of the found bug; could be hardened similarly later.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass (224 unit + 69 integration + 10 doc-tests + others), incl. new `generate_ole_name` UTF-16/fallback and `validate_schlib_coordinate` extreme-value regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)