### PR TITLE
feat(mcp): make all SchLib shape primitives writable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,10 @@
 //! - [`altium`] — Altium file format handling
 //! - [`security`] — Rate limiting and other safety controls
 
+// The `write_schlib` tool schema is a single large `json!` literal whose
+// expansion exceeds the default macro recursion limit of 128.
+#![recursion_limit = "256"]
+
 pub mod altium;
 pub mod config;
 pub mod error;

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -332,7 +332,8 @@ impl McpServer {
                 name: "write_schlib".to_string(),
                 description: Some(
                     "Write schematic symbols to an Altium .SchLib file. Each symbol is defined by \
-                     its primitives: pins, rectangles, lines, polylines, arcs, ellipses, and labels. \
+                     its primitives: pins, rectangles, round_rects, lines, polylines, polygons, \
+                     arcs, ellipses, labels, and text. \
                      Coordinates must be in schematic units (10 units = 1 grid square, not mm)."
                         .to_string(),
                 ),
@@ -390,6 +391,27 @@ impl McpServer {
                                             "required": ["x1", "y1", "x2", "y2"]
                                         }
                                     },
+                                    "round_rects": {
+                                        "type": "array",
+                                        "description": "Rounded-rectangle definitions",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x1": { "type": "integer", "description": "Left X coordinate" },
+                                                "y1": { "type": "integer", "description": "Bottom Y coordinate" },
+                                                "x2": { "type": "integer", "description": "Right X coordinate" },
+                                                "y2": { "type": "integer", "description": "Top Y coordinate" },
+                                                "corner_x_radius": { "type": "integer", "description": "Horizontal corner radius. Default: 0" },
+                                                "corner_y_radius": { "type": "integer", "description": "Vertical corner radius. Default: 0" },
+                                                "line_width": { "type": "integer", "description": "Border width. Default: 1" },
+                                                "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
+                                                "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
+                                                "filled": { "type": "boolean", "description": "Whether filled. Default: true" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
+                                            },
+                                            "required": ["x1", "y1", "x2", "y2", "corner_x_radius", "corner_y_radius"]
+                                        }
+                                    },
                                     "lines": {
                                         "type": "array",
                                         "description": "Line definitions",
@@ -405,6 +427,90 @@ impl McpServer {
                                                 "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2"]
+                                        }
+                                    },
+                                    "polygons": {
+                                        "type": "array",
+                                        "description": "Filled polygon definitions (>= 3 vertices)",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "points": {
+                                                    "type": "array",
+                                                    "description": "Vertices (>= 3) as objects with x/y in schematic units",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "x": { "type": "integer" },
+                                                            "y": { "type": "integer" }
+                                                        },
+                                                        "required": ["x", "y"]
+                                                    }
+                                                },
+                                                "line_width": { "type": "integer", "description": "Border width. Default: 1" },
+                                                "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
+                                                "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
+                                                "filled": { "type": "boolean", "description": "Whether filled. Default: true" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
+                                            },
+                                            "required": ["points"]
+                                        }
+                                    },
+                                    "arcs": {
+                                        "type": "array",
+                                        "description": "Arc/circle definitions",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x": { "type": "integer", "description": "Centre X coordinate" },
+                                                "y": { "type": "integer", "description": "Centre Y coordinate" },
+                                                "radius": { "type": "integer", "description": "Radius in schematic units" },
+                                                "start_angle": { "type": "number", "description": "Start angle in degrees (0 = right, CCW). Default: 0" },
+                                                "end_angle": { "type": "number", "description": "End angle in degrees. Default: 360 (full circle)" },
+                                                "line_width": { "type": "integer", "description": "Line width. Default: 1" },
+                                                "color": { "type": "integer", "description": "Line BGR colour. Default: 0x000080" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
+                                            },
+                                            "required": ["x", "y", "radius"]
+                                        }
+                                    },
+                                    "ellipses": {
+                                        "type": "array",
+                                        "description": "Ellipse definitions",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x": { "type": "integer", "description": "Centre X coordinate" },
+                                                "y": { "type": "integer", "description": "Centre Y coordinate" },
+                                                "radius_x": { "type": "integer", "description": "Horizontal radius" },
+                                                "radius_y": { "type": "integer", "description": "Vertical radius" },
+                                                "line_width": { "type": "integer", "description": "Border width. Default: 1" },
+                                                "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
+                                                "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
+                                                "filled": { "type": "boolean", "description": "Whether filled. Default: true" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
+                                            },
+                                            "required": ["x", "y", "radius_x", "radius_y"]
+                                        }
+                                    },
+                                    "labels": {
+                                        "type": "array",
+                                        "description": "Text label definitions (RECORD=4). For RECORD=3 annotations use 'text'.",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x": { "type": "integer", "description": "X position" },
+                                                "y": { "type": "integer", "description": "Y position" },
+                                                "text": { "type": "string", "description": "Text content" },
+                                                "font_id": { "type": "integer", "description": "Font ID. Default: 1" },
+                                                "color": { "type": "integer", "description": "BGR colour. Default: 0x000080" },
+                                                "justification": { "type": "string", "enum": ["bottom_left", "bottom_center", "bottom_right", "middle_left", "middle_center", "middle_right", "top_left", "top_center", "top_right"], "description": "Alignment. Default: bottom_left" },
+                                                "rotation": { "type": "number", "description": "Rotation in degrees. Default: 0" },
+                                                "is_mirrored": { "type": "boolean", "description": "Mirrored. Default: false" },
+                                                "is_hidden": { "type": "boolean", "description": "Hidden. Default: false" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
+                                            },
+                                            "required": ["x", "y", "text"]
                                         }
                                     },
                                     "text": {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -499,6 +499,54 @@ impl McpServer {
         })
     }
 
