### PR TITLE
fix(schlib): round-trip pin tail fields (FormalType, SwapId, DefaultValue)

### DIFF
--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -82,6 +82,23 @@ pub struct Pin {
     /// Symbol decoration outside the pin line.
     #[serde(default)]
     pub symbol_outside: PinSymbol,
+
+    /// Pin formal type byte. Altium emits `1` for a normal pin; preserved on
+    /// round-trip. Non-default values come from Altium-authored files.
+    #[serde(default = "default_formal_type")]
+    pub formal_type: u8,
+
+    /// Pin swap-id group (empty for a from-scratch pin).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub swap_id_group: String,
+
+    /// Pin part-and-sequence swap id. Altium's default for a fresh pin is `|&|`.
+    #[serde(default = "default_part_and_sequence")]
+    pub part_and_sequence: String,
+
+    /// Pin default value (empty for a from-scratch pin).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub default_value: String,
 }
 
 const fn default_true() -> bool {
@@ -90,6 +107,14 @@ const fn default_true() -> bool {
 
 const fn default_owner_part() -> i32 {
     1
+}
+
+const fn default_formal_type() -> u8 {
+    1
+}
+
+fn default_part_and_sequence() -> String {
+    "|&|".to_string()
 }
 
 impl Pin {
@@ -123,6 +148,10 @@ impl Pin {
             symbol_outer_edge: PinSymbol::None,
             symbol_inside: PinSymbol::None,
             symbol_outside: PinSymbol::None,
+            formal_type: 1,
+            swap_id_group: String::new(),
+            part_and_sequence: "|&|".to_string(),
+            default_value: String::new(),
         }
     }
 }

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -291,7 +291,8 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     let (description, next) = crate::altium::framing::read_pascal_string(data, offset);
     offset = next;
 
-    // formal_type (1 byte) - unused
+    // formal_type (1 byte): preserved on round-trip (Altium emits 1).
+    let formal_type = data.get(offset).copied().unwrap_or(1);
     offset += 1;
 
     // electrical_type (1 byte)
@@ -329,7 +330,19 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     offset = next;
 
     // designator: [length:1][string]
-    let (designator, _) = crate::altium::framing::read_pascal_string(data, offset);
+    let (designator, next) = crate::altium::framing::read_pascal_string(data, offset);
+    offset = next;
+
+    // Swap-id tail (Pascal short strings), in order: swap_id_group,
+    // part_and_sequence, default_value. `read_pascal_string` returns ("", offset)
+    // safely past the end of a truncated record, so a legacy/short pin reads ""
+    // for any absent tail field; we reproduce exactly what was read (do NOT
+    // coerce an empty part_and_sequence back to "|&|" here).
+    let (swap_id_group, next) = crate::altium::framing::read_pascal_string(data, offset);
+    offset = next;
+    let (part_and_sequence, next) = crate::altium::framing::read_pascal_string(data, offset);
+    offset = next;
+    let (default_value, _) = crate::altium::framing::read_pascal_string(data, offset);
 
     Some(Pin {
         name,
@@ -351,6 +364,10 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
         symbol_outer_edge,
         symbol_inside,
         symbol_outside,
+        formal_type,
+        swap_id_group,
+        part_and_sequence,
+        default_value,
     })
 }
 
@@ -986,6 +1003,30 @@ mod tests {
             symbol.part_count, 0,
             "raw PartCount=1 must decode to 0, not be floored to 1"
         );
