### PR TITLE
feat(mcp): make Via and Fill writable via write_pcblib

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -145,8 +145,8 @@ impl McpServer {
                 name: "write_pcblib".to_string(),
                 description: Some(
                     "Write footprints to an Altium .PcbLib file. Each footprint is defined by \
-                     its primitives: pads (with position, size, shape, layer), tracks, arcs, \
-                     regions, and text. The AI is responsible for calculating correct positions \
+                     its primitives: pads (with position, size, shape, layer), tracks, vias, \
+                     fills, arcs, regions, and text. The AI is responsible for calculating correct positions \
                      and sizes based on IPC-7351B or other standards. \
                      All coordinates and dimensions must be in millimetres (mm). \
                      The response 'bodies' array echoes each footprint's 3D body height and source; \
@@ -215,6 +215,49 @@ impl McpServer {
                                                 "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Top Courtyard, Mechanical 1, etc." }
                                             },
                                             "required": ["x1", "y1", "x2", "y2", "width", "layer"]
+                                        }
+                                    },
+                                    "vias": {
+                                        "type": "array",
+                                        "description": "Via definitions (vertical interconnects between copper layers, with a drill hole and annular ring).",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x": { "type": "number", "description": "X position in mm" },
+                                                "y": { "type": "number", "description": "Y position in mm" },
+                                                "diameter": { "type": "number", "description": "Annular ring outer diameter in mm" },
+                                                "hole_size": { "type": "number", "description": "Drill hole diameter in mm (must be smaller than diameter)" },
+                                                "from_layer": { "type": "string", "description": "Starting layer (default Top Layer): Top Layer, Bottom Layer, Mid-Layer 1, etc." },
+                                                "to_layer": { "type": "string", "description": "Ending layer (default Bottom Layer): Top Layer, Bottom Layer, Mid-Layer 1, etc." },
+                                                "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion in mm (negative = tented). Default: 0" },
+                                                "solder_mask_expansion_mode": {
+                                                    "type": "string",
+                                                    "enum": ["none", "from_rule", "manual"],
+                                                    "description": "Solder mask expansion mode. Default: from_rule"
+                                                },
+                                                "thermal_relief_gap": { "type": "number", "description": "Thermal relief air-gap width in mm. Default: 0.254 (10 mil)" },
+                                                "thermal_relief_conductors": { "type": "integer", "description": "Number of thermal relief conductors. Default: 4" },
+                                                "thermal_relief_width": { "type": "number", "description": "Thermal relief conductor width in mm. Default: 0.254 (10 mil)" }
+                                            },
+                                            "required": ["x", "y", "diameter", "hole_size"]
+                                        }
+                                    },
+                                    "fills": {
+                                        "type": "array",
+                                        "description": "Filled rectangle definitions (solid copper/keepout fill defined by two opposite corners).",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x1": { "type": "number", "description": "First corner X in mm" },
+                                                "y1": { "type": "number", "description": "First corner Y in mm" },
+                                                "x2": { "type": "number", "description": "Second corner X in mm" },
+                                                "y2": { "type": "number", "description": "Second corner Y in mm" },
+                                                "layer": { "type": "string", "description": "Layer name (default Top Layer): Top Layer, Bottom Layer, Top Overlay, Mechanical 1, etc." },
+                                                "rotation": { "type": "number", "description": "Rotation in degrees. Default: 0" },
+                                                "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
+                                                "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" }
+                                            },
+                                            "required": ["x1", "y1", "x2", "y2"]
                                         }
                                     },
                                     "arcs": {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -337,6 +337,152 @@ impl McpServer {
         })
     }
 
