### PR TITLE
fix(pcblib): index UniqueIDPrimitiveInformation by a global Data-stream ordinal

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1512,20 +1512,21 @@ mod tests {
         footprint.add_pad(Pad::smd("2", 0.5, 0.0, 0.6, 0.5));
         footprint.add_track(Track::new(-1.0, 0.0, 1.0, 0.0, 0.15, Layer::TopOverlay));
 
-        // Create unique ID entries
+        // Global Data-stream ordinals: no arcs, so the two pads are 0 and 1, and the
+        // track (after the pads/vias slot) is 2.
         let entries = vec![
             reader::UniqueIdEntry {
-                primitive_index: 1,
+                primitive_index: 0,
                 primitive_type: "Pad".to_string(),
                 unique_id: "PADUID01".to_string(),
             },
             reader::UniqueIdEntry {
-                primitive_index: 2,
+                primitive_index: 1,
                 primitive_type: "Pad".to_string(),
                 unique_id: "PADUID02".to_string(),
             },
             reader::UniqueIdEntry {
-                primitive_index: 1,
+                primitive_index: 2,
                 primitive_type: "Track".to_string(),
                 unique_id: "TRKUID01".to_string(),
             },
@@ -1538,6 +1539,47 @@ mod tests {
         assert_eq!(footprint.pads[0].unique_id, Some("PADUID01".to_string()));
         assert_eq!(footprint.pads[1].unique_id, Some("PADUID02".to_string()));
         assert_eq!(footprint.tracks[0].unique_id, Some("TRKUID01".to_string()));
+    }
+
+    #[test]
+    fn unique_id_global_ordinal_round_trip() {
+        // A real footprint often has a silkscreen arc before the pads, so the first
+        // pad is PRIMITIVEINDEX=1 (a single global, 0-based, Data-stream ordinal),
+        // never 0 — the arc occupies ordinal 0. This locks the writer/reader contract.
+        let mut fp = Footprint::new("RT_UID");
+        let mut arc = Arc::circle(0.0, 0.0, 0.5, 0.1, Layer::TopOverlay);
+        arc.unique_id = Some("ARCUID01".to_string());
+        fp.add_arc(arc);
+        let mut p1 = Pad::smd("1", -0.5, 0.0, 0.6, 0.5);
+        p1.unique_id = Some("PADUID01".to_string());
+        fp.add_pad(p1);
+        let mut p2 = Pad::smd("2", 0.5, 0.0, 0.6, 0.5);
+        p2.unique_id = Some("PADUID02".to_string());
+        fp.add_pad(p2);
+
+        let entries =
+            reader::parse_unique_id_stream(&writer::encode_unique_id_stream(&fp).unwrap());
+
+        // Arc=0, then the two pads at 1 and 2 (never 0).
+        let arc_e = entries.iter().find(|e| e.primitive_type == "Arc").unwrap();
+        assert_eq!(arc_e.primitive_index, 0);
+        let mut pad_idx: Vec<usize> = entries
+            .iter()
+            .filter(|e| e.primitive_type == "Pad")
+            .map(|e| e.primitive_index)
+            .collect();
+        pad_idx.sort_unstable();
+        assert_eq!(pad_idx, vec![1, 2]);
+
+        // Round-trip onto a fresh, id-less footprint of identical shape.
+        let mut fresh = Footprint::new("RT_UID");
+        fresh.add_arc(Arc::circle(0.0, 0.0, 0.5, 0.1, Layer::TopOverlay));
+        fresh.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+        fresh.add_pad(Pad::smd("2", 0.5, 0.0, 0.6, 0.5));
+        reader::apply_unique_ids(&mut fresh, &entries);
+        assert_eq!(fresh.arcs[0].unique_id.as_deref(), Some("ARCUID01"));
+        assert_eq!(fresh.pads[0].unique_id.as_deref(), Some("PADUID01"));
+        assert_eq!(fresh.pads[1].unique_id.as_deref(), Some("PADUID02"));
     }
 
     #[test]

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -63,7 +63,8 @@ pub type WideStrings = HashMap<usize, String>;
 /// Each entry maps a primitive (by index and type) to its unique ID.
 #[derive(Debug, Clone)]
 pub struct UniqueIdEntry {
-    /// Primitive index (1-indexed, as stored in Altium files).
+    /// `PRIMITIVEINDEX`: a single global 0-based ordinal over all primitives in
+    /// `Data`-stream emit order (not a per-type index).
     pub primitive_index: usize,
     /// Primitive object type (e.g., "Pad", "Track", "Arc").
     pub primitive_type: String,
@@ -247,84 +248,47 @@ fn parse_unique_id_record(record: &str) -> Option<UniqueIdEntry> {
 
 /// Applies unique IDs from the `UniqueIDPrimitiveInformation` stream to footprint primitives.
 ///
-/// This function assigns unique IDs to primitives based on their type and index.
-/// The index is 1-based in the Altium format, and represents the order of primitives
-/// within each type (e.g., the 3rd Pad is index 3, regardless of Tracks in between).
+/// `PRIMITIVEINDEX` is a single global 0-based ordinal over all primitives in
+/// `Data`-stream emit order (Arc, Pad, Via, Track, Text, Region, Fill,
+/// `ComponentBody`) — NOT a per-type index. This walks that exact order, mirroring
+/// `encode_unique_id_stream`, so a written-then-read footprint round-trips.
 ///
 /// # Arguments
 ///
 /// * `footprint` - The footprint to update with unique IDs
 /// * `unique_ids` - The parsed unique ID map from `parse_unique_id_stream`
 pub fn apply_unique_ids(footprint: &mut Footprint, unique_ids: &UniqueIdMap) {
-    // Build lookup by (type, index) for efficient assignment
-    let mut lookup: HashMap<(&str, usize), &str> = HashMap::new();
+    // Map global ordinal -> (type, uid). Type is kept only to disambiguate a foreign
+    // file whose ordinal base doesn't line up: we skip rather than mis-attach.
+    let mut by_ordinal: HashMap<usize, (&str, &str)> = HashMap::new();
     for entry in unique_ids {
-        lookup.insert(
-            (entry.primitive_type.as_str(), entry.primitive_index),
-            entry.unique_id.as_str(),
+        by_ordinal.insert(
+            entry.primitive_index,
+            (entry.primitive_type.as_str(), entry.unique_id.as_str()),
         );
     }
 
-    // Detect indexing mode: if any entry has index 0, use 0-based;
-    // otherwise assume 1-based (for backward compatibility with older Altium files).
-    let has_zero_index = unique_ids.iter().any(|e| e.primitive_index == 0);
-    let offset: usize = usize::from(!has_zero_index);
-
-    // Pads
-    for (i, pad) in footprint.pads.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Pad", i + offset)) {
-            pad.unique_id = Some(uid.to_string());
-        }
+    let mut ordinal = 0usize;
+    macro_rules! apply {
+        ($iter:expr, $ty:literal) => {
+            for prim in $iter {
+                if let Some(&(ty, uid)) = by_ordinal.get(&ordinal) {
+                    if ty == $ty {
+                        prim.unique_id = Some(uid.to_string());
+                    }
+                }
+                ordinal += 1;
+            }
+        };
     }
-
-    // Vias
-    for (i, via) in footprint.vias.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Via", i + offset)) {
-            via.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // Tracks
-    for (i, track) in footprint.tracks.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Track", i + offset)) {
-            track.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // Arcs
-    for (i, arc) in footprint.arcs.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Arc", i + offset)) {
-            arc.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // Regions
-    for (i, region) in footprint.regions.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Region", i + offset)) {
-            region.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // Text
-    for (i, text) in footprint.text.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Text", i + offset)) {
-            text.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // Fills
-    for (i, fill) in footprint.fills.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("Fill", i + offset)) {
-            fill.unique_id = Some(uid.to_string());
-        }
-    }
-
-    // ComponentBodies
-    for (i, body) in footprint.component_bodies.iter_mut().enumerate() {
-        if let Some(&uid) = lookup.get(&("ComponentBody", i + offset)) {
-            body.unique_id = Some(uid.to_string());
-        }
-    }
+    apply!(footprint.arcs.iter_mut(), "Arc");
+    apply!(footprint.pads.iter_mut(), "Pad");
+    apply!(footprint.vias.iter_mut(), "Via");
+    apply!(footprint.tracks.iter_mut(), "Track");
+    apply!(footprint.text.iter_mut(), "Text");
+    apply!(footprint.regions.iter_mut(), "Region");
+    apply!(footprint.fills.iter_mut(), "Fill");
+    apply!(footprint.component_bodies.iter_mut(), "ComponentBody");
 
     tracing::trace!(
         footprint = %footprint.name,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1342,78 +1342,34 @@ pub fn encode_unique_id_stream(footprint: &Footprint) -> Option<Vec<u8>> {
     let mut data = Vec::new();
     let mut has_any_id = false;
 
-    // Encode each primitive type with its unique IDs
-    // Index is 0-based (AltiumSharp convention)
-
-    // Pads
-    for (i, pad) in footprint.pads.iter().enumerate() {
-        if let Some(ref uid) = pad.unique_id {
-            encode_unique_id_record(&mut data, i, "Pad", uid);
-            has_any_id = true;
-        }
+    // `PRIMITIVEINDEX` is a single global 0-based ordinal over ALL primitives in
+    // `Data`-stream emit order (see `encode_data_stream`): Arc, Pad, Via, Track,
+    // Text, Region, Fill, ComponentBody. Every primitive consumes an ordinal whether
+    // or not it carries a unique id (a record is emitted only when it does) — so e.g.
+    // the first pad behind two silkscreen arcs is `PRIMITIVEINDEX=2`, matching Altium.
+    // `apply_unique_ids` MUST walk this exact order to round-trip.
+    let mut ordinal: usize = 0;
+    macro_rules! emit {
+        ($iter:expr, $ty:literal) => {
+            for prim in $iter {
+                if let Some(ref uid) = prim.unique_id {
+                    encode_unique_id_record(&mut data, ordinal, $ty, uid);
+                    has_any_id = true;
+                }
+                ordinal += 1;
+            }
+        };
     }
+    emit!(&footprint.arcs, "Arc");
+    emit!(&footprint.pads, "Pad");
+    emit!(&footprint.vias, "Via");
+    emit!(&footprint.tracks, "Track");
+    emit!(&footprint.text, "Text");
+    emit!(&footprint.regions, "Region");
+    emit!(&footprint.fills, "Fill");
+    emit!(&footprint.component_bodies, "ComponentBody");
 
-    // Vias
-    for (i, via) in footprint.vias.iter().enumerate() {
-        if let Some(ref uid) = via.unique_id {
-            encode_unique_id_record(&mut data, i, "Via", uid);
-            has_any_id = true;
-        }
-    }
-
-    // Tracks
-    for (i, track) in footprint.tracks.iter().enumerate() {
-        if let Some(ref uid) = track.unique_id {
-            encode_unique_id_record(&mut data, i, "Track", uid);
-            has_any_id = true;
-        }
-    }
-
-    // Arcs
-    for (i, arc) in footprint.arcs.iter().enumerate() {
-        if let Some(ref uid) = arc.unique_id {
-            encode_unique_id_record(&mut data, i, "Arc", uid);
-            has_any_id = true;
-        }
-    }
-
-    // Regions
-    for (i, region) in footprint.regions.iter().enumerate() {
-        if let Some(ref uid) = region.unique_id {
-            encode_unique_id_record(&mut data, i, "Region", uid);
-            has_any_id = true;
-        }
-    }
-
-    // Text
-    for (i, text) in footprint.text.iter().enumerate() {
-        if let Some(ref uid) = text.unique_id {
-            encode_unique_id_record(&mut data, i, "Text", uid);
-            has_any_id = true;
-        }
-    }
-
-    // Fills
-    for (i, fill) in footprint.fills.iter().enumerate() {
-        if let Some(ref uid) = fill.unique_id {
-            encode_unique_id_record(&mut data, i, "Fill", uid);
-            has_any_id = true;
-        }
-    }
-
-    // ComponentBodies
-    for (i, body) in footprint.component_bodies.iter().enumerate() {
-        if let Some(ref uid) = body.unique_id {
-            encode_unique_id_record(&mut data, i, "ComponentBody", uid);
-            has_any_id = true;
-        }
-    }
-
-    if has_any_id {
-        Some(data)
-    } else {
-        None
-    }
+    has_any_id.then_some(data)
 }
 
 /// Encodes a single unique ID record.


### PR DESCRIPTION
Continues the format fix ladder (TODO §A2, PcbLib streams). RE'd against AltiumSharp **and three real vendor files** via a background workflow, then re-verified against the live code.

## The finding was reframed
The TODO entry said *"`PRIMITIVEINDEX` 0-based vs Altium 1-based"* — an off-by-one. It isn't. We emit a **per-type** 0-based index (and read with a 0-vs-1 auto-detect); Altium uses a **single global 0-based ordinal over all primitives in `Data`-stream emit order**.

Empirically confirmed by extracting `UniqueIDPrimitiveInformation/Data` from real vendor files:
- **RFSW6024**: `Arc(0), Arc(1), Pad(2), …` → first pad is `PRIMITIVEINDEX=2`.
- **FCBGA-900 / SDT10A45P5**: `Arc(0), Pad(1), …` → first pad is `PRIMITIVEINDEX=1`.

…and stated in AltiumSharp's own docs (`PcbPrimitiveGuid.cs`: *"0-based ordinal within its source stream"*). The "1-based" reading was just a pad sitting behind a silkscreen arc.

## Fix
Rewrite `encode_unique_id_stream` (writer) and `apply_unique_ids` (reader) **in lockstep** to walk every primitive in the canonical Data-stream order — `Arc, Pad, Via, Track, Text, Region, Fill, ComponentBody` — with one shared ordinal:
- every primitive consumes an ordinal; a record is written only when it carries a `unique_id`;
- the reader re-attaches by ordinal with a **type guard** (skips rather than mis-attaches on a foreign-file base mismatch), replacing the old 0-vs-1 auto-detect.

## Safety
`unique_id` defaults to `None` on tool-placed footprints, so the stream isn't emitted at all (`write_io` gates on `Some`) — output is **byte-identical** for the common path and the oracle stays **13/13**. The change only affects the read-real-file-then-rewrite path, which is exactly what it corrects.

Updated `unique_id_apply_to_footprint` to global ordinals; added an arc-before-pads round-trip test (first pad → index 1, never 0).

## Noted, out of scope
`encode_data_stream` emits **Region before Fill**, which diverges from AltiumSharp's **Fill before Region**. Pre-existing; only bites a footprint with both UID-bearing fills and regions; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
