### PR TITLE
feat(libpkg): generate Altium Library Package (.LibPkg) project files

### DIFF
--- a/src/altium/libpkg.rs
+++ b/src/altium/libpkg.rs
@@ -1,0 +1,123 @@
+//! Altium Library Package (`.LibPkg`) project-file generation.
+//!
+//! A `.LibPkg` is an INI-style project file that groups source library
+//! documents (`.SchLib`, `.PcbLib`) so Altium can compile them into an
+//! Integrated Library (`.IntLib`). Altium backfills every optional project
+//! setting the first time the project is opened, so only the `[Design]`
+//! version and one `[Document{N}]` section per member document are required.
+//!
+//! ```text
+//! [Design]
+//! Version=1.0
+//!
+//! [Document1]
+//! DocumentPath=MyLib.SchLib
+//!
+//! [Document2]
+//! DocumentPath=MyLib.PcbLib
+//! ```
+//!
+//! Member documents are referenced by their path **relative to the `.LibPkg`
+//! file**. This module only generates the project source; compiling it to a
+//! binary `.IntLib` is an operation performed inside Altium Designer.
+
+use std::path::{Component, Path};
+
+/// Computes the path of `document` relative to the directory containing
+/// `libpkg_path`, using Windows-style `\` separators (Altium's convention).
+///
+/// A document in the same directory becomes a bare file name; a document with
+/// no shared root (a bare name, or a different drive) is emitted unchanged.
+#[must_use]
+pub fn relative_to_libpkg(libpkg_path: &Path, document: &str) -> String {
+    let base = libpkg_path.parent().unwrap_or_else(|| Path::new(""));
+    relative_path(base, Path::new(document))
+}
+
+/// Builds the full text of a `.LibPkg` referencing `documents`.
+#[must_use]
+pub fn build_libpkg(libpkg_path: &Path, documents: &[String]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::from("[Design]\r\nVersion=1.0\r\n");
+    for (i, doc) in documents.iter().enumerate() {
+        let rel = relative_to_libpkg(libpkg_path, doc);
+        let _ = write!(out, "\r\n[Document{}]\r\nDocumentPath={rel}\r\n", i + 1);
+    }
+    out
+}
+
+/// Lexically relativizes `target` against the directory `base`.
+fn relative_path(base: &Path, target: &Path) -> String {
+    let b: Vec<Component> = base.components().collect();
+    let t: Vec<Component> = target.components().collect();
+
+    let mut shared = 0;
+    while shared < b.len() && shared < t.len() && b[shared] == t[shared] {
+        shared += 1;
+    }
+
+    // No shared root — a bare file name or a different drive. Emit as given
+    // (normalised to backslashes) rather than inventing a bogus `..` chain.
+    if shared == 0 {
+        return target.to_string_lossy().replace('/', "\\");
+    }
+
+    let mut parts: Vec<String> = vec!["..".to_string(); b.len() - shared];
+    parts.extend(
+        t[shared..]
+            .iter()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned()),
+    );
+    parts.join("\\")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_directory_uses_bare_filename() {
+        let pkg = Path::new(r"C:\lib\TestLib.LibPkg");
+        assert_eq!(
+            relative_to_libpkg(pkg, r"C:\lib\TestLib.SchLib"),
+            "TestLib.SchLib"
+        );
+    }
+
+    #[test]
+    fn subdirectory_is_relative() {
+        let pkg = Path::new(r"C:\lib\TestLib.LibPkg");
+        assert_eq!(
+            relative_to_libpkg(pkg, r"C:\lib\sub\Part.PcbLib"),
+            "sub\\Part.PcbLib"
+        );
+    }
+
+    #[test]
+    fn parent_directory_walks_up() {
+        let pkg = Path::new(r"C:\lib\pkg\TestLib.LibPkg");
+        assert_eq!(
+            relative_to_libpkg(pkg, r"C:\lib\Part.SchLib"),
+            "..\\Part.SchLib"
+        );
+    }
+
+    #[test]
+    fn bare_filename_passes_through() {
+        let pkg = Path::new(r"C:\lib\TestLib.LibPkg");
+        assert_eq!(relative_to_libpkg(pkg, "TestLib.SchLib"), "TestLib.SchLib");
+    }
+
+    #[test]
+    fn build_has_design_and_documents() {
+        let pkg = Path::new(r"C:\lib\TestLib.LibPkg");
+        let docs = vec![
+            r"C:\lib\TestLib.SchLib".to_string(),
+            r"C:\lib\TestLib.PcbLib".to_string(),
+        ];
+        let text = build_libpkg(pkg, &docs);
+        assert!(text.starts_with("[Design]\r\nVersion=1.0"));
+        assert!(text.contains("[Document1]\r\nDocumentPath=TestLib.SchLib"));
+        assert!(text.contains("[Document2]\r\nDocumentPath=TestLib.PcbLib"));
+    }
+}

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -26,6 +26,7 @@
 pub(crate) mod bytes;
 pub mod error;
 pub(crate) mod framing;
+pub mod libpkg;
 pub mod pcblib;
 pub mod schlib;
 pub(crate) mod serde_round;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -769,6 +769,7 @@ impl McpServer {
                 "write_pcblib" => self.call_write_pcblib(&params.arguments),
                 "read_schlib" => self.call_read_schlib(&params.arguments),
                 "write_schlib" => self.call_write_schlib(&params.arguments),
+                "write_libpkg" => self.call_write_libpkg(&params.arguments),
                 "list_components" => self.call_list_components(&params.arguments),
                 "extract_style" => self.call_extract_style(&params.arguments),
                 // Library management tools

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -417,6 +417,33 @@ impl McpServer {
                     "required": ["filepath", "symbols"]
                 }),
             },
