### PR TITLE
fix(pcblib): round-trip ComponentBody MODEL.CHECKSUM (+ prune shipped TODOs)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,19 +40,19 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
       emitted under-length → **Altium rejects them**); octagonal id 3 ≠ Oval; `is_plated` @SR5+60;
       tri-state mask modes @+101/+102; slot length @+263 / hole rotation @+267; identity GUID @+126;
       middle/bottom sizes; full-stack tail (`636+count*15`); solder-mask template-default leak.
-- [ ] 🟠 **Via**: `solder_mask_expansion_mode` bool → tri-state enum (byte 66, default FromRule);
+- [ ] 🟠 **Via**: mask-mode tri-state enum [DONE #140 — shared `MaskExpansionMode`, reused by the pad];
       identity GUIDs @259-274/@275-290; `solder_mask_expansion_back` @242-245; net/comp/power-plane/
-      paste/drill-pair fields. *(Share the mask-mode enum with the pad.)*
-- [ ] 🟠 **Text**: flag word read [DONE #132]; `strokeWidth` @36; raw `fontId` @25 (don't collapse);
-      PCB justification @132 (column-major); mirrored @35 / italic @45 / baseFontType @43; font-name
-      fields @46-109/@161-224; zero/round-trip the InvertedRect stale template bytes @124-131.
-- [ ] 🟠 **Region**: param string (drop leading pipe; 8 canonical keys; `NAME` = single space);
-      `hole_count` @14 + hole contours; KIND/SUBPOLYINDEX/UNIONINDEX/ARCRESOLUTION/ISSHAPEBASED/
-      CAVITYHEIGHT params. *(Empty-block + V7_LAYER token already [DONE #124/#132/#133].)*
+      paste/drill-pair fields.
+- [ ] 🟠 **Text**: flag word [DONE #132], `strokeWidth` @36 [DONE #141]; `mirrored` @35 / `isComment`
+      @40 / `isDesignator` @41; italic @45 / baseFontType @43; font-name fields @46-109/@161-224;
+      InvertedRect template bytes @124-131. *(raw `fontId` @25 + justification @132 are custom-font /
+      inverted-rect only — verified deferred in #141.)*
+- [ ] 🟠 **Region**: param string (no leading pipe + 8 canonical keys) [DONE #139]; `hole_count` @14 +
+      hole contours (multi-contour regions). *(Empty-block + V7_LAYER token [DONE #124/#132/#133].)*
 - [ ] 🟠 **ComponentBody**: MODELTYPE/EXTRUDED/MODELSOURCE/V7_LAYER [DONE #133]; `MODEL.CHECKSUM`
       round-trip; broad field coverage (colour/opacity/texture/2D-placement/identifier).
-- [ ] ⚪ **Fill**: `v7_layer_id` @42-45 (port AltiumSharp `V7LayerId`); `solder_mask_expansion`
-      @37-40 + `keepout_restrictions` @46.
+- [ ] ⚪ **Fill**: `v7_layer_id` @42-45 [DONE #139]; `solder_mask_expansion` @37-40 +
+      `keepout_restrictions` @46.
 
 ### A2. PcbLib stream / container layer
 
@@ -113,8 +113,6 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 
 ## C. On-site Altium tooling
 
-- [ ] Merge **#136** (verify-harness fixes — `REPLACEALL`, BOM, wrapper error-detection,
-      leave-open).
 - [ ] *(Optional)* extend `Verify-Libraries.ps1` to assert primitive counts / specific properties,
       not just "opened".
 
@@ -146,5 +144,9 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
   wire bits) + SchLib semantics (IsSolid, end-marker, implementation record labels).
 - **#132** PcbLib: read the text flag word + emit regions as a single block.
 - **#133** *(contributor @ande2407)* generic extruded ComponentBody + `component_bodies` MCP input.
-- **#135** `scripts/altium/` on-site verify harness + README "Prior Art & Acknowledgements".
-- **#136** *(open)* verify-harness fixes.
+- **#135–#136** `scripts/altium/` on-site verify harness + README "Prior Art & Acknowledgements";
+  harness fixes (`REPLACEALL`, BOM, wrapper error-detection, leave-open).
+- **#137** TODO.md rewrite after the comprehensive RE.
+- **#139** PcbLib: fill `v7_layer_id` + canonical region parameter string (byte-fidelity).
+- **#140** PcbLib: via solder-mask expansion as tri-state `MaskExpansionMode` (fixes wrong default).
+- **#141** *(open)* PcbLib: text `stroke_width` @36 round-trip.

--- a/TODO.md
+++ b/TODO.md
@@ -50,7 +50,8 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 - [ ] 🟠 **Region**: param string (no leading pipe + 8 canonical keys) [DONE #139]; `hole_count` @14 +
       hole contours (multi-contour regions). *(Empty-block + V7_LAYER token [DONE #124/#132/#133].)*
 - [ ] 🟠 **ComponentBody**: MODELTYPE/EXTRUDED/MODELSOURCE/V7_LAYER [DONE #133]; `MODEL.CHECKSUM`
-      round-trip; broad field coverage (colour/opacity/texture/2D-placement/identifier).
+      round-trip (verbatim, never recomputed) [DONE #142]; broad field coverage
+      (colour/opacity/texture/2D-placement/identifier).
 - [ ] ⚪ **Fill**: `v7_layer_id` @42-45 [DONE #139]; `solder_mask_expansion` @37-40 +
       `keepout_restrictions` @46.
 
@@ -149,4 +150,5 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 - **#137** TODO.md rewrite after the comprehensive RE.
 - **#139** PcbLib: fill `v7_layer_id` + canonical region parameter string (byte-fidelity).
 - **#140** PcbLib: via solder-mask expansion as tri-state `MaskExpansionMode` (fixes wrong default).
-- **#141** *(open)* PcbLib: text `stroke_width` @36 round-trip.
+- **#141** PcbLib: text `stroke_width` @36 round-trip.
+- **#142** *(open)* PcbLib: ComponentBody `MODEL.CHECKSUM` round-trip (verbatim, never recomputed).

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -930,6 +930,7 @@ mod tests {
             layer: Layer::Top3DBody,
             outline: vec![(-2.0, 1.0), (-2.0, -1.0), (2.0, -1.0), (2.0, 1.0)],
             unique_id: None,
+            model_checksum: 7_654_321,
         };
         original.add_component_body(body);
 
@@ -951,6 +952,8 @@ mod tests {
         assert!(approx_eq(body.overall_height, 1.0, 0.01));
         assert!(approx_eq(body.standoff_height, 0.1, 0.01));
         assert_eq!(body.layer, Layer::Top3DBody);
+        // MODEL.CHECKSUM round-trips verbatim (previously dropped + hard-coded to 0).
+        assert_eq!(body.model_checksum, 7_654_321);
 
         // The explicit outline round-trips (4 vertices, in mm).
         assert_eq!(body.outline.len(), 4);
@@ -982,6 +985,7 @@ mod tests {
                 layer: Layer::Top3DBody,
                 outline: Vec::new(), // exercise the synthesised-bbox fallback
                 unique_id: None,
+                model_checksum: 0,
             });
         }
 

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -129,6 +129,13 @@ pub struct ComponentBody {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+
+    /// Model integrity checksum (Altium `MODEL.CHECKSUM`). Round-tripped verbatim —
+    /// never recomputed, because the checksum is over the raw (uncompressed) model
+    /// bytes, which the parameter writer does not have. `0` is valid and the default
+    /// for a fresh body, so default output stays byte-identical.
+    #[serde(default)]
+    pub model_checksum: i64,
 }
 
 impl ComponentBody {
@@ -148,6 +155,7 @@ impl ComponentBody {
             layer: Layer::Top3DBody,
             outline: Vec::new(),
             unique_id: None,
+            model_checksum: 0,
         }
     }
 }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1047,6 +1047,13 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
     let standoff_height = parse_mil_value(params.get("STANDOFFHEIGHT").map(String::as_str));
     let overall_height = parse_mil_value(params.get("OVERALLHEIGHT").map(String::as_str));
 
+    // MODEL.CHECKSUM is a plain integer; previously dropped. Round-trip it verbatim
+    // (0 = default/valid) — it is not recomputed from the model bytes here.
+    let model_checksum = params
+        .get("MODEL.CHECKSUM")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0);
+
     // Parse layer from V7_LAYER (e.g., "MECHANICAL6")
     let layer = params
         .get("V7_LAYER")
@@ -1066,6 +1073,7 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         layer,
         outline,
         unique_id: None,
+        model_checksum,
     };
 
     Ok((body, current))

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -160,6 +160,7 @@ impl PcbLib {
                 layer: Layer::Top3DBody,
                 outline: Vec::new(), // Synthesised from the footprint extent on write
                 unique_id: None,
+                model_checksum: 0, // Fresh embed; Altium computes the real checksum on save.
             });
 
             tracing::debug!(

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1173,7 +1173,8 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         body.model_id.clone()
     };
     params.push(format!("MODELID={model_id}"));
-    params.push("MODEL.CHECKSUM=0".to_string());
+    // Round-trip the stored checksum verbatim (default 0 keeps fresh output identical).
+    params.push(format!("MODEL.CHECKSUM={}", body.model_checksum));
     params.push(format!(
         "MODEL.EMBED={}",
         if body.embedded { "TRUE" } else { "FALSE" }

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -299,7 +299,8 @@ impl McpServer {
                                                 "z_offset": { "type": "number", "description": "Z offset in mm. Default: 0" },
                                                 "rotation_x": { "type": "number" },
                                                 "rotation_y": { "type": "number" },
-                                                "rotation_z": { "type": "number" }
+                                                "rotation_z": { "type": "number" },
+                                                "model_checksum": { "type": "integer", "description": "Altium MODEL.CHECKSUM; normally omitted (defaults to 0). Preserved verbatim on a read-modify-write round-trip." }
                                             },
                                             "required": ["overall_height"]
                                         }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -375,6 +375,7 @@ impl McpServer {
                             layer: Layer::Top3DBody,
                             outline: Vec::new(),
                             unique_id: None,
+                            model_checksum: 0, // External reference: no embedded model.
                         });
                     }
                 }
@@ -422,6 +423,12 @@ impl McpServer {
                         layer,
                         outline,
                         unique_id: None,
+                        // Preserve a checksum carried through from a read (read -> write
+                        // round-trip); 0 for genuinely fresh extruded bodies.
+                        model_checksum: body_json
+                            .get("model_checksum")
+                            .and_then(Value::as_i64)
+                            .unwrap_or(0),
                     });
                 }
             }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -784,6 +784,7 @@ fn test_component_body_roundtrip() {
         layer: Layer::TopLayer,
         outline: Vec::new(),
         unique_id: None,
+        model_checksum: 0,
     };
     fp.component_bodies.push(body);
 
@@ -829,6 +830,7 @@ fn test_component_body_with_rotation() {
         layer: Layer::TopLayer,
         outline: Vec::new(),
         unique_id: None,
+        model_checksum: 0,
     };
     fp.component_bodies.push(body);
 
@@ -2593,6 +2595,7 @@ fn test_component_body_external_model_reference() {
         layer: Layer::Top3DBody,
         outline: Vec::new(),
         unique_id: None,
+        model_checksum: 0,
     };
     fp.component_bodies.push(body);
 


### PR DESCRIPTION
Continues the format fix ladder (TODO §A1, ComponentBody) and prunes the shipped items from TODO.md.

## Bug
The ComponentBody parameter writer hard-coded `MODEL.CHECKSUM=0` and the reader **dropped the key entirely** — so a body Altium authored with a real checksum lost it on a read-modify-write.

## Fix
- New `ComponentBody.model_checksum: i64`, round-tripped **verbatim**: the reader parses the `MODEL.CHECKSUM` param (`parsers.rs`), the writer emits the stored value (`writer.rs:1171`).
- Wired through the MCP `component_bodies` input + JSON schema, so a read → write round-trip preserves it.

## Why not recompute
Altium's checksum is a position-weighted sum over the **raw uncompressed model bytes**, which the parameter writer doesn't have in scope. Computing a partial value would desync from the model's own checksum in the *Models/Data* record. Verbatim preservation is correct and safe. The separate `Models/Data` `CHECKSUM` field (`writer.rs:1278`, a different stream) is deliberately **left untouched**.

## Safety
Default is `0`, so a fresh body emits exactly `MODEL.CHECKSUM=0` — **byte-identical** to before. Oracle stays **13/13**; `clippy -D warnings` + fmt clean; 251 lib tests + all integration green. The existing `binary_roundtrip_component_body` test is extended to assert a non-zero checksum survives.

## Process note
RE'd against AltiumSharp via a background workflow. Two of the workflow's three research agents failed their structured-output step, so I **re-verified every claim against the actual code** before implementing (writer line, reader param map, the distinct second CHECKSUM, all construction sites) — the implementation round-trips verbatim, so it doesn't depend on the unverified algorithm details.

## Also
Prunes shipped §A1 sub-items in TODO.md to `[DONE #139/#140/#141/#142]` and moves them to "Recently shipped".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
