### PR TITLE
fix(pcblib): pad paste/solder mask expansion as tri-state mode (not bool)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,11 +24,12 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 
 ### A1. PcbLib primitives (code bugs + missing features)
 
-- [ ] 🔴 **Pad** *(biggest — near last)*: real **596-byte** size/shape block (non-Simple pads are
-      emitted under-length → **Altium rejects them**); octagonal id 3 ≠ Oval; `is_plated` @SR5+60;
-      tri-state mask modes @+101/+102 (reuse `MaskExpansionMode`); slot length @+263 / hole rotation
-      @+267; identity GUID @+126; middle/bottom sizes; full-stack tail (`636+count*15`); solder-mask
-      template-default leak.
+- [ ] 🟠 **Pad** — remaining (mostly golden / on-site / fidelity-gated): `is_plated` @SR5+60
+      read-back; slot length @+263 / hole rotation @+267 (596-body); identity GUIDs @+126/+142
+      read-back; middle/bottom sizes (TopMiddleBottom); **multi-entry** full-stack tail (count>1);
+      oblong/oval SMD pads should route to the 651 size/shape block (golden shows 651, we emit
+      empty). *(596 single-entry tail [#157] + tri-state mask modes [this PR] shipped; octagonal
+      id-3 byte mapping is already correct.)*
 - [ ] 🟠 **Via**: identity GUIDs @259-274/@275-290; net/comp/power-plane/paste/drill-pair fields.
 - [ ] 🟠 **Text**: `mirrored` @35 / `isComment` @40 / `isDesignator` @41; font-name fields
       @46-109/@161-224; InvertedRect template bytes @124-131. *(italic / baseFontType shipped #154;

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -43,9 +43,9 @@ mod writer;
 use serde::{Deserialize, Serialize};
 
 pub use primitives::{
-    Arc, ComponentBody, EmbeddedModel, Fill, HoleShape, Layer, Model3D, Pad, PadShape,
-    PadStackMode, PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track, Vertex,
-    Via,
+    Arc, ComponentBody, EmbeddedModel, Fill, HoleShape, Layer, MaskExpansionMode, Model3D, Pad,
+    PadShape, PadStackMode, PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track,
+    Vertex, Via,
 };
 
 use crate::altium::error::{AltiumError, AltiumResult};
@@ -1296,6 +1296,49 @@ mod tests {
     }
 
     #[test]
+    fn pad_mask_expansion_mode_round_trips() {
+        use super::primitives::MaskExpansionMode;
+
+        // A fresh pad defaults to FromRule (Altium's default, bytes 101/102 = 1) — not
+        // the old `manual=false` which wrote 0 (None). A Manual pad must round-trip.
+        let fresh = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        assert_eq!(fresh.paste_mask_expansion_mode, MaskExpansionMode::FromRule);
+        assert_eq!(
+            fresh.solder_mask_expansion_mode,
+            MaskExpansionMode::FromRule
+        );
+
+        let mut original = Footprint::new("PAD_MASK_MODE");
+        original.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+        let mut manual = Pad::smd("2", 1.0, 1.0, 1.0, 1.0);
+        manual.paste_mask_expansion_mode = MaskExpansionMode::Manual;
+        manual.solder_mask_expansion_mode = MaskExpansionMode::Manual;
+        original.add_pad(manual);
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("PAD_MASK_MODE");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.pads.len(), 2);
+        assert_eq!(
+            decoded.pads[0].paste_mask_expansion_mode,
+            MaskExpansionMode::FromRule
+        );
+        assert_eq!(
+            decoded.pads[0].solder_mask_expansion_mode,
+            MaskExpansionMode::FromRule
+        );
+        assert_eq!(
+            decoded.pads[1].paste_mask_expansion_mode,
+            MaskExpansionMode::Manual
+        );
+        assert_eq!(
+            decoded.pads[1].solder_mask_expansion_mode,
+            MaskExpansionMode::Manual
+        );
+    }
+
+    #[test]
     fn via_solder_mask_back_round_trips() {
         // A default via leaves the back mask `None` (back@242 == front@54), and an
         // asymmetric via must round-trip a distinct back-face expansion. Tests the
@@ -1353,20 +1396,22 @@ mod tests {
 
     #[test]
     fn binary_roundtrip_pad_advanced_features() {
+        use super::primitives::MaskExpansionMode;
+
         let mut original = Footprint::new("ROUNDTRIP_PAD_ADVANCED");
 
         // Create a pad with hole shape and mask expansion
         let mut pad_with_square_hole = Pad::through_hole("1", -2.54, 0.0, 1.8, 1.8, 1.0);
         pad_with_square_hole.hole_shape = HoleShape::Square;
         pad_with_square_hole.solder_mask_expansion = Some(0.1);
-        pad_with_square_hole.solder_mask_expansion_manual = true;
+        pad_with_square_hole.solder_mask_expansion_mode = MaskExpansionMode::Manual;
         original.add_pad(pad_with_square_hole);
 
         // Create a pad with slot hole
         let mut pad_with_slot = Pad::through_hole("2", 0.0, 0.0, 2.0, 1.5, 0.8);
         pad_with_slot.hole_shape = HoleShape::Slot;
         pad_with_slot.paste_mask_expansion = Some(-0.05);
-        pad_with_slot.paste_mask_expansion_manual = true;
+        pad_with_slot.paste_mask_expansion_mode = MaskExpansionMode::Manual;
         original.add_pad(pad_with_slot);
 
         // Create a simple pad with round hole (default)
@@ -1391,7 +1436,10 @@ mod tests {
             0.1,
             0.001
         ));
-        assert!(decoded.pads[0].solder_mask_expansion_manual);
+        assert_eq!(
+            decoded.pads[0].solder_mask_expansion_mode,
+            MaskExpansionMode::Manual
+        );
 
         // Pad 2: Slot hole + paste mask expansion
         assert_eq!(decoded.pads[1].designator, "2");
@@ -1402,7 +1450,10 @@ mod tests {
             -0.05,
             0.001
         ));
-        assert!(decoded.pads[1].paste_mask_expansion_manual);
+        assert_eq!(
+            decoded.pads[1].paste_mask_expansion_mode,
+            MaskExpansionMode::Manual
+        );
 
         // Pad 3: Default round hole (empty Block 5)
         assert_eq!(decoded.pads[2].designator, "3");

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -91,13 +91,13 @@ pub struct Pad {
     )]
     pub solder_mask_expansion: Option<f64>,
 
-    /// Whether paste mask expansion is manually set.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub paste_mask_expansion_manual: bool,
+    /// Paste-mask expansion mode (None/FromRule/Manual) — main-block tri-state byte @101.
+    #[serde(default)]
+    pub paste_mask_expansion_mode: MaskExpansionMode,
 
-    /// Whether solder mask expansion is manually set.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub solder_mask_expansion_manual: bool,
+    /// Solder-mask expansion mode (main-block tri-state byte @102).
+    #[serde(default)]
+    pub solder_mask_expansion_mode: MaskExpansionMode,
 
     /// Corner radius as percentage of smaller pad dimension (0-100).
     /// Only applies to `RoundedRectangle` shape.
@@ -169,8 +169,8 @@ impl Pad {
             rotation: 0.0,
             paste_mask_expansion: None,
             solder_mask_expansion: None,
-            paste_mask_expansion_manual: false,
-            solder_mask_expansion_manual: false,
+            paste_mask_expansion_mode: MaskExpansionMode::FromRule,
+            solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,
@@ -205,8 +205,8 @@ impl Pad {
             rotation: 0.0,
             paste_mask_expansion: None,
             solder_mask_expansion: None,
-            paste_mask_expansion_manual: false,
-            solder_mask_expansion_manual: false,
+            paste_mask_expansion_mode: MaskExpansionMode::FromRule,
+            solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -166,11 +166,13 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         None
     };
 
-    // Paste mask expansion manual flag - offset 101
-    let paste_mask_expansion_manual = geometry.len() > 101 && geometry[101] != 0;
-
-    // Solder mask expansion manual flag - offset 102
-    let solder_mask_expansion_manual = geometry.len() > 102 && geometry[102] != 0;
+    // Paste/solder mask expansion modes - offsets 101/102 (tri-state byte).
+    let paste_mask_expansion_mode = geometry.get(101).map_or(MaskExpansionMode::FromRule, |&b| {
+        MaskExpansionMode::from_id(b)
+    });
+    let solder_mask_expansion_mode = geometry.get(102).map_or(MaskExpansionMode::FromRule, |&b| {
+        MaskExpansionMode::from_id(b)
+    });
 
     // Parse per-layer data when stack mode is not Simple
     // Per-layer data format:
@@ -225,8 +227,8 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         rotation,
         paste_mask_expansion,
         solder_mask_expansion,
-        paste_mask_expansion_manual,
-        solder_mask_expansion_manual,
+        paste_mask_expansion_mode,
+        solder_mask_expansion_mode,
         corner_radius_percent,
         stack_mode,
         per_layer_sizes,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -588,9 +588,9 @@ fn build_pad_extended_tail(pad: &Pad) -> [u8; 141] {
         .copy_from_slice(&from_mm(pad.paste_mask_expansion.unwrap_or(0.0)).to_le_bytes());
     tail[90 - START..94 - START]
         .copy_from_slice(&from_mm(pad.solder_mask_expansion.unwrap_or(0.0)).to_le_bytes());
-    // 101 / 102: paste & solder mask manual flags
-    tail[101 - START] = u8::from(pad.paste_mask_expansion_manual);
-    tail[102 - START] = u8::from(pad.solder_mask_expansion_manual);
+    // 101 / 102: paste & solder mask expansion modes (tri-state, 0/1/2)
+    tail[101 - START] = pad.paste_mask_expansion_mode.to_id();
+    tail[102 - START] = pad.solder_mask_expansion_mode.to_id();
     // 114-117: v7 layer id (derived from the pad's layer)
     tail[114 - START..118 - START]
         .copy_from_slice(&v7_layer_id(layer_to_id(pad.layer)).to_le_bytes());

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -23,7 +23,9 @@ impl McpServer {
     /// Parses a pad from JSON.
     #[allow(clippy::too_many_lines)] // Pad has many fields requiring individual parsing
     pub(crate) fn parse_pad(json: &Value) -> Result<crate::altium::pcblib::Pad, String> {
-        use crate::altium::pcblib::{Layer, Pad, PadShape, PadStackMode, PcbFlags};
+        use crate::altium::pcblib::{
+            Layer, MaskExpansionMode, Pad, PadShape, PadStackMode, PcbFlags,
+        };
 
         let designator = json
             .get("designator")
@@ -118,14 +120,24 @@ impl McpServer {
         // Parse optional mask expansion values
         let paste_mask_expansion = json.get("paste_mask_expansion").and_then(Value::as_f64);
         let solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
-        let paste_mask_expansion_manual = json
-            .get("paste_mask_expansion_manual")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let solder_mask_expansion_manual = json
-            .get("solder_mask_expansion_manual")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        let paste_mask_expansion_mode = json
+            .get("paste_mask_expansion_mode")
+            .and_then(Value::as_str)
+            .map(|s| match s.to_lowercase().as_str() {
+                "none" => MaskExpansionMode::None,
+                "manual" => MaskExpansionMode::Manual,
+                _ => MaskExpansionMode::FromRule,
+            })
+            .unwrap_or_default();
+        let solder_mask_expansion_mode = json
+            .get("solder_mask_expansion_mode")
+            .and_then(Value::as_str)
+            .map(|s| match s.to_lowercase().as_str() {
+                "none" => MaskExpansionMode::None,
+                "manual" => MaskExpansionMode::Manual,
+                _ => MaskExpansionMode::FromRule,
+            })
+            .unwrap_or_default();
 
         // Parse optional corner radius
         let corner_radius_percent = json
@@ -147,8 +159,8 @@ impl McpServer {
             rotation,
             paste_mask_expansion,
             solder_mask_expansion,
-            paste_mask_expansion_manual,
-            solder_mask_expansion_manual,
+            paste_mask_expansion_mode,
+            solder_mask_expansion_mode,
             corner_radius_percent,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,


### PR DESCRIPTION
PcbLib pad main-block field fix (the `SOUND/LOW` half of pad-main-fields). RE'd against AltiumSharp + the golden pads; same migration the Via got in #140.

## Bug
The pad's main-block bytes @101/@102 are **tri-state** (`0`=None, `1`=FromRule, `2`=Manual), but we modelled them as **bools** — so a fresh pad emitted `0,0` and `Manual(2)` was unrepresentable. **Every Altium golden writes `1,1` (FromRule)** by default (verified against the TestData pads), and pyaltiumlib reads the field as tri-state (`==2` means manual).

## Fix
Migrate to `paste_mask_expansion_mode`/`solder_mask_expansion_mode: MaskExpansionMode`, reusing the enum + the exact **via @66 pattern (#140)** — writer `to_id()`, reader `from_id()`, default `FromRule`.

## Note — this is a deliberate byte *change*, not byte-identical
A fresh pad's @101/@102 move `0,0` → `1,1` to **match the golden** (the old `0,0` was the bug). Oracle stays **13/13** (1/2 are valid tri-state values; pyaltiumlib accepts them). MCP input becomes a mode string. New round-trip test (default→FromRule, Manual survives) + the advanced-features test updated. clippy + fmt clean; full suite green.

## Context
This completes the verified pad work. While doing it I also **empirically vindicated #157** against the real goldens (`PAD_SMD_OBLONG`=651, `PAD_HOLE_TYPES`=651,651,0) after the workflow's two pad agents contradicted each other — the under-length tail fix is correct. The remaining pad sub-fields (is_plated, slot/hole-rotation, identity GUIDs, mid/bottom, multi-entry full-stack, and an oblong/oval *routing* gap the goldens revealed) are golden/on-site-gated — TODO §A1 Pad narrowed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
