### PR TITLE
fix(pcblib): read + round-trip TopMiddleBottom pad mid/bottom sizes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 
 - [ ] 🟠 **Pad** — remaining (mostly golden / on-site / fidelity-gated): `is_plated` @SR5+60
       read-back; slot length @+263 / hole rotation @+267 (596-body); identity GUIDs @+126/+142
-      read-back; middle/bottom sizes (TopMiddleBottom); **multi-entry** full-stack tail (count>1);
+      read-back; **multi-entry** full-stack tail (count>1);
       oblong/oval SMD pads should route to the 651 size/shape block (golden shows 651, we emit
       empty). *(596 single-entry tail [#157] + tri-state mask modes [this PR] shipped; octagonal
       id-3 byte mapping is already correct.)*

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -108,9 +108,12 @@ pub struct Pad {
     #[serde(default)]
     pub stack_mode: PadStackMode,
 
-    /// Per-layer pad sizes in mm (width, height) for 32 layers.
+    /// Per-layer pad sizes in mm (width, height).
     /// Only used when `stack_mode` != `Simple`.
-    /// Index 0 = Top Layer, Index 1 = Bottom Layer, Index 2-31 = Mid Layers.
+    ///
+    /// - For `FullStack`: 32 entries, Index 0 = Top Layer, Index 1 = Bottom
+    ///   Layer, Index 2-31 = Mid Layers.
+    /// - For `TopMiddleBottom`: 3 entries, `[top, mid, bottom]`.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -118,8 +121,11 @@ pub struct Pad {
     )]
     pub per_layer_sizes: Option<Vec<(f64, f64)>>,
 
-    /// Per-layer pad shapes for 32 layers.
+    /// Per-layer pad shapes.
     /// Only used when `stack_mode` != `Simple`.
+    ///
+    /// - For `FullStack`: 32 entries (one per layer).
+    /// - For `TopMiddleBottom`: 3 entries, `[top, mid, bottom]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub per_layer_shapes: Option<Vec<PadShape>>,
 

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -201,6 +201,24 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
             (radius > 0 && radius <= 100).then_some(radius)
         });
         (corner_radius, None, None, None, None)
+    } else if stack_mode == PadStackMode::TopMiddleBottom {
+        // For a TopMiddleBottom (LocalStack) pad the top/mid/bottom sizes and
+        // shapes live in the MAIN geometry block (Block 5 is empty); they are
+        // NOT in the 32-entry per-layer block. Surface them as a 3-entry
+        // [top, mid, bottom] vector (mirrors AltiumSharp's Size/Shape Top/Mid/Bottom).
+        // Top X/Y @21/25 are already decoded as width/height; mid @29/33, bot @37/41.
+        let mid_x = read_i32(geometry, 29).map_or(width, to_mm);
+        let mid_y = read_i32(geometry, 33).map_or(height, to_mm);
+        let bot_x = read_i32(geometry, 37).map_or(width, to_mm);
+        let bot_y = read_i32(geometry, 41).map_or(height, to_mm);
+        let sizes = vec![(width, height), (mid_x, mid_y), (bot_x, bot_y)];
+
+        // Shapes: top @49 (already decoded as `shape`), mid @50, bottom @51.
+        let mid_shape = geometry.get(50).map_or(shape, |&b| pad_shape_from_id(b));
+        let bot_shape = geometry.get(51).map_or(shape, |&b| pad_shape_from_id(b));
+        let shapes = vec![shape, mid_shape, bot_shape];
+
+        (None, Some(sizes), Some(shapes), None, None)
     } else {
         parse_per_layer_data(per_layer_data)
     };

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -422,12 +422,12 @@ fn encode_pad(data: &mut Vec<u8>, pad: &Pad) -> crate::altium::error::AltiumResu
     //  - a non-round hole or an explicit corner radius on a simple pad
     //    -> the canonical 596-byte size/shape block (carries hole type @262 and
     //       the rounded-rect corner radius @564, which the main block cannot);
-    //  - otherwise (plain simple pad) -> EMPTY block (matches Altium).
-    let needs_per_layer_data = pad.stack_mode != PadStackMode::Simple
-        || pad.per_layer_sizes.is_some()
-        || pad.per_layer_shapes.is_some()
-        || pad.per_layer_corner_radii.is_some()
-        || pad.per_layer_offsets.is_some();
+    //  - otherwise (plain simple/TopMiddleBottom pad) -> EMPTY block (matches Altium).
+    //
+    // Only FullStack emits the 32-entry per-layer block. A TopMiddleBottom pad
+    // carries its top/mid/bottom sizes+shapes in the MAIN geometry block (see
+    // `encode_pad_geometry`) and keeps Block 5 empty, matching the golden.
+    let needs_per_layer_data = pad.stack_mode == PadStackMode::FullStack;
     let needs_size_shape =
         pad.hole_shape != HoleShape::Round || pad.corner_radius_percent.is_some();
 
