### PR TITLE
fix(schlib): stop flooring PartCount so a single-part symbol round-trips

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,8 +56,6 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
       IsMirrored placement.)
 - [ ] 🟠 **Implementation**: `MapDefiner` (RECORD=47) modelling; `DataFileCount` derive/loop;
       `IsCurrent` only-when-true. *(1-based index + OwnerIndex → live-Altium gaps, section B.)*
-- [ ] 🟠 **Component (RECORD=1)**: emit/read `UniqueID`; `PartCount.max(1)` flooring corrupts
-      round-trip; read more header fields.
 - [ ] 🟠 **Pin**: `FormalType` model field; `DefaultValue` tail string; `SwapId` / `PinFrac` /
       `SymbolLineWidth`.
 
@@ -98,6 +96,10 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
       every coord field is `i32` and can't hold sub-DXP precision — a faithful fix is a breaking
       `i32`→`f64` model/API change, and the per-record `_Frac` key spellings need a byte-compared
       golden. *(EllipticalArc radii already round-trip; the carry bug was fixed separately.)*
+- [ ] **SchLib Component (RECORD=1) header fields**: the `PartCount` floor is fixed; remaining is
+      the component `UniqueID` (AltiumSharp carries it, but a fresh symbol would emit a brand-new
+      random id — not byte-identical) and the dropped header fields (`DesignItemId` / `ComponentKind`
+      / `LibraryPath` / `SheetPartFileName` / `IndexInSheet` / `OwnerPartId`) — need golden fixtures.
 - [ ] Feed confirmed answers back into the fix ladder (especially the pad, A3).
 
 ## C. On-site Altium tooling

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -121,9 +121,12 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
                 symbol.description.clone_from(desc);
             }
             if let Some(part_count) = props.get("partcount") {
-                // Altium stores part_count + 1, so we subtract 1 when reading
+                // Altium stores part_count + 1 (part 0 is the common part), so we
+                // subtract 1 when reading. No floor at 1: a single-part symbol stores
+                // PartCount=1 => internal 0; flooring it to 1 round-tripped as
+                // PartCount=2 (corruption). Matches AltiumSharp's Math.Max(0, dto - 1).
                 let raw_count: u32 = part_count.trim().parse().unwrap_or(2);
-                symbol.part_count = raw_count.saturating_sub(1).max(1);
+                symbol.part_count = raw_count.saturating_sub(1);
             }
             if let Some(display_mode_count) = props.get("displaymodecount") {
                 symbol.display_mode_count = display_mode_count.parse().unwrap_or(1);
@@ -969,6 +972,19 @@ const fn justification_from_id(id: u8) -> TextJustification {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn partcount_one_decodes_to_zero_no_floor() {
+        // Altium stores count+1, so a single-part symbol stores PartCount=1 => internal
+        // 0. The old `.max(1)` floor mutated that to 1, which the writer re-emitted as
+        // PartCount=2 — corrupting the round-trip. Decode must now yield exactly 0.
+        let mut symbol = Symbol::new("PARTCOUNT_TEST");
+        parse_text_record_from_string(&mut symbol, "|RECORD=1|LibReference=R1|PartCount=1");
+        assert_eq!(
+            symbol.part_count, 0,
+            "raw PartCount=1 must decode to 0, not be floored to 1"
+        );
+    }
 
     #[test]
     fn test_parse_properties() {

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -955,6 +955,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn single_part_symbol_emits_partcount_one() {
+        // internal part_count 0 (single part) must re-emit PartCount=1, not the old
+        // floored PartCount=2 — the write-back half of the round-trip fix.
+        let mut symbol = Symbol::new("PC");
+        symbol.part_count = 0;
+        let header = encode_component_header(&symbol);
+        assert!(
+            header.contains("|PartCount=1|"),
+            "single-part symbol re-emits PartCount=1: {header}"
+        );
+    }
+
+    #[test]
     fn test_write_text_record() {
         let mut data = Vec::new();
         write_text_record(&mut data, "|RECORD=1|Name=Test|").unwrap();


### PR DESCRIPTION
SchLib §A3 component-record item. RE'd against AltiumSharp via a background workflow.

## Bug
The reader decoded `PartCount` as `raw.saturating_sub(1).max(1)`. Altium stores **part_count + 1** (part 0 is the common part), so a **single-part** symbol stores `PartCount=1` → internal **0**. The `.max(1)` floor clamped that to **1**, which the writer re-emitted as `PartCount=2` — silently turning a 1-part symbol into a 2-part symbol on read-modify-write.

## Fix
Drop the floor: `raw.saturating_sub(1)`. This matches **AltiumSharp's `Math.Max(0, dto.PartCount - 1)`** (`SchLibReader.cs:771`) exactly. The blank/absent path (`unwrap_or(2)` → internal 1) is untouched and still matches the struct default.

## Safety
Pure read-side change. A from-scratch symbol (default `part_count` 1) still writes `PartCount=2`, so header bytes are unchanged and the oracle stays **13/13**. Reader test (raw `1`→`0`) + writer test (internal `0`→ re-emits `PartCount=1`) added; full suite green.

## Deferred to §B
Component `UniqueID` (AltiumSharp carries it, but a fresh symbol would emit a brand-new *random* id → not byte-identical → unverifiable without golden fixtures) and the other dropped header fields (`DesignItemId`/`ComponentKind`/`LibraryPath`/…). Recorded under §B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
