### PR TITLE
fix(schlib): Altium-canonical booleans + Parameter UniqueID + arc IsNotAccesible

### DIFF
--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -506,6 +506,10 @@ pub struct Arc {
     pub y: i32,
     /// Radius.
     pub radius: i32,
+    /// Whether the arc is marked not-accessible. Altium tags every arc
+    /// `IsNotAccesible` (its own single-'s' spelling), so this defaults to true.
+    #[serde(default = "default_true")]
+    pub is_not_accessible: bool,
     /// Start angle in degrees (0 = right, counter-clockwise).
     #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub start_angle: f64,
@@ -923,6 +927,10 @@ pub struct Parameter {
     /// Owner part ID.
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
+    /// Altium unique ID (8-char). Preserved on read so a round-trip keeps the
+    /// parameter identity; a from-scratch parameter generates a fresh one on write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_id: Option<String>,
 }
 
 impl Parameter {
@@ -940,6 +948,7 @@ impl Parameter {
             read_only_state: 0,
             param_type: 0,
             owner_part_id: 1,
+            unique_id: None,
         }
     }
 }

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -484,6 +484,7 @@ fn parse_parameter(props: &HashMap<String, String>) -> Option<Parameter> {
         read_only_state,
         param_type,
         owner_part_id,
+        unique_id: props.get("uniqueid").cloned(),
     })
 }
 
@@ -677,6 +678,7 @@ fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
         x,
         y,
         radius,
+        is_not_accessible: props.get("isnotaccesible").is_some_and(|s| s == "T"),
         start_angle,
         end_angle,
         line_width,
@@ -1008,5 +1010,37 @@ mod tests {
         ))
         .unwrap();
         assert!(filled.filled, "IsSolid=T must read as filled");
+    }
+
+    #[test]
+    fn test_parameter_uniqueid_preserved() {
+        let p = parse_parameter(&parse_properties(
+            "|RECORD=41|Name=Value|Text=10k|UniqueID=ABCD1234|",
+        ))
+        .unwrap();
+        assert_eq!(p.unique_id.as_deref(), Some("ABCD1234"));
+        assert_eq!(p.name, "Value");
+        assert_eq!(p.value, "10k");
+    }
+
+    #[test]
+    fn test_arc_is_not_accessible_parsed() {
+        let tagged = parse_arc(&parse_properties(
+            "|RECORD=12|Location.X=5|Location.Y=5|Radius=10|IsNotAccesible=T|",
+        ))
+        .unwrap();
+        assert!(
+            tagged.is_not_accessible,
+            "IsNotAccesible=T must parse as true"
+        );
+
+        let untagged = parse_arc(&parse_properties(
+            "|RECORD=12|Location.X=5|Location.Y=5|Radius=10|",
+        ))
+        .unwrap();
+        assert!(
+            !untagged.is_not_accessible,
+            "absent IsNotAccesible defaults false on read"
+        );
     }
 }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -310,23 +310,38 @@ fn encode_line(line: &Line, index: usize) -> String {
 }
 
 /// Encodes a parameter record.
+///
+/// Follows Altium's conventions: `IsHidden` is emitted only when hidden (never
+/// `=F`), `ReadOnlyState` / `ParamType` only when non-zero, `Text` only when
+/// non-empty, and the read `UniqueID` is preserved.
 fn encode_parameter(param: &Parameter, index: usize) -> String {
-    let hidden = if param.hidden { "T" } else { "F" };
-    format!(
-        "|RECORD=41|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Color={}|FontID={}|IsHidden={}|ReadOnlyState={}|ParamType={}|Text={}|Name={}|UniqueID={}",
-        index,
-        param.owner_part_id,
-        param.x,
-        param.y,
-        param.color,
-        param.font_id,
-        hidden,
-        param.read_only_state,
-        param.param_type,
-        param.value,
-        param.name,
-        generate_unique_id()
-    )
+    let mut parts = vec![
+        "RECORD=41".to_string(),
+        format!("IndexInSheet={index}"),
+        format!("OwnerPartId={}", param.owner_part_id),
+        format!("Location.X={}", param.x),
+        format!("Location.Y={}", param.y),
+        format!("Color={}", param.color),
+        format!("FontID={}", param.font_id),
+    ];
+    if param.hidden {
+        parts.push("IsHidden=T".to_string());
+    }
+    if param.read_only_state != 0 {
+        parts.push(format!("ReadOnlyState={}", param.read_only_state));
+    }
+    if param.param_type != 0 {
+        parts.push(format!("ParamType={}", param.param_type));
+    }
+    if !param.value.is_empty() {
+        parts.push(format!("Text={}", param.value));
+    }
+    parts.push(format!("Name={}", param.name));
+    parts.push(format!(
+        "UniqueID={}",
+        param.unique_id.clone().unwrap_or_else(generate_unique_id)
+    ));
+    format!("|{}", parts.join("|"))
 }
 
 /// Encodes a designator record.
