### PR TITLE
fix(pcblib): read text flag word + emit regions as a single block

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -758,6 +758,34 @@ mod tests {
     }
 
     #[test]
+    fn binary_roundtrip_text_flags() {
+        // parse_text previously discarded the flag word (read PcbFlags::empty());
+        // a locked / tented text must now round-trip its flags.
+        let mut original = Footprint::new("TEXT_FLAGS");
+        original.add_text(Text {
+            x: 0.0,
+            y: 0.0,
+            text: "LOCKED".to_string(),
+            height: 0.5,
+            layer: Layer::TopOverlay,
+            rotation: 0.0,
+            kind: TextKind::Stroke,
+            stroke_font: None,
+            justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::LOCKED | PcbFlags::TENTING_TOP,
+            unique_id: None,
+        });
+
+        let data = writer::encode_data_stream(&original).expect("encoding should succeed");
+        let mut decoded = Footprint::new("TEXT_FLAGS");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.text.len(), 1);
+        assert!(decoded.text[0].flags.contains(PcbFlags::LOCKED));
+        assert!(decoded.text[0].flags.contains(PcbFlags::TENTING_TOP));
+    }
+
+    #[test]
     fn binary_roundtrip_region() {
         let mut original = Footprint::new("ROUNDTRIP_REGION");
 

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -631,7 +631,9 @@ pub(super) fn parse_text(
     // Common header (13 bytes): layer at 0, Altium flag word at offsets 1-2.
     let layer_id = geometry_block[0];
     let layer = layer_from_id(layer_id);
-    let flags = PcbFlags::empty();
+    // Decode the lock/tenting/keepout flag word like every other primitive does,
+    // rather than discarding it (the write side already encodes these correctly).
+    let flags = read_flags(geometry_block);
 
     // The authoritative text kind lives at offset 160 in the 252-byte record
     // (0 = Stroke, 1 = TrueType, 2 = BarCode).
@@ -826,10 +828,9 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     //   - Parameter string (ASCII key=value pairs)
     //   - Vertex count (4 bytes)
     //   - Vertices (count * 16 bytes, each as 2 doubles)
-    // Block 1: Usually empty (0 bytes)
-
-    // Block 0: Properties with embedded vertices
-    let (props_block, mut current) = read_block(data, offset).ok_or_else(|| {
+    // A region is a single block: common header, parameter string, and the
+    // vertex outline embedded within it.
+    let (props_block, current) = read_block(data, offset).ok_or_else(|| {
         AltiumError::parse_error(offset, "failed to read Region properties block")
     })?;
 
@@ -908,10 +909,9 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         vertices.push(Vertex { x, y });
     }
 
-    // Block 1: Usually empty, but still need to read it
-    if let Some((_, next)) = read_block(data, current) {
-        current = next;
-    }
+    // A region is a single block — there is no second block. (We previously read a
+    // spurious empty "Block 1"; doing so against a real Altium region would mis-read
+    // the next record's bytes.)
 
     let region = Region {
         vertices,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -885,15 +885,13 @@ fn encode_text_geometry(text: &Text) -> Vec<u8> {
 /// Encodes a Region primitive (filled polygon).
 ///
 /// Region format (matching Altium):
-/// - Block 0: Properties block containing common header, parameter string, and vertices
-/// - Block 1: Empty block
+/// - Single block: common header, parameter string, and the vertex outline.
+///
+/// Altium's `WriteRegion` emits exactly one block; an earlier guess appended a
+/// spurious empty second block, which desynchronised the record stream.
 fn encode_region(data: &mut Vec<u8>, region: &Region) {
-    // Block 0: Properties with embedded vertices
     let props = encode_region_properties(region);
     write_block(data, &props);
-
-    // Block 1: Empty block (required by Altium format)
-    write_block(data, &[]);
 }
 
 /// Returns the canonical Altium `V7_LAYER` token for a layer.


### PR DESCRIPTION
First batch of PcbLib primitive fixes (B6) from the reverse-engineering pass.

## Fixes
- **Text flags discarded on read** (high): `parse_text` hardcoded `flags = PcbFlags::empty()` and never read the common-header flag word, silently dropping lock / tenting / keepout on read (the write side was already correct). Now decodes the word via `read_flags`, like every other primitive.
- **Region spurious empty block** (high): `encode_region` appended an empty second block (with a "required by Altium" comment that was a wrong guess), and `parse_region` consumed it. AltiumSharp's `WriteRegion` emits **exactly one block** (verified in its source + a golden region), so our stray `0x00000000` desynchronised the record stream and the optional read could mis-bind to the next record. Removed both the write and the read.

## Verification
New `binary_roundtrip_text_flags` test; existing region round-trip tests still pass. `clippy -D warnings` clean, full suite green, readability oracle **13/13**.

More B6 fixes (via mask-mode enum, ComponentBody checksum/modeltype, fill v7_layer, text strokeWidth) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
