### PR TITLE
ci: harden the Altium-readability oracle into a real gate

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -146,16 +146,19 @@ jobs:
               if: runner.os == 'Linux'
               run: python3 tests/integration/test_mcp_tools.py
 
-            # Independent-reader check that generated files are Altium-readable
-            # (issue #68). Install is best-effort; the harness skips cleanly if
-            # pyaltiumlib is unavailable and only fails on a NEW regression.
-            - name: Run Altium-readability oracle
+            # Independent-reader gate: confirm generated files are Altium-readable
+            # (issue #68) by parsing them with pyaltiumlib. Dependencies are pinned
+            # (requirements.txt) and isolated in a venv so the install is
+            # reproducible; ORACLE_REQUIRE_DEPS turns a missing dependency into a
+            # hard failure instead of a silent skip. Fails on any NEW regression.
+            - name: Run Altium-readability oracle (pyaltiumlib)
               if: runner.os == 'Linux'
+              env:
+                  ORACLE_REQUIRE_DEPS: "1"
               run: |
-                  python3 -m pip install --user --quiet pyaltiumlib olefile \
-                    || python3 -m pip install --user --quiet --break-system-packages pyaltiumlib olefile \
-                    || echo "pyaltiumlib install failed; oracle will skip"
-                  python3 tests/integration/test_altium_readability.py
+                  python3 -m venv tests/integration/.venv
+                  tests/integration/.venv/bin/pip install --quiet -r tests/integration/requirements.txt
+                  tests/integration/.venv/bin/python tests/integration/test_altium_readability.py
 
     coverage:
         name: Code Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ Cargo.lock
 .claude/settings.local.json
 nul
 .venv/
+# Reserve the oracle's venv location (the .gitkeep placeholder) while still
+# ignoring the venv's own contents.
+!tests/integration/.venv/
+tests/integration/.venv/*
+!tests/integration/.venv/.gitkeep
 node_modules/
 .tmp/
 __pycache__/

--- a/tests/integration/.venv/.gitkeep
+++ b/tests/integration/.venv/.gitkeep
@@ -1,0 +1,3 @@
+# Reserves a home for the oracle's Python virtual environment.
+# Create it here with: python -m venv tests/integration/.venv
+# The venv's contents are gitignored; only this placeholder is tracked.

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,12 @@
+# Dependencies for the Altium-readability oracle (test_altium_readability.py).
+# Pinned for reproducible local + CI runs. The recommended local venv lives next
+# to this file (see the committed .venv/.gitkeep placeholder):
+#
+#   python -m venv tests/integration/.venv
+#   tests/integration/.venv/Scripts/Activate.ps1     # Windows (PowerShell)
+#   source tests/integration/.venv/bin/activate      # Linux / macOS
+#   pip install -r tests/integration/requirements.txt
+#
+# Then: python tests/integration/test_altium_readability.py
+pyaltiumlib==0.6.1
+olefile==0.47

--- a/tests/integration/test_altium_readability.py
+++ b/tests/integration/test_altium_readability.py
@@ -15,8 +15,10 @@ a documented-broken check that fails is tolerated, a NEW failure (regression)
 fails the run, and a known failure that starts passing is flagged so it can be
 promoted. When ``KNOWN_FAILURES`` is empty the harness is fully strict.
 
-Requires ``pyaltiumlib`` and ``olefile`` (``pip install pyaltiumlib olefile``);
-skips cleanly if they are absent so environments without them are not broken.
+Requires ``pyaltiumlib`` and ``olefile`` (``pip install -r
+tests/integration/requirements.txt``); skips cleanly if they are absent so local
+environments without them are not broken — unless ``ORACLE_REQUIRE_DEPS`` is set
+(CI does), which makes a missing dependency a hard failure instead of a silent skip.
 
     cargo build
     python3 tests/integration/test_altium_readability.py
@@ -187,8 +189,12 @@ def main():
         import pyaltiumlib  # noqa: F401
         import olefile  # noqa: F401
     except ImportError as e:
-        print(f"SKIP: Altium-readability oracle needs pyaltiumlib + olefile ({e}). "
-              "Install with: pip install pyaltiumlib olefile")
+        msg = (f"Altium-readability oracle needs pyaltiumlib + olefile ({e}). "
+               "Install with: pip install -r tests/integration/requirements.txt")
+        if os.environ.get("ORACLE_REQUIRE_DEPS"):
+            print(f"ERROR: {msg}")
+            return 1
+        print(f"SKIP: {msg}")
         return 0
 
     binary = find_binary()


### PR DESCRIPTION
Makes the `pyaltiumlib` readability oracle a **proper CI gate** (it already ran, but loosely).

## The gap
The oracle runs in the `build` job, but it installed `pyaltiumlib olefile` **unpinned** and **best-effort**:
```yaml
python3 -m pip install --user --quiet pyaltiumlib olefile \
  || ... --break-system-packages ... \
  || echo "pyaltiumlib install failed; oracle will skip"   # <- silent green
```
So a failed/changed install silently **skips** and CI stays green — and an unpinned `pyaltiumlib` could change behaviour under us.

## The fix
- **Pin** the deps in [`tests/integration/requirements.txt`](tests/integration/requirements.txt) — `pyaltiumlib==0.6.1`, `olefile==0.47`.
- **CI installs into an isolated venv** from the pinned requirements and runs with **`ORACLE_REQUIRE_DEPS=1`** → a missing dependency is now a **hard failure**, not a skip. Any new readability regression fails the job (the script already `sys.exit(1)`s on regressions).
- **Script**: `ORACLE_REQUIRE_DEPS` set → `ERROR` + exit 1 on missing deps (CI); unset → the existing clean `SKIP`, so local devs without the deps aren't broken.
- **Reserve the local venv home** at `tests/integration/.venv/` via a committed `.gitkeep` (next to `requirements.txt`), with a `.gitignore` negation that tracks only the placeholder and ignores the venv contents.

## Verified
| Scenario | Result |
|----------|--------|
| deps present, `ORACLE_REQUIRE_DEPS=1` | `13 passed … 0 regressions`, **exit 0** |
| deps missing, `ORACLE_REQUIRE_DEPS=1` (CI) | `ERROR: …`, **exit 1** (fails closed) |
| deps missing, no env var (local) | `SKIP: …`, **exit 0** (dev unbroken) |

`.gitignore` negation confirmed: `.gitkeep` tracked, venv contents ignored. Workflow YAML validated. No Rust/markdown touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
