### PR TITLE
fix(pcblib): round-trip text italic, via back solder-mask, region holes

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -718,6 +718,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width: None,
+            italic: false,
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
             unique_id: None,
@@ -732,6 +733,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width: None,
+            italic: false,
             justification: TextJustification::TopLeft,
             flags: PcbFlags::empty(),
             unique_id: None,
@@ -774,6 +776,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width: Some(0.2),
+            italic: false,
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
             unique_id: None,
@@ -791,6 +794,61 @@ mod tests {
     }
 
     #[test]
+    fn text_truetype_italic_round_trips() {
+        // A TrueType italic text must round-trip italic@45 and derive baseFontType@43=1.
+        let mut original = Footprint::new("TT_ITALIC");
+        original.add_text(Text {
+            x: 0.0,
+            y: 0.0,
+            text: "String".to_string(),
+            height: 1.0,
+            layer: Layer::TopOverlay,
+            rotation: 0.0,
+            kind: TextKind::TrueType,
+            stroke_font: None,
+            stroke_width: None,
+            italic: true,
+            justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::empty(),
+            unique_id: None,
+        });
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("TT_ITALIC");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.text.len(), 1);
+        assert_eq!(decoded.text[0].kind, TextKind::TrueType);
+        assert!(decoded.text[0].italic, "italic must survive the round-trip");
+    }
+
+    #[test]
+    fn text_default_stroke_geometry_byte_identical() {
+        // Guards the oracle: a from-scratch stroke text with default styling must emit
+        // the unmodified template at the styling offsets (43, 45 == 0).
+        let geom = writer::encode_text_geometry(&Text {
+            x: 0.0,
+            y: 0.0,
+            text: "X".into(),
+            height: 1.0,
+            layer: Layer::TopOverlay,
+            rotation: 0.0,
+            kind: TextKind::Stroke,
+            stroke_font: None,
+            stroke_width: None,
+            italic: false,
+            justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::empty(),
+            unique_id: None,
+        });
+        assert_eq!(
+            geom[43], 0x00,
+            "stroke baseFontType must stay template default"
+        );
+        assert_eq!(geom[45], 0x00, "non-italic must stay template default");
+    }
+
+    #[test]
     fn binary_roundtrip_text_flags() {
         // parse_text previously discarded the flag word (read PcbFlags::empty());
         // a locked / tented text must now round-trip its flags.
@@ -805,6 +863,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width: None,
+            italic: false,
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::LOCKED | PcbFlags::TENTING_TOP,
             unique_id: None,
@@ -839,6 +898,7 @@ mod tests {
                     y: 1.016,
                 },
             ],
+            holes: Vec::new(),
             layer: Layer::TopAssembly,
             flags: PcbFlags::empty(),
             unique_id: None,
@@ -1184,6 +1244,38 @@ mod tests {
             decoded.vias[1].solder_mask_expansion_mode,
             MaskExpansionMode::Manual
         );