@@ -618,20 +618,50 @@ fn encode_pad_geometry(pad: &Pad) -> Vec<u8> {
     write_i32(&mut block, from_mm(pad.x));
     write_i32(&mut block, from_mm(pad.y));
 
-    // Size top/middle/bottom (X, Y) - offsets 21-44 (identical for simple pads)
-    for _ in 0..3 {
-        write_i32(&mut block, from_mm(pad.width));
-        write_i32(&mut block, from_mm(pad.height));
+    // Size top/middle/bottom (X, Y) - offsets 21-44.
+    //
+    // For a TopMiddleBottom (LocalStack) pad the mid/bottom sizes and shapes
+    // live in THIS main block (Block 5 stays empty), so we pull the distinct
+    // mid/bottom values from `per_layer_sizes`/`per_layer_shapes` ([top, mid,
+    // bottom]). For Simple/FullStack pads all three slots are the top size and
+    // shape (FullStack carries its per-layer data in Block 5 instead).
+    let is_tmb = pad.stack_mode == PadStackMode::TopMiddleBottom;
+    let shape_id = pad_shape_to_id(pad.shape);
+    let tmb_size = |index: usize| -> (f64, f64) {
+        if is_tmb {
+            pad.per_layer_sizes
+                .as_ref()
+                .and_then(|sizes| sizes.get(index).copied())
+                .unwrap_or((pad.width, pad.height))
+        } else {
+            (pad.width, pad.height)
+        }
+    };
+    let tmb_shape_id = |index: usize| -> u8 {
+        if is_tmb {
+            pad.per_layer_shapes
+                .as_ref()
+                .and_then(|shapes| shapes.get(index).copied())
+                .map_or(shape_id, pad_shape_to_id)
+        } else {
+            shape_id
+        }
+    };
+
+    // Top @21/25, mid @29/33, bottom @37/41.
+    for index in 0..3 {
+        let (w, h) = tmb_size(index);
+        write_i32(&mut block, from_mm(w));
+        write_i32(&mut block, from_mm(h));
     }
 
     // Hole size - offsets 45-48
     write_i32(&mut block, from_mm(pad.hole_size.unwrap_or(0.0)));
 
-    // Shapes (top, middle, bottom) - offsets 49-51
-    let shape_id = pad_shape_to_id(pad.shape);
-    block.push(shape_id);
-    block.push(shape_id);
-    block.push(shape_id);
+    // Shapes (top @49, middle @50, bottom @51)
+    block.push(tmb_shape_id(0));
+    block.push(tmb_shape_id(1));
+    block.push(tmb_shape_id(2));
 
     // Rotation - offsets 52-59 (8-byte double)
     write_f64(&mut block, pad.rotation);

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -231,6 +231,65 @@ fn pcblib_file_roundtrip_pad_shapes() {
 }
 
 #[test]
+fn pcblib_file_roundtrip_pad_top_middle_bottom() {
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_pad_tmb.PcbLib");
+
+    let mut lib = PcbLib::new();
+    let mut fp = Footprint::new("PAD_TMB");
+
+    // A TopMiddleBottom (LocalStack) through-hole pad with distinct top/mid/bottom
+    // sizes and shapes. The mid/bottom values live in the main geometry block, so
+    // they must survive a write -> read cycle (Block 5 stays empty here).
+    let mut pad = Pad::through_hole("1", 0.0, 0.0, 1.778, 1.778, 0.762);
+    pad.layer = Layer::MultiLayer;
+    pad.shape = PadShape::Round;
+    pad.stack_mode = PadStackMode::TopMiddleBottom;
+    pad.per_layer_sizes = Some(vec![(1.778, 1.778), (1.524, 1.524), (1.27, 1.27)]);
+    pad.per_layer_shapes = Some(vec![PadShape::Round, PadShape::Round, PadShape::Rectangle]);
+    fp.add_pad(pad);
+
+    lib.add(fp);
+
+    lib.save(&file_path).expect("Failed to write PcbLib");
+    let read_lib = PcbLib::open(&file_path).expect("Failed to read PcbLib");
+
+    let read_fp = read_lib.get("PAD_TMB").expect("Footprint not found");
+    assert_eq!(read_fp.pads.len(), 1);
+    let read_pad = &read_fp.pads[0];
+
+    assert_eq!(read_pad.stack_mode, PadStackMode::TopMiddleBottom);
+    assert_eq!(read_pad.layer, Layer::MultiLayer);
+
+    // Top size/shape survive (already exercised elsewhere, asserted here for completeness).
+    assert!(approx_eq(read_pad.width, 1.778, 1e-2));
+    assert!(approx_eq(read_pad.height, 1.778, 1e-2));
+    assert_eq!(read_pad.shape, PadShape::Round);
+
+    // Mid/bottom per-layer sizes round-trip.
+    let sizes = read_pad
+        .per_layer_sizes
+        .as_ref()
+        .expect("per_layer_sizes preserved for TopMiddleBottom");
+    assert_eq!(sizes.len(), 3, "per_layer_sizes is [top, mid, bottom]");
+    let expected_sizes = [(1.778, 1.778), (1.524, 1.524), (1.27, 1.27)];
+    for (i, &(ew, eh)) in expected_sizes.iter().enumerate() {
+        assert!(
+            approx_eq(sizes[i].0, ew, 1e-2) && approx_eq(sizes[i].1, eh, 1e-2),
+            "per-layer size {i}: expected ~({ew},{eh}), got {:?}",
+            sizes[i],
+        );
+    }
+
+    // Mid/bottom per-layer shapes round-trip.
+    assert_eq!(
+        read_pad.per_layer_shapes.as_deref(),
+        Some([PadShape::Round, PadShape::Round, PadShape::Rectangle].as_slice()),
+        "per_layer_shapes is [top, mid, bottom]",
+    );
+}
+
+#[test]
 fn pcblib_file_roundtrip_layers() {
     let temp_dir = test_temp_dir();
     let file_path = temp_dir.path().join("test_layers.PcbLib");

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -113,10 +113,9 @@ fn samples_pcblib_pad_stack() {
 
     // A multi-layer (LocalStack) through-hole pad authored with a 70-mil round top,
     // 60-mil round mid and 50-mil square bottom over a 30-mil round hole. The reader
-    // recognises the stack MODE and surfaces the top layer + hole. The mid/bottom
-    // per-layer sizes are a known reader gap (TODO.md A1, "middle/bottom sizes
-    // (TopMiddleBottom)") — `per_layer_sizes` is still None; this sample is the golden
-    // that unblocks that fix.
+    // recognises the stack MODE, surfaces the top layer + hole, and now also
+    // round-trips the mid/bottom per-layer sizes and shapes (closing TODO.md A1,
+    // "middle/bottom sizes (TopMiddleBottom)") from the main geometry block.
     assert_eq!(
         pad.stack_mode,
         PadStackMode::TopMiddleBottom,
@@ -143,6 +142,28 @@ fn samples_pcblib_pad_stack() {
         pad.hole_size.is_some_and(|h| approx_eq(h, 0.762, 1e-2)),
         "hole ~30 mil, got {:?}",
         pad.hole_size,
+    );
+
+    // Per-layer [top, mid, bottom]: 70 / 60 / 50 mil sizes.
+    let sizes = pad
+        .per_layer_sizes
+        .as_ref()
+        .expect("TopMiddleBottom pad now surfaces per_layer_sizes");
+    let expected_sizes = [(1.778, 1.778), (1.524, 1.524), (1.27, 1.27)];
+    assert_eq!(sizes.len(), 3, "TMB per_layer_sizes is [top, mid, bottom]");
+    for (i, &(ew, eh)) in expected_sizes.iter().enumerate() {
+        assert!(
+            approx_eq(sizes[i].0, ew, 1e-2) && approx_eq(sizes[i].1, eh, 1e-2),
+            "per-layer size {i}: expected ~({ew},{eh}), got {:?}",
+            sizes[i],
+        );
+    }
+
+    // Per-layer [top, mid, bottom] shapes: round top, round mid, square bottom.
+    assert_eq!(
+        pad.per_layer_shapes.as_deref(),
+        Some([PadShape::Round, PadShape::Round, PadShape::Rectangle].as_slice()),
+        "TMB per_layer_shapes is [top, mid, bottom]",
     );
 }
 


### PR DESCRIPTION
Closes the **TODO.md A1 gap** — "middle/bottom sizes (TopMiddleBottom)" — using the `PAD_STACK` golden (#178) to validate.

A TopMiddleBottom (LocalStack) pad stores its top/mid/bottom per-layer sizes and shapes in the **main pad geometry block** (mid @29/33, bottom @37/41, shapes @50/51); Block 5 is empty. Our reader only handled the 32-entry FullStack Block 5 format, so `parse_pad` set `stack_mode = TopMiddleBottom` but **dropped the mid/bottom** (`per_layer_sizes` came back `None`). Offsets verified against AltiumSharp's `PcbLibReader` *and* the golden's actual bytes.

## Reader
`parse_pad` now reads the mid/bottom sizes + shapes from the main geometry block into `per_layer_sizes` / `per_layer_shapes` as a 3-entry `[top, mid, bottom]` vector (Simple and FullStack paths untouched).

## Writer (round-trip safety)
The research flagged two writer asymmetries a reader-only fix would expose:
- `encode_pad_geometry` flattened all three size/shape slots to the top value — now it writes the distinct mid/bottom for a TopMiddleBottom pad.
- Block 5 was emitted whenever `per_layer_sizes.is_some()` — now **only for FullStack**, so a TopMiddleBottom pad keeps Block 5 empty (matching Altium).

## Tests
- `samples_pcblib_pad_stack` now asserts the full stack: `per_layer_sizes` = `[(1.778,1.778),(1.524,1.524),(1.27,1.27)]` (70/60/50 mil), `per_layer_shapes` = `[Round, Round, Rectangle]`.
- New `pcblib_file_roundtrip_pad_top_middle_bottom` writes + reads a TopMiddleBottom pad to lock in the reader/writer round-trip.

Gate: fmt / clippy / full `cargo test` green; **oracle 13/13, 0 regressions** (the writer change keeps our pads pyaltiumlib-readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