+    /// Parses a schematic rounded rectangle from JSON.
+    ///
+    /// Mirrors [`Self::parse_schlib_rectangle`] (geometry + fill/border colours +
+    /// `filled`), adding the `corner_x_radius` / `corner_y_radius` rounding fields.
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::similar_names)] // corner_x_radius / corner_y_radius mirror the struct fields
+    pub(crate) fn parse_schlib_round_rect(
+        json: &Value,
+    ) -> Option<crate::altium::schlib::RoundRect> {
+        use crate::altium::schlib::RoundRect;
+
+        let x1 = json_i32(json, "x1")?;
+        let y1 = json_i32(json, "y1")?;
+        let x2 = json_i32(json, "x2")?;
+        let y2 = json_i32(json, "y2")?;
+        let corner_x_radius = json_i32(json, "corner_x_radius").unwrap_or(0);
+        let corner_y_radius = json_i32(json, "corner_y_radius").unwrap_or(0);
+
+        let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
+        let line_color = json
+            .get("line_color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0x00_00_80) as u32;
+        let fill_color = json
+            .get("fill_color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0xB0_FF_FF) as u32;
+        let filled = json.get("filled").and_then(Value::as_bool).unwrap_or(true);
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
+
+        Some(RoundRect {
+            x1,
+            y1,
+            x2,
+            y2,
+            corner_x_radius,
+            corner_y_radius,
+            line_width,
+            line_color,
+            fill_color,
+            line_style: 0,
+            filled,
+            transparent: false,
+            owner_part_id,
+            unique_id: None,
+        })
+    }
+
     /// Parses a schematic line from JSON.
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn parse_schlib_line(json: &Value) -> Option<crate::altium::schlib::Line> {
@@ -607,6 +655,56 @@ impl McpServer {
             end_line_shape: 0,
             line_shape_size: 0,
             transparent: false,
+            owner_part_id,
+            unique_id: None,
+        })
+    }
+
+    /// Parses a schematic filled polygon from JSON.
+    ///
+    /// Mirrors [`Self::parse_schlib_polyline`] (reads the `points`/`vertices`
+    /// array of `[x, y]` pairs), adding the polygon's `filled` / `fill_color`
+    /// fields.
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn parse_schlib_polygon(json: &Value) -> Option<crate::altium::schlib::Polygon> {
+        use crate::altium::schlib::Polygon;
+
+        // Accept both "points" and "vertices" for flexibility (matches polyline).
+        let points_json = json
+            .get("points")
+            .or_else(|| json.get("vertices"))
+            .and_then(Value::as_array)?;
+        let points: Vec<(i32, i32)> = points_json
+            .iter()
+            .filter_map(|p| {
+                let x = json_i32(p, "x")?;
+                let y = json_i32(p, "y")?;
+                Some((x, y))
+            })
+            .collect();
+
+        if points.len() < 3 {
+            return None; // Need at least 3 vertices for a polygon
+        }
+
+        let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
+        let line_color = json
+            .get("line_color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0x00_00_80) as u32;
+        let fill_color = json
+            .get("fill_color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0xB0_FF_FF) as u32;
+        let filled = json.get("filled").and_then(Value::as_bool).unwrap_or(true);
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
+
+        Some(Polygon {
+            points,
+            line_width,
+            line_color,
+            fill_color,
+            filled,
             owner_part_id,
             unique_id: None,
         })

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1075,6 +1075,15 @@ impl McpServer {
                 }
             }
 
+            // Parse rounded rectangles
+            if let Some(round_rects) = sym_json.get("round_rects").and_then(Value::as_array) {
+                for round_rect_json in round_rects {
+                    if let Some(round_rect) = Self::parse_schlib_round_rect(round_rect_json) {
+                        symbol.add_round_rect(round_rect);
+                    }
+                }
+            }
+
             // Parse lines
             if let Some(lines) = sym_json.get("lines").and_then(Value::as_array) {
                 for line_json in lines {
@@ -1089,6 +1098,15 @@ impl McpServer {
                 for polyline_json in polylines {
                     if let Some(polyline) = Self::parse_schlib_polyline(polyline_json) {
                         symbol.add_polyline(polyline);
+                    }
+                }
+            }
+
+            // Parse polygons
+            if let Some(polygons) = sym_json.get("polygons").and_then(Value::as_array) {
+                for polygon_json in polygons {
+                    if let Some(polygon) = Self::parse_schlib_polygon(polygon_json) {
+                        symbol.add_polygon(polygon);
                     }
                 }
             }

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -229,6 +229,104 @@ def test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_
     runner.check("polygons" in pins, "PINS_ETYPE symbol has 'polygons' field")
 
 
+def test_write_schlib_shapes(client, runner, schlib_path):
+    print("\n=== Test: write_schlib shapes round trip ===")
+    # Coverage PR-1: every SHAPE primitive the read tool round-trips must be
+    # authorable via write_schlib. Write a symbol with a round_rect, polygon,
+    # ellipse, arc and label, then read it back and assert each survived.
+    symbol = {
+        "name": "SHAPES",
+        "pins": [
+            {
+                "designator": "1",
+                "name": "P1",
+                "x": -50,
+                "y": 0,
+                "length": 30,
+                "orientation": "left",
+            }
+        ],
+        "round_rects": [
+            {
+                "x1": 0,
+                "y1": 0,
+                "x2": 40,
+                "y2": 30,
+                "corner_x_radius": 5,
+                "corner_y_radius": 7,
+                "fill_color": 0x112233,
+            }
+        ],
+        "polygons": [
+            {
+                "points": [
+                    {"x": 0, "y": 0},
+                    {"x": 20, "y": 0},
+                    {"x": 10, "y": 20},
+                ],
+                "fill_color": 0x445566,
+            }
+        ],
+        "ellipses": [
+            {"x": 60, "y": 60, "radius_x": 15, "radius_y": 10, "fill_color": 0x778899}
+        ],
+        "arcs": [
+            {"x": 80, "y": 80, "radius": 25, "start_angle": 30, "end_angle": 270}
+        ],
+        "labels": [{"x": 5, "y": 45, "text": "HELLO"}],
+    }
+
+    write = client.call_tool(
+        "write_schlib",
+        {"filepath": schlib_path, "symbols": [symbol], "append": False},
+    )
+    runner.check(not write.get("_isError"), "write_schlib succeeded", actual=write)
+
+    read = client.call_tool("read_schlib", {"filepath": schlib_path})
+    runner.check(not read.get("_isError"), "read_schlib succeeded", actual=read)
+
+    symbols = {s.get("name"): s for s in read.get("symbols", [])}
+    sym = symbols.get("SHAPES", {})
+    runner.check(bool(sym), "SHAPES symbol present", actual=list(symbols))
+
+    # round_rect: count + corner radii + geometry survived
+    round_rects = sym.get("round_rects", [])
+    runner.check(len(round_rects) == 1, "1 round_rect survived", actual=len(round_rects))
+    if round_rects:
+        rr = round_rects[0]
+        runner.check(rr.get("corner_x_radius") == 5, "round_rect corner_x_radius", actual=rr.get("corner_x_radius"), expected=5)
+        runner.check(rr.get("corner_y_radius") == 7, "round_rect corner_y_radius", actual=rr.get("corner_y_radius"), expected=7)
+        runner.check(rr.get("x2") == 40 and rr.get("y2") == 30, "round_rect geometry", actual=rr)
+
+    # polygon: count + vertex count
+    polygons = sym.get("polygons", [])
+    runner.check(len(polygons) == 1, "1 polygon survived", actual=len(polygons))
+    if polygons:
+        pts = polygons[0].get("points", [])
+        runner.check(len(pts) == 3, "polygon has 3 vertices", actual=len(pts))
+
+    # ellipse: count + radii
+    ellipses = sym.get("ellipses", [])
+    runner.check(len(ellipses) == 1, "1 ellipse survived", actual=len(ellipses))
+    if ellipses:
+        el = ellipses[0]
+        runner.check(el.get("radius_x") == 15 and el.get("radius_y") == 10, "ellipse radii", actual=el)
+
+    # arc: count + angle range
+    arcs = sym.get("arcs", [])
+    runner.check(len(arcs) == 1, "1 arc survived", actual=len(arcs))
+    if arcs:
+        ar = arcs[0]
+        runner.check(ar.get("radius") == 25, "arc radius", actual=ar.get("radius"), expected=25)
+        runner.check(ar.get("start_angle") == 30 and ar.get("end_angle") == 270, "arc angles", actual=ar)
+
+    # label: count + text
+    labels = sym.get("labels", [])
+    runner.check(len(labels) == 1, "1 label survived", actual=len(labels))
+    if labels:
+        runner.check(labels[0].get("text") == "HELLO", "label text", actual=labels[0].get("text"), expected="HELLO")
+
+
 def test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path):
     print("\n=== Test: write_pcblib auto_3d_body is opt-in ===")
     # A footprint with a pad but no 3D body. By default the tool must NOT synthesise
@@ -285,6 +383,7 @@ def main():
         )
 
     lib_path = os.path.join(allowed, "RoundTrip.PcbLib")
+    schlib_path = os.path.join(allowed, "RoundTrip.SchLib")
     outside_path = os.path.join(work, "outside.PcbLib")  # in `work`, not `allowed`
     sample_path = os.path.join(samples_dir, "footprints.PcbLib")
     schlib_sample_path = os.path.join(samples_dir, "symbols.SchLib")
@@ -297,6 +396,7 @@ def main():
         test_tools_list(client, runner)
         test_write_read_roundtrip(client, runner, lib_path)
         test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path)
+        test_write_schlib_shapes(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)
         test_unknown_tool(client, runner)


### PR DESCRIPTION
**Coverage roadmap PR-1** — make all SchLib shape primitives authorable.

`read_schlib` already exposes a symbol's `round_rects` / `polygons` / `ellipses` / `arcs` / `labels`, but `write_schlib` couldn't author several: round_rect + polygon had **no handler branch at all**, and round_rect/polygon/ellipse/arc/label were **absent from the input schema** (so an AI driving the documented tool didn't know they were writable).

## Change (pure tool-layer — the models already fully support these)
- New `parse_schlib_round_rect` + `parse_schlib_polygon` (mirror `parse_schlib_rectangle` / `parse_schlib_polyline`, plus round_rect corner radii and polygon `points` + fill).
- `call_write_schlib`: `round_rects` → `add_round_rect`, `polygons` → `add_polygon` branches.
- `write_schlib` input schema: add `round_rects`, `polygons`, `arcs`, `ellipses`, `labels` (all were handler-accepted but undocumented).
- `#![recursion_limit = "256"]` (lib.rs) — the compiler-recommended fix for the larger `json!` schema literal.

## Test
New `test_write_schlib_shapes`: writes a symbol with a round_rect / polygon / ellipse / arc / label, reads it back, asserts each survived with key field values.

Gate: fmt / clippy / full `cargo test` / integration (62 passed) / **oracle 13/13, 0 regressions**.

Flips 5 SchLib primitives from read-only to authorable. Next on the roadmap: PR-2 (Via writable), PR-3 (Fill writable), PR-4 (PcbLib flags/mask on write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
