### PR TITLE
fix(schlib): link footprint models so all resolve in Altium

### DIFF
--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -896,6 +896,13 @@ pub struct FootprintModel {
     /// Description.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
+    /// Path to the `PcbLib` that contains this footprint, written as
+    /// `ModelDatafile0`. When set, Altium resolves the footprint directly from
+    /// that file (rendering the preview); when absent it falls back to searching
+    /// available libraries by name, which reports "footprint not found" if the
+    /// library isn't installed/in the project.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub library_path: Option<String>,
 }
 
 impl FootprintModel {
@@ -905,6 +912,7 @@ impl FootprintModel {
         Self {
             name: name.into(),
             description: String::new(),
+            library_path: None,
         }
     }
 }

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -168,6 +168,12 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
                 if let Some(desc) = props.get("description") {
                     fp.description.clone_from(desc);
                 }
+                // Preserve the PcbLib path (ModelDatafile0) so it round-trips.
+                if let Some(path) = props.get("modeldatafile0") {
+                    if !path.is_empty() {
+                        fp.library_path = Some(path.clone());
+                    }
+                }
                 symbol.add_footprint(fp);
             }
         }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -565,15 +565,62 @@ fn encode_implementation_list() -> String {
     "|RECORD=44".to_string()
 }
 
-/// Encodes a footprint model record.
-fn encode_footprint_model(model: &FootprintModel, owner_index: usize) -> String {
+/// Counts the records already written to a Data-stream buffer, using the
+/// `[u24 length LE][u8 flags][payload]` framing. The result is the stream-index
+/// the next record will occupy (records are 0-indexed, matching the values
+/// Altium stores in `OwnerIndex`).
+fn count_records(data: &[u8]) -> usize {
+    let mut offset = 0;
+    let mut count = 0;
+    while offset + 4 <= data.len() {
+        let len = (data[offset] as usize)
+            | ((data[offset + 1] as usize) << 8)
+            | ((data[offset + 2] as usize) << 16);
+        offset += 4 + len;
+        count += 1;
+    }
+    count
+}
+
+/// Encodes a footprint model record (`RECORD=45`).
+///
+/// `owner_index` is the stream-index of the owning `RECORD=44` implementation list.
+/// `is_current` marks the default footprint (`IsCurrent=T`, set on one model).
+///
+/// `DatafileCount=1` plus `ModelDatafileEntity0` is what lets Altium *resolve*
+/// the model to an actual footprint in a `PcbLib` (rendering the preview and
+/// finding it on placement); a name-only record with `DatafileCount=0` shows in
+/// the list but reports "model not found".
+fn encode_footprint_model(model: &FootprintModel, owner_index: usize, is_current: bool) -> String {
+    // ModelDatafile0 (the .PcbLib path) is what lets Altium resolve the footprint
+    // directly; omitted when no path is known (falls back to name search).
+    let datafile = model
+        .library_path
+        .as_deref()
+        .map(|p| format!("|ModelDatafile0={p}"))
+        .unwrap_or_default();
     format!(
-        "|RECORD=45|OwnerIndex={}|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=0|UniqueID={}",
+        "|RECORD=45|OwnerIndex={}|IndexInSheet=-1|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=1{}|ModelDatafileEntity0={}|ModelDatafileKind0=PCBLib|IsCurrent={}|UniqueID={}",
         owner_index,
         model.description,
         model.name,
+        datafile,
+        model.name,
+        if is_current { "T" } else { "F" },
         generate_unique_id()
     )
+}
+
+/// Encodes a model datafile link record (`RECORD=46`) — a child of a footprint
+/// model. `owner_index` is the stream-index of the owning `RECORD=45`.
+fn encode_model_datafile_link(owner_index: usize) -> String {
+    format!("|RECORD=46|OwnerIndex={owner_index}")
+}
+
+/// Encodes an implementation record (`RECORD=48`) — a child of a footprint
+/// model. `owner_index` is the stream-index of the owning `RECORD=45`.
+fn encode_implementation(owner_index: usize) -> String {
+    format!("|RECORD=48|OwnerIndex={owner_index}")
 }
 
 /// Generates a random 8-character unique ID (similar to Altium's format).
@@ -695,10 +742,22 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
 
     // 16. Implementation list — Altium always writes RECORD=44, then a model
     // record per footprint.
+    // Every footprint model (RECORD=45) is owned by the single RECORD=44
+    // ImplementationList, so its OwnerIndex must be that record's stream-index —
+    // not the model's own position (the previous behaviour, which orphaned every
+    // model after the first).
+    let impl_index = count_records(&data);
     write_text_record(&mut data, &encode_implementation_list())?;
     for (i, model) in symbol.footprints.iter().enumerate() {
-        let record = encode_footprint_model(model, i);
-        write_text_record(&mut data, &record)?;
+        // The RECORD=45 is owned by the RECORD=44; its RECORD=46/48 children are
+        // in turn owned by the RECORD=45 (its own stream-index).
+        let model_index = count_records(&data);
+        write_text_record(
+            &mut data,
+            &encode_footprint_model(model, impl_index, i == 0),
+        )?;
+        write_text_record(&mut data, &encode_model_datafile_link(model_index))?;
+        write_text_record(&mut data, &encode_implementation(model_index))?;
     }
 
     // No end-of-stream sentinel: Altium reads records until the stream is
@@ -800,6 +859,51 @@ mod tests {
         let text = String::from_utf8_lossy(&data);
         assert!(text.contains("RECORD=1"), "component record present");
         assert!(text.contains("RECORD=44"), "implementation list present");
+    }
+
+    #[test]
+    fn footprint_models_owned_by_implementation_list() {
+        let mut symbol = Symbol::new("R");
+        symbol.add_pin(Pin::new("1", "1", -10, 0, 10, PinOrientation::Left));
+        symbol.add_pin(Pin::new("2", "2", 10, 0, 10, PinOrientation::Right));
+        let mut a = FootprintModel::new("R0402");
+        a.library_path = Some("X:/Lib/Test.PcbLib".to_string());
+        symbol.add_footprint(a);
+        symbol.add_footprint(FootprintModel::new("R0603"));
+
+        let data = encode_data_stream(&symbol).expect("encode");
+
+        // Parse records: [u24 length LE][u8 flags][payload].
+        let mut records: Vec<String> = Vec::new();
+        let mut off = 0;
+        while off + 4 <= data.len() {
+            let len = data[off] as usize
+                | ((data[off + 1] as usize) << 8)
+                | ((data[off + 2] as usize) << 16);
+            records.push(String::from_utf8_lossy(&data[off + 4..off + 4 + len]).into_owned());
+            off += 4 + len;
+        }
+
+        let impl_idx = records
+            .iter()
+            .position(|t| t.contains("|RECORD=44"))
+            .expect("RECORD=44 present");
+        let models: Vec<&String> = records.iter().filter(|t| t.contains("|RECORD=45")).collect();
+        assert_eq!(models.len(), 2, "both footprint models written");
+        for m in &models {
+            // Every model is owned by the single implementation list, not its own index.
+            assert!(
+                m.contains(&format!("OwnerIndex={impl_idx}")),
+                "model owned by RECORD=44 (index {impl_idx}): {m}"
+            );
+        }
+        // The library path is emitted as ModelDatafile0 so Altium can resolve it.
+        assert!(records
+            .iter()
+            .any(|t| t.contains("ModelDatafile0=X:/Lib/Test.PcbLib")));
+        // Each model carries its RECORD=46 / RECORD=48 children.
+        assert!(records.iter().any(|t| t.contains("|RECORD=46")));
+        assert!(records.iter().any(|t| t.contains("|RECORD=48")));
     }
 
     #[test]

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -404,6 +404,19 @@ impl McpServer {
                                             },
                                             "required": ["name"]
                                         }
