### PR TITLE
fix(pcblib): round-trip ComponentBody 3D-body params (colour/opacity/kind/...)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,6 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 - [ ] 🟠 **Text**: `mirrored` @35 / `isComment` @40 / `isDesignator` @41; font-name fields
       @46-109/@161-224; InvertedRect template bytes @124-131. *(italic / baseFontType shipped #154;
       raw `fontId` @25 + justification @132 are custom-font / inverted-rect only — deferred.)*
-- [ ] 🟠 **ComponentBody**: broad field coverage (colour/opacity/texture/2D-placement/identifier).
 
 ### A2. PcbLib stream / container layer
 
@@ -102,6 +101,10 @@ still outstanding needs an Altium-authored golden to settle — relocated to §B
       *(IsCurrent read-back shipped #150.)*
 - [ ] **SchLib Pin aux streams**: `SymbolLineWidth` + `PinFrac` live in separate OLE streams, not the
       pin record — need golden byte offsets. *(FormalType / SwapId / DefaultValue tail shipped #151.)*
+- [ ] **PcbLib ComponentBody remaining**: the additive 3D-body param tier shipped; remaining is
+      `IDENTIFIER` (comma-separated codepoint list — would misrender as a plain string),
+      `MODEL.MODELTYPE`, `MODEL.SNAP*`, `TEXTURE`, and the non-default unit-formatted values
+      (`ARCRESOLUTION`/`CAVITYHEIGHT`/`MODEL.2D.X/Y`) — need a golden to validate the formatting.
 - [ ] Feed confirmed answers back into the fix ladder (especially the pad, A3).
 
 ## C. On-site Altium tooling

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1022,6 +1022,15 @@ mod tests {
             outline: vec![(-2.0, 1.0), (-2.0, -1.0), (2.0, -1.0), (2.0, 1.0)],
             unique_id: None,
             model_checksum: 7_654_321,
+            name: " ".to_string(),
+            kind: 0,
+            sub_poly_index: -1,
+            union_index: 0,
+            is_shape_based: false,
+            body_projection: 0,
+            body_color_3d: 8_421_504,
+            body_opacity_3d: 1.0,
+            model_2d_rotation: 0.0,
         };
         original.add_component_body(body);
 
@@ -1077,6 +1086,15 @@ mod tests {
                 outline: Vec::new(), // exercise the synthesised-bbox fallback
                 unique_id: None,
                 model_checksum: 0,
+                name: " ".to_string(),
+                kind: 0,
+                sub_poly_index: -1,
+                union_index: 0,
+                is_shape_based: false,
+                body_projection: 0,
+                body_color_3d: 8_421_504,
+                body_opacity_3d: 1.0,
+                model_2d_rotation: 0.0,
             });
         }
 

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -136,6 +136,62 @@ pub struct ComponentBody {
     /// for a fresh body, so default output stays byte-identical.
     #[serde(default)]
     pub model_checksum: i64,
+
+    /// Body name (Altium `NAME`). Default is a single space `" "`, reproducing the
+    /// `NAME= ` literal that template-default bodies emit (byte-identity).
+    #[serde(default = "default_body_name")]
+    pub name: String,
+
+    /// Body kind (Altium `KIND`). Default `0`.
+    #[serde(default)]
+    pub kind: u8,
+
+    /// Sub-polygon index (Altium `SUBPOLYINDEX`). Default `-1`.
+    #[serde(default = "default_sub_poly_index")]
+    pub sub_poly_index: i32,
+
+    /// Union index (Altium `UNIONINDEX`). Default `0`.
+    #[serde(default)]
+    pub union_index: u32,
+
+    /// Whether the body is shape-based (Altium `ISSHAPEBASED`). Default `false`.
+    #[serde(default)]
+    pub is_shape_based: bool,
+
+    /// Body projection mode (Altium `BODYPROJECTION`). Default `0`.
+    #[serde(default)]
+    pub body_projection: u8,
+
+    /// 3D body colour, decimal RGB (Altium `BODYCOLOR3D`). Default `8421504`
+    /// (`0xE0E0E0`, `AltiumSharp`'s default grey).
+    #[serde(default = "default_body_color")]
+    pub body_color_3d: u32,
+
+    /// 3D body opacity, `0.0`–`1.0` (Altium `BODYOPACITY3D`). Default `1.0`,
+    /// written with `{:.3}` so the default renders as `1.000` (byte-identity).
+    #[serde(default = "default_opacity")]
+    pub body_opacity_3d: f64,
+
+    /// 2D rotation in degrees (Altium `MODEL.2D.ROTATION`). Default `0.0`,
+    /// written with `{:.3}` so the default renders as `0.000` (byte-identity).
+    #[serde(default)]
+    pub model_2d_rotation: f64,
+}
+
+const fn default_body_color() -> u32 {
+    8_421_504
+}
+
+const fn default_opacity() -> f64 {
+    1.0
+}
+
+const fn default_sub_poly_index() -> i32 {
+    -1
+}
+
+fn default_body_name() -> String {
+    " ".to_string()
 }
 
 impl ComponentBody {
@@ -156,6 +212,15 @@ impl ComponentBody {
             outline: Vec::new(),
             unique_id: None,
             model_checksum: 0,
+            name: default_body_name(),
+            kind: 0,
+            sub_poly_index: default_sub_poly_index(),
+            union_index: 0,
+            is_shape_based: false,
+            body_projection: 0,
+            body_color_3d: default_body_color(),
+            body_opacity_3d: default_opacity(),
+            model_2d_rotation: 0.0,
         }
     }
 }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1105,6 +1105,39 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         .and_then(|v| parse_v7_layer(v))
         .unwrap_or(Layer::Top3DBody);
 