@@ -401,10 +416,17 @@ fn encode_polygon(polygon: &Polygon, index: usize) -> String {
 
 /// Encodes an arc record.
 fn encode_arc(arc: &Arc, index: usize) -> String {
+    // Altium tags arcs IsNotAccesible (its own single-'s' spelling); emit only when set.
+    let not_accessible = if arc.is_not_accessible {
+        "|IsNotAccesible=T"
+    } else {
+        ""
+    };
     format!(
-        "|RECORD=12|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|StartAngle={}|EndAngle={}|LineWidth={}|Color={}|UniqueID={}",
+        "|RECORD=12|IndexInSheet={}|OwnerPartId={}{}|Location.X={}|Location.Y={}|Radius={}|StartAngle={}|EndAngle={}|LineWidth={}|Color={}|UniqueID={}",
         index,
         arc.owner_part_id,
+        not_accessible,
         arc.x,
         arc.y,
         arc.radius,
@@ -523,10 +545,15 @@ fn encode_label(label: &Label, index: usize) -> String {
     #[allow(clippy::cast_possible_truncation)]
     let orientation = (label.rotation / 90.0).round() as i32 % 4;
     let justification = justification_to_id(label.justification);
-    let is_mirrored = if label.is_mirrored { "T" } else { "F" };
-    let is_hidden = if label.is_hidden { "T" } else { "F" };
+    // Altium emits IsMirrored / IsHidden only when true — never `=F`.
+    let is_mirrored = if label.is_mirrored {
+        "|IsMirrored=T"
+    } else {
+        ""
+    };
+    let is_hidden = if label.is_hidden { "|IsHidden=T" } else { "" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}|IsMirrored={}|IsHidden={}|Text={}|UniqueID={}",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|Location.X={}|Location.Y={}|Color={}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
         index,
         label.owner_part_id,
         label.x,
@@ -1054,5 +1081,89 @@ mod tests {
         // LibRef should use the OLE-safe name
         let text = String::from_utf8_lossy(&data[4..]);
         assert!(text.contains("LibRef0=AAAAAAAAAAAAAAAAAAAAAAAAAAA~001"));
+    }
+
+    #[test]
+    fn test_parameter_canonical_emission() {
+        // Not hidden, empty value, zero read-only/param-type: Altium omits those keys.
+        let mut p = Parameter::new("Comment", "");
+        let s = encode_parameter(&p, 1);
+        assert!(
+            !s.contains("IsHidden"),
+            "omit IsHidden when not hidden: {s}"
+        );
+        assert!(!s.contains("Text="), "omit Text when empty: {s}");
+        assert!(
+            !s.contains("ReadOnlyState"),
+            "omit ReadOnlyState when 0: {s}"
+        );
+        assert!(!s.contains("ParamType"), "omit ParamType when 0: {s}");
+
+        // Hidden + value + a preserved UniqueID.
+        p.hidden = true;
+        p.value = "10k".to_string();
+        p.unique_id = Some("ABCD1234".to_string());
+        let s = encode_parameter(&p, 1);
+        assert!(
+            s.contains("|IsHidden=T"),
+            "emit IsHidden=T when hidden: {s}"
+        );
+        assert!(!s.contains("IsHidden=F"), "never IsHidden=F: {s}");
+        assert!(s.contains("|Text=10k"), "emit Text when set: {s}");
+        assert!(
+            s.contains("|UniqueID=ABCD1234"),
+            "preserve read UniqueID: {s}"
+        );
+    }
+
+    #[test]
+    fn test_label_booleans_only_when_true() {
+        let mut label = Label {
+            x: 0,
+            y: 0,
+            text: "R".to_string(),
+            font_id: 1,
+            color: 0,
+            justification: TextJustification::BottomLeft,
+            rotation: 0.0,
+            is_mirrored: false,
+            is_hidden: false,
+            owner_part_id: 1,
+            unique_id: Some("ABCD1234".to_string()),
+        };
+        let s = encode_label(&label, 1);
+        assert!(!s.contains("IsMirrored"), "omit IsMirrored when false: {s}");
+        assert!(!s.contains("IsHidden"), "omit IsHidden when false: {s}");
+
+        label.is_mirrored = true;
+        label.is_hidden = true;
+        let s = encode_label(&label, 1);
+        assert!(s.contains("|IsMirrored=T"), "emit IsMirrored=T: {s}");
+        assert!(s.contains("|IsHidden=T"), "emit IsHidden=T: {s}");
+        assert!(
+            !s.contains("IsMirrored=F") && !s.contains("IsHidden=F"),
+            "never =F: {s}"
+        );
+    }
+
+    #[test]
+    fn test_arc_tags_is_not_accessible() {
+        let arc = Arc {
+            x: 0,
+            y: 0,
+            radius: 10,
+            is_not_accessible: true,
+            start_angle: 0.0,
+            end_angle: 360.0,
+            line_width: 1,
+            color: 0,
+            owner_part_id: 1,
+            unique_id: Some("ABCD1234".to_string()),
+        };
+        let s = encode_arc(&arc, 1);
+        assert!(
+            s.contains("|IsNotAccesible=T"),
+            "arc must tag IsNotAccesible: {s}"
+        );
     }
 }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -535,6 +535,7 @@ impl McpServer {
             read_only_state: 0,
             param_type: 0,
             owner_part_id,
+            unique_id: None,
         })
     }
 
@@ -609,6 +610,7 @@ impl McpServer {
             x,
             y,
             radius,
+            is_not_accessible: true,
             start_angle,
             end_angle,
             line_width,


### PR DESCRIPTION
Batch 3 of the format reverse-engineering follow-up (after #126).

Brings the SchLib writer in line with Altium's own serialisation conventions for several records, and adds two missing model fields so those records round-trip. Altium already reads our output fine (oracle stays 13/13) — this makes our output match what **Altium itself** writes, and fixes two genuine round-trip gaps.

## Changes

**Parameter (RECORD=41)**
- Emit `IsHidden` only when hidden — never `IsHidden=F` (0/160 golden parameters carry `=F`).
- Emit `ReadOnlyState` / `ParamType` only when non-zero (Altium's `AddNonZero`).
- Emit `Text` only when non-empty.
- **New `unique_id` field** — the read `UniqueID` is now preserved instead of regenerated on every save (every other primitive already did this).

**Label (RECORD=4)**
- Emit `IsMirrored` / `IsHidden` only when true — never `=F`.

**Arc (RECORD=12)**
- **New `is_not_accessible` field** (default true) — Altium tags every arc `IsNotAccesible` (its own single-'s' spelling), present in 42/42 golden arcs; now emitted and read.

## Safety
The reader already defaults these keys correctly when absent (booleans → false, `ReadOnlyState`/`ParamType` → 0, `Text` → empty), so omitting them on write is round-trip-safe. Field-order canonicalisation and `F3` angle formatting are deferred to a golden-verified batch.

## Verification
New writer + reader round-trip tests (Parameter UniqueID preserved; booleans never `=F`; arc tags `IsNotAccesible`). `clippy -D warnings` clean, full suite green (247 tests), readability oracle **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