+    }
+
+    #[test]
+    fn pin_tail_round_trips_non_default_values() {
+        use crate::altium::schlib::primitives::{Pin, PinOrientation};
+        use crate::altium::schlib::writer::write_binary_pin;
+
+        let mut pin = Pin::new("VCC", "1", 10, -20, 100, PinOrientation::Right);
+        pin.formal_type = 7;
+        pin.swap_id_group = "GRP".to_string();
+        pin.part_and_sequence = "A|&|B".to_string();
+        pin.default_value = "5V".to_string();
+
+        let mut data = Vec::new();
+        write_binary_pin(&mut data, &pin).unwrap();
+
+        // Strip the [u24 length LE][u8 flags] frame written by write_record_frame.
+        let body = &data[4..];
+        let parsed = parse_binary_pin(body).unwrap();
+
+        assert_eq!(parsed.formal_type, 7);
+        assert_eq!(parsed.swap_id_group, "GRP");
+        assert_eq!(parsed.part_and_sequence, "A|&|B");
+        assert_eq!(parsed.default_value, "5V");
     }
 
     #[test]

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -82,7 +82,10 @@ fn write_text_record(data: &mut Vec<u8>, content: &str) -> crate::altium::error:
 /// - Pin coordinates (x, y, length) exceed the i16 range (±32767)
 /// - Pin name, designator, or description exceeds 255 bytes
 #[allow(clippy::too_many_lines)] // Complex binary format requires detailed validation and encoding
-fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::AltiumResult<()> {
+pub(crate) fn write_binary_pin(
+    data: &mut Vec<u8>,
+    pin: &Pin,
+) -> crate::altium::error::AltiumResult<()> {
     use crate::altium::error::AltiumError;
 
     // Validation constants
@@ -127,10 +130,16 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     let name = crate::altium::encode_windows1252(&pin.name);
     let designator = crate::altium::encode_windows1252(&pin.designator);
     let description = crate::altium::encode_windows1252(&pin.description);
+    let swap_id_group = crate::altium::encode_windows1252(&pin.swap_id_group);
+    let part_and_sequence = crate::altium::encode_windows1252(&pin.part_and_sequence);
+    let default_value = crate::altium::encode_windows1252(&pin.default_value);
     for (bytes, field) in [
         (&name, "name"),
         (&designator, "designator"),
         (&description, "description"),
+        (&swap_id_group, "swap_id_group"),
+        (&part_and_sequence, "part_and_sequence"),
+        (&default_value, "default_value"),
     ] {
         if bytes.len() > MAX_STRING_LEN {
             return Err(AltiumError::InvalidParameter {
@@ -178,8 +187,8 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     // Description: Pascal short string [length:1][string]
     write_pascal_string(&mut record, &description);
 
-    // Formal type (1 byte) - 0x01 for a normal pin (matches Altium's output).
-    record.push(0x01);
+    // Formal type (1 byte) - 0x01 for a normal pin; round-tripped from the pin.
+    record.push(pin.formal_type);
 
     // Electrical type (1 byte)
     record.push(pin.electrical_type.to_id());
@@ -232,12 +241,12 @@ fn write_binary_pin(data: &mut Vec<u8>, pin: &Pin) -> crate::altium::error::Alti
     // Designator: [length:1][string]
     write_pascal_string(&mut record, &designator);
 
-    // Pin swap-id tail (Pascal short strings), matching Altium's output:
-    //   SwapIdGroup = "" , PartAndSequence = "|&|" , DefaultValue = "".
-    record.push(0); // SwapIdGroup (empty)
-    record.push(3); // PartAndSequence length
-    record.extend_from_slice(b"|&|");
-    record.push(0); // DefaultValue (empty)
+    // Pin swap-id tail (Pascal short strings), round-tripped from the pin. For a
+    // from-scratch pin the defaults (`""`, `"|&|"`, `""`) reproduce Altium's
+    // output byte-for-byte.
+    write_pascal_string(&mut record, &swap_id_group);
+    write_pascal_string(&mut record, &part_and_sequence);
+    write_pascal_string(&mut record, &default_value);
 
     // Header: Altium's [u24 length LE][u8 flags=1 for pin], then the record.
     write_record_frame(data, &record, 1)
@@ -965,6 +974,19 @@ mod tests {
             header.contains("|PartCount=1|"),
             "single-part symbol re-emits PartCount=1: {header}"
         );
+    }
+
+    #[test]
+    fn pin_tail_default_is_byte_identical() {
+        use crate::altium::schlib::primitives::Pin;
+        let pin = Pin::new("VCC", "1", 0, 0, 100, PinOrientation::Right);
+        let mut data = Vec::new();
+        write_binary_pin(&mut data, &pin).unwrap();
+        // Default tail must be exactly: swap_id_group="", part_and_sequence="|&|",
+        // default_value="" — the same bytes the writer emitted before the tail
+        // fields became round-trippable. This is the load-bearing byte-identity
+        // check; formal_type=1 leaves the formal-type byte at 0x01 unchanged.
+        assert!(data.ends_with(&[0x00, 0x03, b'|', b'&', b'|', 0x00]));
     }
 
     #[test]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -439,6 +439,10 @@ impl McpServer {
             symbol_inside,
             symbol_outside,
             is_not_accessible: false,
+            formal_type: 1,
+            swap_id_group: String::new(),
+            part_and_sequence: "|&|".to_string(),
+            default_value: String::new(),
         })
     }
 

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -1313,6 +1313,10 @@ fn test_schlib_rename_component() {
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
         is_not_accessible: false,
+        formal_type: 1,
+        swap_id_group: String::new(),
+        part_and_sequence: "|&|".to_string(),
+        default_value: String::new(),
     });
     lib.add(sym);
     lib.save(&file_path).expect("Failed to write");
@@ -1535,6 +1539,10 @@ fn test_schlib_copy_cross_library() {
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
         is_not_accessible: false,
+        formal_type: 1,
+        swap_id_group: String::new(),
+        part_and_sequence: "|&|".to_string(),
+        default_value: String::new(),
     });
     source_lib.add(sym);
     source_lib
