### PR TITLE
fix(pcblib): write vias as a single block, not six (#113)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -978,6 +978,32 @@ mod tests {
     }
 
     #[test]
+    fn via_is_single_321_byte_block() {
+        // #113: Altium writes a via as ONE block — the 13-byte common header plus
+        // the 321-byte via SubRecord-1 — matching `PcbLibWriter.WriteVia`. We used
+        // to emit six pad-style blocks, which Altium misreads. A self-consistent
+        // round-trip can't catch that, so assert the on-disk block structure.
+        let mut fp = Footprint::new("VIA_ONLY");
+        fp.add_via(Via::new(1.0, 2.0, 0.6, 0.3));
+        let data = writer::encode_data_stream(&fp).expect("encode");
+
+        // The via record is `[0x03][block_len: u32 LE][block]`; 321 == 0x0000_0141.
+        let sig = [0x03u8, 0x41, 0x01, 0x00, 0x00];
+        let pos = data
+            .windows(sig.len())
+            .position(|w| w == sig)
+            .expect("via must be a single 321-byte block");
+        let block = &data[pos + 5..pos + 5 + 321];
+        // Common-header layer byte is MultiLayer (74) for a via.
+        assert_eq!(block[0], 74, "via common header should be on MultiLayer");
+        // Exactly one block — no second via sub-block follows (the old 6-block bug).
+        assert!(
+            !data[pos + 5 + 321..].windows(sig.len()).any(|w| w == sig),
+            "via should emit exactly one block, not several"
+        );
+    }
+
+    #[test]
     fn binary_roundtrip_via() {
         let mut original = Footprint::new("ROUNDTRIP_VIA");
 

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -364,142 +364,61 @@ const fn pad_stack_mode_from_id(id: u8) -> PadStackMode {
 /// - Block 3: Net/connectivity data
 /// - Block 4: Geometry data
 /// - Block 5: Per-layer data
-#[allow(clippy::too_many_lines)]
 pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
-    let mut current = offset;
+    // Altium writes a via as a single block: the 13-byte common header followed
+    // by the 321-byte via SubRecord-1 (offsets 13-320). Mirror of `encode_via`
+    // (#113); the old reader expected six pad-style blocks.
+    let (block, next) = read_block(data, offset)
+        .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Via block"))?;
 
-    // Block 0: Name/designator (typically empty for vias)
-    let (_, next) = read_block(data, current)
-        .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Via block 0 (name)"))?;
-    current = next;
-
-    // Block 1: Layer stack data (skip)
-    let (_, next) = read_block(data, current).ok_or_else(|| {
-        AltiumError::parse_error(current, "failed to read Via block 1 (layer stack)")
-    })?;
-    current = next;
-
-    // Block 2: Marker string ("|&|0")
-    let (_, next) = read_block(data, current)
-        .ok_or_else(|| AltiumError::parse_error(current, "failed to read Via block 2 (marker)"))?;
-    current = next;
-
-    // Block 3: Net/connectivity data (skip)
-    let (_, next) = read_block(data, current).ok_or_else(|| {
-        AltiumError::parse_error(current, "failed to read Via block 3 (net data)")
-    })?;
-    current = next;
-
-    // Block 4: Geometry data
-    let (geometry, next) = read_block(data, current).ok_or_else(|| {
-        AltiumError::parse_error(current, "failed to read Via block 4 (geometry)")
-    })?;
-    current = next;
-
-    // Block 5: Per-layer data (optional)
-    if let Some((_, next)) = read_block(data, current) {
-        current = next;
-    }
-
-    // Parse geometry block
-    // Minimum size: 13 (header) + 4 (x) + 4 (y) + 4 (diameter) + 4 (hole) + 2 (layers) = 31 bytes
-    if geometry.len() < 31 {
+    if block.len() < 31 {
         return Err(AltiumError::parse_error(
             offset,
             format!(
-                "Via geometry block too short: {} bytes, expected at least 31",
-                geometry.len()
+                "Via block too short: {} bytes, expected at least 31",
+                block.len()
             ),
         ));
     }
 
-    // Common header (13 bytes) - layer ID at offset 0
-    // Note: Via layer is typically MultiLayer (74), but we read from/to layers separately
-
-    // Location (X, Y) - offsets 13-20
-    let x =
-        to_mm(read_i32(geometry, 13).ok_or_else(|| {
-            AltiumError::parse_error(offset + 13, "failed to read Via x coordinate")
-        })?);
-    let y =
-        to_mm(read_i32(geometry, 17).ok_or_else(|| {
-            AltiumError::parse_error(offset + 17, "failed to read Via y coordinate")
-        })?);
-
-    // Diameter - offset 21
+    let x = to_mm(
+        read_i32(block, 13)
+            .ok_or_else(|| AltiumError::parse_error(offset + 13, "failed to read Via x"))?,
+    );
+    let y = to_mm(
+        read_i32(block, 17)
+            .ok_or_else(|| AltiumError::parse_error(offset + 17, "failed to read Via y"))?,
+    );
     let diameter = to_mm(
-        read_i32(geometry, 21)
+        read_i32(block, 21)
             .ok_or_else(|| AltiumError::parse_error(offset + 21, "failed to read Via diameter"))?,
     );
-
-    // Hole size - offset 25
     let hole_size =
-        to_mm(read_i32(geometry, 25).ok_or_else(|| {
+        to_mm(read_i32(block, 25).ok_or_else(|| {
             AltiumError::parse_error(offset + 25, "failed to read Via hole size")
         })?);
+    let from_layer = layer_from_id(block[29]);
+    let to_layer = layer_from_id(block[30]);
 
-    // From/To layers - offsets 29-30
-    let from_layer = if geometry.len() > 29 {
-        layer_from_id(geometry[29])
-    } else {
-        Layer::TopLayer
-    };
+    // Extended SubRecord-1 fields (offsets 32-74). A short block falls back to
+    // the same defaults the Via struct uses.
+    let thermal_relief_gap = read_i32(block, 32).map_or(0.254, to_mm);
+    let thermal_relief_conductors = block.get(36).copied().unwrap_or(4);
+    let thermal_relief_width = read_i32(block, 38).map_or(0.254, to_mm);
+    let solder_mask_expansion = read_i32(block, 54).map_or(0.0, to_mm);
+    let solder_mask_expansion_manual = block.get(66).is_some_and(|&b| b != 0);
+    let diameter_stack_mode = block
+        .get(74)
+        .map_or(ViaStackMode::Simple, |&b| via_stack_mode_from_id(b));
 
-    let to_layer = if geometry.len() > 30 {
-        layer_from_id(geometry[30])
-    } else {
-        Layer::BottomLayer
-    };
-
-    // Thermal relief settings - offsets 31-39
-    let thermal_relief_gap = if geometry.len() > 34 {
-        to_mm(read_i32(geometry, 31).unwrap_or(2540)) // Default: 10 mils = 2540 internal units
-    } else {
-        0.254 // Default: 10 mils
-    };
-
-    let thermal_relief_conductors = if geometry.len() > 35 {
-        geometry[35]
-    } else {
-        4 // Default: 4 conductors
-    };
-
-    let thermal_relief_width = if geometry.len() > 39 {
-        to_mm(read_i32(geometry, 36).unwrap_or(2540)) // Default: 10 mils = 2540 internal units
-    } else {
-        0.254 // Default: 10 mils
-    };
-
-    // Solder mask expansion - offset 40
-    let solder_mask_expansion = if geometry.len() > 43 {
-        to_mm(read_i32(geometry, 40).unwrap_or(0))
-    } else {
-        0.0
-    };
-
-    // Solder mask expansion manual flag - offset 44
-    let solder_mask_expansion_manual = geometry.len() > 44 && geometry[44] != 0;
-
-    // Diameter stack mode - offset 45
-    let diameter_stack_mode = if geometry.len() > 45 {
-        via_stack_mode_from_id(geometry[45])
-    } else {
-        ViaStackMode::Simple
-    };
-
-    // Per-layer diameters - offset 46+ (32 × 4 bytes = 128 bytes)
+    // Per-layer diameters: 32 x i32 from offset 75, only for a non-simple stack.
     let per_layer_diameters =
-        if diameter_stack_mode != ViaStackMode::Simple && geometry.len() > 45 + 128 {
-            let mut diameters = Vec::with_capacity(32);
-            for i in 0..32 {
-                let layer_offset = 46 + (i * 4);
-                if let Some(val) = read_i32(geometry, layer_offset) {
-                    diameters.push(to_mm(val));
-                } else {
-                    diameters.push(diameter); // Fallback to main diameter
-                }
-            }
-            Some(diameters)
+        if diameter_stack_mode != ViaStackMode::Simple && block.len() >= 75 + 32 * 4 {
+            Some(
+                (0..32)
+                    .map(|i| read_i32(block, 75 + i * 4).map_or(diameter, to_mm))
+                    .collect(),
+            )
         } else {
             None
         };
@@ -521,7 +440,7 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         unique_id: None,
     };
 
-    Ok((via, current))
+    Ok((via, next))
 }
 
 /// Converts a via stack mode ID to `ViaStackMode`.

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -279,7 +279,7 @@ pub fn encode_data_stream(footprint: &Footprint) -> crate::altium::error::Altium
 
     for via in &footprint.vias {
         data.push(0x03); // Via record type
-        encode_via(&mut data, via)?;
+        encode_via(&mut data, via);
     }
 
     for track in &footprint.tracks {
@@ -620,119 +620,83 @@ fn encode_pad_geometry(pad: &Pad) -> Vec<u8> {
     block
 }
 
-/// Encodes a Via primitive.
+/// Canonical 321-byte via `SubRecord-1` (offsets 0-320) captured from a standard
+/// Altium via. [`encode_via`] clones it and overlays the typed fields we model;
+/// the reserved/cache/identity regions keep their template defaults so the via
+/// stays Altium-readable (matches `PcbLibWriter.BuildViaExtended`).
+const VIA_SR1_TEMPLATE: [u8; 321] = [
+    0x4A, 0x0C, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xF0, 0x49, 0x02, 0x00, 0x02, 0x20, 0x00,
+    0xA0, 0x86, 0x01, 0x00, 0x04, 0x00, 0xA0, 0x86, 0x01, 0x00, 0x40, 0x0D, 0x03, 0x00, 0x40, 0x0D,
+    0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x9C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0,
+    0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0xE0, 0x93, 0x04, 0x00, 0x0F, 0x00, 0x03, 0x01, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x40, 0x9C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, 0x00,
+    0x00, 0x00, 0x00, 0x80, 0x63, 0xD4, 0xE4, 0x65, 0xC4, 0xF4, 0x4E, 0x8B, 0xAD, 0xA7, 0xCE, 0x97,
+    0xDC, 0x40, 0xDA, 0xA5, 0xB1, 0xE3, 0xB2, 0x84, 0x25, 0x11, 0x43, 0x83, 0xDB, 0x2B, 0x6A, 0x87,
+    0x7C, 0xB1, 0x74, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x1E, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x01,
+];
+
+/// Encodes a Via primitive as Altium's single-block via record.
 ///
-/// Via has 6 blocks (similar to Pad):
-/// - Block 0: Name/designator (empty for vias)
-/// - Block 1: Layer stack data (empty)
-/// - Block 2: Marker string ("|&|0")
-/// - Block 3: Net/connectivity data (empty)
-/// - Block 4: Geometry data
-/// - Block 5: Per-layer data (empty for simple vias)
-fn encode_via(data: &mut Vec<u8>, via: &Via) -> crate::altium::error::AltiumResult<()> {
-    // Block 0: Name/designator (empty for vias)
-    write_block(data, &[0u8; 1]); // Single null byte for empty string
+/// Altium writes a via as **one** block: the 13-byte common header (offsets
+/// 0-12) followed by the 321-byte via `SubRecord-1` (offsets 13-320) — see
+/// [`VIA_SR1_TEMPLATE`]. Our previous 6-block layout (copied from the pad
+/// encoder) was misread by Altium; this matches `PcbLibWriter.WriteVia` (#113).
+fn encode_via(data: &mut Vec<u8>, via: &Via) {
+    let mut block = VIA_SR1_TEMPLATE;
 
-    // Block 1: Layer stack data (empty)
-    write_block(data, &[]);
+    // Common header (offsets 0-12): MultiLayer + default (saved + unlocked) flags.
+    let mut header = Vec::with_capacity(13);
+    write_common_header(&mut header, Layer::MultiLayer, PcbFlags::empty());
+    block[0..13].copy_from_slice(&header);
 
-    // Block 2: "|&|0" marker string
-    write_string_block(data, "|&|0", "via.marker")?;
+    // Geometry (offsets 13-30).
+    block[13..17].copy_from_slice(&from_mm(via.x).to_le_bytes());
+    block[17..21].copy_from_slice(&from_mm(via.y).to_le_bytes());
+    block[21..25].copy_from_slice(&from_mm(via.diameter).to_le_bytes());
+    block[25..29].copy_from_slice(&from_mm(via.hole_size).to_le_bytes());
+    block[29] = layer_to_id(via.from_layer);
+    block[30] = layer_to_id(via.to_layer);
 
-    // Block 3: Net/connectivity data (empty for library vias)
-    write_block(data, &[]);
+    // Thermal relief (air gap @32, conductor count @36, conductor width @38).
+    block[32..36].copy_from_slice(&from_mm(via.thermal_relief_gap).to_le_bytes());
+    block[36] = via.thermal_relief_conductors;
+    block[38..42].copy_from_slice(&from_mm(via.thermal_relief_width).to_le_bytes());
 
-    // Block 4: Geometry data
-    let geometry = encode_via_geometry(via);
-    write_block(data, &geometry);
+    // Solder mask expansion @54, its mode @66, diameter stack mode @74.
+    block[54..58].copy_from_slice(&from_mm(via.solder_mask_expansion).to_le_bytes());
+    block[66] = u8::from(via.solder_mask_expansion_manual);
+    block[74] = via_stack_mode_to_id(via.diameter_stack_mode);
 
-    // Block 5: Per-layer data (empty for simple vias)
-    write_block(data, &[]);
-
-    Ok(())
-}
-
-/// Encodes the geometry block for a via.
-///
-/// # Format
-///
-/// ```text
-/// [layer:1]                 // Layer ID (typically MultiLayer = 74)
-/// [flags:12]                // Flags and padding
-/// [x:4 i32]                 // X position
-/// [y:4 i32]                 // Y position
-/// [diameter:4 i32]          // Via diameter
-/// [hole_size:4 i32]         // Hole diameter
-/// [from_layer:1]            // Starting layer ID
-/// [to_layer:1]              // Ending layer ID
-/// [thermal_gap:4 i32]       // Thermal relief air gap width
-/// [thermal_count:1]         // Thermal relief conductors count
-/// [thermal_width:4 i32]     // Thermal relief conductors width
-/// [solder_expansion:4 i32]  // Solder mask expansion
-/// [solder_manual:1]         // Solder mask expansion manual flag
-/// [stack_mode:1]            // Diameter stack mode (0 = Simple)
-/// ```
-fn encode_via_geometry(via: &Via) -> Vec<u8> {
-    let mut block = Vec::with_capacity(256); // Larger for potential per-layer data
-
-    // Common header (13 bytes) - use MultiLayer for vias
-    // Note: Via primitive doesn't have flags field (different binary structure)
-    write_common_header(&mut block, Layer::MultiLayer, PcbFlags::empty());
-
-    // Location (X, Y) - offsets 13-20
-    write_i32(&mut block, from_mm(via.x));
-    write_i32(&mut block, from_mm(via.y));
-
-    // Diameter - offset 21
-    write_i32(&mut block, from_mm(via.diameter));
-
-    // Hole size - offset 25
-    write_i32(&mut block, from_mm(via.hole_size));
-
-    // From/To layers - offsets 29-30
-    block.push(layer_to_id(via.from_layer));
-    block.push(layer_to_id(via.to_layer));
-
-    // Thermal relief air gap width - offset 31
-    write_i32(&mut block, from_mm(via.thermal_relief_gap));
-
-    // Thermal relief conductors count - offset 35
-    block.push(via.thermal_relief_conductors);
-
-    // Thermal relief conductors width - offset 36
-    write_i32(&mut block, from_mm(via.thermal_relief_width));
-
-    // Solder mask expansion - offset 40
-    write_i32(&mut block, from_mm(via.solder_mask_expansion));
-
-    // Solder mask expansion manual flag - offset 44
-    block.push(u8::from(via.solder_mask_expansion_manual));
-
-    // Diameter stack mode - offset 45
-    block.push(via_stack_mode_to_id(via.diameter_stack_mode));
-
-    // Per-layer diameters - offset 46+ (32 × 4 bytes = 128 bytes)
-    // Only write if stack mode is not Simple
-    if via.diameter_stack_mode != ViaStackMode::Simple {
-        if let Some(ref diameters) = via.per_layer_diameters {
-            for i in 0..32 {
-                let diameter = diameters.get(i).copied().unwrap_or(via.diameter);
-                write_i32(&mut block, from_mm(diameter));
-            }
+    // Per-layer diameters: 32 x i32 from offset 75. A real stack uses the
+    // per-layer array; a simple via repeats its diameter on every layer so it
+    // never reads back as zero-diameter per layer.
+    for i in 0..32 {
+        let d = if via.diameter_stack_mode == ViaStackMode::Simple {
+            via.diameter
         } else {
-            // No per-layer data provided, use main diameter for all layers
-            for _ in 0..32 {
-                write_i32(&mut block, from_mm(via.diameter));
-            }
-        }
+            via.per_layer_diameters
+                .as_ref()
+                .and_then(|v| v.get(i).copied())
+                .unwrap_or(via.diameter)
+        };
+        let off = 75 + i * 4;
+        block[off..off + 4].copy_from_slice(&from_mm(d).to_le_bytes());
     }
 
-    // Pad to minimum expected size
-    while block.len() < 46 {
-        block.push(0x00);
-    }
-
-    block
+    write_block(data, &block);
 }
 
 /// Converts a `ViaStackMode` to its binary ID.

--- a/tests/integration/test_altium_readability.py
+++ b/tests/integration/test_altium_readability.py
@@ -99,6 +99,8 @@ def _generate(binary, out_dir):
                 {"designator": "1", "x": -0.5, "y": 0.0, "width": 0.6, "height": 0.5},
                 {"designator": "2", "x": 0.5, "y": 0.0, "width": 0.6, "height": 0.5},
             ],
+            # Via exercises the single-block via record (issue #113).
+            "vias": [{"x": 0.0, "y": -0.8, "diameter": 0.6, "hole_size": 0.3}],
             "tracks": [{"x1": -1, "y1": 0.5, "x2": 1, "y2": 0.5,
                         "width": 0.1, "layer": "Top Overlay"}],
             "arcs": [{"x": 0, "y": 0, "radius": 0.3, "start_angle": 0,


### PR DESCRIPTION
## The bug
Altium writes a via as **one** block — the 13-byte common header + a 321-byte via `SubRecord-1` (offsets 13–320), exactly like a track. Our `encode_via` instead emitted **six** pad-style sub-blocks (name / layer-stack / marker / net / geometry / per-layer), and `parse_via` read them back — so it round-tripped through *our own* code but a footprint containing a via was **misread by Altium**. The internal geometry offsets diverged too (thermal at 31 vs 32; per-layer diameters at 46 vs 75).

Confirmed against `PcbLibWriter.WriteVia` / `BuildViaExtended` in the AltiumSharp golden source (this was the one true-positive critical from the #68 byte-audit; the others were round-trip fidelity or false positives).

## The fix
- **`encode_via`** clones a canonical **321-byte `VIA_SR1_TEMPLATE`** (extracted verbatim from the golden `ViaSr1Template`) and overlays only the typed fields we model — location, diameter, hole, from/to layer, thermal relief, solder-mask expansion, stack mode, per-layer diameters. Reserved/cache/identity regions keep their template defaults, so the via stays Altium-readable.
- **`parse_via`** reads the single block at the correct offsets.

Vias aren't in the MCP tool's *documented* schema but are accepted via serde (`Footprint.vias`), so this path is reachable.

## Tests
- New **`via_is_single_321_byte_block`** asserts the on-disk record is one 321-byte block on `MultiLayer` (a self-consistent round-trip can't catch a paired-but-wrong format — which is exactly how this bug hid).
- The **pyaltiumlib readability oracle now generates a via**, and reads the single-block via with **zero parser warnings** — a permanent regression guard.

## Verification
- `cargo test` — **225 unit** + 70 stress + 10 doc, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt` clean
- Oracle **13/13** (now including a via)

Addresses the via half of #113 (the round-trip-fidelity items remain tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)