### PR TITLE
fix(pcblib): fill v7 layer id + canonical region param string

### DIFF
--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -995,8 +995,12 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
     // Rotation (8 bytes)
     write_f64(&mut block, fill.rotation);
 
-    // Unknown padding (13 bytes to match Altium's 50-byte block)
-    block.extend_from_slice(&[0x00; 13]);
+    // Tail (13 bytes, offsets 37-49). Altium carries a layer-derived v7 layer id
+    // at offsets 42-45; the solder-mask (37-40), paste-mask (41) and keepout (46)
+    // sub-fields are not yet modelled and stay zero.
+    let mut tail = [0x00u8; 13];
+    tail[5..9].copy_from_slice(&v7_layer_id(layer_to_id(fill.layer)).to_le_bytes());
+    block.extend_from_slice(&tail);
 
     block
 }
@@ -1860,5 +1864,16 @@ mod tests {
         // Verify each is compressed
         assert!(!prepared[0].1.is_empty());
         assert!(!prepared[1].1.is_empty());
+    }
+
+    #[test]
+    fn fill_block_writes_v7_layer_id() {
+        // The fill tail (offsets 37-49) carries the layer-derived v7 layer id at
+        // 42-45 — previously a blanket [0x00; 13] that left it zeroed.
+        let block = encode_fill_block(&Fill::new(-1.0, -1.0, 1.0, 1.0, Layer::TopPaste));
+        assert_eq!(block.len(), 50);
+        let v7 = u32::from_le_bytes([block[42], block[43], block[44], block[45]]);
+        assert_eq!(v7, v7_layer_id(layer_to_id(Layer::TopPaste)));
+        assert_ne!(v7, 0, "a real layer must yield a non-zero v7 id");
     }
 }

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -927,9 +927,16 @@ fn region_v7_layer_token(layer: Layer) -> String {
 fn encode_region_properties(region: &Region) -> Vec<u8> {
     let vertex_count = region.vertices.len();
 
-    // Build parameter string (leading pipe, matching Altium).
+    // Parameter string in Altium's canonical key order. Unlike other Altium param
+    // blocks, a region's nested block has NO leading pipe and carries the full
+    // canonical key set (matching AltiumSharp `BuildRegionParamText`); the values are
+    // the from-scratch defaults. Our reader skips this block by length, so the format
+    // only affects byte-fidelity with genuine Altium output.
     let layer_name = region_v7_layer_token(region.layer);
-    let params = format!("|V7_LAYER={layer_name}|NAME=|KIND=0");
+    let params = format!(
+        "V7_LAYER={layer_name}|NAME=|KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0\
+         |ARCRESOLUTION=0mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil"
+    );
     let params_bytes = crate::altium::encode_windows1252(&params);
 
     let mut block = Vec::with_capacity(22 + params_bytes.len() + 4 + vertex_count * 16);
@@ -1875,5 +1882,39 @@ mod tests {
         let v7 = u32::from_le_bytes([block[42], block[43], block[44], block[45]]);
         assert_eq!(v7, v7_layer_id(layer_to_id(Layer::TopPaste)));
         assert_ne!(v7, 0, "a real layer must yield a non-zero v7 id");
+    }
+
+    #[test]
+    fn region_param_string_is_canonical() {
+        use crate::altium::pcblib::primitives::Vertex;
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            flags: PcbFlags::default(),
+            unique_id: None,
+        };
+        let block = encode_region_properties(&region);
+        let param_len = u32::from_le_bytes([block[18], block[19], block[20], block[21]]) as usize;
+        let params = String::from_utf8_lossy(&block[22..22 + param_len]);
+        let params = params.trim_end_matches('\0');
+        // No leading pipe (region blocks are special), and the full canonical key set.
+        assert!(!params.starts_with('|'), "no leading pipe: {params}");
+        for key in [
+            "V7_LAYER=MECHANICAL4",
+            "NAME=",
+            "KIND=0",
+            "SUBPOLYINDEX=-1",
+            "UNIONINDEX=0",
+            "ARCRESOLUTION=0mil",
+            "ISSHAPEBASED=FALSE",
+            "CAVITYHEIGHT=0mil",
+        ] {
+            assert!(params.contains(key), "missing '{key}' in: {params}");
+        }
     }
 }


### PR DESCRIPTION
Resumes the format fix ladder (TODO §A1) — two contained PcbLib **writer-side byte-fidelity** fixes (verified against AltiumSharp + the readability oracle 13/13).

## Fixes
1. **Fill v7 layer id** — `encode_fill_block` wrote a blanket `[0x00; 13]` over the 37-49 tail, leaving the v7 layer id (offsets 42-45) zeroed. Now writes the layer-derived id via the existing `v7_layer_id` helper.
2. **Region param string** — `encode_region_properties` emitted `|V7_LAYER=...|NAME=|KIND=0` (leading pipe, 3 keys). A region's nested param block is special: **no leading pipe**, and Altium writes the full canonical key set (`V7_LAYER|NAME|KIND|SUBPOLYINDEX|UNIONINDEX|ARCRESOLUTION|ISSHAPEBASED|CAVITYHEIGHT`, matching AltiumSharp `BuildRegionParamText`). Now emits that with from-scratch defaults.

## Safety
Both are byte-fidelity (AltiumSharp ignores the fill tail on read; our reader skips the region param block by length and reads the layer byte). The oracle's courtyard region stays readable — **13/13**.

Byte-level tests for both; `clippy -D warnings` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