+    }
+
+    #[test]
+    fn via_solder_mask_back_round_trips() {
+        // A default via leaves the back mask `None` (back@242 == front@54), and an
+        // asymmetric via must round-trip a distinct back-face expansion. Tests the
+        // deterministic encode_via -> parse_via path (a full library write embeds
+        // fresh UUIDs/timestamps, so it is not byte-deterministic).
+        let mut original = Footprint::new("VIA_SMASK");
+
+        // Default via: back is None and must survive the round-trip as None.
+        original.add_via(Via::new(0.0, 0.0, 0.6, 0.3));
+
+        // Asymmetric via: distinct front/back mask expansion.
+        let mut asym = Via::new(2.54, 0.0, 0.6, 0.3);
+        asym.solder_mask_expansion = 0.1; // front 0.1 mm
+        asym.solder_mask_expansion_back = Some(0.2); // back 0.2 mm
+        original.add_via(asym);
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("VIA_SMASK");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.vias.len(), 2);
+        assert_eq!(decoded.vias[0].solder_mask_expansion_back, None);
+        assert_eq!(decoded.vias[1].solder_mask_expansion_back, Some(0.2));
+        // Front face unaffected.
+        assert!((decoded.vias[1].solder_mask_expansion - 0.1).abs() < 1e-6);
+
+        // Idempotent re-encode proves a byte-stable round-trip for vias.
+        let data2 = writer::encode_data_stream(&decoded).expect("re-encode");
+        assert_eq!(data, data2);
     }
 
     #[test]

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -358,6 +358,16 @@ pub struct Via {
     #[serde(default)]
     pub solder_mask_expansion_mode: MaskExpansionMode,
 
+    /// Bottom-face solder-mask expansion in mm (Altium geometry offset 242). `None`
+    /// mirrors the front-face `solder_mask_expansion` (Altium's template encodes both
+    /// faces equally), so a default via round-trips byte-identically.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub solder_mask_expansion_back: Option<f64>,
+
     // Thermal relief settings (for polygon pours)
     /// Thermal relief air gap width in mm (default: 0.254mm = 10 mils).
     #[serde(
@@ -427,6 +437,7 @@ impl Via {
             to_layer: Layer::BottomLayer,
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
+            solder_mask_expansion_back: None,
             thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils
@@ -455,6 +466,7 @@ impl Via {
             to_layer: to,
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
+            solder_mask_expansion_back: None,
             thermal_relief_gap: 0.254, // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -182,6 +182,11 @@ impl Arc {
 pub struct Region {
     /// Vertices of the polygon.
     pub vertices: Vec<Vertex>,
+    /// Interior hole contours (multi-contour region). Empty for a simple polygon.
+    /// Each contour is appended after the outline as `[u32 count][count x 16-byte
+    /// (x, y) doubles]`, mirroring Altium's `WriteRegion`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub holes: Vec<Vec<Vertex>>,
     /// Layer the region is on.
     pub layer: Layer,
     /// Primitive flags (locked, keepout, etc.).
@@ -203,6 +208,7 @@ impl Region {
                 Vertex { x: max_x, y: max_y },
                 Vertex { x: min_x, y: max_y },
             ],
+            holes: Vec::new(),
             layer,
             flags: PcbFlags::empty(),
             unique_id: None,

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -67,6 +67,11 @@ pub struct Text {
     /// Stroke font type (only applies when `kind` is `Stroke`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stroke_font: Option<StrokeFont>,
+    /// TrueType italic style (Altium `FontItalic`, geometry offset 45). Only
+    /// meaningful when `kind` is `TrueType`. `false` (the from-scratch default)
+    /// reproduces the template byte exactly.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub italic: bool,
     /// Stroke line width in mm (Altium `StrokeWidth`, geometry offset 36). `None`
     /// uses Altium's template default (4 mil); a read value round-trips exactly.
     #[serde(

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -410,6 +410,13 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
     let solder_mask_expansion_mode = block.get(66).map_or(MaskExpansionMode::FromRule, |&b| {
         MaskExpansionMode::from_id(b)
     });
+    // Bottom-face solder-mask expansion @242. Only surfaced when it differs from the
+    // front @54, so a template-default via (both faces equal) reads back as `None`
+    // and re-emits byte-identically.
+    let solder_mask_expansion_back = match (read_i32(block, 242), read_i32(block, 54)) {
+        (Some(back), Some(front)) if back != front => Some(to_mm(back)),
+        _ => None,
+    };
     let diameter_stack_mode = block
         .get(74)
         .map_or(ViaStackMode::Simple, |&b| via_stack_mode_from_id(b));
@@ -435,6 +442,7 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         to_layer,
         solder_mask_expansion,
         solder_mask_expansion_mode,
+        solder_mask_expansion_back,
         thermal_relief_gap,
         thermal_relief_conductors,
         thermal_relief_width,
@@ -687,6 +695,10 @@ pub(super) fn parse_text(
     // A positive value is surfaced explicitly; 0/absent leaves it as the default.
     let stroke_width = read_i32(geometry_block, 36).filter(|&w| w > 0).map(to_mm);
 
+    // Italic style - offset 45 (bool). Absent/short blocks default to false.
+    // baseFontType@43 is not read: it is fully derived from `kind` (offset 160).
+    let italic = geometry_block.get(45).is_some_and(|&b| b != 0);
+
     // Normal (non-inverted) text does not carry a justification field in this
     // record — it only exists inside the inverted-rectangle sub-block — so
     // default it rather than mis-read a byte inside the font-name field.
@@ -719,6 +731,7 @@ pub(super) fn parse_text(
         kind,
         stroke_font,
         stroke_width,
+        italic,
         justification,
         flags,
         unique_id: None,
@@ -826,6 +839,56 @@ pub(super) fn find_ascii_in_block(block: &[u8], pattern: &str) -> Option<usize> 
 /// [x:8 f64][y:8 f64]       // Vertex 2
 /// ...
 /// ```
+/// Reads one count-prefixed vertex contour (`[u32 count][count x 16-byte (x, y)
+/// doubles]`) from `props_block` starting at `at`. Returns the vertices and the
+/// offset just past the contour. `label` names the contour in error messages and
+/// `offset` is the record's absolute base for error reporting.
+#[allow(clippy::cast_possible_truncation)] // Altium coords fit in i32
+fn read_region_contour(
+    props_block: &[u8],
+    at: usize,
+    offset: usize,
+    label: &str,
+) -> Result<(Vec<Vertex>, usize), AltiumError> {
+    let count = read_u32(props_block, at).ok_or_else(|| {
+        AltiumError::parse_error(offset + at, format!("failed to read {label} count"))
+    })? as usize;
+    let data_offset = at + 4;
+    let end = data_offset + count * 16;
+    if props_block.len() < end {
+        return Err(AltiumError::parse_error(
+            offset + at,
+            format!(
+                "Region block too short for {label} with {count} vertices: {} bytes, expected {end}",
+                props_block.len()
+            ),
+        ));
+    }
+
+    let mut contour = Vec::with_capacity(count);
+    for i in 0..count {
+        let base = data_offset + i * 16;
+        let x_internal = read_f64(props_block, base).ok_or_else(|| {
+            AltiumError::parse_error(
+                offset + base,
+                format!("failed to read {label} vertex {i} x"),
+            )
+        })?;
+        let y_internal = read_f64(props_block, base + 8).ok_or_else(|| {
+            AltiumError::parse_error(
+                offset + base + 8,
+                format!("failed to read {label} vertex {i} y"),
+            )
+        })?;
+        // Coordinates are doubles in internal units; quantise to mm.
+        contour.push(Vertex {
+            x: to_mm(x_internal.round() as i32),
+            y: to_mm(y_internal.round() as i32),
+        });
+    }
+    Ok((contour, end))
+}
+
 #[allow(clippy::cast_possible_truncation)] // Altium coords fit in i32
 pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     // Region format (observed from Altium files): a single block containing:
@@ -856,7 +919,10 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     let layer = layer_from_id(layer_id);
     let flags = read_flags(props_block);
 
-    // Skip unknown bytes (5 bytes after header)
+    // @13 reserved | @14-15 hole_count (u16) | @16-17 reserved. The trailing hole
+    // contours (if any) follow the outline. A no-hole region reports 0 here.
+    let hole_count = read_u16(props_block, 14).unwrap_or(0) as usize;
+
     // Read parameter string length at offset 18
     let param_len = read_u32(props_block, 18).ok_or_else(|| {
         AltiumError::parse_error(offset + 18, "failed to read Region parameter string length")
@@ -872,48 +938,19 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         ));
     }
 
-    // Read vertex count
-    let vertex_count = read_u32(props_block, vertex_offset).ok_or_else(|| {
-        AltiumError::parse_error(offset + vertex_offset, "failed to read Region vertex count")
-    })? as usize;
+    // Outline contour: count-prefixed vertices immediately after the param string.
+    let (vertices, mut next_offset) =
+        read_region_contour(props_block, vertex_offset, offset, "Region vertex")?;
 
-    // Each vertex is 2 doubles (16 bytes)
-    let vertex_data_offset = vertex_offset + 4;
-    let expected_size = vertex_data_offset + vertex_count * 16;
-
-    if props_block.len() < expected_size {
-        return Err(AltiumError::parse_error(
-            offset,
-            format!(
-                "Region block too short for {vertex_count} vertices: {} bytes, expected {expected_size}",
-                props_block.len()
-            ),
-        ));
-    }
-
-    // Parse vertices
-    let mut vertices = Vec::with_capacity(vertex_count);
-    for i in 0..vertex_count {
-        let base = vertex_data_offset + i * 16;
-        // Coordinates stored as doubles in internal units
-        let x_internal = read_f64(props_block, base).ok_or_else(|| {
-            AltiumError::parse_error(
-                offset + base,
-                format!("failed to read Region vertex {i} x coordinate"),
-            )
-        })?;
-        let y_internal = read_f64(props_block, base + 8).ok_or_else(|| {
-            AltiumError::parse_error(
-                offset + base + 8,
-                format!("failed to read Region vertex {i} y coordinate"),
-            )
-        })?;
-
-        // Convert from internal units to mm
-        let x = to_mm(x_internal.round() as i32);
-        let y = to_mm(y_internal.round() as i32);
-
-        vertices.push(Vertex { x, y });
+    // Trailing hole contours follow the outline, each as `[u32 count][count*16B]`.
+    // `hole_count` (read from @14) bounds the loop; the helper length-guards each
+    // contour so a truncated block fails cleanly instead of over-reading.
+    let mut holes = Vec::with_capacity(hole_count);
+    for h in 0..hole_count {
+        let label = format!("Region hole {h}");
+        let (contour, end) = read_region_contour(props_block, next_offset, offset, &label)?;
+        holes.push(contour);
+        next_offset = end;
     }
 
     // A region is a single block — there is no trailing empty "Block 1". Altium
@@ -922,6 +959,7 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     // which against a real Altium region would mis-read the next record's bytes.)
     let region = Region {
         vertices,
+        holes,
         layer,
         flags,
         unique_id: None,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -26,6 +26,11 @@ fn write_u32(data: &mut Vec<u8>, value: u32) {
     data.extend_from_slice(&value.to_le_bytes());
 }
 
+/// Writes a 2-byte little-endian unsigned integer.
+fn write_u16(data: &mut Vec<u8>, value: u16) {
+    data.extend_from_slice(&value.to_le_bytes());
+}
+
 /// Writes a 4-byte little-endian signed integer.
 fn write_i32(data: &mut Vec<u8>, value: i32) {
     data.extend_from_slice(&value.to_le_bytes());
@@ -680,6 +685,13 @@ fn encode_via(data: &mut Vec<u8>, via: &Via) {
     block[66] = via.solder_mask_expansion_mode.to_id();
     block[74] = via_stack_mode_to_id(via.diameter_stack_mode);
 
+    // Bottom-face solder-mask expansion @242. `None` mirrors the front face, so a
+    // default via reproduces the front bytes (preserving round-trip identity).
+    let back = via
+        .solder_mask_expansion_back
+        .unwrap_or(via.solder_mask_expansion);
+    block[242..246].copy_from_slice(&from_mm(back).to_le_bytes());
+
     // Per-layer diameters: 32 x i32 from offset 75. A real stack uses the
     // per-layer array; a simple via repeats its diameter on every layer so it
     // never reads back as zero-diameter per layer.
@@ -853,7 +865,7 @@ const TEXT_SR1_TEMPLATE: [u8; 252] = [
 /// varying field is written at its fixed offset. Real Altium text records are
 /// always this fixed 252-byte block — the previous ~80-byte guessed layout put
 /// the kind, stroke width, font id and v7 layer id at the wrong places.
-fn encode_text_geometry(text: &Text) -> Vec<u8> {
+pub fn encode_text_geometry(text: &Text) -> Vec<u8> {
     let mut block = TEXT_SR1_TEMPLATE;
 
     // Common header (offsets 0-12): layer + Altium flag word + 0xFF net/poly/comp.
@@ -880,6 +892,14 @@ fn encode_text_geometry(text: &Text) -> Vec<u8> {
 
     // Authoritative text kind (offset 160).
     block[160] = text_kind_to_id(text.kind);
+
+    // Base font type (offset 43) is derived from the text kind: Stroke -> 0,
+    // TrueType -> 1. The template default is 0, so stroke text stays
+    // byte-identical; the only change is the previously malformed TrueType record
+    // (kind@160=1 with base@43=0). BarCode is a deferred kind and not modelled here.
+    block[43] = u8::from(!matches!(text.kind, TextKind::Stroke));
+    // Italic style (offset 45). Default false reproduces the template's 0x00.
+    block[45] = u8::from(text.italic);
 
     // v7 layer id (offsets 226-229), derived from the layer.
     block[226..230].copy_from_slice(&v7_layer_id(layer_to_id(text.layer)).to_le_bytes());
@@ -922,13 +942,16 @@ fn region_v7_layer_token(layer: Layer) -> String {
 /// Format (matching Altium):
 /// ```text
 /// [common_header:13]       // Layer, flags, padding
-/// [unknown:5]              // Unknown bytes
+/// [reserved:1]             // @13 reserved (0)
+/// [hole_count:2 u16]       // @14-15 number of interior hole contours
+/// [reserved:2]             // @16-17 reserved (0)
 /// [param_len:4 u32]        // Parameter string length
 /// [params:param_len]       // Parameter string (ASCII)
-/// [vertex_count:4 u32]     // Number of vertices
-/// [vertices:count*16]      // Vertices as doubles
+/// [vertex_count:4 u32]     // Number of outline vertices
+/// [vertices:count*16]      // Outline vertices as doubles
+/// [hole:...]               // hole_count x [u32 count][count*16] hole contours
 /// ```
-#[allow(clippy::cast_possible_truncation)] // Vertex count and param length fit in u32
+#[allow(clippy::cast_possible_truncation)] // Vertex/hole count and param length fit in u32/u16
 fn encode_region_properties(region: &Region) -> Vec<u8> {
     let vertex_count = region.vertices.len();
 
@@ -949,21 +972,34 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     // Common header (13 bytes)
     write_common_header(&mut block, region.layer, region.flags);
 
-    // Unknown bytes (5 bytes)
-    block.extend_from_slice(&[0x00; 5]);
+    // @13 reserved | @14-15 hole_count (u16 LE) | @16-17 reserved. With no holes
+    // this collapses to `00 00 00 00 00`, byte-identical to the previous output.
+    block.push(0x00);
+    write_u16(&mut block, region.holes.len() as u16);
+    block.extend_from_slice(&[0x00; 2]);
 
     // C-string parameter block (length includes the null terminator).
     write_cstring_param_block(&mut block, &params_bytes);
 
-    // Vertex count
+    // Outline vertex count
     write_u32(&mut block, vertex_count as u32);
 
-    // Vertices as doubles in internal units
+    // Outline vertices as doubles in internal units
     for vertex in &region.vertices {
         let x_internal = f64::from(from_mm(vertex.x));
         let y_internal = f64::from(from_mm(vertex.y));
         write_f64(&mut block, x_internal);
         write_f64(&mut block, y_internal);
+    }
+
+    // Trailing hole contours, each count-prefixed exactly like the outline. With
+    // no holes nothing is appended, so the output is unchanged.
+    for hole in &region.holes {
+        write_u32(&mut block, hole.len() as u32);
+        for vertex in hole {
+            write_f64(&mut block, f64::from(from_mm(vertex.x)));
+            write_f64(&mut block, f64::from(from_mm(vertex.y)));
+        }
     }
 
     block
@@ -1664,6 +1700,7 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
+            holes: Vec::new(),
             layer: Layer::TopCourtyard,
             flags: PcbFlags::default(),
             unique_id: None,
@@ -1688,6 +1725,7 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
+            holes: Vec::new(),
             layer: Layer::TopCourtyard,
             flags: PcbFlags::default(),
             unique_id: None,
@@ -1700,6 +1738,32 @@ mod tests {
             4 + block_len,
             "region must be a single block (4-byte length prefix + payload); \
              trailing bytes indicate a spurious empty block"
+        );
+    }
+
+    #[test]
+    fn encode_region_no_holes_keeps_reserved_bytes() {
+        use crate::altium::pcblib::primitives::Vertex;
+        // Oracle-safety: a region with no holes must emit hole_count=0 and no trailing
+        // arrays, leaving the @13-17 reserved slot as `00 00 00 00 00` (byte-identical
+        // to the pre-holes output). The header is 13 bytes, so the slot is props[13..18].
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            holes: Vec::new(),
+            layer: Layer::TopCourtyard,
+            flags: PcbFlags::default(),
+            unique_id: None,
+        };
+        let props = encode_region_properties(&region);
+        assert_eq!(
+            &props[13..18],
+            &[0x00, 0x00, 0x00, 0x00, 0x00],
+            "no-hole region must keep the reserved @13-17 slot zeroed (hole_count=0)"
         );
     }
 
@@ -1860,6 +1924,7 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
+            holes: Vec::new(),
             layer: Layer::TopCourtyard,
             flags: PcbFlags::default(),
             unique_id: None,
@@ -1908,6 +1973,7 @@ mod tests {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width: None,
+            italic: false,
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
             unique_id: None,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -280,6 +280,7 @@ impl McpServer {
 
         Some(Region {
             vertices,
+            holes: Vec::new(),
             layer,
             flags: PcbFlags::empty(),
             unique_id: None,
@@ -316,6 +317,7 @@ impl McpServer {
             kind: TextKind::Stroke,
             stroke_font: None,
             stroke_width,
+            italic: false,
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
             unique_id: None,

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -155,6 +155,7 @@ fn pcblib_file_roundtrip_all_primitives() {
         rotation: 0.0,
         stroke_font: None,
         stroke_width: None,
+        italic: false,
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
         unique_id: None,

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -354,6 +354,7 @@ fn test_complex_region() {
             Vertex { x: 1.0, y: 2.0 },
             Vertex { x: 0.0, y: 2.0 },
         ],
+        holes: Vec::new(),
         layer: Layer::TopCourtyard,
         flags: PcbFlags::default(),
         unique_id: None,
@@ -392,6 +393,7 @@ fn test_region_with_many_vertices() {
 
     let region = Region {
         vertices,
+        holes: Vec::new(),
         layer: Layer::TopCourtyard,
         flags: PcbFlags::default(),
         unique_id: None,
@@ -406,6 +408,49 @@ fn test_region_with_many_vertices() {
 
     assert_eq!(read_fp.regions.len(), 1);
     assert_eq!(read_fp.regions[0].vertices.len(), n);
+}
+
+#[test]
+fn region_with_holes_round_trips_through_write_then_read() {
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("region_holes.PcbLib");
+
+    let mut lib = PcbLib::new();
+    let mut fp = Footprint::new("REGION_HOLES");
+
+    let mut region = Region::rectangle(0.0, 0.0, 10.0, 10.0, Layer::TopCourtyard);
+    region.holes = vec![
+        vec![
+            Vertex { x: 2.0, y: 2.0 },
+            Vertex { x: 4.0, y: 2.0 },
+            Vertex { x: 4.0, y: 4.0 },
+        ],
+        vec![
+            Vertex { x: 6.0, y: 6.0 },
+            Vertex { x: 8.0, y: 6.0 },
+            Vertex { x: 8.0, y: 8.0 },
+            Vertex { x: 6.0, y: 8.0 },
+        ],
+    ];
+    fp.add_region(region);
+
+    lib.add(fp);
+    lib.save(&file_path).expect("Failed to write");
+
+    let read_lib = PcbLib::open(&file_path).expect("Failed to read");
+    let read_fp = read_lib.get("REGION_HOLES").expect("Footprint not found");
+
+    assert_eq!(read_fp.regions.len(), 1);
+    let r = &read_fp.regions[0];
+    assert_eq!(r.vertices.len(), 4);
+    assert_eq!(r.holes.len(), 2);
+    assert_eq!(r.holes[0].len(), 3);
+    assert_eq!(r.holes[1].len(), 4);
+    // Vertices round-trip via from_mm/to_mm quantisation, so allow a small tolerance
+    // (exact-double fidelity for loaded regions is a separate, deferred change).
+    let v = r.holes[1][3];
+    assert!((v.x - 6.0).abs() < 1e-3, "hole vertex x: {}", v.x);
+    assert!((v.y - 8.0).abs() < 1e-3, "hole vertex y: {}", v.y);
 }
 
 // =============================================================================
@@ -509,6 +554,7 @@ fn test_text_special_strings() {
         rotation: 0.0,
         stroke_font: None,
         stroke_width: None,
+        italic: false,
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
         unique_id: None,
@@ -526,6 +572,7 @@ fn test_text_special_strings() {
         rotation: 0.0,
         stroke_font: None,
         stroke_width: None,
+        italic: false,
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
         unique_id: None,


### PR DESCRIPTION
Three PcbLib §A1 primitive field round-trips — RE'd against AltiumSharp via a background workflow, implementation delegated then gated (oracle + byte-identity tests).

| Fix | Field | Byte-identity for default |
|-----|-------|---------------------------|
| **Text** | `italic` (@45) + derived `baseFontType` (@43, from kind) | stroke text writes @43=@45=`0` — unchanged; also fixes TrueType emitting `baseFontType=0` |
| **Via** | `solder_mask_expansion_back` (@242, `Option`) | reader returns `None` when @242 == front @54 → default via re-emits the template byte-for-byte |
| **Region** | `hole_count` (u16 @14) + trailing per-hole vertex arrays | no-hole region still emits `00 00 00 00 00` + nothing — unchanged; enables multi-contour regions |

All three are fixed-offset/append-only changes that **reproduce the template bytes at the default**, so the readability oracle stays **13/13**. The region layout matches `PcbLibWriter.cs:1088-1093` / `PcbLibReader.cs:1595` *identically* (verified by the workflow).

Byte-identity guard tests (stroke @43/@45=0, default via reads `None`, no-hole region keeps reserved bytes) **plus** round-trip tests (TrueType italic survives; non-default back-mask survives; a region with holes round-trips). `clippy -D warnings` + fmt clean; full suite (374 tests) green.

Deferred (workflow `DEFER`/`NEEDS-WORK`): text mirrored/isComment/isDesignator + font-name fields, via identity GUIDs, ComponentBody field coverage, fill solder-mask — they need a consumer or a golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
