### PR TITLE
fix(schlib): stop dropping shapes on zero coords + round-trip IsSolid fill

### DIFF
--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -357,7 +357,10 @@ fn coord<T>(props: &HashMap<String, String>, key: &str) -> T
 where
     T: std::str::FromStr + Default,
 {
-    props.get(key).and_then(|s| s.parse().ok()).unwrap_or_default()
+    props
+        .get(key)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default()
 }
 
 /// Parses a rectangle from properties.

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -345,12 +345,28 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     })
 }
 
+/// Parses a numeric coordinate property, defaulting to zero when the key is
+/// absent or unparseable.
+///
+/// Altium omits zero-valued coordinates from a record's pipe-delimited text
+/// (`AddCoordParam` skips zeros), so a missing `Location.X` / `Corner.Y` /
+/// `Radius` / `X{n}` key means the value is zero — **not** a malformed record.
+/// Treating a missing key as fatal (the old `?` behaviour) silently dropped any
+/// shape that happened to sit on a zero coordinate.
+fn coord<T>(props: &HashMap<String, String>, key: &str) -> T
+where
+    T: std::str::FromStr + Default,
+{
+    props.get(key).and_then(|s| s.parse().ok()).unwrap_or_default()
+}
+
 /// Parses a rectangle from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
-    let x1 = props.get("location.x")?.parse().ok()?;
-    let y1 = props.get("location.y")?.parse().ok()?;
-    let x2 = props.get("corner.x")?.parse().ok()?;
-    let y2 = props.get("corner.y")?.parse().ok()?;
+    let x1 = coord(props, "location.x");
+    let y1 = coord(props, "location.y");
+    let x2 = coord(props, "corner.x");
+    let y2 = coord(props, "corner.y");
 
     let line_width = props
         .get("linewidth")
@@ -379,7 +395,7 @@ fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
         line_width,
         line_color,
         fill_color,
-        filled: true,
+        filled: props.get("issolid").is_some_and(|s| s == "T"),
         transparent,
         owner_part_id,
         unique_id: props.get("uniqueid").cloned(),
@@ -387,11 +403,12 @@ fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
 }
 
 /// Parses a line from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_line(props: &HashMap<String, String>) -> Option<Line> {
-    let x1 = props.get("location.x")?.parse().ok()?;
-    let y1 = props.get("location.y")?.parse().ok()?;
-    let x2 = props.get("corner.x")?.parse().ok()?;
-    let y2 = props.get("corner.y")?.parse().ok()?;
+    let x1 = coord(props, "location.x");
+    let y1 = coord(props, "location.y");
+    let x2 = coord(props, "corner.x");
+    let y2 = coord(props, "corner.y");
 
     let line_width = props
         .get("linewidth")
@@ -483,8 +500,8 @@ fn parse_polyline(props: &HashMap<String, String>) -> Option<Polyline> {
     for i in 1..=location_count {
         let x_key = format!("x{i}");
         let y_key = format!("y{i}");
-        let x = props.get(&x_key).and_then(|s| s.parse().ok())?;
-        let y = props.get(&y_key).and_then(|s| s.parse().ok())?;
+        let x = coord(props, &x_key);
+        let y = coord(props, &y_key);
         points.push((x, y));
     }
 
@@ -546,8 +563,8 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
     for i in 1..=location_count {
         let x_key = format!("x{i}");
         let y_key = format!("y{i}");
-        let x = props.get(&x_key).and_then(|s| s.parse().ok())?;
-        let y = props.get(&y_key).and_then(|s| s.parse().ok())?;
+        let x = coord(props, &x_key);
+        let y = coord(props, &y_key);
         points.push((x, y));
     }
 
@@ -563,7 +580,7 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
         .get("areacolor")
         .and_then(|s| s.parse().ok())
         .unwrap_or(0xFF_FF_B0);
-    let filled = !props.get("issolid").is_some_and(|s| s == "F");
+    let filled = props.get("issolid").is_some_and(|s| s == "T");
     let owner_part_id = props
         .get("ownerpartid")
         .and_then(|s| s.parse().ok())
@@ -581,10 +598,11 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
 }
 
 /// Parses an ellipse from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
-    let x = props.get("location.x")?.parse().ok()?;
-    let y = props.get("location.y")?.parse().ok()?;
-    let radius_x = props.get("radius")?.parse().ok()?;
+    let x = coord(props, "location.x");
+    let y = coord(props, "location.y");
+    let radius_x = coord(props, "radius");
     // Secondary radius, defaults to radius for circles
     let radius_y = props
         .get("secondaryradius")
@@ -603,7 +621,7 @@ fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
         .get("areacolor")
         .and_then(|s| s.parse().ok())
         .unwrap_or(0xFF_FF_B0);
