### PR TITLE
fix(schlib): round-trip the footprint-model IsCurrent flag

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -16,8 +16,10 @@
 //! ```text
 //! [RecordLength:2 LE][RecordType:2 BE][data:RecordLength]
 //! ...
-//! [0x00 0x00]  // End marker
 //! ```
+//!
+//! There is NO end-of-stream marker — records run until the stream is exhausted.
+//! (A trailing `0x0000` would be mis-read as a zero-length record; see issue #68.)
 //!
 //! Record types:
 //! - `0x0000`: Text record (pipe-delimited key=value pairs)
@@ -641,6 +643,33 @@ mod tests {
         assert_eq!(pin1.x, -20);
         assert_eq!(pin1.y, 0);
         assert_eq!(pin1.length, 10);
+    }
+
+    #[test]
+    fn roundtrip_footprint_iscurrent_flag() {
+        // The writer emits IsCurrent positionally (first model = current); the reader
+        // now preserves that flag instead of dropping it.
+        let mut symbol = Symbol::new("R1");
+        symbol.add_footprint(FootprintModel::new("0603"));
+        symbol.add_footprint(FootprintModel::new("0805"));
+
+        let data = writer::encode_data_stream(&symbol).expect("encode");
+        let mut decoded = Symbol::new("R1");
+        reader::parse_data_stream(&mut decoded, &data);
+
+        assert_eq!(
+            decoded.footprints.len(),
+            2,
+            "both models survive the round-trip"
+        );
+        assert!(
+            decoded.footprints[0].is_current,
+            "first model is current (IsCurrent=T)"
+        );
+        assert!(
+            !decoded.footprints[1].is_current,
+            "second model is not current"
+        );
     }
 
     #[test]

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -1011,6 +1011,11 @@ pub struct FootprintModel {
     /// library isn't installed/in the project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub library_path: Option<String>,
+    /// Whether this is the current/default footprint model (`IsCurrent=T`).
+    /// Preserved on read; on write the first model is still emitted as current
+    /// (positional), so this is read-preserved only until multi-model authoring lands.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_current: bool,
 }
 
 impl FootprintModel {
@@ -1021,6 +1026,7 @@ impl FootprintModel {
             name: name.into(),
             description: String::new(),
             library_path: None,
+            is_current: false,
         }
     }
 }

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -178,6 +178,8 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
                         fp.library_path = Some(path.clone());
                     }
                 }
+                // Preserve the current/default-model flag (Altium omits it when false).
+                fp.is_current = props.get("iscurrent").is_some_and(|v| v == "T");
                 symbol.add_footprint(fp);
             }
         }


### PR DESCRIPTION
SchLib §A3 implementation-record item. RE'd against AltiumSharp via a background workflow.

## What
The RECORD=45 (Model) reader dropped `IsCurrent`, losing the current/default-model flag on read. Add `FootprintModel.is_current` (serde-skipped when false) and parse it in the RECORD=45 arm.

## Safety
**Writer untouched** — it still emits `IsCurrent` positionally (first model = current, `writer.rs` `i == 0`), so a from-scratch symbol is **byte-identical** and the oracle stays **13/13**. The flag is read-preserved only; a two-model round-trip test asserts it. Also drops a stale module-doc line claiming a `0x00 0x00` end marker the writer deliberately omits (issue #68).

## Deferred to §B (need golden libraries)
- **RECORD=47 MapDefiner** (pin→pad map) — needs a live map + the 46→47 child framing.
- **46/48 payload bodies + the cross-record OwnerIndex chain.**
- **Honouring `is_current` on write** + AltiumSharp's omit-`IsCurrent=F` convention (a byte-changing reformat — proven by `SchLibWriter.cs:1483`, but unmotivated for the single-model case).
- **`DataFileCount` > 1 / multi-datafile models.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