+    /// Parses a via from JSON.
+    ///
+    /// Mirrors [`Self::parse_pad`]'s layer-name parsing for the `from_layer` /
+    /// `to_layer` fields and reuses [`crate::altium::pcblib::MaskExpansionMode`]
+    /// string parsing for the mask mode. Optionals default exactly as
+    /// [`crate::altium::pcblib::Via::new`] does when absent.
+    pub(crate) fn parse_via(json: &Value) -> Result<crate::altium::pcblib::Via, String> {
+        use crate::altium::pcblib::{Layer, MaskExpansionMode, Via};
+
+        let x = json
+            .get("x")
+            .and_then(Value::as_f64)
+            .ok_or("Via missing required field 'x'")?;
+        let y = json
+            .get("y")
+            .and_then(Value::as_f64)
+            .ok_or("Via missing required field 'y'")?;
+        let diameter = json
+            .get("diameter")
+            .and_then(Value::as_f64)
+            .ok_or("Via missing required field 'diameter'")?;
+        let hole_size = json
+            .get("hole_size")
+            .and_then(Value::as_f64)
+            .ok_or("Via missing required field 'hole_size'")?;
+
+        // Validate via dimensions are sensible: the hole must fit inside the
+        // annular ring, both positive.
+        if diameter <= 0.0 {
+            return Err(format!(
+                "Via has invalid diameter {diameter}. Diameter must be greater than 0."
+            ));
+        }
+        if hole_size <= 0.0 {
+            return Err(format!(
+                "Via has invalid hole_size {hole_size}. Hole size must be greater than 0."
+            ));
+        }
+        if hole_size >= diameter {
+            return Err(format!(
+                "Via hole_size {hole_size} must be smaller than diameter {diameter}."
+            ));
+        }
+
+        // Start from the struct's defaults (top->bottom layers, standard thermal
+        // relief), then override with any supplied fields.
+        let mut via = Via::new(x, y, diameter, hole_size);
+
+        if let Some(s) = json.get("from_layer").and_then(Value::as_str) {
+            via.from_layer = Layer::parse(s).ok_or_else(|| {
+                format!(
+                    "Via has invalid from_layer '{s}'. \
+                     Valid layers include: Top Layer, Bottom Layer, Mid-Layer 1, etc."
+                )
+            })?;
+        }
+        if let Some(s) = json.get("to_layer").and_then(Value::as_str) {
+            via.to_layer = Layer::parse(s).ok_or_else(|| {
+                format!(
+                    "Via has invalid to_layer '{s}'. \
+                     Valid layers include: Top Layer, Bottom Layer, Mid-Layer 1, etc."
+                )
+            })?;
+        }
+
+        if let Some(v) = json.get("solder_mask_expansion").and_then(Value::as_f64) {
+            via.solder_mask_expansion = v;
+        }
+        if let Some(s) = json
+            .get("solder_mask_expansion_mode")
+            .and_then(Value::as_str)
+        {
+            via.solder_mask_expansion_mode = match s.to_lowercase().as_str() {
+                "none" => MaskExpansionMode::None,
+                "manual" => MaskExpansionMode::Manual,
+                _ => MaskExpansionMode::FromRule,
+            };
+        }
+        if let Some(v) = json.get("thermal_relief_gap").and_then(Value::as_f64) {
+            via.thermal_relief_gap = v;
+        }
+        if let Some(v) = json
+            .get("thermal_relief_conductors")
+            .and_then(Value::as_u64)
+            .and_then(|v| u8::try_from(v).ok())
+        {
+            via.thermal_relief_conductors = v;
+        }
+        if let Some(v) = json.get("thermal_relief_width").and_then(Value::as_f64) {
+            via.thermal_relief_width = v;
+        }
+
+        Ok(via)
+    }
+
+    /// Parses a fill from JSON.
+    ///
+    /// Reuses [`Self::parse_pad`]'s layer-name parsing for `layer`. Geometry
+    /// (`x1`/`y1`/`x2`/`y2`) is required; `rotation` and the mask/keepout
+    /// optionals default as [`crate::altium::pcblib::Fill::new`] does when absent.
+    pub(crate) fn parse_fill(json: &Value) -> Result<crate::altium::pcblib::Fill, String> {
+        use crate::altium::pcblib::{Fill, Layer};
+
+        let x1 = json
+            .get("x1")
+            .and_then(Value::as_f64)
+            .ok_or("Fill missing required field 'x1'")?;
+        let y1 = json
+            .get("y1")
+            .and_then(Value::as_f64)
+            .ok_or("Fill missing required field 'y1'")?;
+        let x2 = json
+            .get("x2")
+            .and_then(Value::as_f64)
+            .ok_or("Fill missing required field 'x2'")?;
+        let y2 = json
+            .get("y2")
+            .and_then(Value::as_f64)
+            .ok_or("Fill missing required field 'y2'")?;
+
+        let layer_str = json.get("layer").and_then(Value::as_str);
+        let layer = match layer_str {
+            Some(s) => Layer::parse(s).ok_or_else(|| {
+                format!(
+                    "Fill has invalid layer '{s}'. \
+                     Valid layers include: Top Layer, Bottom Layer, Top Overlay, Mechanical 1, etc."
+                )
+            })?,
+            None => Layer::TopLayer, // Default for fills is Top Layer
+        };
+
+        let mut fill = Fill::new(x1, y1, x2, y2, layer);
+
+        if let Some(r) = json.get("rotation").and_then(Value::as_f64) {
+            fill.rotation = r;
+        }
+        // Optional mask/keepout tail (mirrors the modelled optionals).
+        fill.solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
+        fill.keepout_restrictions = json
+            .get("keepout_restrictions")
+            .and_then(Value::as_u64)
+            .and_then(|v| u8::try_from(v).ok());
+
+        Ok(fill)
+    }
+
     // ==================== SchLib Primitive Parsing Helpers ====================
 
     /// Parses a schematic pin from JSON.

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -535,6 +535,40 @@ impl McpServer {
                 }
             }
 
