### PR TITLE
refactor(pcblib): untangle the 3D-model write path (#103)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -860,47 +860,28 @@ impl PcbLib {
         use uuid::Uuid;
 
         for footprint in &mut self.footprints {
-            if let Some(ref model_3d) = footprint.model_3d {
-                let path = std::path::Path::new(&model_3d.filepath);
+            let Some(ref model_3d) = footprint.model_3d else {
+                continue;
+            };
+            let path = std::path::Path::new(&model_3d.filepath);
 
-                // Only ever surface the bare file name in logs/errors, never the
-                // caller's full path (sanitisation rule).
-                let display_name = path.file_name().map_or_else(
-                    || "<model>".to_string(),
-                    |n| n.to_string_lossy().into_owned(),
-                );
+            // Only ever surface the bare file name in logs/errors, never the
+            // caller's full path (sanitisation rule).
+            let display_name = path.file_name().map_or_else(
+                || "<model>".to_string(),
+                |n| n.to_string_lossy().into_owned(),
+            );
 
-                // Check if the filepath looks like an explicit path (has directory components)
-                // vs just a model name (which gets set during read from ComponentBody)
-                let is_explicit_path = path.parent().is_some_and(|p| !p.as_os_str().is_empty());
+            // The three conditions that decide what to do with this model_3d.
+            let has_bodies = !footprint.component_bodies.is_empty();
+            // An explicit path has directory components; a bare model name (set
+            // when reading a ComponentBody back) does not.
+            let is_explicit_path = path.parent().is_some_and(|p| !p.as_os_str().is_empty());
+            let file_present = path.exists() && path.is_file();
 
-                // If footprint already has component_bodies AND filepath is just a name
-                // (not an explicit path), skip to prevent Bug #2 (duplicate component bodies
-                // from accidentally matching a file with the same name as the model)
-                if !footprint.component_bodies.is_empty() && !is_explicit_path {
-                    tracing::trace!(
-                        footprint = %footprint.name,
-                        component_bodies = footprint.component_bodies.len(),
-                        model = %display_name,
-                        "Skipping model_3d - footprint already has ComponentBody and filepath is not explicit"
-                    );
-                    continue;
-                }
-
-                // Check if file exists
-                if !path.exists() || !path.is_file() {
-                    // If footprint has existing component_bodies, the model is already embedded
-                    // from a previous save - just skip (the filepath is stale)
-                    if !footprint.component_bodies.is_empty() {
-                        tracing::trace!(
-                            footprint = %footprint.name,
-                            model = %display_name,
-                            "Skipping model_3d - file not found but ComponentBody exists"
-                        );
-                        continue;
-                    }
-
-                    // For NEW footprints, the file MUST exist - return error
+            match (has_bodies, is_explicit_path, file_present) {
+                // New footprint whose STEP file is missing — the path is required.
+                (false, _, false) => {
                     return Err(AltiumError::InvalidParameter {
                         name: "step_model.filepath".to_string(),
                         message: format!(
@@ -910,17 +891,26 @@ impl PcbLib {
                         ),
                     });
                 }
-
-                // If we have component_bodies but the user explicitly set a path
-                // that exists, they want to re-embed. Clear the old
-                // component_bodies first — and drop the embedded models those
-                // bodies referenced, so they don't linger in self.models as
+                // Already embedded, and either the filepath is a bare model name
+                // (from a prior read) or it no longer points at a file — keep the
+                // existing ComponentBody as-is.
+                (true, false, _) | (true, _, false) => {
+                    tracing::trace!(
+                        footprint = %footprint.name,
+                        model = %display_name,
+                        "Skipping model_3d - already embedded or filepath not actionable"
+                    );
+                    continue;
+                }
+                // Already embedded but the user pointed at a new explicit path that
+                // exists — re-embed. Drop the old ComponentBodies AND the models
+                // they referenced, so the latter don't linger in self.models as
                 // orphans (which previously bloated the library on every save).
-                if !footprint.component_bodies.is_empty() {
+                (true, true, true) => {
                     tracing::debug!(
                         footprint = %footprint.name,
                         old_bodies = footprint.component_bodies.len(),
-                        "Clearing old ComponentBodies for re-embedding from new path"
+                        "Re-embedding model_3d from new explicit path"
                     );
                     let stale: std::collections::HashSet<String> = footprint
                         .component_bodies
@@ -932,47 +922,41 @@ impl PcbLib {
                     self.models
                         .retain(|m| !stale.contains(&m.id.to_lowercase()));
                 }
-
-                // Read the STEP file
-                let step_data = std::fs::read(path).map_err(|e| AltiumError::file_read(path, e))?;
-
-                // Generate a GUID for the model
-                let guid = format!("{{{}}}", Uuid::new_v4().to_string().to_uppercase());
-
-                // Extract filename from path
-                let filename = path.file_name().map_or_else(
-                    || "model.step".to_string(),
-                    |n| n.to_string_lossy().to_string(),
-                );
-
-                // Create EmbeddedModel
-                let embedded_model = EmbeddedModel::new(&guid, &filename, step_data);
-                self.models.push(embedded_model);
-
-                // Create ComponentBody referencing the model
-                let component_body = ComponentBody {
-                    model_id: guid,
-                    model_name: filename,
-                    embedded: true,
-                    rotation_x: 0.0,
-                    rotation_y: 0.0,
-                    rotation_z: model_3d.rotation,
-                    z_offset: model_3d.z_offset,
-                    overall_height: 0.0, // Could be calculated from STEP, but not implemented
-                    standoff_height: 0.0,
-                    layer: Layer::Top3DBody,
-                    outline: Vec::new(), // Synthesised from the footprint extent on write
-                    unique_id: None,
-                };
-
-                footprint.component_bodies.push(component_body);
-
-                tracing::debug!(
-                    footprint = %footprint.name,
-                    filepath = %model_3d.filepath,
-                    "Converted model_3d to ComponentBody"
-                );
+                // Fresh embed: new footprint, file present.
+                (false, _, true) => {}
             }
+
+            // Embed: read the STEP file, then create the EmbeddedModel +
+            // ComponentBody (shared by the fresh-embed and re-embed cases above).
+            let step_data = std::fs::read(path).map_err(|e| AltiumError::file_read(path, e))?;
+            let guid = format!("{{{}}}", Uuid::new_v4().to_string().to_uppercase());
+            let filename = path.file_name().map_or_else(
+                || "model.step".to_string(),
+                |n| n.to_string_lossy().to_string(),
+            );
+
+            self.models
+                .push(EmbeddedModel::new(&guid, &filename, step_data));
+            footprint.component_bodies.push(ComponentBody {
+                model_id: guid,
+                model_name: filename,
+                embedded: true,
+                rotation_x: 0.0,
+                rotation_y: 0.0,
+                rotation_z: model_3d.rotation,
+                z_offset: model_3d.z_offset,
+                overall_height: 0.0, // Could be calculated from STEP, but not implemented
+                standoff_height: 0.0,
+                layer: Layer::Top3DBody,
+                outline: Vec::new(), // Synthesised from the footprint extent on write
+                unique_id: None,
+            });
+
+            tracing::debug!(
+                footprint = %footprint.name,
+                filepath = %model_3d.filepath,
+                "Converted model_3d to ComponentBody"
+            );
         }
 
         Ok(())

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -2402,6 +2402,64 @@ fn test_multiple_step_models_in_library() {
     }
 }
 
+/// Re-embedding a footprint's model from a new explicit path (and re-saving)
+/// must replace the previously-embedded model, not leave it orphaned in the
+/// library — otherwise self.models bloats on every save (bug #7 / issue #103).
+#[test]
+fn test_reembed_model_replaces_without_bloat() {
+    use std::io::Write;
+
+    let temp_dir = test_temp_dir();
+    let pcblib_path = temp_dir.path().join("reembed.PcbLib");
+    let step_a = temp_dir.path().join("model_a.step");
+    let step_b = temp_dir.path().join("model_b.step");
+    File::create(&step_a)
+        .unwrap()
+        .write_all(b"ISO-10303-21;HEADER;FILE_DESCRIPTION(('Model A'));ENDSEC;DATA;ENDSEC;END-ISO-10303-21;")
+        .unwrap();
+    File::create(&step_b)
+        .unwrap()
+        .write_all(b"ISO-10303-21;HEADER;FILE_DESCRIPTION(('Model B'));ENDSEC;DATA;ENDSEC;END-ISO-10303-21;")
+        .unwrap();
+
+    let mut lib = PcbLib::new();
+    let mut fp = Footprint::new("FP");
+    fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+    fp.model_3d = Some(Model3D {
+        filepath: step_a.to_string_lossy().to_string(),
+        x_offset: 0.0,
+        y_offset: 0.0,
+        z_offset: 0.0,
+        rotation: 0.0,
+    });
+    lib.add(fp);
+
+    // First save embeds model A (footprint now has a ComponentBody).
+    lib.save(&pcblib_path).expect("first save");
+    assert_eq!(lib.model_count(), 1, "one model after the first embed");
+
+    // Point the footprint at a new explicit path and save again -> re-embed.
+    lib.get_mut("FP")
+        .unwrap()
+        .model_3d
+        .as_mut()
+        .unwrap()
+        .filepath = step_b.to_string_lossy().to_string();
+    lib.save(&pcblib_path).expect("second save");
+
+    // The old model must be dropped, not left as an orphan.
+    assert_eq!(lib.model_count(), 1, "re-embed must not bloat self.models");
+
+    // And the on-disk library now holds model B.
+    let read = PcbLib::open(&pcblib_path).expect("read back");
+    assert_eq!(read.model_count(), 1);
+    let content = read.models().next().unwrap().as_string().unwrap();
+    assert!(
+        content.contains("Model B"),
+        "re-embedded model should be B, got: {content}"
+    );
+}
+
 /// Tests copying a footprint with embedded STEP model between libraries.
 /// The STEP file must remain available since the target library re-embeds from the filepath.
 #[test]


### PR DESCRIPTION
Closes **#103**.

`prepare_3d_models_for_writing` decided what to do with each footprint's `model_3d` via nested `if … continue` / `if … return` / `if … clear` branches — the tangle where bug #7 (orphaned models on re-embed) hid. This replaces it with a **single exhaustive `match`** over the three conditions that actually drive the decision:

```rust
match (has_bodies, is_explicit_path, file_present) {
    (false, _, false)              => return MissingFile error,
    (true, false, _) | (true, _, false) => Skip (keep existing embed),
    (true, true, true)             => ReEmbed (drop old bodies + orphan models),
    (false, _, true)              => Embed (fresh),
}
```

Now the full decision table is explicit in one place, and the shared embed step (read STEP → `EmbeddedModel` + `ComponentBody`) runs once after the match instead of being duplicated.

**Behaviour-identical** — verified the truth table matches the old branches exactly; all existing model/round-trip/orphan tests pass.

Also adds **`test_reembed_model_replaces_without_bloat`**, a regression test for the re-embed path (previously uncovered): embed model A, repoint to model B, re-save, and assert `model_count == 1` (old model dropped, not orphaned) and the on-disk model is B.

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass (224 unit + 70 integration + 10 doc-tests + others), incl. the new re-embed test

🤖 Generated with [Claude Code](https://claude.com/claude-code)