### PR TITLE
refactor(tools): centralise backup→save into a shared helper

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -420,6 +420,22 @@ impl McpServer {
     /// Maximum number of timestamped backups to retain per file.
     const MAX_BACKUPS: usize = 5;
 
+    /// Backs up `filepath`, then persists the library via `save`.
+    ///
+    /// Centralises the backup → save sequence shared by every mutating tool
+    /// handler so create and update paths cannot drift (see #104). On failure it
+    /// returns the tool-error response; the caller builds its own success result.
+    pub(crate) fn backup_then_save(
+        filepath: &str,
+        save: impl FnOnce() -> crate::altium::AltiumResult<()>,
+    ) -> Result<(), ToolCallResult> {
+        if let Err(e) = Self::create_backup(filepath) {
+            return Err(ToolCallResult::error(e));
+        }
+        save().map_err(|e| ToolCallResult::error(format!("Failed to write library: {e}")))?;
+        Ok(())
+    }
+
     /// Creates a timestamped backup of an existing file before modification.
     ///
     /// Copies `filepath` to `filepath.YYYYMMDD_HHMMSS.bak`, keeping up to

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -190,13 +190,8 @@ impl McpServer {
 
         // Write back if any updates were made (and not dry-run)
         if symbols_updated > 0 && !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to write library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 
@@ -284,13 +279,8 @@ impl McpServer {
 
         // Write the updated library if any changes were made (and not dry-run)
         if total_updated > 0 && !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to write updated library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 
@@ -417,13 +407,8 @@ impl McpServer {
 
         // Write the updated library if any changes were made (and not dry-run)
         if total_updated > 0 && !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to write updated library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -118,14 +118,8 @@ impl McpServer {
             return ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the updated library
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({
@@ -201,14 +195,8 @@ impl McpServer {
             return ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the updated library
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({
@@ -326,14 +314,8 @@ impl McpServer {
             return ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the updated library
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({
@@ -399,14 +381,8 @@ impl McpServer {
             return ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the updated library
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({
@@ -620,14 +596,10 @@ impl McpServer {
         // Add the footprint to target library
         target_library.add(new_footprint);
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(target_filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the target library
-        if let Err(e) = target_library.save(target_filepath) {
-            return ToolCallResult::error(format!("Failed to write target library: {e}"));
+        if let Err(resp) =
+            Self::backup_then_save(target_filepath, || target_library.save(target_filepath))
+        {
+            return resp;
         }
 
         let mut result = json!({
@@ -739,14 +711,10 @@ impl McpServer {
         // Add the symbol to target library
         target_library.add(new_symbol);
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(target_filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the target library
-        if let Err(e) = target_library.save(target_filepath) {
-            return ToolCallResult::error(format!("Failed to write target library: {e}"));
+        if let Err(resp) =
+            Self::backup_then_save(target_filepath, || target_library.save(target_filepath))
+        {
+            return resp;
         }
 
         let mut result = json!({
@@ -980,14 +948,10 @@ impl McpServer {
 
         // Only write if not dry-run
         if !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(target_filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            // Write the merged library
-            if let Err(e) = target_library.save(target_filepath) {
-                return ToolCallResult::error(format!("Failed to write target library: {e}"));
+            if let Err(resp) =
+                Self::backup_then_save(target_filepath, || target_library.save(target_filepath))
+            {
+                return resp;
             }
         }
 
@@ -1140,14 +1104,10 @@ impl McpServer {
 
         // Only write if not dry-run
         if !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(target_filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            // Write the merged library
-            if let Err(e) = target_library.save(target_filepath) {
-                return ToolCallResult::error(format!("Failed to write target library: {e}"));
+            if let Err(resp) =
+                Self::backup_then_save(target_filepath, || target_library.save(target_filepath))
+            {
+                return resp;
             }
         }
 

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1114,14 +1114,8 @@ impl McpServer {
             }
         }
 
-        // Create backup before destructive operation (if file exists)
-        if let Err(e) = Self::create_backup(output_path) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the library
-        if let Err(e) = library.save(output_path) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(output_path, || library.save(output_path)) {
+            return resp;
         }
 
         let total_count = library.len();
@@ -1320,14 +1314,8 @@ impl McpServer {
             }
         }
 
-        // Create backup before destructive operation (if file exists)
-        if let Err(e) = Self::create_backup(output_path) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the library
-        if let Err(e) = library.save(output_path) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(output_path, || library.save(output_path)) {
+            return resp;
         }
 
         let total_count = library.len();

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -49,13 +49,8 @@ impl McpServer {
 
         // Save if not dry run and changes were made
         if needs_save && !dry_run {
-            // Create backup before destructive operation
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to save library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 
@@ -630,11 +625,8 @@ impl McpServer {
 
         // Save if not dry run
         if !dry_run {
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to save library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 
@@ -1077,11 +1069,8 @@ impl McpServer {
 
         // Save if not dry run
         if !dry_run {
-            if let Err(e) = Self::create_backup(filepath) {
-                return ToolCallResult::error(e);
-            }
-            if let Err(e) = library.save(filepath) {
-                return ToolCallResult::error(format!("Failed to save library: {e}"));
+            if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                return resp;
             }
         }
 

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -183,14 +183,8 @@ impl McpServer {
         // Perform the actual update
         library.update(component_name, footprint);
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the library back
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({
@@ -421,14 +415,8 @@ impl McpServer {
         // Perform the actual update
         library.update(component_name, symbol);
 
-        // Create backup before destructive operation
-        if let Err(e) = Self::create_backup(filepath) {
-            return ToolCallResult::error(e);
-        }
-
-        // Write the library back
-        if let Err(e) = library.save(filepath) {
-            return ToolCallResult::error(format!("Failed to write library: {e}"));
+        if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+            return resp;
         }
 
         let mut result = json!({

--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -264,14 +264,8 @@ impl McpServer {
                     _ => unreachable!(),
                 };
 
-                // Create backup before destructive operation
-                if let Err(e) = Self::create_backup(filepath) {
-                    return ToolCallResult::error(e);
-                }
-
-                // Save the modified library
-                if let Err(e) = library.save(filepath) {
-                    return ToolCallResult::error(format!("Failed to save library: {e}"));
+                if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                    return resp;
                 }
 
                 // Run post-write validation
@@ -430,14 +424,8 @@ impl McpServer {
                     })
                 };
 
-                // Create backup before destructive operation
-                if let Err(e) = Self::create_backup(filepath) {
-                    return ToolCallResult::error(e);
-                }
-
-                // Save the modified library
-                if let Err(e) = library.save(filepath) {
-                    return ToolCallResult::error(format!("Failed to save library: {e}"));
+                if let Err(resp) = Self::backup_then_save(filepath, || library.save(filepath)) {
+                    return resp;
                 }
 
                 // Run post-write validation


### PR DESCRIPTION
Completes #104. The shared-validation half landed in #107; this PR addresses the second half — the repeated **backup → save** orchestration.

## Why
Every mutating MCP tool handler re-implemented:
```rust
if let Err(e) = Self::create_backup(path) { return ToolCallResult::error(e); }
if let Err(e) = library.save(path) { return ToolCallResult::error(format!("Failed to … : {e}")); }
```
8 of the 10 bugs fixed in #102 clustered in this layer precisely because create and update paths could drift.

## What
- New `McpServer::backup_then_save(path, || lib.save(path))` helper. The **closure form** absorbs the `&mut self` (PcbLib) vs `&self` (SchLib) difference between the two `save` signatures, so one helper serves both.
- Routed the **20 standard backup→save pairs** through it across `batch`, `components`, `library_ops`, `maintenance`, `query_update`, `schlib_manage` (in-place updates, copy targets, exports).

## Intentionally left as-is (different behaviour)
- Handlers that return a **custom JSON error body** on save failure (components reorder/move, library create).
- `read_write` paths that build their result inside a **`match library.save()`**.
- `maintenance` rename paths where the save is **non-adjacent** (a loop sits between backup and save).

## Behaviour note
Four synonymous save-error messages (`write`/`save`/`write updated`/`write target` library) unify to a single `Failed to write library: {e}`. The underlying `AltiumError` still carries the specifics.

## Verification
- `cargo fmt` clean · `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test`: 224 unit + 70 integration + 10 doc-tests pass
- Net **−86 lines** (150 deleted, 64 added)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)