### PR TITLE
feat(pcblib): auto-add extruded 3D body + actionable height echo

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -149,8 +149,13 @@ impl McpServer {
                      regions, and text. The AI is responsible for calculating correct positions \
                      and sizes based on IPC-7351B or other standards. \
                      All coordinates and dimensions must be in millimetres (mm). \
-                     The response includes a 'warnings' array flagging silkscreen (overlay) \
-                     tracks that overlap a pad (silk-on-pad) so you can move them clear."
+                     If a footprint has no STEP model and no component body, an extruded 3D body \
+                     is added automatically (default height 1.0 mm). The response 'bodies' array \
+                     echoes each footprint's 3D body height and source ('auto-extruded' bodies are \
+                     flagged 'assumed_height': true) so you can confirm or override the height by \
+                     supplying 'component_bodies' explicitly. The response also includes a \
+                     'warnings' array flagging silkscreen (overlay) tracks that overlap a pad \
+                     (silk-on-pad) so you can move them clear."
                         .to_string(),
                 ),
                 input_schema: json!({

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -199,6 +199,32 @@ fn silk_over_pad_warnings(fp: &crate::altium::pcblib::Footprint) -> Vec<Value> {
     warnings
 }
 
+/// Summarises a footprint's 3D body for the `write_pcblib` response so the caller
+/// knows the body height that was written and whether one was auto-created (with
+/// a default, `assumed` height it should confirm). All heights are in mm.
+fn body_3d_summary(fp: &crate::altium::pcblib::Footprint, assumed_height: bool) -> Value {
+    if fp.model_3d.is_some() {
+        return json!({ "name": fp.name, "source": "step-embedded" });
+    }
+    if let Some(ext) = fp
+        .component_bodies
+        .iter()
+        .find(|b| !b.model_name.is_empty())
+    {
+        return json!({ "name": fp.name, "source": "step-external", "model": ext.model_name });
+    }
+    if let Some(b) = fp.component_bodies.iter().find(|b| b.model_name.is_empty()) {
+        return json!({
+            "name": fp.name,
+            "source": if assumed_height { "auto-extruded" } else { "extruded" },
+            "overall_height": b.overall_height,
+            "standoff_height": b.standoff_height,
+            "assumed_height": assumed_height,
+        });
+    }
+    json!({ "name": fp.name, "source": "none" })
+}
+
 impl McpServer {
     // ==================== Tool Handlers ====================
 
@@ -433,6 +459,10 @@ impl McpServer {
         // Silkscreen-over-pad warnings, echoed back so the caller can fix silk that
         // prints on a pad (a DRC defect) without opening Altium.
         let mut silk_warnings: Vec<Value> = Vec::new();
+
+        // Per-footprint 3D-body summary echoed back so the caller sees the body
+        // height that was written and whether one was auto-created.
+        let mut bodies_echo: Vec<Value> = Vec::new();
 
         for fp_json in footprints_json {
             let name = fp_json
@@ -685,6 +715,46 @@ impl McpServer {
                 });
             }
 
+            // Auto-include an extruded 3D body when the footprint has no STEP model
+            // and no component body, so it has a 3D presence in Altium. Height can't
+            // be inferred from a 2D footprint, so it defaults to 1.0 mm and is flagged
+            // `assumed_height` in the response for the caller to confirm/override.
+            // The empty outline makes the writer synthesise a bounding box from pads.
+            let assumed_height = if footprint.model_3d.is_none()
+                && footprint.component_bodies.is_empty()
+                && !footprint.pads.is_empty()
+            {
+                use crate::altium::pcblib::{ComponentBody, Layer};
+                footprint.add_component_body(ComponentBody {
+                    model_id: String::new(),
+                    model_name: String::new(),
+                    embedded: false,
+                    rotation_x: 0.0,
+                    rotation_y: 0.0,
+                    rotation_z: 0.0,
+                    z_offset: 0.0,
+                    overall_height: 1.0,
+                    standoff_height: 0.0,
+                    layer: Layer::Top3DBody,
+                    outline: Vec::new(),
+                    unique_id: None,
+                    model_checksum: 0,
+                    name: " ".to_string(),
+                    kind: 0,
+                    sub_poly_index: -1,
+                    union_index: 0,
+                    is_shape_based: false,
+                    body_projection: 0,
+                    body_color_3d: 8_421_504,
+                    body_opacity_3d: 1.0,
+                    model_2d_rotation: 0.0,
+                });
+                true
+            } else {
+                false
+            };
+            bodies_echo.push(body_3d_summary(&footprint, assumed_height));
+
             // Validate coordinates before adding
             if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
                 return ToolCallResult::error(e);
@@ -713,6 +783,10 @@ impl McpServer {
                 // is almost always a defect. Always present so the caller knows the
                 // check ran; empty array when clean.
                 result["warnings"] = Value::Array(silk_warnings);
+
+                // Echo each footprint's 3D body (height + source), so the caller can
+                // confirm an auto-created body's assumed height or correct it.
+                result["bodies"] = Value::Array(bodies_echo);
 
                 // Run post-write validation
                 if let Some(validation) = Self::post_write_validation_pcblib(filepath) {
@@ -1614,7 +1688,7 @@ impl McpServer {
 #[cfg(test)]
 mod tests {
     use super::ieee_designator_prefix;
-    use super::{pin_tip, symbol_geometry};
+    use super::{body_3d_summary, pin_tip, symbol_geometry};
     use crate::altium::schlib::{Pin, PinOrientation, Rectangle, Symbol};
 
     #[test]
@@ -1640,6 +1714,50 @@ mod tests {
         assert!(!segment_intersects_rect(
             -5.0, 2.0, 5.0, 2.0, -1.0, -1.0, 1.0, 1.0
         ));
+    }
+
+    #[test]
+    fn body_3d_summary_reports_source_and_height() {
+        use crate::altium::pcblib::{ComponentBody, Footprint, Layer};
+        let body = |h: f64, name: &str| ComponentBody {
+            model_id: String::new(),
+            model_name: name.to_string(),
+            embedded: false,
+            rotation_x: 0.0,
+            rotation_y: 0.0,
+            rotation_z: 0.0,
+            z_offset: 0.0,
+            overall_height: h,
+            standoff_height: 0.0,
+            layer: Layer::Top3DBody,
+            outline: Vec::new(),
+            unique_id: None,
+            model_checksum: 0,
+            name: " ".to_string(),
+            kind: 0,
+            sub_poly_index: -1,
+            union_index: 0,
+            is_shape_based: false,
+            body_projection: 0,
+            body_color_3d: 8_421_504,
+            body_opacity_3d: 1.0,
+            model_2d_rotation: 0.0,
+        };
+
+        // Explicit extruded body: reports its height, not assumed.
+        let mut ext = Footprint::new("EXT");
+        ext.add_component_body(body(2.5, ""));
+        assert_eq!(body_3d_summary(&ext, false)["source"], "extruded");
+        assert_eq!(body_3d_summary(&ext, false)["overall_height"], 2.5);
+        assert_eq!(body_3d_summary(&ext, false)["assumed_height"], false);
+
+        // Same body, auto-created path: flagged assumed.
+        assert_eq!(body_3d_summary(&ext, true)["source"], "auto-extruded");
+        assert_eq!(body_3d_summary(&ext, true)["assumed_height"], true);
+
+        // No body at all: source none.
+        let none = Footprint::new("NONE");
+        assert_eq!(body_3d_summary(&none, false)["source"], "none");
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -214,13 +214,25 @@ fn body_3d_summary(fp: &crate::altium::pcblib::Footprint, assumed_height: bool) 
         return json!({ "name": fp.name, "source": "step-external", "model": ext.model_name });
     }
     if let Some(b) = fp.component_bodies.iter().find(|b| b.model_name.is_empty()) {
-        return json!({
+        let mut summary = json!({
             "name": fp.name,
             "source": if assumed_height { "auto-extruded" } else { "extruded" },
             "overall_height": b.overall_height,
             "standoff_height": b.standoff_height,
             "assumed_height": assumed_height,
         });
+        if assumed_height {
+            // Make the placeholder actionable: tell the caller to replace it rather
+            // than leaving the guessed 1.0 mm height in the part.
+            summary["action_required"] = json!(format!(
+                "No 3D body height was given for '{}', so a {} mm placeholder was used. \
+                 This is almost certainly wrong — look up the component's real height from \
+                 its datasheet and call write_pcblib again with component_bodies[].overall_height \
+                 set to the correct value.",
+                fp.name, b.overall_height
+            ));
+        }
+        return summary;
     }
     json!({ "name": fp.name, "source": "none" })
 }
@@ -1754,6 +1766,10 @@ mod tests {
         // Same body, auto-created path: flagged assumed.
         assert_eq!(body_3d_summary(&ext, true)["source"], "auto-extruded");
         assert_eq!(body_3d_summary(&ext, true)["assumed_height"], true);
+        // The assumed case carries an actionable message prompting a real height.
+        assert!(body_3d_summary(&ext, true)["action_required"].is_string());
+        // The explicit case does not.
+        assert!(body_3d_summary(&ext, false)["action_required"].is_null());
 
         // No body at all: source none.
         let none = Footprint::new("NONE");


### PR DESCRIPTION
## Summary

Two related changes to `write_pcblib`:
1. **Auto-add an extruded 3D body** to any footprint written with no STEP model and no `component_bodies` (and at least one pad). The outline is synthesised from the pads; height defaults to **1.0 mm**, sitting flush (standoff 0).
2. **Echo each footprint's 3D body** back in a new `bodies` array — `source` (`step-embedded` / `step-external` / `extruded` / `auto-extruded` / `none`), `overall_height`, `standoff_height`, and `assumed_height`. When the height was the auto default, the entry also carries an **`action_required`** message telling the caller it's a placeholder and to look up the real height and re-write.

## Motivation — first-run quality of life

First impressions decide whether a tool gets a second chance. When someone points a *fresh* agent at this MCP for the first time, the agent has none of their conventions or feedback yet — and that's exactly when output tends to be rough. A footprint that silently ships with **no 3D body**, or a wrong one, is the kind of early papercut that makes a new user conclude "it doesn't work" and walk away before the agent has had any chance to learn what they want.

This is a quality-of-life safety net for that initial window:
- Every footprint gets a sensible 3D body by default, so a placed part is never flat/empty in 3D.
- Any guessed value is made **loud and self-correcting** rather than silent — the response tells the agent the height is a placeholder and to replace it.

The goal is to turn the most common first-run failure mode into a self-fixing nudge, so people don't abandon the tool over a first-try miss while it's still learning their preferences.

## In practice

Capable agents usually research and set the real height up front, so the 1.0 mm default never persists for them. When an agent *does* omit it, the `action_required` message reliably drives self-correction — verified end-to-end: a fresh agent that wrote a body-less inductor footprint received the message, pulled the datasheet height, and rewrote with `overall_height: 6.2` (`assumed_height` → false). Either way, the placeholder shouldn't survive into a finished part.

## Testing

- Unit test: body summary reports the right source/height, and `action_required` is present only in the assumed case.
- End-to-end: auto-body fires with a pad-derived outline; the assumed-height self-correction loop completes.
- `cargo test` green; `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