+    // Additive fields previously discarded. Each default matches the writer's
+    // hard-coded literal default so a default body round-trips byte-identically.
+    let name = params
+        .get("NAME")
+        .cloned()
+        .unwrap_or_else(|| " ".to_string());
+    let kind = params.get("KIND").and_then(|v| v.parse().ok()).unwrap_or(0);
+    let sub_poly_index = params
+        .get("SUBPOLYINDEX")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(-1);
+    let union_index = params
+        .get("UNIONINDEX")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let is_shape_based = params.get("ISSHAPEBASED").is_some_and(|v| v == "TRUE");
+    let body_projection = params
+        .get("BODYPROJECTION")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let body_color_3d = params
+        .get("BODYCOLOR3D")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8_421_504);
+    let body_opacity_3d = params
+        .get("BODYOPACITY3D")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+    let model_2d_rotation = params
+        .get("MODEL.2D.ROTATION")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0.0);
+
     let body = ComponentBody {
         model_id,
         model_name,
@@ -1119,6 +1152,15 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         outline,
         unique_id: None,
         model_checksum,
+        name,
+        kind,
+        sub_poly_index,
+        union_index,
+        is_shape_based,
+        body_projection,
+        body_color_3d,
+        body_opacity_3d,
+        model_2d_rotation,
     };
 
     Ok((body, current))

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -161,6 +161,15 @@ impl PcbLib {
                 outline: Vec::new(), // Synthesised from the footprint extent on write
                 unique_id: None,
                 model_checksum: 0, // Fresh embed; Altium computes the real checksum on save.
+                name: " ".to_string(),
+                kind: 0,
+                sub_poly_index: -1,
+                union_index: 0,
+                is_shape_based: false,
+                body_projection: 0,
+                body_color_3d: 8_421_504,
+                body_opacity_3d: 1.0,
+                model_2d_rotation: 0.0,
             });
 
             tracing::debug!(

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1174,13 +1174,18 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     // between the param string and the layer byte makes Altium drop the body.
     params.push(format!("V7_LAYER={}", region_v7_layer_token(body.layer)));
 
-    // Standard parameters
-    params.push("NAME= ".to_string());
-    params.push("KIND=0".to_string());
-    params.push("SUBPOLYINDEX=-1".to_string());
-    params.push("UNIONINDEX=0".to_string());
+    // Standard parameters. Each field's default reproduces the prior hard-coded
+    // literal exactly, so a template-default body stays byte-identical (the oracle
+    // depends on this).
+    params.push(format!("NAME={}", body.name));
+    params.push(format!("KIND={}", body.kind));
+    params.push(format!("SUBPOLYINDEX={}", body.sub_poly_index));
+    params.push(format!("UNIONINDEX={}", body.union_index));
     params.push("ARCRESOLUTION=0.5mil".to_string());
-    params.push("ISSHAPEBASED=FALSE".to_string());
+    params.push(format!(
+        "ISSHAPEBASED={}",
+        if body.is_shape_based { "TRUE" } else { "FALSE" }
+    ));
     params.push("CAVITYHEIGHT=0mil".to_string());
     params.push(format!(
         "STANDOFFHEIGHT={}mil",
@@ -1190,12 +1195,15 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         "OVERALLHEIGHT={}mil",
         mm_to_mil(body.overall_height)
     ));
-    params.push("BODYPROJECTION=0".to_string());
+    params.push(format!("BODYPROJECTION={}", body.body_projection));
     // Altium repeats ARCRESOLUTION after BODYPROJECTION (verbatim shape from the
     // BODY_3D golden files).
     params.push("ARCRESOLUTION=0.5mil".to_string());
-    params.push("BODYCOLOR3D=8421504".to_string());
-    params.push("BODYOPACITY3D=1.000".to_string());
+    params.push(format!("BODYCOLOR3D={}", body.body_color_3d));
+    params.push(format!("BODYOPACITY3D={:.3}", body.body_opacity_3d));
+    // IDENTIFIER is deferred: AltiumSharp stores it as a comma-separated codepoint
+    // list, so a plain-string round-trip would write a file Altium misreads. Keep
+    // the empty literal hard-coded (empty -> empty is oracle-safe).
     params.push("IDENTIFIER=".to_string());
     params.push("TEXTURE=".to_string());
     params.push("TEXTURECENTERX=0mil".to_string());
@@ -1221,7 +1229,7 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     params.push(format!("MODEL.NAME={}", body.model_name));
     params.push("MODEL.2D.X=0mil".to_string());
     params.push("MODEL.2D.Y=0mil".to_string());
-    params.push("MODEL.2D.ROTATION=0.000".to_string());
+    params.push(format!("MODEL.2D.ROTATION={:.3}", body.model_2d_rotation));
     params.push(format!("MODEL.3D.ROTX={:.3}", body.rotation_x));
     params.push(format!("MODEL.3D.ROTY={:.3}", body.rotation_y));
     params.push(format!("MODEL.3D.ROTZ={:.3}", body.rotation_z));
@@ -1797,6 +1805,62 @@ mod tests {
         assert!(s.contains("MODEL.MODELTYPE=1"), "got: {s}");
         assert!(s.contains("MODEL.MODELSOURCE=Undefined"), "got: {s}");
         assert!(!s.contains("EXTRUDED"), "got: {s}");
+    }
+
+    #[test]
+    fn component_body_default_params_byte_identical() {
+        // Locks the template-default param string. If a new field's default or the
+        // key order drifts, this fails *before* the pyaltiumlib oracle would. The
+        // model-backed (STEP) path with embedded=true emits MODELID verbatim, so
+        // the literal is stable.
+        let mut model = ComponentBody::new("{G}", "part.step");
+        model.embedded = true;
+        let s = build_component_body_params(&model);
+        let expected = "V7_LAYER=MECHANICAL6|NAME= |KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0|\
+            ARCRESOLUTION=0.5mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil|STANDOFFHEIGHT=0mil|\
+            OVERALLHEIGHT=0mil|BODYPROJECTION=0|ARCRESOLUTION=0.5mil|BODYCOLOR3D=8421504|\
+            BODYOPACITY3D=1.000|IDENTIFIER=|TEXTURE=|TEXTURECENTERX=0mil|TEXTURECENTERY=0mil|\
+            TEXTURESIZEX=0.0001mil|TEXTURESIZEY=0.0001mil|TEXTUREROTATION= 0.00000000000000E+0000|\
+            MODELID={G}|MODEL.CHECKSUM=0|MODEL.EMBED=TRUE|MODEL.NAME=part.step|MODEL.2D.X=0mil|\
+            MODEL.2D.Y=0mil|MODEL.2D.ROTATION=0.000|MODEL.3D.ROTX=0.000|MODEL.3D.ROTY=0.000|\
+            MODEL.3D.ROTZ=0.000|MODEL.3D.DZ=0mil|MODEL.MODELTYPE=1|MODEL.MODELSOURCE=Undefined";
+        assert_eq!(s, expected);
+        // Explicit guards for the two field-promoted literals callers most care about.
+        assert!(s.contains("|BODYCOLOR3D=8421504|"), "got: {s}");
+        assert!(s.contains("|BODYOPACITY3D=1.000|"), "got: {s}");
+    }
+
+    #[test]
+    fn component_body_additive_fields_roundtrip() {
+        use super::super::reader;
+        let mut original = Footprint::new("RT_BODY_FIELDS");
+        let mut body = ComponentBody::new("{G-1234}", "p.step");
+        body.embedded = true;
+        body.body_color_3d = 0x00FF_0000; // non-default red
+        body.body_opacity_3d = 0.5;
+        body.kind = 2;
+        body.sub_poly_index = 3;
+        body.union_index = 4;
+        body.body_projection = 1;
+        body.is_shape_based = true;
+        body.model_2d_rotation = 90.0;
+        body.name = "BODY_A".into();
+        original.add_component_body(body);
+
+        let data = encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("RT_BODY_FIELDS");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        let b = &decoded.component_bodies[0];
+        assert_eq!(b.body_color_3d, 0x00FF_0000);
+        assert!((b.body_opacity_3d - 0.5).abs() < 1e-9);
+        assert_eq!(b.kind, 2);
+        assert_eq!(b.sub_poly_index, 3);
+        assert_eq!(b.union_index, 4);
+        assert_eq!(b.body_projection, 1);
+        assert!(b.is_shape_based);
+        assert!((b.model_2d_rotation - 90.0).abs() < 1e-9);
+        assert_eq!(b.name, "BODY_A");
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -421,6 +421,15 @@ impl McpServer {
                             outline: Vec::new(),
                             unique_id: None,
                             model_checksum: 0, // External reference: no embedded model.
+                            name: " ".to_string(),
+                            kind: 0,
+                            sub_poly_index: -1,
+                            union_index: 0,
+                            is_shape_based: false,
+                            body_projection: 0,
+                            body_color_3d: 8_421_504,
+                            body_opacity_3d: 1.0,
+                            model_2d_rotation: 0.0,
                         });
                     }
                 }
