### PR TITLE
fix(scripts): make the on-site Altium verify harness actually run on AD24

### DIFF
--- a/scripts/altium/Verify-Libraries.ps1
+++ b/scripts/altium/Verify-Libraries.ps1
@@ -59,7 +59,8 @@ $abs = foreach ($f in $Files) {
 
 # 3. Write the request; clear any stale response
 New-Item -ItemType Directory -Force -Path $BridgeDir | Out-Null
-$abs | Set-Content -Path $RequestFile -Encoding UTF8
+# Write the paths without a BOM (a UTF-8 BOM would prefix the first path).
+[System.IO.File]::WriteAllLines($RequestFile, [string[]]$abs)
 if (Test-Path $ResponseFile) { Remove-Item $ResponseFile -Force }
 Write-Host "Verifying $($abs.Count) file(s)..."
 
@@ -82,11 +83,17 @@ if (-not (Test-Path $ResponseFile)) {
 }
 
 # 6. Report
-$results = Get-Content $ResponseFile -Raw | ConvertFrom-Json
-if ($results.error) { throw "Verify script error: $($results.error)" }
+$raw = Get-Content $ResponseFile -Raw
+$results = $raw | ConvertFrom-Json
+# An error response is a single JSON object {"error":...}; a success response is a
+# JSON array. (Testing $results.error directly mis-fires on an array, because member
+# enumeration returns one item per element.)
+if ($raw.TrimStart([char]0xFEFF, ' ', "`t", "`r", "`n").StartsWith('{')) {
+    throw "Altium verify script error: $($results.error)"
+}
 
 $allOk = $true
-foreach ($r in $results) {
+foreach ($r in @($results)) {
     if ($r.opened) {
         Write-Host ("  PASS  {0}" -f $r.file) -ForegroundColor Green
     } else {

--- a/scripts/altium/verify/AltiumVerify.pas
+++ b/scripts/altium/verify/AltiumVerify.pas
@@ -22,6 +22,7 @@
 
 const
     BRIDGE_DIR = 'C:\Users\Public\altium_designer_mcp\';
+    REPLACEALL = 1; // StringReplace flags value for rfReplaceAll (DelphiScript)
 
 // Escapes a string for embedding in JSON (paths contain backslashes).
 function JsonEscape(const S : String) : String;
@@ -82,7 +83,8 @@ begin
                         Client.ShowDocument(Doc);
                         Opened := True;
                         Detail := 'opened';
-                        Client.CloseDocument(Doc);
+                        // Leave the document open so it stays visible for inspection
+                        // (e.g. to check a footprint's 3D body).
                     end
                     else
                         Detail := 'Altium OpenDocument returned nil (could not parse)';


### PR DESCRIPTION
Follow-up to #135. First real run on **Altium Designer 24** surfaced three issues — all fixed, and the harness now runs **green end-to-end**: a generated PcbLib *and* SchLib both report `PASS` (opened cleanly in real Altium, the ultimate ground-truth check).

```
  PASS  C:\tmp\Verify.PcbLib
  PASS  C:\tmp\Verify.SchLib
All libraries opened in Altium.
```

## Fixes
- **`Undeclared identifier: REPLACEALL`** — the DelphiScript used `REPLACEALL` without declaring it. Added `const REPLACEALL = 1;` (the `rfReplaceAll` flag value), matching the upstream coffeenmusic/altium-mcp idiom.
- **Request-file BOM** — the wrapper wrote the request with a UTF-8 BOM (prefixing the first path). Now BOM-less via `File::WriteAllLines`.
- **Wrapper false error** — `if ($results.error)` mis-fired on the success *array* (PowerShell member-enumeration makes a 2-element array truthy). Now detects the error response by its leading `{`.
- **Leave docs open** — dropped `CloseDocument` so verified libraries stay visible for inspection (e.g. a footprint's 3D body).

The mechanism (RunScript launch + file bridge, adapted from coffeenmusic/altium-mcp) was proven correct on the first run — these were just the expected on-site polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
