### PR TITLE
docs: tighten SSOT + add scope/non-goals & design principles to VISION

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -41,22 +41,12 @@ See `CONTRIBUTING.md` § British Spelling for the full spelling guide.
 
 ## Rust
 
-### Formatting
+Standard Rust conventions, enforced by CI:
 
-Use `rustfmt` with default settings. CI enforces this.
+- **Formatting:** `rustfmt` with default settings.
+- **Linting:** `clippy` with warnings as errors.
 
-```bash
-cargo fmt --all         # Format all code
-cargo fmt --all --check # Check without modifying
-```
-
-### Linting
-
-Use `clippy` with warnings as errors. CI enforces this.
-
-```bash
-cargo clippy --all-targets --all-features -- -D warnings
-```
+The exact commands are canonical in [`CONTRIBUTING.md` § Development Setup](CONTRIBUTING.md#setup) — this guide does not repeat them.
 
 ### Naming Conventions
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -96,6 +96,39 @@ The AI already knows IPC-7351B. We don't need to duplicate that knowledge.
 
 ---
 
+## Scope & Non-Goals
+
+**This tool does:** read, write, and edit Altium `.PcbLib` / `.SchLib` libraries — place
+primitives, attach STEP models, and validate the result — i.e. the file I/O an AI cannot do
+for itself.
+
+**This tool deliberately does NOT:**
+
+- **Do the engineering.** IPC-7351B sizing, courtyards, and styling are the AI's job — see the
+  [Core Principle](#core-principle).
+- **Replace Altium Designer.** It generates *source* libraries; compiling to an IntLib,
+  rendering, and manufacturing happen inside Altium.
+- **Capture schematics or boards.** It manages component *libraries*, not `.SchDoc` / `.PcbDoc`
+  designs.
+- **Touch the network.** All I/O is local files (see [ARCHITECTURE § Network Requirements](ARCHITECTURE.md#network-requirements)).
+
+---
+
+## Design Principles
+
+1. **The AI owns the intelligence; the tool owns the bytes.** The whole point of the
+   [Core Principle](#core-principle) — keep the tool package-agnostic.
+2. **Fail loudly, never corrupt silently.** Altium refuses to open a malformed file, so the
+   writer is checked against an independent Altium-readability oracle, not just its own reader.
+3. **Round-trip fidelity.** Reading a library and writing it back preserves everything the
+   model represents — coordinates, parameters, and unique IDs.
+4. **Byte-exact Altium output.** Windows-1252 strings and the precise binary record layout —
+   match Altium on disk, not an approximation.
+5. **Safe by default.** Validate and canonicalise every path, back up before mutating, and keep
+   file paths out of error messages.
+
+---
+
 ## IPC Standards
 
 The AI applies industry standards when calculating footprints:


### PR DESCRIPTION
PR 3 (final) of the documentation audit.

## Finding: SSOT was already largely in place
The audit flagged the core principle as "duplicated in 5 files", but on inspection the *content* is already canonical: **CONTRIBUTING.md** hosts a 20-entry canonical-source registry (`Core principle → docs/VISION.md`, etc.), and ARCHITECTURE / AI_WORKFLOW / CLAUDE state the one-line tagline then **cross-reference VISION** for the actual responsibility split. That's good SSOT (a stable header line + one canonical home). Likely set up in earlier work — credit where due.

## What this PR changes
- **STYLE.md** repeated the `cargo fmt` / `cargo clippy` commands that are canonical in `CONTRIBUTING.md § Development Setup`. Replaced with the convention + a cross-reference (the *one* genuine remaining duplication — and commands are exactly the kind of thing that drifts).
- **VISION.md** gains **Scope & Non-Goals** (what the tool deliberately does *not* do — engineering, replacing Altium, schematic capture, networking) and **Design Principles** (fail-loud / round-trip fidelity / byte-exact output / safe-by-default) — the framing git-proxy-mcp's VISION has.

## A deliberate non-change (honesty over byte-count)
**ARCHITECTURE.md is left concise.** git-proxy's is bigger because *its* domain (zero-storage streaming, credential security, tiers) warrants it. Ours correctly keeps the deep binary-format detail in the canonical `PCBLIB_FORMAT.md` / `SCHLIB_FORMAT.md` — padding ARCHITECTURE to match a byte count would duplicate them, violating the very SSOT we're enforcing.

All 18 markdown files lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)