+            // Parse vias
+            if let Some(vias) = fp_json.get("vias").and_then(Value::as_array) {
+                for (i, via_json) in vias.iter().enumerate() {
+                    match Self::parse_via(via_json) {
+                        Ok(via) => footprint.add_via(via),
+                        Err(e) => {
+                            return ToolCallResult::error_with_context(
+                                ErrorContext::new("write_pcblib", e)
+                                    .with_filepath(filepath)
+                                    .with_component(name)
+                                    .with_details(format!("Failed to parse via at index {i}")),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Parse fills
+            if let Some(fills) = fp_json.get("fills").and_then(Value::as_array) {
+                for (i, fill_json) in fills.iter().enumerate() {
+                    match Self::parse_fill(fill_json) {
+                        Ok(fill) => footprint.add_fill(fill),
+                        Err(e) => {
+                            return ToolCallResult::error_with_context(
+                                ErrorContext::new("write_pcblib", e)
+                                    .with_filepath(filepath)
+                                    .with_component(name)
+                                    .with_details(format!("Failed to parse fill at index {i}")),
+                            )
+                        }
+                    }
+                }
+            }
+
             // Parse arcs
             if let Some(arcs) = fp_json.get("arcs").and_then(Value::as_array) {
                 for (i, arc_json) in arcs.iter().enumerate() {

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -363,6 +363,91 @@ def test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path):
     )
 
 
+def test_write_pcblib_via_fill(client, runner, lib_path):
+    print("\n=== Test: write_pcblib via + fill round trip ===")
+    # Coverage PR-2/PR-3: vias and fills the read tool round-trips must be
+    # authorable via write_pcblib. Write a footprint with one via and one fill,
+    # read it back, and assert each survived with its key field values.
+    footprint = {
+        "name": "VIAFILL",
+        "pads": [
+            {"designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+        ],
+        "vias": [
+            {
+                "x": 1.5,
+                "y": 2.5,
+                "diameter": 0.6,
+                "hole_size": 0.3,
+                "from_layer": "Top Layer",
+                "to_layer": "Bottom Layer",
+            }
+        ],
+        "fills": [
+            {
+                "x1": -1.0,
+                "y1": -2.0,
+                "x2": 3.0,
+                "y2": 4.0,
+                "layer": "Top Layer",
+                "rotation": 45.0,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(not write.get("_isError"), "write_pcblib (via+fill) succeeded", actual=write)
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("VIAFILL", {})
+
+    # Tolerance: Altium stores coordinates as fixed-point internal units, so a
+    # round-trip carries sub-micron quantisation error (~1e-6 mm). 1e-4 mm
+    # (0.1 micron) is well below any meaningful PCB tolerance.
+    tol = 1e-4
+
+    vias = fp.get("vias", [])
+    runner.check(len(vias) == 1, "1 via survived", actual=len(vias))
+    if vias:
+        v = vias[0]
+        runner.check(
+            abs(v.get("diameter", 0) - 0.6) < tol,
+            "via diameter",
+            actual=v.get("diameter"),
+            expected=0.6,
+        )
+        runner.check(
+            abs(v.get("hole_size", 0) - 0.3) < tol,
+            "via hole_size",
+            actual=v.get("hole_size"),
+            expected=0.3,
+        )
+
+    fills = fp.get("fills", [])
+    runner.check(len(fills) == 1, "1 fill survived", actual=len(fills))
+    if fills:
+        fl = fills[0]
+        runner.check(
+            abs(fl.get("x1", 0) - (-1.0)) < tol
+            and abs(fl.get("y1", 0) - (-2.0)) < tol
+            and abs(fl.get("x2", 0) - 3.0) < tol
+            and abs(fl.get("y2", 0) - 4.0) < tol,
+            "fill corners",
+            actual=(fl.get("x1"), fl.get("y1"), fl.get("x2"), fl.get("y2")),
+            expected=(-1.0, -2.0, 3.0, 4.0),
+        )
+        runner.check(
+            abs(fl.get("rotation", 0) - 45.0) < tol,
+            "fill rotation",
+            actual=fl.get("rotation"),
+            expected=45.0,
+        )
+
+
 def main():
     binary = find_binary()
     print(f"Using binary: {binary}")
@@ -396,6 +481,7 @@ def main():
         test_tools_list(client, runner)
         test_write_read_roundtrip(client, runner, lib_path)
         test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path)
+        test_write_pcblib_via_fill(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)


### PR DESCRIPTION
**Coverage roadmap PR-2 + PR-3** — make PcbLib **Via** and **Fill** authorable via `write_pcblib`.

`read_pcblib` already exposes a footprint's vias/fills (model, reader, writer all complete), but `write_pcblib` couldn't create either — absent from the input schema and never parsed. Pure tool-layer wiring.

## Change
- New tool-side `parse_via` + `parse_fill` (`parsing.rs`), mirroring `parse_pad`/`parse_track`: required geometry (via `x/y/diameter/hole_size`, validated `hole < diameter`; fill `x1/y1/x2/y2`) + `Layer::parse` for layers, starting from `Via::new`/`Fill::new` so absent optionals default exactly as the struct does. Wired optionals: via `from/to_layer`, `solder_mask_expansion(+mode)`, `thermal_relief_*`; fill `layer`, `rotation`, `solder_mask_expansion`, `keepout_restrictions`. (Not-yet-modelled via fields — tenting/net/per-layer stack — are later format PR-7.)
- `call_write_pcblib`: `vias` → `add_via`, `fills` → `add_fill` branches (same per-index error echo as pads/tracks).
- `write_pcblib` schema: `vias` + `fills` arrays documenting those fields.

## Test
New `test_write_pcblib_via_fill`: writes a footprint with a via (0.6/0.3 mm, Top→Bottom) and a fill (corners, Top, 45°), reads back, asserts both survive with key values.

Gate: fmt / clippy / full `cargo test` / integration (70 passed) / **oracle 13/13, 0 regressions**.

With PR-1, **every PcbLib + SchLib primitive is now authorable** via the write tools. Next: PR-4 (expose flags/mask/keepout on write for all PcbLib 2D primitives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
