### PR TITLE
fix(pcblib): round-trip fill solder-mask expansion + keepout restrictions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,14 +29,11 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
       tri-state mask modes @+101/+102 (reuse `MaskExpansionMode`); slot length @+263 / hole rotation
       @+267; identity GUID @+126; middle/bottom sizes; full-stack tail (`636+count*15`); solder-mask
       template-default leak.
-- [ ] 🟠 **Via**: identity GUIDs @259-274/@275-290; `solder_mask_expansion_back` @242-245;
-      net/comp/power-plane/paste/drill-pair fields.
-- [ ] 🟠 **Text**: `mirrored` @35 / `isComment` @40 / `isDesignator` @41; italic @45 / baseFontType
-      @43; font-name fields @46-109/@161-224; InvertedRect template bytes @124-131. *(raw `fontId`
-      @25 + justification @132 are custom-font / inverted-rect only — verified deferred.)*
-- [ ] 🟠 **Region**: `hole_count` @14 + hole contours (multi-contour regions).
+- [ ] 🟠 **Via**: identity GUIDs @259-274/@275-290; net/comp/power-plane/paste/drill-pair fields.
+- [ ] 🟠 **Text**: `mirrored` @35 / `isComment` @40 / `isDesignator` @41; font-name fields
+      @46-109/@161-224; InvertedRect template bytes @124-131. *(italic / baseFontType shipped #154;
+      raw `fontId` @25 + justification @132 are custom-font / inverted-rect only — deferred.)*
 - [ ] 🟠 **ComponentBody**: broad field coverage (colour/opacity/texture/2D-placement/identifier).
-- [ ] ⚪ **Fill**: `solder_mask_expansion` @37-40 + `keepout_restrictions` @46.
 
 ### A2. PcbLib stream / container layer
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -944,6 +944,8 @@ mod tests {
             layer: Layer::BottomPaste,
             rotation: 45.0,
             flags: PcbFlags::empty(),
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
             unique_id: None,
         });
 
@@ -968,6 +970,35 @@ mod tests {
         assert!(approx_eq(decoded.fills[1].y2, 0.5, 0.001));
         assert_eq!(decoded.fills[1].layer, Layer::BottomPaste);
         assert!(approx_eq(decoded.fills[1].rotation, 45.0, 0.001));
+    }
+
+    #[test]
+    fn fill_extended_tail_round_trips() {
+        use super::primitives::Fill;
+
+        // Solder-mask expansion @37-40 and keepout @46 round-trip; a default fill
+        // stays None (additive — byte-identical to the old zero-tail output).
+        let mut fp = Footprint::new("FILL_TAIL");
+        let mut fill = Fill::new(0.0, 0.0, 2.0, 1.0, Layer::TopLayer);
+        fill.solder_mask_expansion = Some(0.1);
+        fill.keepout_restrictions = Some(0x05);
+        fp.add_fill(fill);
+        fp.add_fill(Fill::new(5.0, 0.0, 6.0, 1.0, Layer::TopOverlay));
+
+        let data = writer::encode_data_stream(&fp).expect("encode");
+        let mut decoded = Footprint::new("FILL_TAIL");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.fills.len(), 2);
+        assert!(approx_eq(
+            decoded.fills[0].solder_mask_expansion.unwrap(),
+            0.1,
+            0.001
+        ));
+        assert_eq!(decoded.fills[0].keepout_restrictions, Some(0x05));
+        // Additive: the default fill did not gain these fields.
+        assert_eq!(decoded.fills[1].solder_mask_expansion, None);
+        assert_eq!(decoded.fills[1].keepout_restrictions, None);
     }
 
     #[test]

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -114,6 +114,17 @@ pub struct Fill {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Solder-mask expansion override in mm (geometry offset 37). `None` uses the
+    /// rule default; round-trips like the Track/Arc extended tail.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub solder_mask_expansion: Option<f64>,
+    /// Keepout restriction bitmask (geometry offset 46). `None` = zero on disk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keepout_restrictions: Option<u8>,
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -131,6 +142,8 @@ impl Fill {
             layer,
             rotation: 0.0,
             flags: PcbFlags::empty(),
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
             unique_id: None,
         }
     }
@@ -148,6 +161,8 @@ impl Fill {
             layer,
             rotation: 0.0,
             flags: PcbFlags::empty(),
+            solder_mask_expansion: None,
+            keepout_restrictions: None,
             unique_id: None,
         }
     }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1023,6 +1023,11 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
     let rotation = read_f64(block, 29)
         .ok_or_else(|| AltiumError::parse_error(offset + 29, "failed to read Fill rotation"))?;
 
+    // Extended tail (round-trip fidelity): solder-mask expansion @37-40, keepout @46.
+    // Kept `None` when absent/zero so a from-scratch fill round-trips unchanged.
+    let solder_mask_expansion = read_i32(block, 37).map(to_mm).filter(|v| v.abs() > 1e-4);
+    let keepout_restrictions = block.get(46).copied().filter(|&b| b != 0);
+
     let fill = Fill {
         x1,
         y1,
@@ -1031,6 +1036,8 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
         layer,
         rotation,
         flags,
+        solder_mask_expansion,
+        keepout_restrictions,
         unique_id: None,
     };
 

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1043,11 +1043,14 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
     // Rotation (8 bytes)
     write_f64(&mut block, fill.rotation);
 
-    // Tail (13 bytes, offsets 37-49). Altium carries a layer-derived v7 layer id
-    // at offsets 42-45; the solder-mask (37-40), paste-mask (41) and keepout (46)
-    // sub-fields are not yet modelled and stay zero.
+    // Tail (13 bytes, offsets 37-49), ported from AltiumSharp `WriteFill`:
+    // solder-mask expansion i32 @37-40, paste-mask byte @41 (0), v7 layer id @42-45,
+    // keepout byte @46, reserved @47-49. Both modelled fields default to 0, so a
+    // from-scratch fill emits the same bytes as before (byte-identical).
     let mut tail = [0x00u8; 13];
+    tail[0..4].copy_from_slice(&from_mm(fill.solder_mask_expansion.unwrap_or(0.0)).to_le_bytes());
     tail[5..9].copy_from_slice(&v7_layer_id(layer_to_id(fill.layer)).to_le_bytes());
+    tail[9] = fill.keepout_restrictions.unwrap_or(0);
     block.extend_from_slice(&tail);
 
     block


### PR DESCRIPTION
PcbLib §A1 fill-fields item. Verified byte-exact against AltiumSharp `WriteFill`/`ReadFill` via a background workflow, then gated against the oracle.

## What
The Fill block already reserves tail bytes for **solder-mask expansion** (@37-40, i32) and **keepout restrictions** (@46, u8); we emitted zeros and dropped them on read. Model them as `Option<f64>` / `Option<u8>` and round-trip them — the exact shipped **Track/Arc extended-tail** pattern (#113).

## Safety — byte-identical at default
Both `None` ⇒ writer emits `0i32`@37-40 and `0`@46 — **the same bytes the previous blanket-zero tail produced** (v7 layer id @42-45 unchanged, block still 50 bytes). The reader keeps `None` when the field is zero/absent, so a from-scratch fill round-trips without gaining keys. Oracle stays **13/13**.

Round-trip + additivity test added (non-default survives; a default fill stays `None`). `clippy -D warnings` + fmt clean; full suite green.

## TODO sync
Drops the shipped **Region holes** (#154) and this **Fill** item from §A1, and narrows **Via** (back solder-mask shipped) / **Text** (italic+baseFontType shipped) to their remaining deferred sub-fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
