### PR TITLE
Fix Region layer: emit canonical V7_LAYER token (MECHANICAL{n})

### DIFF
--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -896,6 +896,22 @@ fn encode_region(data: &mut Vec<u8>, region: &Region) {
     write_block(data, &[]);
 }
 
+/// Returns the canonical Altium `V7_LAYER` token for a layer.
+///
+/// Altium identifies a Region's layer by this parameter string, NOT the
+/// common-header layer byte. Mechanical and component-pair layers must use their
+/// `MECHANICAL{n}` token (e.g. Top Courtyard -> `MECHANICAL4`). The display name
+/// with spaces stripped (`TOPCOURTYARD`) is not a valid token, so Altium fails to
+/// resolve the layer and silently drops the region onto Top Layer (copper). The
+/// 3D-body encoder already hardcodes `MECHANICAL6`/`MECHANICAL7` for this reason.
+fn region_v7_layer_token(layer: Layer) -> String {
+    match layer_to_id(layer) {
+        id @ 57..=72 => format!("MECHANICAL{}", id - 56),
+        id @ 186..=201 => format!("MECHANICAL{}", id - 169),
+        _ => layer.as_str().replace(' ', "").to_uppercase(),
+    }
+}
+
 /// Encodes the properties block for a region.
 ///
 /// Format (matching Altium):
@@ -912,7 +928,7 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     let vertex_count = region.vertices.len();
 
     // Build parameter string (leading pipe, matching Altium).
-    let layer_name = region.layer.as_str().replace(' ', "").to_uppercase();
+    let layer_name = region_v7_layer_token(region.layer);
     let params = format!("|V7_LAYER={layer_name}|NAME=|KIND=0");
     let params_bytes = crate::altium::encode_windows1252(&params);
 
@@ -1614,6 +1630,38 @@ mod tests {
         assert_eq!(layer_to_id(Layer::TopPadMaster), 83);
         assert_eq!(layer_to_id(Layer::BottomPadMaster), 84);
         assert_eq!(layer_to_id(Layer::DRCDetailLayer), 85);
+    }
+
+    #[test]
+    fn test_region_v7_layer_token() {
+        use crate::altium::pcblib::primitives::Vertex;
+        // Component-pair / mechanical layers must use the MECHANICAL{n} token,
+        // not the display name (which Altium can't resolve -> falls back to Top Layer).
+        assert_eq!(region_v7_layer_token(Layer::TopCourtyard), "MECHANICAL4");
+        assert_eq!(region_v7_layer_token(Layer::TopAssembly), "MECHANICAL2");
+        assert_eq!(region_v7_layer_token(Layer::Mechanical1), "MECHANICAL1");
+        assert_eq!(region_v7_layer_token(Layer::Mechanical17), "MECHANICAL17");
+        assert_eq!(region_v7_layer_token(Layer::Mechanical32), "MECHANICAL32");
+        // Non-mechanical layers keep the stripped/uppercased display token.
+        assert_eq!(region_v7_layer_token(Layer::TopLayer), "TOPLAYER");
+        assert_eq!(region_v7_layer_token(Layer::TopOverlay), "TOPOVERLAY");
+
+        // A region on Top Courtyard must serialize V7_LAYER=MECHANICAL4.
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            flags: PcbFlags::default(),
+            unique_id: None,
+        };
+        let props = encode_region_properties(&region);
+        let s = String::from_utf8_lossy(&props);
+        assert!(s.contains("V7_LAYER=MECHANICAL4"), "got: {s}");
+        assert!(!s.contains("TOPCOURTYARD"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A footprint Region placed on a component-pair / mechanical layer (e.g. `Top Courtyard`) renders on **Top Layer (copper)** in Altium and does **not** appear in the footprint primitives list.

Repro: write a footprint with a `regions` entry on `"Top Courtyard"`, open the `.PcbLib` in Altium → giant copper region covering the pads, absent from the Footprint Primitives panel.

## Root cause

`encode_region_properties` built the `V7_LAYER` param from the display name with spaces stripped:

```rust
let layer_name = region.layer.as_str().replace(' ', "").to_uppercase(); // "TOPCOURTYARD"
```

Altium keys a Region's layer off the `V7_LAYER` **string param**, not the common-header layer byte. `TOPCOURTYARD` is not a valid Altium layer token (the layer's canonical token is `MECHANICAL4`), so Altium fails to resolve it and falls back to Top Layer.

The common-header layer byte was written correctly (`60` = Mech 4), so the MCP reader (which reads the byte) round-tripped the region fine — masking the bug. It only shows up in Altium itself.

This affects every region on a named component-layer alias (`Top Courtyard`, `Top Assembly`, the 3D-body layers, etc.). It works for `Top Layer`/`Top Overlay` only because their stripped display name happens to equal the canonical token. The 3D-body encoder already sidesteps this by hardcoding `MECHANICAL6`/`MECHANICAL7`.

## Fix

Map the layer to its canonical `V7_LAYER` token — `MECHANICAL{n}` for mechanical/component-pair layer IDs (57–72, 186–201), stripped display name otherwise — and use it in `encode_region_properties`.

Verified end-to-end: regenerating a WSON-8 footprint with a `Top Courtyard` region now writes `V7_LAYER=MECHANICAL4`; Altium places it on Top Courtyard and lists it as a Region.

Added a unit test for the token mapping and the serialized properties block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)