### PR TITLE
fix(schlib): carry elliptical-arc radius frac at the boundary (defer cross-cutting *_FRAC)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,8 +51,6 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 - [ ] 🟠 **Designator**: model `Location.X/Y` (Altium `X=-5, Y=5`; we hardcode `Y=-6`, omit `X`).
 - [ ] 🟠 **`IndexInSheet`** from a stored model field (default `-1`), not the write counter —
       cross-cutting across most records.
-- [ ] 🟠 **Fractional coordinates** (`*_FRAC`, sub-DXP precision) — cross-cutting across arc,
-      ellipse, ellipticalarc, label, line, rectangle, roundrect, bezier.
 - [ ] 🟠 **Label / Text**: RECORD=3 is *Symbol*, not Text — `encode_text` writes RECORD=4 (clashing
       with Label); map RECORD=3/4 correctly. (Colour/Orientation/Justification omit + IsHidden/
       IsMirrored placement.)
@@ -95,6 +93,11 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 - [ ] **SchLib `IsNotAccesible` on Ellipse / Polyline**: the other per-record fields shipped, but
       these two emit no token today, so adding the field changes from-scratch bytes — confirm the
       default against a golden ellipse/polyline first.
+- [ ] **SchLib `*_FRAC` cross-cutting** (Location/Corner/X1..n on arc, ellipse, line, rectangle,
+      roundrect, label, bezier, polyline): encoding known (`raw = DXP*100000 + FRAC`, signed), but
+      every coord field is `i32` and can't hold sub-DXP precision — a faithful fix is a breaking
+      `i32`→`f64` model/API change, and the per-record `_Frac` key spellings need a byte-compared
+      golden. *(EllipticalArc radii already round-trip; the carry bug was fixed separately.)*
 - [ ] Feed confirmed answers back into the fix ladder (especially the pad, A3).
 
 ## C. On-site Altium tooling

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -1085,6 +1085,58 @@ mod tests {
     }
 
     #[test]
