### PR TITLE
feat(pcblib): preserve track/arc solder-mask + keepout on round-trip (#113)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1004,6 +1004,45 @@ mod tests {
     }
 
     #[test]
+    fn track_arc_extended_tail_round_trips() {
+        // #113: a track/arc's solder-mask expansion and keepout restrictions are
+        // preserved on read->write (previously silently dropped). Additive: a
+        // default primitive (None) must round-trip back to None.
+        let mut fp = Footprint::new("FIDELITY");
+        let mut track = Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::TopLayer);
+        track.solder_mask_expansion = Some(0.1);
+        track.keepout_restrictions = Some(0x05);
+        fp.add_track(track);
+        let mut arc = Arc::circle(2.0, 0.0, 0.5, 0.15, Layer::TopLayer);
+        arc.solder_mask_expansion = Some(0.08);
+        arc.keepout_restrictions = Some(0x03);
+        fp.add_arc(arc);
+        // A default track to prove additivity (None stays None).
+        fp.add_track(Track::new(5.0, 0.0, 6.0, 0.0, 0.2, Layer::TopOverlay));
+
+        let data = writer::encode_data_stream(&fp).expect("encode");
+        let mut decoded = Footprint::new("FIDELITY");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.tracks.len(), 2);
+        assert!(approx_eq(
+            decoded.tracks[0].solder_mask_expansion.unwrap(),
+            0.1,
+            0.001
+        ));
+        assert_eq!(decoded.tracks[0].keepout_restrictions, Some(0x05));
+        assert!(approx_eq(
+            decoded.arcs[0].solder_mask_expansion.unwrap(),
+            0.08,
+            0.001
+        ));
+        assert_eq!(decoded.arcs[0].keepout_restrictions, Some(0x03));
+        // Additive: the default track did not gain these fields.
+        assert_eq!(decoded.tracks[1].solder_mask_expansion, None);
+        assert_eq!(decoded.tracks[1].keepout_restrictions, None);
+    }
+
+    #[test]
     fn binary_roundtrip_via() {
         let mut original = Footprint::new("ROUNDTRIP_VIA");
 

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -48,6 +48,17 @@ pub struct Track {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Solder mask expansion in mm. `None` (the default) writes 0; preserved
+    /// when reading an Altium-authored track (round-trip fidelity, #113).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub solder_mask_expansion: Option<f64>,
+    /// Keepout restrictions bitmask. `None` (the default) writes 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepout_restrictions: Option<u8>,
 }
 
 impl Track {
@@ -63,6 +74,8 @@ impl Track {
             layer,
             flags: PcbFlags::empty(),
             unique_id: None,
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
         }
     }
 }
@@ -99,6 +112,8 @@ impl Track {
 ///     layer: Layer::TopOverlay,
 ///     flags: Default::default(),
 ///     unique_id: None,
+///     solder_mask_expansion: None,
+///     keepout_restrictions: None,
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -129,6 +144,17 @@ pub struct Arc {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Solder mask expansion in mm. `None` (the default) writes 0; preserved
+    /// when reading an Altium-authored arc (round-trip fidelity, #113).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub solder_mask_expansion: Option<f64>,
+    /// Keepout restrictions bitmask. `None` (the default) writes 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepout_restrictions: Option<u8>,
 }
 
 impl Arc {
@@ -145,6 +171,8 @@ impl Arc {
             layer,
             flags: PcbFlags::empty(),
             unique_id: None,
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
         }
     }
 }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -496,6 +496,12 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
             .ok_or_else(|| AltiumError::parse_error(offset + 29, "failed to read Track width"))?,
     );
 
+    // Extended tail (round-trip fidelity, #113): solder-mask expansion @35-38,
+    // keepout restrictions @45. Kept `None` when absent or zero so a from-scratch
+    // track (which writes 0) round-trips without gaining these keys.
+    let solder_mask_expansion = read_i32(block, 35).map(to_mm).filter(|v| v.abs() > 1e-4);
+    let keepout_restrictions = block.get(45).copied().filter(|&b| b != 0);
+
     let track = Track {
         x1,
         y1,
@@ -505,6 +511,8 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
         layer,
         flags,
         unique_id: None,
+        solder_mask_expansion,
+        keepout_restrictions,
     };
 
     Ok((track, next))
@@ -558,6 +566,10 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
             .ok_or_else(|| AltiumError::parse_error(offset + 41, "failed to read Arc width"))?,
     );
 
