### PR TITLE
fix(tools): route all write paths through shared geometry validation (#104)

### DIFF
--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -253,6 +253,10 @@ impl McpServer {
         if to_width <= 0.0 {
             return ToolCallResult::error("to_width must be greater than 0");
         }
+        // Range-check too, so a huge width can't saturate in from_mm() on save.
+        if let Err(e) = Self::validate_coordinate(to_width, "to_width") {
+            return ToolCallResult::error(e);
+        }
 
         let mut total_updated = 0usize;
         let mut footprints_updated = Vec::new();

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1098,6 +1098,11 @@ impl McpServer {
             // Use write_pcblib parsing logic via serde
             match serde_json::from_value::<Footprint>(fp_json.clone()) {
                 Ok(footprint) => {
+                    // Validate fresh geometry before it reaches save (serde
+                    // bypasses the create-path validators).
+                    if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
+                        return ToolCallResult::error(format!("Footprint {idx} ('{name}'): {e}"));
+                    }
                     library.add(footprint);
                     imported_count += 1;
                 }
@@ -1299,6 +1304,11 @@ impl McpServer {
             // Parse symbol via serde
             match serde_json::from_value::<Symbol>(sym_json.clone()) {
                 Ok(symbol) => {
+                    // Range-validate fresh geometry (validate_symbol_json only
+                    // checks presence; serde bypasses the create validators).
+                    if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
+                        return ToolCallResult::error(format!("Symbol {idx} ('{name}'): {e}"));
+                    }
                     library.add(symbol);
                     imported_count += 1;
                 }

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -129,13 +129,27 @@ impl McpServer {
             }
         }
 
-        // Parse text
-        if let Some(texts) = fp_json.get("texts").and_then(Value::as_array) {
+        // Parse text. Accept both "text" (the create-path key) and the legacy
+        // "texts" so reusing the create schema for an update no longer silently
+        // drops text primitives.
+        if let Some(texts) = fp_json
+            .get("text")
+            .or_else(|| fp_json.get("texts"))
+            .and_then(Value::as_array)
+        {
             for text_json in texts {
                 if let Some(text) = Self::parse_text(text_json) {
                     footprint.add_text(text);
                 }
             }
+        }
+
+        // Reject out-of-range / non-finite geometry before it can saturate in
+        // from_mm() on save. The create path validates here; this path skipped
+        // it (parallels the #102 update_pad/update_primitive bug). Runs in
+        // dry-run too so previews report the error.
+        if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
+            return ToolCallResult::error(e);
         }
 
         // Get the old component for comparison
@@ -368,6 +382,12 @@ impl McpServer {
                     symbol.parameters.push(param);
                 }
             }
+        }
+
+        // Reject out-of-range geometry before save (the create path validates
+        // here; this path skipped it entirely). Runs in dry-run too.
+        if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
+            return ToolCallResult::error(e);
         }
 
         // Get the old component for comparison

--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -207,16 +207,22 @@ impl McpServer {
                             param.hidden = hidden;
                         }
                         if let Some(x) = arguments.get("x").and_then(Value::as_i64) {
-                            #[allow(clippy::cast_possible_truncation)]
-                            {
-                                param.x = x as i32;
+                            let Ok(x) = i32::try_from(x) else {
+                                return ToolCallResult::error("Parameter 'x' is out of range");
+                            };
+                            if let Err(e) = Self::validate_schlib_coordinate(x, "parameter x") {
+                                return ToolCallResult::error(e);
                             }
+                            param.x = x;
                         }
                         if let Some(y) = arguments.get("y").and_then(Value::as_i64) {
-                            #[allow(clippy::cast_possible_truncation)]
-                            {
-                                param.y = y as i32;
+                            let Ok(y) = i32::try_from(y) else {
+                                return ToolCallResult::error("Parameter 'y' is out of range");
+                            };
+                            if let Err(e) = Self::validate_schlib_coordinate(y, "parameter y") {
+                                return ToolCallResult::error(e);
                             }
+                            param.y = y;
                         }
 
                         symbol.add_parameter(param);


### PR DESCRIPTION
Addresses **#104**. A mapping pass over every write-path handler found that #102's validation fix was **incomplete** — the same "build geometry from caller JSON, save without range-validating it" bypass (out-of-range coords silently saturate in `from_mm()` and write corrupt bytes with a *success* status) existed in **6 more paths**. This routes them all through the existing shared validators, plus fixes a silent data-loss bug.

## Bugs closed

| Path | Was | Now |
|------|-----|-----|
| `update_pcblib_component` | no range validation (whole-footprint replace) | `validate_footprint_coordinates` before save |
| `update_schlib_component` | **no validation at all** | `validate_symbol_coordinates` before save |
| `import_pcblib` | serde build, no validation | range-validate each footprint |
| `import_schlib` | presence-only, no range | range-validate each symbol |
| `batch_update_track_width` | `>0` only | + `validate_coordinate` range check |
| `schlib_manage` param-add | raw `as i32` truncation, no validation | checked `i32::try_from` + `validate_schlib_coordinate` |

Plus a **silent data-loss fix**: `update_pcblib_component` read footprint text from key `"texts"` while the create path uses `"text"` — reusing the create schema for an update dropped all text primitives. Now accepts both.

## Why this is safe

Each path validates only its **fresh** geometry (the component/library being written), never pre-existing on-disk data — so a legacy library with an out-of-range primitive the user never touched is not newly rejected. The validators are the *same* ones create/`update_pad`/`update_primitive` already use, so no currently-valid input is rejected. Validation runs in **dry-run** too, so previews now report the error instead of falsely showing "would update".

**Behaviour change (intended):** the listed paths now **reject** out-of-range / non-finite geometry that previously saved as corrupt bytes. This is the fix.

## Scope note
This is the high-value **validation half** of #104 (the single-entry-point consolidation + bug fixes). The cosmetic *backup→save→post-validate* orchestration dedup (~25 inlined triads) is a lower-risk follow-up; I left it out to keep this PR focused on the bug-closing change. Handler-level rejection tests would need new test infra (none exists for the MCP handlers today) — also a reasonable follow-up; the underlying validators are unit-tested and all existing tests pass.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass (224 + 69 + 10 + others), zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)