### PR TITLE
fix(altium): encode on-disk strings as Windows-1252, not UTF-8 (#68)

### DIFF
--- a/src/altium/pcblib/read_io.rs
+++ b/src/altium/pcblib/read_io.rs
@@ -194,10 +194,9 @@ impl PcbLib {
             }
         }
 
-        // Fall back to pipe-delimited key=value format (legacy)
-        let Ok(text) = String::from_utf8(data) else {
-            return Ok(metadata);
-        };
+        // Fall back to pipe-delimited key=value format (legacy).
+        // Altium stores these as Windows-1252, not UTF-8 (#68).
+        let text = crate::altium::decode_windows1252(&data);
 
         for pair in text.split('|') {
             if let Some((key, value)) = pair.split_once('=') {
@@ -489,18 +488,18 @@ impl PcbLib {
             data
         };
 
-        if let Ok(text) = String::from_utf8(text_data.to_vec()) {
-            let params = crate::altium::parse_pipe_params(&text);
-            // Use PATTERN as the canonical name since OLE storage names are
-            // limited to 31 characters; DESCRIPTION is free text.
-            if let Some(pattern) = params.get("pattern") {
-                if !pattern.is_empty() {
-                    footprint.name.clone_from(pattern);
-                }
+        // Altium stores parameter strings as Windows-1252, not UTF-8 (#68).
+        let text = crate::altium::decode_windows1252(text_data);
+        let params = crate::altium::parse_pipe_params(&text);
+        // Use PATTERN as the canonical name since OLE storage names are
+        // limited to 31 characters; DESCRIPTION is free text.
+        if let Some(pattern) = params.get("pattern") {
+            if !pattern.is_empty() {
+                footprint.name.clone_from(pattern);
             }
-            if let Some(description) = params.get("description") {
-                footprint.description.clone_from(description);
-            }
+        }
+        if let Some(description) = params.get("description") {
+            footprint.description.clone_from(description);
         }
     }
 

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1077,7 +1077,8 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
     // Parse block 0 to extract parameters
     // Format: [header bytes][parameter_string]
     // Parameter string is pipe-separated key=value pairs starting with V7_LAYER=
-    let block_str = String::from_utf8_lossy(block0);
+    // Altium stores these as Windows-1252, not UTF-8 (#68).
+    let block_str = crate::altium::decode_windows1252(block0);
 
     // Find the parameter string (starts with V7_LAYER= or similar key)
     let params = parse_component_body_params(&block_str);

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -296,7 +296,10 @@ impl PcbLib {
         // component count + names.
         let params = Self::build_library_params(self.filepath.as_deref().unwrap_or(""));
         let mut data = Vec::new();
-        crate::altium::framing::write_cstring_param_block(&mut data, params.as_bytes());
+        crate::altium::framing::write_cstring_param_block(
+            &mut data,
+            &crate::altium::encode_windows1252(&params),
+        );
 
         // Component count
         #[allow(clippy::cast_possible_truncation)]
@@ -305,7 +308,10 @@ impl PcbLib {
         // Component names as WriteStringBlock: [block_len:4][str_len:1][string].
         // The read-side mirror is `read_library_data`.
         for ole_name in ole_names {
-            crate::altium::framing::write_string_block(&mut data, ole_name.as_bytes());
+            crate::altium::framing::write_string_block(
+                &mut data,
+                &crate::altium::encode_windows1252(ole_name),
+            );
         }
 
         // Write Library/Data
@@ -324,7 +330,10 @@ impl PcbLib {
     /// [`crate::altium::framing::write_cstring_param_block`] frame.
     fn param_block(text: &str) -> Vec<u8> {
         let mut v = Vec::new();
-        crate::altium::framing::write_cstring_param_block(&mut v, text.as_bytes());
+        crate::altium::framing::write_cstring_param_block(
+            &mut v,
+            &crate::altium::encode_windows1252(text),
+        );
         v
     }
 
@@ -491,7 +500,10 @@ impl PcbLib {
             footprint.name, footprint.description
         );
         let mut params_data = Vec::new();
-        crate::altium::framing::write_cstring_param_block(&mut params_data, params.as_bytes());
+        crate::altium::framing::write_cstring_param_block(
+            &mut params_data,
+            &crate::altium::encode_windows1252(&params),
+        );
         crate::altium::write_stream(cfb, &format!("{storage_path}/Parameters"), &params_data)?;
 
         // Write Data stream with primitives

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -944,7 +944,7 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     // Build parameter string (leading pipe, matching Altium).
     let layer_name = region.layer.as_str().replace(' ', "").to_uppercase();
     let params = format!("|V7_LAYER={layer_name}|NAME=|KIND=0");
-    let params_bytes = params.as_bytes();
+    let params_bytes = crate::altium::encode_windows1252(&params);
 
     let mut block = Vec::with_capacity(22 + params_bytes.len() + 4 + vertex_count * 16);
 
@@ -955,7 +955,7 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     block.extend_from_slice(&[0x00; 5]);
 
     // C-string parameter block (length includes the null terminator).
-    write_cstring_param_block(&mut block, params_bytes);
+    write_cstring_param_block(&mut block, &params_bytes);
 
     // Vertex count
     write_u32(&mut block, vertex_count as u32);
@@ -1059,7 +1059,7 @@ fn encode_component_body_block(body: &ComponentBody, outline: &[(f64, f64)]) -> 
 
     // Parameter string as a C-string block (length includes the null).
     let param_str = build_component_body_params(body);
-    write_cstring_param_block(&mut block, param_str.as_bytes());
+    write_cstring_param_block(&mut block, &crate::altium::encode_windows1252(&param_str));
 
     // Outline polygon: vertex count then (f64 x, f64 y) per vertex, in Altium
     // internal units (1 mil = 10000). Altium needs a non-empty outline to place

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -751,14 +751,15 @@ pub fn encode_file_header(symbols: &[&Symbol], ole_names: &[String]) -> Vec<u8> 
     }
 
     let text = format!("|{}", parts.join("|"));
-    let text_bytes = text.as_bytes();
+    // Altium stores parameter strings as Windows-1252, not UTF-8 (#68).
+    let text_bytes = crate::altium::encode_windows1252(&text);
 
     // Format: [length:4 LE][text + 0x00]. The block is a C-string: it MUST be
     // null-terminated and the length MUST include the terminator (matches Altium
     // WriteCStringParameterBlockRaw). Omitting it is issue #68's "Data does not
     // end with 0x00".
     let mut data = Vec::with_capacity(4 + text_bytes.len() + 1);
-    write_cstring_param_block(&mut data, text_bytes);
+    write_cstring_param_block(&mut data, &text_bytes);
 
     data
 }

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -304,6 +304,77 @@ fn schlib_file_roundtrip_simple_symbol() {
     assert_eq!(read_sym.rectangles.len(), 1);
 }
 
+// =============================================================================
+// Issue #68: on-disk strings must be Windows-1252, not UTF-8
+// =============================================================================
+
+/// Returns true if `haystack` contains `needle` as a contiguous byte run.
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    needle.is_empty() || haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Altium stores strings as Windows-1252. A footprint description with non-ASCII
+/// characters must round-trip AND be written as single-byte Windows-1252 (e.g.
+/// `µ` = `0xB5`), never as the two-byte UTF-8 sequence (`0xC2 0xB5`) that Altium
+/// misreads. ASCII is identical in both encodings, so only non-ASCII exposes the
+/// bug — which is why it survived an all-ASCII test suite.
+#[test]
+fn pcblib_non_ascii_description_is_windows1252() {
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_win1252.PcbLib");
+
+    let mut lib = PcbLib::new();
+    let mut fp = Footprint::new("CAP_0402");
+    fp.description = "cap 10µF ±5% é°".to_string();
+    fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+    lib.add(fp);
+    lib.save(&file_path).expect("Failed to write PcbLib");
+
+    // Round-trip preserves the exact string.
+    let read_lib = PcbLib::open(&file_path).expect("Failed to read PcbLib");
+    let read_fp = read_lib.get("CAP_0402").expect("Footprint not found");
+    assert_eq!(read_fp.description, "cap 10µF ±5% é°");
+
+    // The on-disk bytes are Windows-1252, not UTF-8.
+    let raw = std::fs::read(&file_path).expect("read raw file");
+    assert!(
+        contains_bytes(&raw, b"10\xb5F"),
+        "description should be Windows-1252 (0xB5 for µ)"
+    );
+    assert!(
+        !contains_bytes(&raw, b"10\xc2\xb5F"),
+        "description must NOT be UTF-8 (0xC2 0xB5 for µ) — Altium would misread it"
+    );
+}
+
+/// The `SchLib` `FileHeader` (component description) must likewise be Windows-1252.
+#[test]
+fn schlib_non_ascii_description_is_windows1252() {
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_win1252.SchLib");
+
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("RES");
+    sym.description = "résistance 10µF".to_string();
+    sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+    lib.add(sym);
+    lib.save(&file_path).expect("Failed to write SchLib");
+
+    let read_lib = SchLib::open(&file_path).expect("Failed to read SchLib");
+    let read_sym = read_lib.get("RES").expect("Symbol not found");
+    assert_eq!(read_sym.description, "résistance 10µF");
+
+    let raw = std::fs::read(&file_path).expect("read raw file");
+    assert!(
+        contains_bytes(&raw, b"10\xb5F"),
+        "description should be Windows-1252 (0xB5 for µ)"
+    );
+    assert!(
+        !contains_bytes(&raw, b"10\xc2\xb5F"),
+        "description must NOT be UTF-8 (0xC2 0xB5 for µ)"
+    );
+}
+
 #[test]
 fn schlib_file_roundtrip_multiple_symbols() {
     let temp_dir = test_temp_dir();


### PR DESCRIPTION
## Context
While re-investigating #68, I ran a **byte-level audit of our writer against the AltiumSharp golden binaries + DTO/serializer spec** (15 primitive families, adversarially verified). The core #68 readability was already fixed (#86/#87/#88, oracle 13/13 green). The audit surfaced one clear **#68-class correctness bug** that survived because the test suite is all-ASCII.

## The bug
Altium stores every on-disk string as **Windows-1252**. Several PcbLib writer paths still emitted **UTF-8** via `.as_bytes()`, and the matching reader paths decoded UTF-8 — a *paired* mismatch that round-trips fine in our own tests but corrupts non-ASCII for Altium:

> description `"10µF"` → written as UTF-8 `0xC2 0xB5` → Altium reads `"10ÂµF"`

`BinaryFormatWriter` in the reference Windows-1252-encodes every string; our own `framing::read_pascal_string` *already* decoded Windows-1252 — the writers simply weren't paired with it.

## Fix (writer ↔ reader paired)
**Writer → `encode_windows1252`:** PcbLib component Parameters (`PATTERN`/`DESCRIPTION`), `Library/Data` params, component OLE names, the `param_block` metadata helper, region params, ComponentBody params; SchLib FileHeader (`CompDescr`/`LibRef`).
**Reader → `decode_windows1252`:** PcbLib `parse_parameters`, ComponentBody params, legacy pipe-header fallback. (Names + SchLib header already decoded Windows-1252.)

ASCII is byte-identical in both encodings ⇒ **behaviour-neutral for existing content**.

## Tests
Two new tests prove non-ASCII descriptions **round-trip** *and* are written as **single-byte Windows-1252** (`0xB5`), never UTF-8 (`0xC2 0xB5`) — the assertion the all-ASCII suite couldn't make.

## Verification
- `cargo test` — 226 unit/integration + 70 stress + 10 doc, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt` clean
- **pyaltiumlib readability oracle: 13/13, no regression**

## Scope note
Contributes to #68; does **not** close it (final closure needs the reporter to confirm in Altium 24). The audit's other findings are round-trip-fidelity gaps (missing optional struct fields — don't affect from-scratch generation) and a few false positives; I'll file a separate tracking issue for the genuine fidelity items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)