### PR TITLE
docs(schlib): document pin coordinate + orientation convention

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -350,10 +350,10 @@ impl McpServer {
                                             "properties": {
                                                 "designator": { "type": "string" },
                                                 "name": { "type": "string" },
-                                                "x": { "type": "number" },
-                                                "y": { "type": "number" },
-                                                "length": { "type": "number" },
-                                                "orientation": { "type": "string", "enum": ["left", "right", "up", "down"] },
+                                                "x": { "type": "number", "description": "Pin's body-attach (INNER) end, in schematic units (10 units = 1 grid square). This is the end that touches the symbol body, NOT the connection tip. The pin is drawn from (x,y) extending 'length' units in the 'orientation' direction; the connection tip is at the far end." },
+                                                "y": { "type": "number", "description": "Y of the pin's body-attach (inner) end, in schematic units. See 'x'." },
+                                                "length": { "type": "number", "description": "Pin length in schematic units (10 = 1 grid). Drawn from (x,y) outward in the 'orientation' direction." },
+                                                "orientation": { "type": "string", "enum": ["left", "right", "up", "down"], "description": "Direction the pin POINTS, away from the body — NOT which side it sits on. A pin on the LEFT side uses 'left' (tip at x-length); a RIGHT-side pin uses 'right' (tip at x+length); 'up'/'down' for top/bottom pins. Put each pin's (x,y) on the matching body-rectangle edge so it attaches flush, e.g. left pin {x:-50,y:20,length:30,orientation:'left'} with rectangle x1=-50, and the matching right pin {x:50,y:20,length:30,orientation:'right'} with x2=50." },
                                                 "electrical_type": { "type": "string", "enum": ["input", "output", "bidirectional", "passive", "power"] },
                                                 "owner_part_id": { "type": "integer", "description": "Part number this pin belongs to (1-based). Default: 1" }
                                             },


### PR DESCRIPTION
## Summary

The `write_schlib` **pin** schema left `x`, `y`, `length`, and `orientation` undocumented (bare `{ "type": "number" }` / a raw enum). That hides the two genuinely non-obvious conventions in the symbol API:

- **`(x,y)` is the pin's body-attach (inner) end** — not the connection tip and not the center.
- **`orientation` is the direction the pin *points away from the body*** — a pin on the **left** side uses `"left"` — not which side it sits on.

Guessing either wrong yields **flipped pins that don't line up on the body** — the most common first-symbol failure. This adds field descriptions plus a worked two-pin example that also shows the body-edge alignment (pin `x` == rectangle edge). **Docs only — no behaviour change.**

## How this was tested

- **Cross-model confirmation:** the failure was first seen **live on a different AI model** — Gemini (via Google Antigravity) flipped and misaligned pins on its first IC, the same way Claude did. That rules out a model-specific quirk and points at the tool contract.
- **Controlled A/B (fresh agents, no prior context):** same 8-pin IC task, one arm given the current bare schema, one given this documented schema.
  - Bare schema: orientation flipped (left pins set to `"right"`) and pins placed ~100 units off the body edge — **2/2 runs failed**.
  - Documented schema: correct per-side orientation and pin `x` exactly on the rectangle edges (flush), evenly spaced — **2/2 runs correct**.

## Scope

This is **part 1 of 2**. A separate PR proposes echoing computed pin geometry (tip/body-end + bounding box) back in the `write_schlib` response as a self-check feedback loop. They're independent — this docs change stands alone and can be merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
