### PR TITLE
fix(pcblib): via solder-mask expansion as tri-state mode (shared MaskExpansionMode)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1118,6 +1118,37 @@ mod tests {
     }
 
     #[test]
+    fn via_solder_mask_mode_round_trips() {
+        use super::primitives::MaskExpansionMode;
+
+        // A fresh via defaults to FromRule (Altium's default, byte 66 = 1) — not the
+        // old `manual=false` which wrote 0 (None). A Manual via must round-trip.
+        let mut original = Footprint::new("VIA_MASK_MODE");
+        assert_eq!(
+            Via::new(0.0, 0.0, 0.6, 0.3).solder_mask_expansion_mode,
+            MaskExpansionMode::FromRule
+        );
+        original.add_via(Via::new(0.0, 0.0, 0.6, 0.3));
+        let mut manual = Via::new(1.0, 1.0, 0.6, 0.3);
+        manual.solder_mask_expansion_mode = MaskExpansionMode::Manual;
+        original.add_via(manual);
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("VIA_MASK_MODE");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.vias.len(), 2);
+        assert_eq!(
+            decoded.vias[0].solder_mask_expansion_mode,
+            MaskExpansionMode::FromRule
+        );
+        assert_eq!(
+            decoded.vias[1].solder_mask_expansion_mode,
+            MaskExpansionMode::Manual
+        );
+    }
+
+    #[test]
     fn binary_roundtrip_mixed_with_vias() {
         let mut original = Footprint::new("ROUNDTRIP_MIXED_VIA");
 

--- a/src/altium/pcblib/primitives/mod.rs
+++ b/src/altium/pcblib/primitives/mod.rs
@@ -44,7 +44,7 @@ pub use layer::Layer;
 mod models3d;
 pub use models3d::{ComponentBody, EmbeddedModel, Model3D};
 mod pads;
-pub use pads::{HoleShape, Pad, PadShape, PadStackMode, Via, ViaStackMode};
+pub use pads::{HoleShape, MaskExpansionMode, Pad, PadShape, PadStackMode, Via, ViaStackMode};
 mod shapes;
 pub use shapes::{Arc, Region, Track, Vertex};
 mod text;

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -280,6 +280,45 @@ pub enum ViaStackMode {
     FullStack,
 }
 
+/// Solder / paste mask expansion mode.
+///
+/// Altium stores this as a tri-state byte, not a boolean: the expansion can be
+/// off, taken from the design rule, or a manually-specified value. (Shared by
+/// vias and, later, pads.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaskExpansionMode {
+    /// No mask expansion.
+    None,
+    /// Expansion taken from the design rule (Altium's default).
+    #[default]
+    FromRule,
+    /// A manually-specified expansion value is used.
+    Manual,
+}
+
+impl MaskExpansionMode {
+    /// Creates from the Altium tri-state byte (`0` = `None`, `1` = `FromRule`, `2` = `Manual`).
+    #[must_use]
+    pub const fn from_id(id: u8) -> Self {
+        match id {
+            0 => Self::None,
+            2 => Self::Manual,
+            _ => Self::FromRule,
+        }
+    }
+
+    /// Returns the Altium tri-state byte.
+    #[must_use]
+    pub const fn to_id(self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::FromRule => 1,
+            Self::Manual => 2,
+        }
+    }
+}
+
 /// A PCB via (vertical interconnect access).
 ///
 /// Vias connect traces between different copper layers. They have a drill hole
