### PR TITLE
fix(scripts): GenerateSamples.pas to verified AD24 scripting API

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,10 +42,21 @@ The `RunScript` launch and the file-based request/response bridge are adapted fr
 ## `samples/` — golden libraries
 
 Altium-authored reference libraries, generated on-site by `Generate-Samples.ps1` and committed
-as binaries (like AltiumSharp's `TestData`) so CI can read them without Altium. They are the
+as binaries (like [AltiumSharp](https://github.com/issus/AltiumSharp)'s `TestData`) so CI can read them without Altium. They are the
 ground truth the reader and round-trip tests validate against. See
 [`samples/README.md`](samples/README.md).
 
 > Building the golden set is **iterative**: generate → read back with the Rust tests → extend
 > the authoring script's primitive coverage → regenerate. The `samples/` folder is empty until
 > the first set lands.
+
+## References
+
+Working on the DelphiScript automation in [`altium/`](altium/)? Altium's official scripting docs:
+
+- [DelphiScript language guide](https://www.altium.com/documentation/altium-designer/scripting/delphiscript/support)
+  — the language reference for the `.pas` scripts.
+- [Scripting Examples Reference](https://www.altium.com/documentation/altium-designer/scripting/examples-reference)
+  — worked examples (creating PCB/Schematic objects, saving documents, etc.).
+- [Scripting API Objects](https://techdocs.altium.com/display/SCRT/Script+API+Objects)
+  — the `IPCB_*` / `ISch_*` interface reference (note: last revised for an older AD version).

--- a/scripts/altium/generate/GenerateSamples.pas
+++ b/scripts/altium/generate/GenerateSamples.pas
@@ -50,31 +50,48 @@ var
     Pad  : IPCB_Pad;
     Doc  : IServerDocument;
 begin
-    Client.OpenNewDocumentOfKind('PCBLIB');
-    Lib := PCBServer.GetCurrentPCBLibrary;
+    // CreateNewDocumentFromDocumentKind is the global that creates + focuses a blank
+    // document and returns its IServerDocument (Client.OpenNewDocumentOfKind, used in
+    // the v0, does not exist in AD24).
+    Doc := CreateNewDocumentFromDocumentKind('PCBLIB');
+    if Doc = nil then Exit;
+
+    Lib := PCBServer.GetCurrentPCBLibrary;   // the new doc is focused
     if Lib = nil then Exit;
 
     Comp := PCBServer.CreatePCBLibComp;
     Comp.Name := 'PAD_SMD';
+    Lib.RegisterComponent(Comp);             // register before mutating
+
+    // Primitive creation runs inside a Pre/PostProcess transaction, with a board-
+    // registration broadcast so the editor registers each new object.
+    PCBServer.PreProcess;
 
     Pad := PCBServer.PCBObjectFactory(ePadObject, eNoDimension, eCreate_Default);
     Pad.X        := MMsToCoord(0.0);
     Pad.Y        := MMsToCoord(0.0);
     Pad.TopXSize := MMsToCoord(1.0);
     Pad.TopYSize := MMsToCoord(0.6);
-    Pad.Layer    := eTopLayer;
+    Pad.Layer    := eTopLayer;               // SMD pad -> top copper only
     Pad.Name     := '1';
     Comp.AddPCBObject(Pad);
+    // Altium's own constant is spelled PCBM_BoardRegisteration (the typo is real).
+    PCBServer.SendMessageToRobots(Comp.I_ObjectAddress, c_Broadcast,
+                                  PCBM_BoardRegisteration, Pad.I_ObjectAddress);
+
+    PCBServer.PostProcess;
 
     // TODO(iterate): one footprint per feature — non-round holes (slot/square),
     //   corner-radius / oblong pads (the 651-byte size/shape cases), tracks, arcs,
     //   regions (incl. holes), text, vias, fills, ComponentBody 3D models.
 
-    Lib.RegisterComponent(Comp);
+    Lib.CurrentComponent := Comp;
     Lib.Board.ViewManager_FullUpdate;
 
-    Doc := Client.GetCurrentDocument;
-    if Doc <> nil then Doc.DoFileSaveAs(OUT_DIR + 'PADS.PcbLib', True);
+    // IServerDocument has no DoFileSaveAs; DoSafeChangeFileNameAndSave is the
+    // documented "Save As to a path" (the second arg is the document kind).
+    Doc.SetModified(True);
+    Doc.DoSafeChangeFileNameAndSave(OUT_DIR + 'PADS.PcbLib', 'PCBLIB');
 end;
 
 { ---- SchLib authoring -------------------------------------------------------
@@ -89,27 +106,44 @@ var
     Pin  : ISch_Pin;
     Doc  : IServerDocument;
 begin
-    Client.OpenNewDocumentOfKind('SCHLIB');
+    // CreateNewDocumentFromDocumentKind returns the new doc's IServerDocument
+    // (Client.OpenNewDocumentOfKind, used in the v0, does not exist in AD24).
+    Doc := CreateNewDocumentFromDocumentKind('SCHLIB');
+    if Doc = nil then Exit;
+
+    // GetCurrentSchDocument returns an ISch_Document that also implements ISch_Lib;
+    // DelphiScript's loose COM typing lets us assign it straight into an ISch_Lib.
     Lib := SchServer.GetCurrentSchDocument;
     if Lib = nil then Exit;
 
     Comp := SchServer.SchObjectFactory(eSchComponent, eCreate_Default);
-    Comp.LibReference := 'SYM_BASIC';
+    if Comp = nil then Exit;
+    Comp.CurrentPartID   := 1;
+    Comp.DisplayMode     := 0;
+    Comp.LibReference    := 'SYM_BASIC';
     Comp.Designator.Text := 'U?';
 
     Pin := SchServer.SchObjectFactory(ePin, eCreate_Default);
+    if Pin = nil then Exit;
     Pin.Designator := '1';
     Pin.Name       := 'A';
-    Pin.Location    := Point(MilsToCoord(0), MilsToCoord(0));
+    Pin.Location   := Point(MilsToCoord(0), MilsToCoord(0));
     Comp.AddSchObject(Pin);
 
     // TODO(iterate): rectangles, lines, arcs, labels, parameters, multi-part
     //   symbols, footprint model references, designator placement.
 
+    // AddSchComponent is the library registration call; then broadcast a
+    // primitive-registration message and refresh, so the symbol is committed.
     Lib.AddSchComponent(Comp);
+    Lib.CurrentSchComponent := Comp;
+    SchServer.RobotManager.SendMessage(Lib.I_ObjectAddress, c_BroadCast,
+                                       SCHM_PrimitiveRegistration, Comp.I_ObjectAddress);
+    Lib.GraphicallyInvalidate;
 
-    Doc := Client.GetCurrentDocument;
-    if Doc <> nil then Doc.DoFileSaveAs(OUT_DIR + 'SYMBOLS.SchLib', True);
+    // IServerDocument has no DoFileSaveAs; use DoSafeChangeFileNameAndSave.
+    Doc.SetModified(True);
+    Doc.DoSafeChangeFileNameAndSave(OUT_DIR + 'SYMBOLS.SchLib', 'SCHLIB');
 end;
 
 procedure Run;

--- a/scripts/samples/README.md
+++ b/scripts/samples/README.md
@@ -5,8 +5,8 @@ tests. **Generated on-site, never hand-edited:** run `scripts\Generate-Samples.p
 which drives a real Altium Designer (via `altium\generate\GenerateSamples.pas`) to
 author the libraries, then moves them here to be committed.
 
-Committed as binaries (like AltiumSharp's `TestData`) so CI can read them without
-Altium. Regenerate and re-commit whenever the authoring script's coverage grows.
+Committed as binaries (like [AltiumSharp](https://github.com/issus/AltiumSharp)'s `TestData`)
+so CI can read them without Altium. Regenerate and re-commit whenever the authoring script's coverage grows.
 
 > Building these is iterative — generate, read back with the Rust tests, extend the
 > primitive set, regenerate. This folder is empty until the first golden set lands.


### PR DESCRIPTION
The golden-library generation harness now **works end-to-end on AD24**. The v0 `GenerateSamples.pas` was a structural skeleton with guessed API calls; on first launch Altium rejected it (`Undeclared identifier: OpenNewDocumentOfKind`). This corrects it against **Altium's own shipped example script (`UL_Import`)** cross-checked with the official PCB/SCH scripting docs.

## Fixes
| v0 (broken) | Corrected (verified) |
|-------------|----------------------|
| `Client.OpenNewDocumentOfKind('PCBLIB')` | `CreateNewDocumentFromDocumentKind('PCBLIB')` (returns `IServerDocument`) |
| `Doc.DoFileSaveAs(path, True)` | `Doc.SetModified(True)` + `Doc.DoSafeChangeFileNameAndSave(path, kind)` |
| pad added with no transaction | wrapped in `PCBServer.PreProcess/PostProcess` + `SendMessageToRobots(PCBM_BoardRegisteration)` |
| `AddSchComponent` only | + `CurrentSchComponent` + `SCHM_PrimitiveRegistration` broadcast + `GraphicallyInvalidate` |

## Verified
Ran `Generate-Samples.ps1` against AD24 — it authored `PADS.PcbLib` + `SYMBOLS.SchLib`, and **`pyaltiumlib` reads both cleanly** (full PcbLib OLE stream set present). 

## Deliberately *not* in this PR
The generated goldens aren't committed: they still carry Altium's auto-created default component (`PCBComponent_1` / `Component_1`) and cover one primitive each. **Clean, feature-covering goldens + round-trip read tests come in follow-up iterations** — this PR just lands the working harness.

Also adds the official [Altium DelphiScript guide](https://www.altium.com/documentation/altium-designer/scripting/delphiscript/support) references to `scripts/README.md` and links AltiumSharp in both scripts READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