+            ToolDefinition {
+                name: "write_libpkg".to_string(),
+                description: Some(
+                    "Write an Altium Library Package (.LibPkg) project file that groups source \
+                     library documents (.SchLib and .PcbLib) so they can be compiled into an \
+                     Integrated Library (.IntLib). Member documents are referenced by their path \
+                     relative to the .LibPkg. This generates only the project source; compiling \
+                     to a binary .IntLib is a one-click operation inside Altium Designer \
+                     (Project > Compile Integrated Library)."
+                        .to_string(),
+                ),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "filepath": {
+                            "type": "string",
+                            "description": "Path to the .LibPkg file to create"
+                        },
+                        "documents": {
+                            "type": "array",
+                            "description": "Member document paths (.SchLib / .PcbLib). Each is referenced relative to the .LibPkg location; same-folder files become bare names.",
+                            "items": { "type": "string" }
+                        }
+                    },
+                    "required": ["filepath", "documents"]
+                }),
+            },
             // === Library Management ===
             ToolDefinition {
                 name: "delete_component".to_string(),

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -763,6 +763,64 @@ impl McpServer {
         }
     }
 
+    /// Writes an Altium Library Package (`.LibPkg`) project file that groups
+    /// the given source documents so Altium can compile them into an
+    /// Integrated Library. Only generates the project source; compiling to
+    /// `.IntLib` is done inside Altium.
+    pub(crate) fn call_write_libpkg(&self, arguments: &Value) -> ToolCallResult {
+        use crate::altium::libpkg;
+
+        let Some(filepath) = arguments.get("filepath").and_then(Value::as_str) else {
+            return ToolCallResult::error("Missing required parameter: filepath");
+        };
+
+        // Validate path is within allowed directories
+        if let Err(e) = self.validate_path(filepath) {
+            return ToolCallResult::error(e);
+        }
+
+        // Validate file extension
+        let ext = std::path::Path::new(filepath)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_lowercase);
+        if ext.as_deref() != Some("libpkg") {
+            return ToolCallResult::error("write_libpkg only supports .LibPkg files");
+        }
+
+        let Some(documents) = arguments.get("documents").and_then(Value::as_array) else {
+            return ToolCallResult::error("Missing required parameter: documents");
+        };
+        let docs: Vec<String> = documents
+            .iter()
+            .filter_map(|d| d.as_str().map(String::from))
+            .collect();
+        if docs.is_empty() {
+            return ToolCallResult::error(
+                "documents must contain at least one .SchLib/.PcbLib path",
+            );
+        }
+
+        let path = std::path::Path::new(filepath);
+        let content = libpkg::build_libpkg(path, &docs);
+        if let Err(e) = std::fs::write(path, content) {
+            return ToolCallResult::error(format!("Failed to write LibPkg: {e}"));
+        }
+
+        let relative: Vec<String> = docs
+            .iter()
+            .map(|d| libpkg::relative_to_libpkg(path, d))
+            .collect();
+        let result = json!({
+            "status": "success",
+            "filepath": filepath,
+            "documents": relative,
+            "count": relative.len(),
+            "note": "Open in Altium and run Project > Compile Integrated Library to produce the .IntLib.",
+        });
+        ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
+    }
+
     /// Lists component names in a library file.
     #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
     pub(crate) fn call_list_components(&self, arguments: &Value) -> ToolCallResult {


### PR DESCRIPTION
## What

Adds a `write_libpkg` MCP tool that generates an Altium **Library Package** (`.LibPkg`) — the project file that groups a `.SchLib` + `.PcbLib` so Altium can **Compile Integrated Library** into a single `.IntLib`.

## Why

The tool could already write source `.SchLib`/`.PcbLib` files but had no way to package them into a combined library. `.LibPkg` is the standard source for an Integrated Library, so this closes the gap from "two source files" to "one compilable library project."

## Format

A `.LibPkg` is an INI-style project file. Real ones run ~1000 lines, but Altium backfills every optional setting on open — only this is required, with members referenced by path **relative to the `.LibPkg`**:

```ini
[Design]
Version=1.0

[Document1]
DocumentPath=MyLib.SchLib

[Document2]
DocumentPath=MyLib.PcbLib
```

## Implementation

- **`altium::libpkg` module** — `build_libpkg` + lexical relative-path computation (same-folder → bare name; subdirectory and parent handled; bare name / different-drive passed through). 5 unit tests.
- **`write_libpkg` tool** — `filepath` + an explicit `documents` list, wired through dispatch and the tool schema.
- **Scope boundary** — generates project *source* only; compiling to the binary `.IntLib` is a one-click step in Altium (we can't produce the compiled binary). Documented in the tool description and module docs.

## Verification

- Generated a `.LibPkg` for a resistor `.SchLib` + `.PcbLib` pair; Altium opened it with both members and **Compile Integrated Library** produced a clean `.IntLib`.
- `cargo test` (229, +5 new), `cargo clippy`, `cargo fmt --check` all clean.

## Notes for maintainers

- The document list is **explicit** rather than auto-discovered, for predictability (no sweeping in unrelated sibling libraries). An auto-discover convenience flag could be added later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