@@ -314,9 +353,10 @@ pub struct Via {
     #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub solder_mask_expansion: f64,
 
-    /// Whether solder mask expansion is manually set.
+    /// Solder mask expansion mode (`None` / `FromRule` / `Manual`). Altium stores this
+    /// as a tri-state byte; `FromRule` is the default for a fresh via.
     #[serde(default)]
-    pub solder_mask_expansion_manual: bool,
+    pub solder_mask_expansion_mode: MaskExpansionMode,
 
     // Thermal relief settings (for polygon pours)
     /// Thermal relief air gap width in mm (default: 0.254mm = 10 mils).
@@ -386,7 +426,7 @@ impl Via {
             from_layer: Layer::TopLayer,
             to_layer: Layer::BottomLayer,
             solder_mask_expansion: 0.0,
-            solder_mask_expansion_manual: false,
+            solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils
@@ -414,7 +454,7 @@ impl Via {
             from_layer: from,
             to_layer: to,
             solder_mask_expansion: 0.0,
-            solder_mask_expansion_manual: false,
+            solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -27,8 +27,9 @@
 use std::collections::HashMap;
 
 use super::primitives::{
-    Arc, ComponentBody, Fill, HoleShape, Layer, Pad, PadShape, PadStackMode, PcbFlags, Region,
-    StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via, ViaStackMode,
+    Arc, ComponentBody, Fill, HoleShape, Layer, MaskExpansionMode, Pad, PadShape, PadStackMode,
+    PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via,
+    ViaStackMode,
 };
 use super::Footprint;
 use crate::altium::bytes::{

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -406,7 +406,10 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
     let thermal_relief_conductors = block.get(36).copied().unwrap_or(4);
     let thermal_relief_width = read_i32(block, 38).map_or(0.254, to_mm);
     let solder_mask_expansion = read_i32(block, 54).map_or(0.0, to_mm);
-    let solder_mask_expansion_manual = block.get(66).is_some_and(|&b| b != 0);
+    // Offset 66 is a tri-state mode byte (0=None, 1=FromRule, 2=Manual), not a bool.
+    let solder_mask_expansion_mode = block.get(66).map_or(MaskExpansionMode::FromRule, |&b| {
+        MaskExpansionMode::from_id(b)
+    });
     let diameter_stack_mode = block
         .get(74)
         .map_or(ViaStackMode::Simple, |&b| via_stack_mode_from_id(b));
@@ -431,7 +434,7 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         from_layer,
         to_layer,
         solder_mask_expansion,
-        solder_mask_expansion_manual,
+        solder_mask_expansion_mode,
         thermal_relief_gap,
         thermal_relief_conductors,
         thermal_relief_width,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -677,7 +677,7 @@ fn encode_via(data: &mut Vec<u8>, via: &Via) {
 
     // Solder mask expansion @54, its mode @66, diameter stack mode @74.
     block[54..58].copy_from_slice(&from_mm(via.solder_mask_expansion).to_le_bytes());
-    block[66] = u8::from(via.solder_mask_expansion_manual);
+    block[66] = via.solder_mask_expansion_mode.to_id();
     block[74] = via_stack_mode_to_id(via.diameter_stack_mode);
 
     // Per-layer diameters: 32 x i32 from offset 75. A real stack uses the


### PR DESCRIPTION
Continues the format fix ladder (TODO §A1, Via). A PcbLib **model + byte-fidelity** fix verified against AltiumSharp and the readability oracle.

## What
A via's solder-mask expansion *mode* lives at geometry offset 66 as an Altium **tri-state byte** — `0` = None, `1` = FromRule, `2` = Manual. We modelled it as `solder_mask_expansion_manual: bool`, which had two bugs:
1. **`FromRule` was unrepresentable** — a bool only covers None (`false`) / Manual (`true`).
2. **Wrong default** — a from-scratch via wrote byte 66 = `0` (None) instead of Altium's `1` (FromRule).

## Change
- New shared `MaskExpansionMode` enum (`None`/`FromRule`/`Manual`, `Default = FromRule`) with `from_id`/`to_id` for the tri-state byte.
- `Via.solder_mask_expansion_manual: bool` → `solder_mask_expansion_mode: MaskExpansionMode`.
- Reader reads the real mode; writer emits it; fresh vias default to `FromRule`.
- The pad's two mask modes (still bools) will adopt this same enum in the **596-byte pad rewrite (B5)** — that's why the enum is shared/standalone now.

## API note
The Via's MCP/serde input field changes:
`solder_mask_expansion_manual: bool` → `solder_mask_expansion_mode: "none" | "from_rule" | "manual"`.

## Safety
Round-trip test added (fresh via → `FromRule`; a `Manual` via survives the round-trip). Oracle stays **13/13**; `clippy -D warnings` + fmt clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
