### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/scripts/analyse/analyse_pcblib.py
+++ b/scripts/analyse/analyse_pcblib.py
@@ -543,7 +543,20 @@ def main():
             print(f"  Or place a sample file at: {default_path}")
             sys.exit(1)
     else:
-        filepath = Path(sys.argv[1])
+        script_dir = Path(__file__).parent
+        safe_root = script_dir.parent.resolve()
+        filepath = Path(sys.argv[1]).expanduser().resolve()
+
+        try:
+            filepath.relative_to(safe_root)
+        except ValueError:
+            print(f"Error: Path not allowed (must be under {safe_root}): {filepath}")
+            sys.exit(1)
+
+        if filepath.suffix.lower() != ".pcblib":
+            print(f"Error: Unsupported file type (expected .PcbLib): {filepath}")
+            sys.exit(1)
+
         if not filepath.exists():
             print(f"Error: File not found: {filepath}")
             sys.exit(1)


### PR DESCRIPTION
Potential fix for [https://github.com/embedded-society/altium-designer-mcp/security/code-scanning/10](https://github.com/embedded-society/altium-designer-mcp/security/code-scanning/10)

To fix this safely, normalize and validate the user-supplied path before any filesystem access. The best approach here is:

1. Resolve the input path to an absolute canonical path (`Path.resolve()`).
2. Restrict it to a safe root (the repo’s `scripts` directory in this file’s context).
3. Enforce expected extension (`.PcbLib`).
4. Use the validated path for existence checks and analysis.

In `scripts/analyse/analyse_pcblib.py`, update the `else` branch in `main()` (around lines 546–550) to:
- compute `script_dir = Path(__file__).parent`,
- set `safe_root = script_dir.parent.resolve()`,
- resolve `filepath = Path(sys.argv[1]).expanduser().resolve()`,
- reject if `filepath` is outside `safe_root` using `filepath.relative_to(safe_root)` in a `try/except ValueError`,
- reject if suffix is not `.pcblib` (case-insensitive),
- keep existing existence check and call `analyse_pcblib(filepath)`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
