### PR TITLE
feat(schlib): preserve shape UniqueIDs + pin IsNotAccessible on round-trip (#113)

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -793,6 +793,7 @@ mod tests {
             fill_color: 0xFF_00_00, // Blue fill
             filled: true,
             owner_part_id: 1,
+            unique_id: None,
         };
         symbol.add_polygon(polygon.clone());
 
@@ -804,6 +805,7 @@ mod tests {
             fill_color: 0,
             filled: false,
             owner_part_id: 1,
+            unique_id: None,
         };
         symbol.add_polygon(polygon);
 

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -62,6 +62,11 @@ pub struct Pin {
     #[serde(default)]
     pub graphically_locked: bool,
 
+    /// Whether the pin is not accessible for selection in Altium's editor
+    /// (conglomerate bit `0x20`); preserved on round-trip (#113).
+    #[serde(default)]
+    pub is_not_accessible: bool,
+
     /// Symbol decoration on the inner edge (closest to component body).
     #[serde(default)]
     pub symbol_inner_edge: PinSymbol,
@@ -113,6 +118,7 @@ impl Pin {
             owner_part_id: 1,
             colour: 0,
             graphically_locked: false,
+            is_not_accessible: false,
             symbol_inner_edge: PinSymbol::None,
             symbol_outer_edge: PinSymbol::None,
             symbol_inside: PinSymbol::None,
@@ -360,6 +366,10 @@ pub struct Rectangle {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 const fn default_line_width() -> u8 {
@@ -381,6 +391,7 @@ impl Rectangle {
             filled: true,
             transparent: false,
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 }
@@ -405,6 +416,10 @@ pub struct Line {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl Line {
@@ -419,6 +434,7 @@ impl Line {
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 }
@@ -449,6 +465,10 @@ pub struct Polyline {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 /// A filled polygon.
@@ -471,6 +491,10 @@ pub struct Polygon {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 /// An arc or circle.
@@ -500,6 +524,10 @@ pub struct Arc {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 const fn default_end_angle() -> f64 {
@@ -540,6 +568,10 @@ pub struct Bezier {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl Bezier {
@@ -568,6 +600,7 @@ impl Bezier {
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 }
@@ -598,6 +631,10 @@ pub struct Ellipse {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl Ellipse {
@@ -614,6 +651,7 @@ impl Ellipse {
             fill_color: 0xFF_FF_B0, // Light yellow (BGR)
             filled: true,
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 
@@ -656,6 +694,10 @@ pub struct RoundRect {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl RoundRect {
@@ -682,6 +724,7 @@ impl RoundRect {
             fill_color: 0xFF_FF_B0, // Light yellow (BGR)
             filled: true,
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 }
@@ -720,6 +763,10 @@ pub struct EllipticalArc {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl EllipticalArc {
@@ -743,6 +790,7 @@ impl EllipticalArc {
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 
@@ -783,6 +831,10 @@ pub struct Label {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 /// A text annotation (RECORD=3).
@@ -818,6 +870,10 @@ pub struct Text {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// shape identity; a from-scratch shape generates a fresh one on write (#113).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 const fn default_font_id() -> u8 {

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -293,6 +293,7 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     let show_name = (flags & 0x08) != 0;
     let show_designator = (flags & 0x10) != 0;
     let graphically_locked = (flags & 0x40) != 0;
+    let is_not_accessible = (flags & 0x20) != 0;
 
     // length (2 bytes)
     let length = i32::from(read_i16(data, offset).unwrap_or(10));
@@ -330,6 +331,7 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
         owner_part_id: owner_part_id.into(),
         colour,
         graphically_locked,
+        is_not_accessible,
         symbol_inner_edge,
         symbol_outer_edge,
         symbol_inside,
@@ -374,6 +376,7 @@ fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
         filled: true,
         transparent,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -405,6 +408,7 @@ fn parse_line(props: &HashMap<String, String>) -> Option<Line> {
         line_width,
         color,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -516,6 +520,7 @@ fn parse_polyline(props: &HashMap<String, String>) -> Option<Polyline> {
         end_line_shape,
         line_shape_size,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -565,6 +570,7 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
         fill_color,
         filled,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -607,6 +613,7 @@ fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
         fill_color,
         filled,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -647,6 +654,7 @@ fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
         line_width,
         color,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -687,6 +695,7 @@ fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
         line_width,
         color,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -737,6 +746,7 @@ fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
         fill_color,
         filled,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -800,6 +810,7 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
         line_width,
         color,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -843,6 +854,7 @@ fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
         is_mirrored,
         is_hidden,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -886,6 +898,7 @@ fn parse_text(props: &HashMap<String, String>) -> Option<Text> {
         is_mirrored,
         is_hidden,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -205,6 +205,9 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     if pin.graphically_locked {
         flags |= 0x40;
     }
+    if pin.is_not_accessible {
+        flags |= 0x20;
+    }
     record.push(flags);
 
     // Length (2 bytes)
@@ -283,7 +286,7 @@ fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
         rect.line_color,
         rect.fill_color,
         transparent,
-        generate_unique_id()
+        rect.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -299,7 +302,7 @@ fn encode_line(line: &Line, index: usize) -> String {
         line.y2,
         line.line_width,
         line.color,
-        generate_unique_id()
+        line.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -352,7 +355,13 @@ fn encode_polyline(polyline: &Polyline, index: usize) -> String {
         parts.push(format!("Y{}={}", i + 1, y));
     }
 
-    parts.push(format!("UniqueID={}", generate_unique_id()));
+    parts.push(format!(
+        "UniqueID={}",
+        polyline
+            .unique_id
+            .clone()
+            .unwrap_or_else(generate_unique_id)
+    ));
 
     format!("|{}", parts.join("|"))
 }
@@ -377,7 +386,10 @@ fn encode_polygon(polygon: &Polygon, index: usize) -> String {
         parts.push(format!("Y{}={}", i + 1, y));
     }
 
-    parts.push(format!("UniqueID={}", generate_unique_id()));
+    parts.push(format!(
+        "UniqueID={}",
+        polygon.unique_id.clone().unwrap_or_else(generate_unique_id)
+    ));
 
     format!("|{}", parts.join("|"))
 }
@@ -395,7 +407,7 @@ fn encode_arc(arc: &Arc, index: usize) -> String {
         arc.end_angle,
         arc.line_width,
         arc.color,
-        generate_unique_id()
+        arc.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -415,7 +427,7 @@ fn encode_bezier(bezier: &Bezier, index: usize) -> String {
         bezier.y3,
         bezier.x4,
         bezier.y4,
-        generate_unique_id()
+        bezier.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -434,7 +446,7 @@ fn encode_ellipse(ellipse: &Ellipse, index: usize) -> String {
         ellipse.line_color,
         ellipse.fill_color,
         is_solid,
-        generate_unique_id()
+        ellipse.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -458,7 +470,10 @@ fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
         round_rect.line_color,
         round_rect.fill_color,
         is_solid,
-        generate_unique_id()
+        round_rect
+            .unique_id
+            .clone()
+            .unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -492,7 +507,7 @@ fn encode_elliptical_arc(arc: &EllipticalArc, index: usize) -> String {
         arc.end_angle,
         arc.line_width,
         arc.color,
-        generate_unique_id()
+        arc.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -516,7 +531,7 @@ fn encode_label(label: &Label, index: usize) -> String {
         is_mirrored,
         is_hidden,
         label.text,
-        generate_unique_id()
+        label.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 
@@ -540,7 +555,7 @@ fn encode_text(text: &Text, index: usize) -> String {
         is_mirrored,
         is_hidden,
         text.text,
-        generate_unique_id()
+        text.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
 

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -430,6 +430,7 @@ impl McpServer {
             symbol_outer_edge,
             symbol_inside,
             symbol_outside,
+            is_not_accessible: false,
         })
     }
 
@@ -466,6 +467,7 @@ impl McpServer {
             filled,
             transparent: false,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -494,6 +496,7 @@ impl McpServer {
             line_width,
             color,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -573,6 +576,7 @@ impl McpServer {
             end_line_shape: 0,
             line_shape_size: 0,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -608,6 +612,7 @@ impl McpServer {
             line_width,
             color,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -643,6 +648,7 @@ impl McpServer {
             fill_color,
             filled,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -702,6 +708,7 @@ impl McpServer {
             is_mirrored,
             is_hidden,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -761,6 +768,7 @@ impl McpServer {
             is_mirrored,
             is_hidden,
             owner_part_id,
+            unique_id: None,
         })
     }
 }

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -376,6 +376,38 @@ fn schlib_non_ascii_description_is_windows1252() {
 }
 
 #[test]
+fn schlib_preserves_unique_id_and_pin_accessibility() {
+    // #113: reading an Altium symbol and writing it back must preserve each
+    // shape's UniqueID (object identity) and the pin IsNotAccessible flag,
+    // rather than regenerating/dropping them.
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_fidelity.SchLib");
+
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("RES");
+    let mut pin = Pin::new("1", "1", -20, 0, 10, PinOrientation::Left);
+    pin.is_not_accessible = true;
+    sym.add_pin(pin);
+    let mut rect = Rectangle::new(-20, -50, 20, 50);
+    rect.unique_id = Some("ABCD1234".to_string());
+    sym.add_rectangle(rect);
+    lib.add(sym);
+    lib.save(&file_path).expect("Failed to write SchLib");
+
+    let read_lib = SchLib::open(&file_path).expect("Failed to read SchLib");
+    let read_sym = read_lib.get("RES").expect("Symbol not found");
+    assert_eq!(
+        read_sym.rectangles[0].unique_id.as_deref(),
+        Some("ABCD1234"),
+        "rectangle UniqueID must survive read->write, not be regenerated"
+    );
+    assert!(
+        read_sym.pins[0].is_not_accessible,
+        "pin IsNotAccessible must survive read->write"
+    );
+}
+
+#[test]
 fn schlib_file_roundtrip_multiple_symbols() {
     let temp_dir = test_temp_dir();
     let file_path = temp_dir.path().join("test_multi.SchLib");

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -1286,6 +1286,7 @@ fn test_schlib_rename_component() {
         filled: true,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     sym.pins.push(Pin {
         name: "VCC".to_string(),
@@ -1306,6 +1307,7 @@ fn test_schlib_rename_component() {
         symbol_outer_edge: PinSymbol::None,
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
+        is_not_accessible: false,
     });
     lib.add(sym);
     lib.save(&file_path).expect("Failed to write");
@@ -1505,6 +1507,7 @@ fn test_schlib_copy_cross_library() {
         filled: true,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     sym.pins.push(Pin {
         name: "VCC".to_string(),
@@ -1525,6 +1528,7 @@ fn test_schlib_copy_cross_library() {
         symbol_outer_edge: PinSymbol::None,
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
+        is_not_accessible: false,
     });
     source_lib.add(sym);
     source_lib
@@ -1646,6 +1650,7 @@ fn test_schlib_json_roundtrip() {
         filled: true,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     sym.pins.push(Pin {
         name: "VCC".to_string(),
@@ -1666,6 +1671,7 @@ fn test_schlib_json_roundtrip() {
         symbol_outer_edge: PinSymbol::None,
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
+        is_not_accessible: false,
     });
     lib.add(sym);
     lib.save(&original_path).expect("Failed to write original");
@@ -1904,6 +1910,7 @@ fn test_schlib_merge_libraries() {
         filled: true,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     lib1.add(sym1);
     lib1.save(&source1_path).expect("Failed to write source1");
@@ -1932,6 +1939,7 @@ fn test_schlib_merge_libraries() {
         symbol_outer_edge: PinSymbol::None,
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
+        is_not_accessible: false,
     });
     lib2.add(sym2);
     lib2.save(&source2_path).expect("Failed to write source2");
@@ -2082,6 +2090,7 @@ fn test_schlib_search() {
         filled: false,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     lib.add(sym1);
 
@@ -2097,6 +2106,7 @@ fn test_schlib_search() {
         filled: false,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     lib.add(sym2);
 
@@ -2112,6 +2122,7 @@ fn test_schlib_search() {
         filled: false,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     lib.add(sym3);
 
@@ -2208,6 +2219,7 @@ fn test_schlib_get_component() {
         filled: false,
         transparent: false,
         owner_part_id: 1,
+        unique_id: None,
     });
     sym1.pins.push(Pin {
         name: "IN".to_string(),
@@ -2228,6 +2240,7 @@ fn test_schlib_get_component() {
         symbol_outer_edge: PinSymbol::None,
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
+        is_not_accessible: false,
     });
     lib.add(sym1);
 


### PR DESCRIPTION
Second slice of #113's round-trip fidelity — the SchLib half. (PR #117 did the PcbLib Track/Arc half.)

## Problems
1. **UniqueID regenerated every save.** All 11 SchLib shape encoders called `generate_unique_id()` unconditionally, and the reader discarded the `UNIQUEID` param. So a *read → edit → write* of an Altium symbol gave every primitive a brand-new ID on each save — breaking Altium's object tracking / undo history.
2. **Pin `IsNotAccessible` (conglomerate bit `0x20`)** was neither written nor read, so it was lost on round-trip.

## Fix
- `unique_id: Option<String>` added to all 11 shape types (rectangle, line, polyline, polygon, arc, bezier, ellipse, round-rect, elliptical-arc, label, text). Reader stores the parsed ID; writer emits the stored value, generating a fresh one only when absent.
- `Pin::is_not_accessible` wired through writer (sets `0x20`) and reader (extracts it).

**Both additive:** a from-scratch shape (`unique_id: None`) still generates a fresh ID on write; a default pin leaves `0x20` clear — byte-identical output. New test reads back a preserved `UniqueID` (`ABCD1234`) and the pin flag.

## Verification & scope
- Spec-verified against the AltiumSharp golden + C# (adversarial pass). The audit's other SchLib candidates (line `AreaColor`/lock-flags, rect `disabled`/`dimmed`, fractional coords) were **rejected as false positives** — lines are stroke-only, those flags are pin/filled-shape-only — and are intentionally not implemented.
- `cargo test` 225 unit + 70 stress + 10 doc; `clippy -D warnings`; `fmt`; **oracle 13/13** (additive).

This completes the actionable #113 fidelity items (the ComponentBody flag/index preservation remains the only deferred piece — niche, 3D-body-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)