+    // Extended tail (round-trip fidelity, #113): solder-mask @47-50, keepout @56.
+    let solder_mask_expansion = read_i32(block, 47).map(to_mm).filter(|v| v.abs() > 1e-4);
+    let keepout_restrictions = block.get(56).copied().filter(|&b| b != 0);
+
     let arc = Arc {
         x,
         y,
@@ -568,6 +580,8 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
         layer,
         flags,
         unique_id: None,
+        solder_mask_expansion,
+        keepout_restrictions,
     };
 
     Ok((arc, next))

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -757,10 +757,13 @@ fn encode_track(data: &mut Vec<u8>, track: &Track) {
     // Extended tail (offsets 33-48) — every Altium-authored track carries it.
     // Ported from `AltiumSharp` `WriteTrack`.
     block.extend_from_slice(&0i16.to_le_bytes()); // 33-34 subpoly index
-    write_i32(&mut block, 0); // 35-38 solder mask expansion
+    write_i32(
+        &mut block,
+        from_mm(track.solder_mask_expansion.unwrap_or(0.0)),
+    ); // 35-38 solder mask expansion
     block.extend_from_slice(&0i16.to_le_bytes()); // 39-40 paste mask expansion
     write_u32(&mut block, v7_layer_id(layer_to_id(track.layer))); // 41-44 v7 layer id
-    block.push(0); // 45 keepout restrictions
+    block.push(track.keepout_restrictions.unwrap_or(0)); // 45 keepout restrictions
     block.extend_from_slice(&[0u8; 3]); // 46-48 reserved
 
     write_block(data, &block);
@@ -791,10 +794,13 @@ fn encode_arc(data: &mut Vec<u8>, arc: &Arc) {
     // Ported from `AltiumSharp` `WriteArc` (note: 1-byte paste-mask field,
     // versus the track's 2-byte field).
     block.extend_from_slice(&0i16.to_le_bytes()); // 45-46 subpoly index
-    write_i32(&mut block, 0); // 47-50 solder mask expansion
+    write_i32(
+        &mut block,
+        from_mm(arc.solder_mask_expansion.unwrap_or(0.0)),
+    ); // 47-50 solder mask expansion
     block.push(0); // 51 paste mask expansion
     write_u32(&mut block, v7_layer_id(layer_to_id(arc.layer))); // 52-55 v7 layer id
-    block.push(0); // 56 keepout restrictions
+    block.push(arc.keepout_restrictions.unwrap_or(0)); // 56 keepout restrictions
     block.extend_from_slice(&[0u8; 3]); // 57-59 reserved
 
     write_block(data, &block);

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -249,6 +249,8 @@ impl McpServer {
             layer,
             flags: PcbFlags::empty(),
             unique_id: None,
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
         })
     }
 


### PR DESCRIPTION
First slice of #113's round-trip-fidelity work (verified via a spec workflow against the AltiumSharp golden + C# source, adversarially checked).

## Problem
`encode_track`/`encode_arc` already write the extended tail (solder-mask expansion + keepout restrictions) at Altium's offsets — but **hardcoded to 0** — while `parse_track`/`parse_arc` stop reading before those bytes. So a *read → edit → write* of an Altium-authored track/arc **silently dropped** both fields.

## Fix
- Add `solder_mask_expansion: Option<f64>` and `keepout_restrictions: Option<u8>` to `Track` and `Arc`.
- Read them (track `@35-38`/`@45`, arc `@47-50`/`@56`) and write the stored value.

**Strictly additive:** fields stay `None` when absent/zero, so a from-scratch primitive writes byte-identical output and round-trips back to `None`. The new test asserts **both** preservation (non-zero values survive) **and** additivity (a default primitive gains nothing).

## Scope note
This is the PcbLib half. The SchLib items from #113 (UniqueID preservation across 11 shape types, pin `IsNotAccessible`, a few verified rect/line/label params) will follow in a separate PR. The spec workflow rejected ~half the audit's candidate fields as false positives (line `AreaColor`/lock-flags are filled-shape/pin-only) — those are intentionally not implemented.

## Verification
- `cargo test` — 227 unit + 70 stress + 10 doc, all pass
- `cargo clippy --all-targets --all-features -- -D warnings` clean · `cargo fmt` clean
- Oracle **13/13** (unchanged — additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)