+                                    },
+                                    "footprints": {
+                                        "type": "array",
+                                        "description": "Footprint model references (links to PCB footprints)",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": { "type": "string", "description": "Footprint name (entity in the PcbLib)" },
+                                                "description": { "type": "string", "description": "Model description" },
+                                                "library_path": { "type": "string", "description": "Optional absolute path to the .PcbLib containing the footprint, written as ModelDatafile0 so Altium resolves/previews the model. Omit to link by name only (requires the library to be installed/in the project)." }
+                                            },
+                                            "required": ["name"]
+                                        }
                                     }
                                 },
                                 "required": ["name", "pins"]
@@ -1092,6 +1105,10 @@ impl McpServer {
                         "description": {
                             "type": "string",
                             "description": "Footprint description (optional for add)"
+                        },
+                        "library_path": {
+                            "type": "string",
+                            "description": "Optional (add): absolute path to the .PcbLib containing the footprint, written as ModelDatafile0 so Altium can resolve and preview the model. Omit to link by name only (requires the library to be installed/in the project, else 'footprint not found')."
                         }
                     },
                     "required": ["filepath", "component_name", "operation"]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -717,6 +717,12 @@ impl McpServer {
                         if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
                             fp.description = desc.to_string();
                         }
+                        // Optional PcbLib path -> ModelDatafile0, so Altium can
+                        // resolve the footprint instead of reporting "not found".
+                        if let Some(lib_path) = fp_json.get("library_path").and_then(Value::as_str)
+                        {
+                            fp.library_path = Some(lib_path.to_string());
+                        }
                         symbol.add_footprint(fp);
                     }
                 }

