### PR TITLE
refactor(altium): unify pt.6 — shared WriteStringBlock frame + pipe-record parsing

### DIFF
--- a/src/altium/framing.rs
+++ b/src/altium/framing.rs
@@ -46,6 +46,17 @@ pub fn write_pascal_string(record: &mut Vec<u8>, bytes: &[u8]) {
     record.extend_from_slice(bytes);
 }
 
+/// Appends a `WriteStringBlock`: a Pascal short string wrapped in an outer
+/// length-prefixed block — `[u32 LE block_len][u8 str_len][bytes]`.
+///
+/// The exact inverse of reading with [`read_block`] then [`read_pascal_string`].
+/// Callers validate `bytes.len() <= 255` (the inner Pascal length prefix).
+pub fn write_string_block(data: &mut Vec<u8>, bytes: &[u8]) {
+    let mut inner = Vec::with_capacity(1 + bytes.len());
+    write_pascal_string(&mut inner, bytes);
+    write_block(data, &inner);
+}
+
 /// Reads a length-prefixed binary block written by [`write_block`]:
 /// `[u32 LE length][bytes]`.
 ///

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -286,6 +286,23 @@ pub(crate) fn parse_pipe_params(text: &str) -> std::collections::HashMap<String,
     map
 }
 
+/// Like [`parse_pipe_params`] but preserves key case verbatim and trims trailing
+/// NUL padding (then surrounding whitespace) from values. `PcbLib` records match
+/// keys in their native UPPERCASE form and pad values with `\0`, neither of which
+/// the lowercasing `parse_pipe_params` handles. Callers look keys up in UPPERCASE.
+pub(crate) fn parse_pipe_params_raw(text: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for part in text.split('|') {
+        if let Some((key, value)) = part.split_once('=') {
+            map.insert(
+                key.to_string(),
+                value.trim_end_matches('\0').trim().to_string(),
+            );
+        }
+    }
+    map
+}
+
 /// Builds a stable-reorder ranking function from a desired name order.
 ///
 /// The returned closure maps a name to its sort rank: its index in `new_order`,

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1111,9 +1111,7 @@ impl PcbLib {
         // Component names as WriteStringBlock: [block_len:4][str_len:1][string].
         // The read-side mirror is `read_library_data`.
         for ole_name in ole_names {
-            let mut name_block = Vec::new();
-            crate::altium::framing::write_pascal_string(&mut name_block, ole_name.as_bytes());
-            crate::altium::framing::write_block(&mut data, &name_block);
+            crate::altium::framing::write_string_block(&mut data, ole_name.as_bytes());
         }
 
         // Write Library/Data

--- a/src/altium/pcblib/reader.rs
+++ b/src/altium/pcblib/reader.rs
@@ -225,40 +225,16 @@ pub fn parse_unique_id_stream(data: &[u8]) -> UniqueIdMap {
 /// |PRIMITIVEINDEX=1|PRIMITIVEOBJECTID=Pad|UNIQUEID=QHHMRSCB
 /// ```
 fn parse_unique_id_record(record: &str) -> Option<UniqueIdEntry> {
-    let mut primitive_index: Option<usize> = None;
-    let mut primitive_type: Option<String> = None;
-    let mut unique_id: Option<String> = None;
-
-    for pair in record.split('|') {
-        if pair.is_empty() {
-            continue;
-        }
-
-        if let Some((key, value)) = pair.split_once('=') {
-            match key {
-                "PRIMITIVEINDEX" => {
-                    primitive_index = value.parse().ok();
-                }
-                "PRIMITIVEOBJECTID" => {
-                    primitive_type = Some(value.to_string());
-                }
-                "UNIQUEID" => {
-                    unique_id = Some(value.to_string());
-                }
-                _ => {}
-            }
-        }
-    }
-
-    // Only return if we have all required fields
-    match (primitive_index, primitive_type, unique_id) {
-        (Some(index), Some(ptype), Some(uid)) if !uid.is_empty() => Some(UniqueIdEntry {
-            primitive_index: index,
-            primitive_type: ptype,
-            unique_id: uid,
-        }),
-        _ => None,
-    }
+    let params = crate::altium::parse_pipe_params_raw(record);
+    let primitive_index: usize = params.get("PRIMITIVEINDEX")?.parse().ok()?;
+    let primitive_type = params.get("PRIMITIVEOBJECTID")?.clone();
+    let unique_id = params.get("UNIQUEID")?.clone();
+    // Only return if all required fields are present and the id is non-empty.
+    (!unique_id.is_empty()).then_some(UniqueIdEntry {
+        primitive_index,
+        primitive_type,
+        unique_id,
+    })
 }
 
 /// Applies unique IDs from the `UniqueIDPrimitiveInformation` stream to footprint primitives.
@@ -1897,21 +1873,10 @@ fn parse_component_body_outline(block0: &[u8]) -> Vec<(f64, f64)> {
 
 /// Parses key=value parameters from a `ComponentBody` block string.
 fn parse_component_body_params(s: &str) -> std::collections::HashMap<String, String> {
-    let mut params = std::collections::HashMap::new();
-
-    // Find the start of parameters (look for V7_LAYER=)
-    if let Some(start) = s.find("V7_LAYER") {
-        let params_str = &s[start..];
-        for pair in params_str.split('|') {
-            if let Some((key, val)) = pair.split_once('=') {
-                // Clean up null bytes and whitespace
-                let val = val.trim_end_matches('\0').trim();
-                params.insert(key.to_string(), val.to_string());
-            }
-        }
-    }
-
-    params
+    // Parameters begin at the first `V7_LAYER=` key (after the binary header).
+    s.find("V7_LAYER")
+        .map(|start| crate::altium::parse_pipe_params_raw(&s[start..]))
+        .unwrap_or_default()
 }
 
 /// Parses a value in mils (e.g., "15.748mil") to mm.
@@ -2008,22 +1973,9 @@ pub fn parse_model_data_stream(data: &[u8]) -> ModelIndex {
             .unwrap_or_else(|_| record_data.iter().map(|&b| b as char).collect());
 
         // Extract ID (GUID) and NAME from the record
-        let mut guid = String::new();
-        let mut name = String::new();
-
-        for pair in record_text.split('|') {
-            if pair.is_empty() {
-                continue;
-            }
-
-            if let Some((key, value)) = pair.split_once('=') {
-                match key {
-                    "ID" => guid = value.trim_end_matches('\0').to_string(),
-                    "NAME" => name = value.trim_end_matches('\0').to_string(),
-                    _ => {}
-                }
-            }
-        }
+        let params = crate::altium::parse_pipe_params_raw(&record_text);
+        let guid = params.get("ID").cloned().unwrap_or_default();
+        let name = params.get("NAME").cloned().unwrap_or_default();
 
         if !guid.is_empty() {
             tracing::trace!(

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -38,7 +38,7 @@ fn write_f64(data: &mut Vec<u8>, value: f64) {
 
 // Shared byte frames live in crate::altium::framing so PcbLib and SchLib use
 // one implementation each (see that module).
-use crate::altium::framing::{write_block, write_cstring_param_block, write_pascal_string};
+use crate::altium::framing::{write_block, write_cstring_param_block};
 
 /// Writes a length-prefixed string block: outer `[u32 len]` wrapping a Pascal
 /// short string `[u8 len][bytes]`.
@@ -67,9 +67,7 @@ fn write_string_block(
         });
     }
 
-    let mut block = Vec::with_capacity(1 + bytes.len());
-    write_pascal_string(&mut block, &bytes);
-    write_block(data, &block);
+    crate::altium::framing::write_string_block(data, &bytes);
     Ok(())
 }
 


### PR DESCRIPTION
## What

Finishes the `unify-altium` series by routing the last genuinely-duplicated PcbLib code through the shared layer. Net **−24 lines**.

- **`framing::write_string_block`** — PcbLib open-coded the `[u32 len][u8 str_len][bytes]` WriteStringBlock frame in two places (the writer's `write_string_block` and the `/Library/Data` component-name loop). It's the exact inverse of the already-shared `read_block` + `read_pascal_string`, so it now lives in `framing.rs` and both sites delegate to it. **Byte-output identical.**
- **`parse_pipe_params_raw`** — PcbLib hand-rolled the case-preserving, NUL-trimming pipe parse in three reader sites (`parse_component_body_params`, `parse_model_data_stream`, `parse_unique_id_record`). Added a shared `parse_pipe_params_raw` (verbatim keys + trailing-`\0` then whitespace trim) next to the existing `parse_pipe_params`, and routed them through it.

## Behaviour note

`parse_component_body_params` is byte-identical. The **model** and **unique-id** record parsers now also whitespace-trim values that previously weren't trimmed — inert for real GUID / filename / integer-index data (no surrounding whitespace or embedded NULs occur there), and confirmed by the existing round-trip and unique-id tests.

This is deliberately the *last* of the cross-format dedup — the remaining SchLib/PcbLib parallelism is genuinely domain-specific (different binary formats) and is intentionally left split.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass (224 unit + 69 integration + 10 doc-tests + others)

🤖 Generated with [Claude Code](https://claude.com/claude-code)