### PR TITLE
refactor(mcp): make write_pcblib auto-3D-body opt-in

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -149,11 +149,11 @@ impl McpServer {
                      regions, and text. The AI is responsible for calculating correct positions \
                      and sizes based on IPC-7351B or other standards. \
                      All coordinates and dimensions must be in millimetres (mm). \
-                     If a footprint has no STEP model and no component body, an extruded 3D body \
-                     is added automatically (default height 1.0 mm). The response 'bodies' array \
-                     echoes each footprint's 3D body height and source ('auto-extruded' bodies are \
-                     flagged 'assumed_height': true) so you can confirm or override the height by \
-                     supplying 'component_bodies' explicitly. The response also includes a \
+                     The response 'bodies' array echoes each footprint's 3D body height and source; \
+                     a footprint with no STEP model and no component body reports source 'none'. \
+                     Set 'auto_3d_body': true to have an extruded placeholder body (default height \
+                     1.0 mm, flagged 'assumed_height': true) added to such footprints, then confirm \
+                     or override it by supplying 'component_bodies' explicitly. The response also includes a \
                      'warnings' array flagging silkscreen (overlay) tracks that overlap a pad \
                      (silk-on-pad) so you can move them clear."
                         .to_string(),
@@ -319,6 +319,10 @@ impl McpServer {
                         "append": {
                             "type": "boolean",
                             "description": "If true, append to existing file; if false, create new file"
+                        },
+                        "auto_3d_body": {
+                            "type": "boolean",
+                            "description": "If true, footprints with pads but no STEP model and no component body get a placeholder extruded 3D body (1.0 mm tall, flagged assumed_height). Default false: nothing is added unless you ask, since many footprints (fiducials, test points, mounting holes) legitimately have no body. Prefer supplying real heights via component_bodies."
                         }
                     },
                     "required": ["filepath", "footprints"]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -234,7 +234,12 @@ fn body_3d_summary(fp: &crate::altium::pcblib::Footprint, assumed_height: bool) 
         }
         return summary;
     }
-    json!({ "name": fp.name, "source": "none" })
+    json!({
+        "name": fp.name,
+        "source": "none",
+        "note": "No 3D body written. Set component_bodies[].overall_height to the real \
+                 part height, or pass auto_3d_body:true for a flagged 1.0 mm placeholder.",
+    })
 }
 
 impl McpServer {
@@ -431,6 +436,15 @@ impl McpServer {
 
         let append = arguments
             .get("append")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        // Opt-in: synthesise a placeholder extruded 3D body for footprints that have
+        // pads but no body/STEP. Off by default so the tool never adds geometry the
+        // caller didn't request (a body is wrong for fiducials / test points / mounting
+        // holes); the always-on `bodies` echo still reports `source: "none"` to nudge.
+        let auto_3d_body = arguments
+            .get("auto_3d_body")
             .and_then(Value::as_bool)
             .unwrap_or(false);
 
@@ -727,12 +741,13 @@ impl McpServer {
                 });
             }
 
-            // Auto-include an extruded 3D body when the footprint has no STEP model
-            // and no component body, so it has a 3D presence in Altium. Height can't
-            // be inferred from a 2D footprint, so it defaults to 1.0 mm and is flagged
-            // `assumed_height` in the response for the caller to confirm/override.
+            // Opt-in (`auto_3d_body`): synthesise an extruded 3D body for a footprint
+            // with pads but no STEP model and no component body, so it has a 3D presence
+            // in Altium. Height can't be inferred from a 2D footprint, so it defaults to
+            // 1.0 mm and is flagged `assumed_height` for the caller to confirm/override.
             // The empty outline makes the writer synthesise a bounding box from pads.
-            let assumed_height = if footprint.model_3d.is_none()
+            let assumed_height = if auto_3d_body
+                && footprint.model_3d.is_none()
                 && footprint.component_bodies.is_empty()
                 && !footprint.pads.is_empty()
             {

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -229,6 +229,42 @@ def test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_
     runner.check("polygons" in pins, "PINS_ETYPE symbol has 'polygons' field")
 
 
+def test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path):
+    print("\n=== Test: write_pcblib auto_3d_body is opt-in ===")
+    # A footprint with a pad but no 3D body. By default the tool must NOT synthesise
+    # a body (geometry the caller didn't request); the `bodies` echo reports 'none'.
+    # Passing auto_3d_body:true opts into a flagged 1.0mm placeholder.
+    fp = {
+        "name": "NOBODY",
+        "pads": [{"designator": "1", "x": 0, "y": 0, "width": 1.0, "height": 1.0}],
+    }
+
+    default = client.call_tool("write_pcblib", {"filepath": lib_path, "footprints": [fp], "append": False})
+    runner.check(not default.get("_isError"), "write_pcblib (default) succeeded", actual=default)
+    d_bodies = {b.get("name"): b for b in default.get("bodies", [])}
+    runner.check(
+        d_bodies.get("NOBODY", {}).get("source") == "none",
+        "default: no auto 3D body (source 'none')",
+        actual=d_bodies.get("NOBODY"),
+    )
+
+    optin = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [fp], "append": False, "auto_3d_body": True},
+    )
+    runner.check(not optin.get("_isError"), "write_pcblib (auto_3d_body) succeeded", actual=optin)
+    o_bodies = {b.get("name"): b for b in optin.get("bodies", [])}
+    runner.check(
+        o_bodies.get("NOBODY", {}).get("source") == "auto-extruded",
+        "auto_3d_body:true adds an extruded body",
+        actual=o_bodies.get("NOBODY"),
+    )
+    runner.check(
+        o_bodies.get("NOBODY", {}).get("assumed_height") is True,
+        "auto body is flagged assumed_height",
+    )
+
+
 def main():
     binary = find_binary()
     print(f"Using binary: {binary}")
@@ -260,6 +296,7 @@ def main():
         test_initialise(client, runner)
         test_tools_list(client, runner)
         test_write_read_roundtrip(client, runner, lib_path)
+        test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)
         test_unknown_tool(client, runner)


### PR DESCRIPTION
Follow-up to #182, which we merged as-is with the agreement to **sharpen the auto-add scope** afterward.

#182 auto-added a 1.0 mm placeholder 3D body to *every* footprint with pads and no existing body/STEP. That's the tool synthesising geometry the caller didn't request — **wrong for footprints that legitimately have no body** (fiducials, test points, mounting holes) and in tension with this repo's core principle (*"the AI handles the intelligence, the tool handles file I/O"*).

## Change
Gate the auto-add behind a new **`auto_3d_body`** `write_pcblib` parameter, **default `false`** — nothing is added unless the caller opts in.

The **`bodies` echo stays always-on** (the genuinely useful part of #182): a footprint with no body now reports `source: "none"` with a note pointing at `auto_3d_body` / `component_bodies`, so the caller is still nudged toward a real 3D body — without the tool unilaterally adding geometry. When `auto_3d_body: true`, #182's behaviour (flagged 1.0 mm placeholder + `action_required`) is unchanged.

## Tests
- New `test_write_pcblib_auto_3d_body_opt_in`: default write of a body-less footprint → `source: "none"`; with `auto_3d_body: true` → `source: "auto-extruded"`, `assumed_height: true`.
- Tool description + input schema document the param.

Gate: fmt / clippy / full `cargo test` / integration suite (46 passed) / **oracle 13/13, 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