--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -337,6 +337,7 @@ impl McpServer {
                         json!({
                             "name": f.name,
                             "description": f.description,
+                            "library_path": f.library_path,
                         })
                     })
                     .collect();
@@ -391,6 +392,14 @@ impl McpServer {
                     // Apply optional description
                     if let Some(desc) = arguments.get("description").and_then(Value::as_str) {
                         footprint.description = desc.to_string();
+                    }
+
+                    // Apply optional PcbLib path so Altium can resolve the
+                    // footprint (written as ModelDatafile0). Without it the model
+                    // links by name only and shows "footprint not found" unless
+                    // the library is installed/in the project.
+                    if let Some(lib_path) = arguments.get("library_path").and_then(Value::as_str) {
+                        footprint.library_path = Some(lib_path.to_string());
                     }
 
                     symbol.add_footprint(footprint);


### PR DESCRIPTION
## Problem

A symbol written with multiple footprint models showed **only the first** in Altium's SCH Library editor, and each footprint's model preview reported **"footprint not found."**

## Root causes

Found by diffing a tool-written symbol against the same symbol after adding a footprint by hand in Altium.

1. **`OwnerIndex`** — `encode_data_stream` passed each model's *enumerate index* (`0,1,2,3`) as its `RECORD=45` `OwnerIndex`. But `OwnerIndex` must reference the single `RECORD=44` ImplementationList that owns every model. Altium attached only the model whose owner happened to resolve (the first) and orphaned the rest.
2. **Resolution** — models were written `DatafileCount=0` (name only), so Altium couldn't bind them to a footprint or render a preview. Real models carry `DatafileCount=1` + `ModelDatafileEntity0` + `ModelDatafileKind0`, and a `ModelDatafile0` path.

## Fix

- Compute the `RECORD=44` stream-index (new `count_records` helper) and use it as `OwnerIndex` for **all** models; emit each model's `RECORD=46` + `RECORD=48` child records owned by their `RECORD=45`.
- Write `DatafileCount=1` + entity/kind + `IsCurrent`; add an optional `FootprintModel.library_path` → `ModelDatafile0`, plumbed through `manage_schlib_footprints` (new optional `library_path` arg) and `write_schlib` (per-footprint `library_path`), and parsed back by the reader so it round-trips.

## Verification

- A resistor symbol with `R0402`/`R0603`/`R0805`/`R2512` now shows **all four**, and the model previews **render** (was "not found"). Confirmed in Altium Designer.
- `cargo test` (225, incl. a new regression test that asserts every model is owned by the `RECORD=44` and the path is emitted), `cargo clippy`, and `cargo fmt --check` are clean.

## Notes for maintainers

- `library_path` is the one small **API addition** (optional arg on `manage_schlib_footprints`, and per-footprint in `write_schlib`). When omitted, models link by name only — which works when the PcbLib is installed/in the project, but reports "not found" otherwise. Happy to rename it or auto-derive the path if you'd prefer a different shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