+    fn elliptical_arc_radius_frac_carry_and_roundtrip() {
+        // Grid-aligned radii must emit NO _Frac token — the byte-identical / oracle-safe
+        // path for from-scratch symbols.
+        let mut grid = Symbol::new("EARC_GRID");
+        grid.add_elliptical_arc(EllipticalArc::new(0, 0, 5.0, 3.0, 0.0, 360.0));
+        let g = String::from_utf8_lossy(&writer::encode_data_stream(&grid).expect("encode"))
+            .into_owned();
+        assert!(!g.contains("_Frac"), "grid-aligned radii omit _Frac: {g}");
+        assert!(
+            g.contains("|Radius=5|"),
+            "integer radius emitted plainly: {g}"
+        );
+
+        // A near-boundary radius must CARRY into the integer part, not clamp to 99999.
+        let mut sym = Symbol::new("EARC_CARRY");
+        sym.add_elliptical_arc(EllipticalArc::new(0, 0, 4.999_995, 3.5, 0.0, 360.0));
+        let enc = String::from_utf8_lossy(&writer::encode_data_stream(&sym).expect("encode"))
+            .into_owned();
+        assert!(
+            enc.contains("|Radius=5|"),
+            "boundary radius carries to int: {enc}"
+        );
+        assert!(
+            !enc.contains("|Radius_Frac"),
+            "primary radius carried, so no Radius_Frac: {enc}"
+        );
+        assert!(
+            enc.contains("|SecondaryRadius_Frac=50000"),
+            "secondary 3.5 keeps its frac: {enc}"
+        );
+
+        // Round-trip: 4.999995 -> 5.0; 3.5 -> SecondaryRadius_Frac=50000 -> 3.5.
+        let mut lib = SchLib::new();
+        lib.add(sym);
+        let mut buf = Cursor::new(Vec::new());
+        lib.write(&mut buf).expect("write");
+        buf.set_position(0);
+        let read = SchLib::read(buf).expect("read");
+        let ea = &read.get("EARC_CARRY").expect("symbol").elliptical_arcs[0];
+        assert!(
+            (ea.radius - 5.0).abs() < 1e-9,
+            "carried radius round-trips: {}",
+            ea.radius
+        );
+        assert!(
+            (ea.secondary_radius - 3.5).abs() < 1e-9,
+            "frac round-trips: {}",
+            ea.secondary_radius
+        );
+    }
+
+    #[test]
     fn wrong_file_type_pcblib_as_schlib() {
         // Create a PcbLib file in memory (using SchLib format with length prefix)
         let mut buffer = Cursor::new(Vec::new());

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -572,13 +572,18 @@ fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
 /// Encodes an elliptical arc record.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn encode_elliptical_arc(arc: &EllipticalArc, index: usize) -> String {
-    // Extract integer and fractional parts from the radii
-    let radius_int = arc.radius.trunc() as i32;
-    let radius_frac = ((arc.radius.fract() * 100_000.0).round() as u32).min(99999);
+    // Split each radius from a single rounded raw integer (`raw = round(r * 100_000)`)
+    // so a near-boundary value carries into the integer part exactly, matching
+    // AltiumSharp's `AddCoordParam` — rather than the old `trunc`/`fract` split, which
+    // clamped e.g. 4.999995 to `Radius=4|Radius_Frac=99999` instead of `Radius=5`.
+    // Radii are non-negative, so `raw % 100_000` is non-negative.
+    let radius_raw = (arc.radius * 100_000.0).round() as i64;
+    let radius_int = (radius_raw / 100_000) as i32;
+    let radius_frac = (radius_raw % 100_000) as u32;
 
-    let secondary_radius_int = arc.secondary_radius.trunc() as i32;
-    let secondary_radius_frac =
-        ((arc.secondary_radius.fract() * 100_000.0).round() as u32).min(99999);
+    let secondary_raw = (arc.secondary_radius * 100_000.0).round() as i64;
+    let secondary_radius_int = (secondary_raw / 100_000) as i32;
+    let secondary_radius_frac = (secondary_raw % 100_000) as u32;
 
     format!(
         "|RECORD=11|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\


### PR DESCRIPTION
SchLib §A3 fractional-coords item. RE'd against AltiumSharp via a background workflow — and the verified conclusion **reshaped the work**.

## The honest outcome: ship one bug, defer the rest
The cross-cutting "add `*_FRAC` everywhere" is **deferred to §B**, not shipped — for two solid reasons the verification surfaced:
- Every coord field is `i32`, which **cannot hold** sub-DXP precision. Reading `X_Frac` would just truncate (no real fidelity) unless we change `i32`→`f64` — a **breaking API change**.
- The per-record `_Frac` key spellings come from AltiumSharp **DTOs, not a byte-compared golden file** — the guess the project rules forbid.

What the verification *did* surface is a genuine, self-contained **correctness bug** in the one frac path we already ship.

## The bug (Defect A)
`encode_elliptical_arc` split each radius with `trunc()/fract()`. A near-boundary radius like **4.999995** rounded `fract()*100_000` to `100000`, clamped to `99999`, and emitted `Radius=4|Radius_Frac=99999` (= 4.99999) — wrong by 5e-6 — instead of **carrying** to `Radius=5`.

## Fix
Split from a single rounded raw integer (`raw = round(r * 100_000)`, then `/` and `%`). This carries exactly and **converges on AltiumSharp's `AddCoordParam`** integer split.

## Safety
Grid-aligned radii still yield frac 0 ⇒ `nonzero` omits the key ⇒ from-scratch output **byte-identical**, oracle **13/13**. Carry + round-trip test added (`4.999995 → Radius=5`, `3.5 → SecondaryRadius_Frac=50000 → 3.5`). clippy/fmt clean; full suite green.

The deferred cross-cutting spec (encoding + per-record key table) is recorded under TODO §B for when a golden `.SchLib` is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