@@ -1679,6 +1687,10 @@ fn test_schlib_json_roundtrip() {
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
         is_not_accessible: false,
+        formal_type: 1,
+        swap_id_group: String::new(),
+        part_and_sequence: "|&|".to_string(),
+        default_value: String::new(),
     });
     lib.add(sym);
     lib.save(&original_path).expect("Failed to write original");
@@ -1948,6 +1960,10 @@ fn test_schlib_merge_libraries() {
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
         is_not_accessible: false,
+        formal_type: 1,
+        swap_id_group: String::new(),
+        part_and_sequence: "|&|".to_string(),
+        default_value: String::new(),
     });
     lib2.add(sym2);
     lib2.save(&source2_path).expect("Failed to write source2");
@@ -2253,6 +2269,10 @@ fn test_schlib_get_component() {
         symbol_inside: PinSymbol::None,
         symbol_outside: PinSymbol::None,
         is_not_accessible: false,
+        formal_type: 1,
+        swap_id_group: String::new(),
+        part_and_sequence: "|&|".to_string(),
+        default_value: String::new(),
     });
     lib.add(sym1);
 


### PR DESCRIPTION
SchLib §A3 pin-fields item. Byte layout verified **field-for-field against AltiumSharp** via a background workflow + adversarial review; implementation delegated then gated (oracle + byte-identity diff).

## What
The binary pin record already contains `FormalType`, `SwapIdGroup`, `PartAndSequence` and `DefaultValue`, but the reader skipped them and the writer hard-coded the defaults — so Altium-authored values were lost on a read-modify-write. Promote them to real `Pin` fields that round-trip.

## Safety — byte-identical for a fresh pin
`formal_type` default `1` → `0x01` (unchanged); tail = `00 03 |&| 00`, **exactly the old hard-coded constants**. Confirmed by diffing the removed code against the new pascal-string output. Oracle stays **13/13**. The reader does **not** coerce an empty `PartAndSequence` back to `"|&|"`, so a truncated legacy record reproduces what it read.

Two tests: default-pin byte-identity (`ends_with` the exact tail) + non-default round-trip through `write`→`parse`.

## Deferred to §B
`SymbolLineWidth` and `PinFrac` — these live in **separate OLE streams** (`PinSymbolLineWidth`, `PinFrac`), not this record, so adding them would change the record length and break byte-identity. Need golden offsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