@@ -474,6 +483,15 @@ impl McpServer {
                             .get("model_checksum")
                             .and_then(Value::as_i64)
                             .unwrap_or(0),
+                        name: " ".to_string(),
+                        kind: 0,
+                        sub_poly_index: -1,
+                        union_index: 0,
+                        is_shape_based: false,
+                        body_projection: 0,
+                        body_color_3d: 8_421_504,
+                        body_opacity_3d: 1.0,
+                        model_2d_rotation: 0.0,
                     });
                 }
             }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -832,6 +832,15 @@ fn test_component_body_roundtrip() {
         outline: Vec::new(),
         unique_id: None,
         model_checksum: 0,
+        name: " ".to_string(),
+        kind: 0,
+        sub_poly_index: -1,
+        union_index: 0,
+        is_shape_based: false,
+        body_projection: 0,
+        body_color_3d: 8_421_504,
+        body_opacity_3d: 1.0,
+        model_2d_rotation: 0.0,
     };
     fp.component_bodies.push(body);
 
@@ -878,6 +887,15 @@ fn test_component_body_with_rotation() {
         outline: Vec::new(),
         unique_id: None,
         model_checksum: 0,
+        name: " ".to_string(),
+        kind: 0,
+        sub_poly_index: -1,
+        union_index: 0,
+        is_shape_based: false,
+        body_projection: 0,
+        body_color_3d: 8_421_504,
+        body_opacity_3d: 1.0,
+        model_2d_rotation: 0.0,
     };
     fp.component_bodies.push(body);
 