-    let filled = !props.get("issolid").is_some_and(|s| s == "F");
+    let filled = props.get("issolid").is_some_and(|s| s == "T");
     let owner_part_id = props
         .get("ownerpartid")
         .and_then(|s| s.parse().ok())
@@ -624,10 +642,11 @@ fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
 }
 
 /// Parses an arc from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
-    let x = props.get("location.x")?.parse().ok()?;
-    let y = props.get("location.y")?.parse().ok()?;
-    let radius = props.get("radius")?.parse().ok()?;
+    let x = coord(props, "location.x");
+    let y = coord(props, "location.y");
+    let radius = coord(props, "radius");
 
     let start_angle = props
         .get("startangle")
@@ -665,16 +684,17 @@ fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
 }
 
 /// Parses a Bezier curve from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
     // Bezier curves have 4 control points: X1,Y1 through X4,Y4
-    let x1 = props.get("x1")?.parse().ok()?;
-    let y1 = props.get("y1")?.parse().ok()?;
-    let x2 = props.get("x2")?.parse().ok()?;
-    let y2 = props.get("y2")?.parse().ok()?;
-    let x3 = props.get("x3")?.parse().ok()?;
-    let y3 = props.get("y3")?.parse().ok()?;
-    let x4 = props.get("x4")?.parse().ok()?;
-    let y4 = props.get("y4")?.parse().ok()?;
+    let x1 = coord(props, "x1");
+    let y1 = coord(props, "y1");
+    let x2 = coord(props, "x2");
+    let y2 = coord(props, "y2");
+    let x3 = coord(props, "x3");
+    let y3 = coord(props, "y3");
+    let x4 = coord(props, "x4");
+    let y4 = coord(props, "y4");
 
     let line_width = props
         .get("linewidth")
@@ -707,11 +727,12 @@ fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
 
 /// Parses a rounded rectangle from properties.
 #[allow(clippy::similar_names)]
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
-    let x1 = props.get("location.x")?.parse().ok()?;
-    let y1 = props.get("location.y")?.parse().ok()?;
-    let x2 = props.get("corner.x")?.parse().ok()?;
-    let y2 = props.get("corner.y")?.parse().ok()?;
+    let x1 = coord(props, "location.x");
+    let y1 = coord(props, "location.y");
+    let x2 = coord(props, "corner.x");
+    let y2 = coord(props, "corner.y");
 
     let corner_x_radius = props
         .get("cornerxradius")
@@ -734,7 +755,7 @@ fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
         .get("areacolor")
         .and_then(|s| s.parse().ok())
         .unwrap_or(0xFF_FF_B0);
-    let filled = !props.get("issolid").is_some_and(|s| s == "F");
+    let filled = props.get("issolid").is_some_and(|s| s == "T");
     let owner_part_id = props
         .get("ownerpartid")
         .and_then(|s| s.parse().ok())
@@ -757,8 +778,9 @@ fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
 }
 
 /// Parses an elliptical arc from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc> {
-    let x = props.get("location.x")?.parse().ok()?;
+    let x = coord(props, "location.x");
     // Location.Y may be omitted if it's 0
     let y = props
         .get("location.y")
@@ -766,7 +788,7 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
         .unwrap_or(0);
 
     // Primary radius with optional fractional part
-    let radius_int: f64 = props.get("radius")?.parse().ok()?;
+    let radius_int: f64 = coord(props, "radius");
     let radius_frac: f64 = props
         .get("radius_frac")
         .and_then(|s| s.parse::<u32>().ok())
@@ -821,9 +843,10 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
 }
 
 /// Parses a label from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
-    let x = props.get("location.x")?.parse().ok()?;
-    let y = props.get("location.y")?.parse().ok()?;
+    let x = coord(props, "location.x");
+    let y = coord(props, "location.y");
     let text = props.get("text").cloned().unwrap_or_default();
 
     let font_id = props
@@ -865,9 +888,10 @@ fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
 }
 
 /// Parses a text annotation from properties.
+#[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_text(props: &HashMap<String, String>) -> Option<Text> {
-    let x = props.get("location.x")?.parse().ok()?;
-    let y = props.get("location.y")?.parse().ok()?;
+    let x = coord(props, "location.x");
+    let y = coord(props, "location.y");
     let text = props.get("text").cloned().unwrap_or_default();
 
     let font_id = props