@@ -2671,6 +2689,15 @@ fn test_component_body_external_model_reference() {
         outline: Vec::new(),
         unique_id: None,
         model_checksum: 0,
+        name: " ".to_string(),
+        kind: 0,
+        sub_poly_index: -1,
+        union_index: 0,
+        is_shape_based: false,
+        body_projection: 0,
+        body_color_3d: 8_421_504,
+        body_opacity_3d: 1.0,
+        model_2d_rotation: 0.0,
     };
     fp.component_bodies.push(body);
 


### PR DESCRIPTION
The last PcbLib §A1 field item. RE'd field-for-field against AltiumSharp via a background workflow; implementation delegated then gated (oracle + exact-default-string byte-identity test).

## What
`build_component_body_params` hard-coded ten 3D-body params and the reader dropped them, so a real Altium body's custom colour/opacity/etc. were overwritten on read-modify-write. Promote them to round-tripping fields: `name`, `kind`, `sub_poly_index`, `union_index`, `is_shape_based`, `body_projection`, **`body_color_3d`**, **`body_opacity_3d`**, `model_2d_rotation`.

## Safety — byte-identical at default
Each field's default reproduces the **exact** prior literal: `BODYCOLOR3D=8421504`, `BODYOPACITY3D=1.000` (via `{:.3}`), `NAME= ` (single space), `ISSHAPEBASED=FALSE`, etc. A new test asserts the **full default param string** with `assert_eq!` (exact match). Oracle stays **13/13**. Round-trip test sets non-defaults (colour `0xFF0000`, opacity `0.5`, `is_shape_based=true`) and asserts they survive.

## Deferred (golden-gated / encoding traps)
- **`IDENTIFIER`** — AltiumSharp stores it as a **comma-separated codepoint list** (like WideStrings); a plain-string round-trip would write a file Altium misreads. Left hard-coded empty.
- `MODEL.MODELTYPE`, `MODEL.SNAP*`, `TEXTURE`, and the non-default unit-formatted values — formatting unvalidated without a golden.

`clippy -D warnings` + fmt clean; full suite green. TODO §A1 ComponentBody cleared; remainder relocated to §B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