@@ -947,5 +971,39 @@ mod tests {
         assert_eq!(rect.y1, -4);
         assert_eq!(rect.x2, 10);
         assert_eq!(rect.y2, 4);
+    }
+
+    #[test]
+    fn test_parse_shapes_with_omitted_zero_coords_not_dropped() {
+        // Altium omits zero-valued coordinates, so a shape sitting on a zero
+        // axis arrives with the key missing. The old `?` reader dropped it; we
+        // must instead default the missing coordinate to 0.
+        let rect = parse_rectangle(&parse_properties(
+            "|RECORD=14|Corner.X=10|Corner.Y=4|", // Location.X / Location.Y omitted (== 0)
+        ))
+        .expect("rectangle with omitted zero Location must not be dropped");
+        assert_eq!((rect.x1, rect.y1, rect.x2, rect.y2), (0, 0, 10, 4));
+
+        let arc = parse_arc(&parse_properties(
+            "|RECORD=12|Radius=20|StartAngle=0|EndAngle=90|", // Location.X / Location.Y omitted
+        ))
+        .expect("arc with omitted zero Location must not be dropped");
+        assert_eq!((arc.x, arc.y, arc.radius), (0, 0, 20));
+    }
+
+    #[test]
+    fn test_parse_fill_polarity_matches_altium() {
+        // Altium emits IsSolid only when filled; absent means unfilled.
+        let unfilled = parse_rectangle(&parse_properties(
+            "|RECORD=14|Location.X=-1|Location.Y=-1|Corner.X=1|Corner.Y=1|",
+        ))
+        .unwrap();
+        assert!(!unfilled.filled, "absent IsSolid must read as unfilled");
+
+        let filled = parse_rectangle(&parse_properties(
+            "|RECORD=14|Location.X=-1|Location.Y=-1|Corner.X=1|Corner.Y=1|IsSolid=T|",
+        ))
+        .unwrap();
+        assert!(filled.filled, "IsSolid=T must read as filled");
     }
 }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -894,12 +894,18 @@ mod tests {
         let mut unfilled = Rectangle::new(-5, -5, 5, 5);
         unfilled.filled = false;
         let s = encode_rectangle(&unfilled, 1);
-        assert!(!s.contains("IsSolid"), "unfilled rectangle must omit IsSolid: {s}");
+        assert!(
+            !s.contains("IsSolid"),
+            "unfilled rectangle must omit IsSolid: {s}"
+        );
 
         let mut filled = Rectangle::new(-5, -5, 5, 5);
         filled.filled = true;
         let s = encode_rectangle(&filled, 1);
-        assert!(s.contains("|IsSolid=T"), "filled rectangle must emit IsSolid=T: {s}");
+        assert!(
+            s.contains("|IsSolid=T"),
+            "filled rectangle must emit IsSolid=T: {s}"
+        );
         assert!(!s.contains("IsSolid=F"), "never emit IsSolid=F: {s}");
     }
 

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -272,10 +272,12 @@ fn encode_component_header(symbol: &Symbol) -> String {
 /// Encodes a rectangle record.
 fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
     let transparent = if rect.transparent { "T" } else { "F" };
+    // Altium emits IsSolid only when the shape is filled, and omits it otherwise.
+    let is_solid = if rect.filled { "|IsSolid=T" } else { "" };
     format!(
         "|RECORD=14|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
          |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
-         |LineWidth={}|Color={}|AreaColor={}|IsSolid=T|Transparent={}|UniqueID={}",
+         |LineWidth={}|Color={}|AreaColor={}{}|Transparent={}|UniqueID={}",
         index,
         rect.owner_part_id,
         rect.x1,
@@ -285,6 +287,7 @@ fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
         rect.line_width,
         rect.line_color,
         rect.fill_color,
+        is_solid,
         transparent,
         rect.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
@@ -368,7 +371,6 @@ fn encode_polyline(polyline: &Polyline, index: usize) -> String {
 
 /// Encodes a polygon record.
 fn encode_polygon(polygon: &Polygon, index: usize) -> String {
-    let is_solid = if polygon.filled { "T" } else { "F" };
     let mut parts = vec![
         "RECORD=7".to_string(),
         format!("IndexInSheet={index}"),
@@ -377,9 +379,12 @@ fn encode_polygon(polygon: &Polygon, index: usize) -> String {
         format!("LineWidth={}", polygon.line_width),
         format!("Color={}", polygon.line_color),
         format!("AreaColor={}", polygon.fill_color),
-        format!("IsSolid={is_solid}"),
-        format!("LocationCount={}", polygon.points.len()),
     ];
+    // Altium emits IsSolid only when filled, and omits it otherwise.
+    if polygon.filled {
+        parts.push("IsSolid=T".to_string());
+    }
+    parts.push(format!("LocationCount={}", polygon.points.len()));
 
     for (i, (x, y)) in polygon.points.iter().enumerate() {
         parts.push(format!("X{}={}", i + 1, x));
@@ -433,9 +438,10 @@ fn encode_bezier(bezier: &Bezier, index: usize) -> String {
 
 /// Encodes an ellipse record.
 fn encode_ellipse(ellipse: &Ellipse, index: usize) -> String {
-    let is_solid = if ellipse.filled { "T" } else { "F" };
+    // Altium emits IsSolid only when filled, and omits it otherwise.
+    let is_solid = if ellipse.filled { "|IsSolid=T" } else { "" };
     format!(
-        "|RECORD=8|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|SecondaryRadius={}|LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}",
+        "|RECORD=8|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|SecondaryRadius={}|LineWidth={}|Color={}|AreaColor={}{}|UniqueID={}",
         index,
         ellipse.owner_part_id,
         ellipse.x,
@@ -452,12 +458,13 @@ fn encode_ellipse(ellipse: &Ellipse, index: usize) -> String {
 
 /// Encodes a rounded rectangle record.
 fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
-    let is_solid = if round_rect.filled { "T" } else { "F" };
+    // Altium emits IsSolid only when filled, and omits it otherwise.
+    let is_solid = if round_rect.filled { "|IsSolid=T" } else { "" };
     format!(
         "|RECORD=10|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
          |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
          |CornerXRadius={}|CornerYRadius={}\
-         |LineWidth={}|Color={}|AreaColor={}|IsSolid={}|UniqueID={}",
+         |LineWidth={}|Color={}|AreaColor={}{}|UniqueID={}",
         index,
         round_rect.owner_part_id,
         round_rect.x1,
@@ -878,6 +885,22 @@ mod tests {
         let text = String::from_utf8_lossy(&data);
         assert!(text.contains("RECORD=1"), "component record present");
         assert!(text.contains("RECORD=44"), "implementation list present");
+    }
+
+    #[test]
+    fn test_rectangle_issolid_emitted_only_when_filled() {
+        // Altium omits IsSolid for unfilled shapes and emits IsSolid=T only when
+        // filled — never IsSolid=F.
+        let mut unfilled = Rectangle::new(-5, -5, 5, 5);
+        unfilled.filled = false;
+        let s = encode_rectangle(&unfilled, 1);
+        assert!(!s.contains("IsSolid"), "unfilled rectangle must omit IsSolid: {s}");
+
+        let mut filled = Rectangle::new(-5, -5, 5, 5);
+        filled.filled = true;
+        let s = encode_rectangle(&filled, 1);
+        assert!(s.contains("|IsSolid=T"), "filled rectangle must emit IsSolid=T: {s}");
+        assert!(!s.contains("IsSolid=F"), "never emit IsSolid=F: {s}");
     }
 
     #[test]


### PR DESCRIPTION
First batch of fixes from the comprehensive PcbLib/SchLib reverse-engineering pass (triangulated against the AltiumSharp answer key + real golden bytes, adversarially verified).

## Bugs fixed

### 1. Reader silently dropped shapes on a zero coordinate (high)
Every SchLib shape parser used `props.get("location.x")?.parse().ok()?`. Altium **omits zero-valued coordinates** from a record's pipe-delimited text (`AddCoordParam` skips zeros), so a shape on a zero axis arrives with the key absent — and the `?` dropped the **entire primitive**. In the golden corpus, `Location.X` was present in only 34/42 arcs and `Location.Y` in 26/42; those shapes would vanish on read.

Fix: a `coord()` helper defaults a missing coordinate to 0 (matching AltiumSharp's `AsIntOrDefault()`), applied across rectangle, line, ellipse, arc, bezier, rounded-rectangle, elliptical-arc, label, text, and the polyline/polygon vertex loops. The infallible parsers keep `Option<T>` for uniform dispatch (annotated).

### 2. IsSolid (fill) did not round-trip (high)
`encode_rectangle` hardcoded `IsSolid=T` (and the other shapes emitted `IsSolid=F`), while the reader defaulted `filled = true`. Altium emits `IsSolid=T` **only when filled** and omits it otherwise (`SchLibReader.TryGetBool` ⇒ default false). So unfilled shapes couldn't be represented and every read shape became filled.

Fix: emit `IsSolid=T` only when filled; read `filled = IsSolid == "T"` (default false) across rectangle, ellipse, polygon, rounded-rectangle.

## Verification
- New round-trip tests: omitted-zero-coord shapes are no longer dropped; IsSolid emitted only when filled; fill polarity matches Altium.
- `clippy -D warnings` clean, full test suite green (33 SchLib unit tests), readability oracle **13/13**.

Part of the RE follow-up; further batches (SchLib writer field correctness, PcbLib pad stack layout, doc corrections) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
