### PR TITLE
feat(schlib): fractional (off-grid) coordinate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-*This changelog will be populated once the first official release is published.*
+## [Unreleased]
+
+### Added
+
+- **Fractional (off-grid) SchLib coordinates.** All graphic primitives — lines,
+  rectangles, rounded rectangles, arcs, ellipses, polylines, polygons, Béziers,
+  labels, text, and parameters — now accept `f64` coordinates and round-trip
+  through Altium's `<key>_Frac` companion fields. Integer-grid coordinates are
+  unchanged on disk (no `_Frac` emitted). Pins remain integer-only. See
+  [`docs/SCHLIB_FORMAT.md`](docs/SCHLIB_FORMAT.md#fractional-coordinates).
+
+---
+
+*Released versions will be documented here once the first official release is published.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### Added
-
-- **Fractional (off-grid) SchLib coordinates.** All graphic primitives — lines,
-  rectangles, rounded rectangles, arcs, ellipses, polylines, polygons, Béziers,
-  labels, text, and parameters — now accept `f64` coordinates and round-trip
-  through Altium's `<key>_Frac` companion fields. Integer-grid coordinates are
-  unchanged on disk (no `_Frac` emitted). Pins remain integer-only. See
-  [`docs/SCHLIB_FORMAT.md`](docs/SCHLIB_FORMAT.md#fractional-coordinates).
-
----
-
-*Released versions will be documented here once the first official release is published.*
+*This changelog will be populated once the first official release is published.*

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -279,6 +279,29 @@ Derived from Rotated and Flipped flags:
 - Standard grid is 10 units
 - Pins are typically 10-30 units long
 
+### Fractional coordinates
+
+Graphic-primitive coordinates may sit off the integer grid. Altium stores each
+coordinate as an integer key plus an optional `<key>_Frac` companion holding the
+fractional part scaled by 100,000, reconstructed as:
+
+```text
+value = <key> + <key>_Frac / 100000
+```
+
+This applies to every coordinate key — `Location.X`/`Y`, `Corner.X`/`Y`,
+`Radius`, `SecondaryRadius`, `CornerXRadius`/`CornerYRadius`, and the polyline /
+polygon vertices `X{n}`/`Y{n}`. The `_Frac` field is **non-negative** (range
+`0..=99999`); for negative coordinates the integer part is the **floor**, so e.g.
+`-28.995` is stored as `Location.X=-29` with `Location.X_Frac=500`
+(`-29 + 500/100000 = -28.995`). A `_Frac` of `0` is omitted, so integer-grid
+coordinates serialise exactly as before. When the fractional part rounds up to a
+whole unit it **carries** into the integer part (e.g. `4.999995` → `Radius=5`,
+no `_Frac`) rather than being clamped.
+
+Binary pin records (Type 1) store integer coordinates only and do not use
+`_Frac`.
+
 ## Colour Format
 
 Colours are stored as 32-bit BGR values:
@@ -558,8 +581,9 @@ The designator record identifies the component (e.g., R?, U?, C?).
 | `LineWidth` | int | Line width |
 | `Color` | int | Line colour (BGR) |
 
-> **Note:** Fractional radius values are stored multiplied by 100,000 for precision without floating point.
-> Maximum fractional value is 99999 (clamped during writing).
+> **Note:** Fractional radius values are stored multiplied by 100,000 for precision without floating point
+> (see [Fractional coordinates](#fractional-coordinates)). The fractional field is non-negative
+> (`0..=99999`); a value rounding up to a whole unit carries into the integer part rather than being clamped.
 >
 > `Location.Y` may be omitted if the value is 0.
 >

--- a/src/altium/schlib/coord.rs
+++ b/src/altium/schlib/coord.rs
@@ -11,10 +11,11 @@
 //! through [`combine`] across the whole coordinate range — not just the
 //! non-negative radii the elliptical-arc encoder originally special-cased.
 //!
-//! NOTE: the floor convention matches this crate's reader (`int + frac`) and the
-//! documented non-negative `_Frac`. The negative-coordinate case has not yet been
-//! confirmed against an Altium-authored file; verify it before relying on
-//! fractional encoding for off-grid negative positions.
+//! The floor convention matches this crate's reader (`int + frac`) and the
+//! documented non-negative `_Frac`, and was confirmed in Altium: a floor-encoded
+//! `-10.5` line (`Location.X=-11`, `_Frac=50000`) renders mirror-equal to a
+//! `+10.5` line, whereas a truncate-magnitude decode would have placed it at
+//! `-11.5`.
 
 use std::collections::HashMap;
 

--- a/src/altium/schlib/coord.rs
+++ b/src/altium/schlib/coord.rs
@@ -1,0 +1,100 @@
+//! Fractional schematic-coordinate encoding.
+//!
+//! Altium stores a coordinate as an integer property (e.g. `Location.X`) plus an
+//! optional `<key>_Frac` companion holding the fractional part scaled by
+//! [`FRAC_SCALE`] (100,000). The `_Frac` field is non-negative (Altium's maximum
+//! is 99,999), so a value is reconstructed as `int + frac / FRAC_SCALE`.
+//!
+//! [`split`] therefore uses *floor* division (`div_euclid` / `rem_euclid`) rather
+//! than truncation, which keeps the fraction in `[0, FRAC_SCALE)` for negative
+//! coordinates as well (e.g. `-28.995` → int `-29`, frac `500`). It round-trips
+//! through [`combine`] across the whole coordinate range — not just the
+//! non-negative radii the elliptical-arc encoder originally special-cased.
+//!
+//! NOTE: the floor convention matches this crate's reader (`int + frac`) and the
+//! documented non-negative `_Frac`. The negative-coordinate case has not yet been
+//! confirmed against an Altium-authored file; verify it before relying on
+//! fractional encoding for off-grid negative positions.
+
+use std::collections::HashMap;
+
+/// Scale factor for the fractional companion field (`<key>_Frac`).
+pub const FRAC_SCALE: i64 = 100_000;
+
+/// Splits a coordinate value into Altium's integer and (non-negative) fractional
+/// parts, rounding to the nearest `1 / FRAC_SCALE` and carrying into the integer
+/// part. Floor semantics keep `frac` in `[0, FRAC_SCALE)` for negative values.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn split(value: f64) -> (i64, u32) {
+    #[allow(clippy::cast_precision_loss)]
+    let scaled = (value * FRAC_SCALE as f64).round() as i64;
+    (
+        scaled.div_euclid(FRAC_SCALE),
+        scaled.rem_euclid(FRAC_SCALE) as u32,
+    )
+}
+
+/// Reconstructs a coordinate value from its integer and fractional parts.
+#[allow(clippy::cast_precision_loss)]
+pub fn combine(int: i64, frac: u32) -> f64 {
+    int as f64 + f64::from(frac) / FRAC_SCALE as f64
+}
+
+/// Reads a coordinate that may carry a `<key>_frac` companion from parsed record
+/// properties. `key` must be the lower-cased property name (the reader
+/// lower-cases all keys). A missing integer or fractional part defaults to 0.
+pub fn read(props: &HashMap<String, String>, key: &str) -> f64 {
+    let int: i64 = props.get(key).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let frac: u32 = props
+        .get(&format!("{key}_frac"))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    combine(int, frac)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{combine, read, split};
+    use std::collections::HashMap;
+
+    #[test]
+    fn integer_values_have_zero_fraction() {
+        // Byte-identity invariant: integer coordinates must emit no `_Frac`.
+        assert_eq!(split(0.0), (0, 0));
+        assert_eq!(split(21.0), (21, 0));
+        assert_eq!(split(-10.0), (-10, 0));
+    }
+
+    #[test]
+    fn positive_fraction_round_trips() {
+        let (int, frac) = split(7.5);
+        assert_eq!((int, frac), (7, 50_000));
+        assert!((combine(int, frac) - 7.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn negative_fraction_uses_floor_and_round_trips() {
+        // The case the elliptical-arc encoder never exercised: floor integer part
+        // with a non-negative fraction.
+        let (int, frac) = split(-28.995);
+        assert_eq!((int, frac), (-29, 500));
+        assert!((combine(int, frac) - (-28.995)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn near_boundary_value_carries_into_integer() {
+        // 4.999995 must carry to 5 with no fraction (matches the elliptical-arc
+        // carry behaviour) rather than clamping to 4 + 99999.
+        assert_eq!(split(4.999_995), (5, 0));
+    }
+
+    #[test]
+    fn read_combines_int_and_frac_keys() {
+        let mut props = HashMap::new();
+        props.insert("location.x".to_string(), "-29".to_string());
+        props.insert("location.x_frac".to_string(), "500".to_string());
+        assert!((read(&props, "location.x") - (-28.995)).abs() < 1e-9);
+        // A key with no `_frac` companion reads as the bare integer.
+        assert!((read(&props, "missing") - 0.0).abs() < 1e-9);
+    }
+}

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -790,21 +790,14 @@ mod tests {
 
         // Verify first Bezier
         let b1 = &read_symbol.beziers[0];
-        assert_eq!(b1.x1, -50);
-        assert_eq!(b1.y1, 20);
-        assert_eq!(b1.x2, -60);
-        assert_eq!(b1.y2, 30);
-        assert_eq!(b1.x3, -50);
-        assert_eq!(b1.y3, 30);
-        assert_eq!(b1.x4, -40);
-        assert_eq!(b1.y4, 30);
+        assert_eq!(
+            (b1.x1, b1.y1, b1.x2, b1.y2, b1.x3, b1.y3, b1.x4, b1.y4),
+            (-50.0, 20.0, -60.0, 30.0, -50.0, 30.0, -40.0, 30.0)
+        );
 
         // Verify second Bezier
         let b2 = &read_symbol.beziers[1];
-        assert_eq!(b2.x1, 0);
-        assert_eq!(b2.y1, 0);
-        assert_eq!(b2.x4, 30);
-        assert_eq!(b2.y4, 0);
+        assert_eq!((b2.x1, b2.y1, b2.x4, b2.y4), (0.0, 0.0, 30.0, 0.0));
         assert_eq!(b2.line_width, 2);
         assert_eq!(b2.color, 0x00_00_FF);
     }
@@ -817,7 +810,7 @@ mod tests {
 
         // Add a filled triangle polygon
         let mut polygon = Polygon {
-            points: vec![(-30, 40), (-20, 30), (-10, 40)],
+            points: vec![(-30.0, 40.0), (-20.0, 30.0), (-10.0, 40.0)],
             line_width: 2,
             line_color: 0x00_00_FF, // Red border
             fill_color: 0xFF_00_00, // Blue fill
@@ -829,7 +822,7 @@ mod tests {
 
         // Add an unfilled rectangle polygon
         polygon = Polygon {
-            points: vec![(0, 0), (20, 0), (20, 20), (0, 20)],
+            points: vec![(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
             line_width: 1,
             line_color: 0x00_80_00, // Green border
             fill_color: 0,
@@ -856,9 +849,9 @@ mod tests {
         // Verify first polygon (triangle)
         let p1 = &read_symbol.polygons[0];
         assert_eq!(p1.points.len(), 3);
-        assert_eq!(p1.points[0], (-30, 40));
-        assert_eq!(p1.points[1], (-20, 30));
-        assert_eq!(p1.points[2], (-10, 40));
+        assert_eq!(p1.points[0], (-30.0, 40.0));
+        assert_eq!(p1.points[1], (-20.0, 30.0));
+        assert_eq!(p1.points[2], (-10.0, 40.0));
         assert_eq!(p1.line_width, 2);
         assert_eq!(p1.line_color, 0x00_00_FF);
         assert_eq!(p1.fill_color, 0xFF_00_00);
@@ -904,22 +897,32 @@ mod tests {
 
         // Verify first rounded rectangle
         let rr1 = &read_symbol.round_rects[0];
-        assert_eq!(rr1.x1, 40);
-        assert_eq!(rr1.y1, 20);
-        assert_eq!(rr1.x2, 90);
-        assert_eq!(rr1.y2, 50);
-        assert_eq!(rr1.corner_x_radius, 20);
-        assert_eq!(rr1.corner_y_radius, 20);
+        assert_eq!(
+            (
+                rr1.x1,
+                rr1.y1,
+                rr1.x2,
+                rr1.y2,
+                rr1.corner_x_radius,
+                rr1.corner_y_radius
+            ),
+            (40.0, 20.0, 90.0, 50.0, 20.0, 20.0)
+        );
         assert!(rr1.filled);
 
         // Verify second rounded rectangle
         let rr2 = &read_symbol.round_rects[1];
-        assert_eq!(rr2.x1, 0);
-        assert_eq!(rr2.y1, 0);
-        assert_eq!(rr2.x2, 30);
-        assert_eq!(rr2.y2, 20);
-        assert_eq!(rr2.corner_x_radius, 5);
-        assert_eq!(rr2.corner_y_radius, 10);
+        assert_eq!(
+            (
+                rr2.x1,
+                rr2.y1,
+                rr2.x2,
+                rr2.y2,
+                rr2.corner_x_radius,
+                rr2.corner_y_radius
+            ),
+            (0.0, 0.0, 30.0, 20.0, 5.0, 10.0)
+        );
         assert_eq!(rr2.line_width, 2);
         assert!(!rr2.filled);
     }
@@ -962,8 +965,7 @@ mod tests {
 
         // Verify first elliptical arc
         let ea1 = &read_symbol.elliptical_arcs[0];
-        assert_eq!(ea1.x, -60);
-        assert_eq!(ea1.y, 0);
+        assert_eq!((ea1.x, ea1.y), (-60.0, 0.0));
         // Check radii are close (allowing for fractional representation)
         assert!((ea1.radius - 9.96689).abs() < 0.001);
         assert!((ea1.secondary_radius - 9.99668).abs() < 0.001);
@@ -972,8 +974,7 @@ mod tests {
 
         // Verify second elliptical arc
         let ea2 = &read_symbol.elliptical_arcs[1];
-        assert_eq!(ea2.x, 20);
-        assert_eq!(ea2.y, 30);
+        assert_eq!((ea2.x, ea2.y), (20.0, 30.0));
         assert!((ea2.radius - 15.5).abs() < 0.001);
         assert!((ea2.secondary_radius - 10.25).abs() < 0.001);
         assert_eq!(ea2.line_width, 2);
@@ -990,9 +991,9 @@ mod tests {
 
         // AreaColor on Arc (Arc has no ::new — build a struct literal).
         let arc = Arc {
-            x: 0,
-            y: 0,
-            radius: 10,
+            x: 0.0,
+            y: 0.0,
+            radius: 10.0,
             is_not_accessible: true,
             start_angle: 0.0,
             end_angle: 360.0,
@@ -1244,5 +1245,113 @@ mod tests {
         reader::parse_data_stream(&mut decoded, &data);
         let l = &decoded.lines[0];
         assert!((l.x1 - (-30.0)).abs() < 1e-9 && (l.x2 - 30.0).abs() < 1e-9);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines, clippy::many_single_char_names)] // exercises every fractional-capable primitive
+    fn roundtrip_all_primitives_fractional_and_negative_coords() {
+        // Every graphic primitive carries off-grid (including negative) coordinates
+        // through a write -> read round-trip via the `_Frac` companion fields.
+        let approx = |a: f64, b: f64| (a - b).abs() < 1e-9;
+
+        let mut sym = Symbol::new("FRAC_ALL");
+        sym.add_rectangle(Rectangle::new(-10.25, -0.5, 10.75, 20.125));
+        sym.add_round_rect(RoundRect::new(-5.5, -5.5, 5.5, 5.5, 1.25, 2.75));
+        sym.add_ellipse(Ellipse::new(-1.5, 2.5, 7.5, 3.25));
+        let arc = Arc {
+            x: -3.5,
+            y: 4.25,
+            radius: 6.75,
+            is_not_accessible: true,
+            start_angle: 0.0,
+            end_angle: 180.0,
+            line_width: 1,
+            color: 0,
+            fill_color: 0,
+            owner_part_id: 1,
+            unique_id: None,
+        };
+        sym.add_arc(arc);
+        sym.add_bezier(Bezier::new(-0.5, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, -6.5));
+        sym.add_polyline(Polyline {
+            points: vec![(-1.25, 0.0), (2.5, -3.75), (10.0, 0.5)],
+            line_width: 1,
+            color: 0,
+            line_style: 0,
+            start_line_shape: 0,
+            end_line_shape: 0,
+            line_shape_size: 0,
+            transparent: false,
+            owner_part_id: 1,
+            unique_id: None,
+        });
+        sym.add_polygon(Polygon {
+            points: vec![(-2.5, -2.5), (2.5, -2.5), (0.0, 3.125)],
+            line_width: 1,
+            line_color: 0,
+            fill_color: 0,
+            filled: true,
+            owner_part_id: 1,
+            unique_id: None,
+        });
+        let label = Label {
+            x: -7.5,
+            y: 0.25,
+            text: "L".to_string(),
+            font_id: 1,
+            color: 0,
+            justification: TextJustification::BottomLeft,
+            rotation: 0.0,
+            is_mirrored: false,
+            is_hidden: false,
+            owner_part_id: 1,
+            unique_id: None,
+        };
+        sym.add_label(label);
+        let mut param = Parameter::new("Value", "1k");
+        param.x = -20.5;
+        param.y = 30.25;
+        sym.add_parameter(param);
+
+        let mut lib = SchLib::new();
+        lib.add(sym);
+        let mut buf = std::io::Cursor::new(Vec::new());
+        lib.write(&mut buf).expect("write");
+        buf.set_position(0);
+        let s = SchLib::read(buf).expect("read");
+        let s = s.get("FRAC_ALL").expect("symbol present");
+
+        let r = &s.rectangles[0];
+        assert!(
+            approx(r.x1, -10.25)
+                && approx(r.y1, -0.5)
+                && approx(r.x2, 10.75)
+                && approx(r.y2, 20.125)
+        );
+        let rr = &s.round_rects[0];
+        assert!(
+            approx(rr.x1, -5.5)
+                && approx(rr.corner_x_radius, 1.25)
+                && approx(rr.corner_y_radius, 2.75)
+        );
+        let e = &s.ellipses[0];
+        assert!(
+            approx(e.x, -1.5)
+                && approx(e.y, 2.5)
+                && approx(e.radius_x, 7.5)
+                && approx(e.radius_y, 3.25)
+        );
+        let a = &s.arcs[0];
+        assert!(approx(a.x, -3.5) && approx(a.y, 4.25) && approx(a.radius, 6.75));
+        let b = &s.beziers[0];
+        assert!(approx(b.x1, -0.5) && approx(b.y4, -6.5));
+        let pl = &s.polylines[0];
+        assert!(approx(pl.points[1].0, 2.5) && approx(pl.points[1].1, -3.75));
+        let pg = &s.polygons[0];
+        assert!(approx(pg.points[2].1, 3.125));
+        let lab = &s.labels[0];
+        assert!(approx(lab.x, -7.5) && approx(lab.y, 0.25));
+        let p = &s.parameters[0];
+        assert!(approx(p.x, -20.5) && approx(p.y, 30.25));
     }
 }

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -1204,4 +1204,45 @@ mod tests {
             "Expected 'expected SchLib' in error, got: {err_str}"
         );
     }
+
+    #[test]
+    fn roundtrip_line_fractional_and_negative_coords() {
+        // Off-grid endpoints — including a negative fractional coordinate, the
+        // case the elliptical-arc encoder never exercised — must survive a
+        // write -> read round-trip through the `_Frac` companion fields.
+        let mut symbol = Symbol::new("FRAC_LINE");
+        symbol.add_line(Line::new(-28.995, 7.5, 10.25, -0.5));
+
+        let mut lib = SchLib::new();
+        lib.add(symbol);
+        let mut buf = Cursor::new(Vec::new());
+        lib.write(&mut buf).expect("Failed to write SchLib");
+        buf.set_position(0);
+        let read = SchLib::read(buf).expect("Failed to read SchLib");
+
+        let l = &read.get("FRAC_LINE").expect("symbol present").lines[0];
+        assert!((l.x1 - (-28.995)).abs() < 1e-9, "x1 round-trips: {}", l.x1);
+        assert!((l.y1 - 7.5).abs() < 1e-9, "y1 round-trips: {}", l.y1);
+        assert!((l.x2 - 10.25).abs() < 1e-9, "x2 round-trips: {}", l.x2);
+        assert!((l.y2 - (-0.5)).abs() < 1e-9, "y2 round-trips: {}", l.y2);
+    }
+
+    #[test]
+    fn roundtrip_line_integer_coords_emit_no_frac() {
+        // Integer-grid lines must serialise without any `_Frac` token (byte
+        // identity with pre-migration output) and still round-trip exactly.
+        let mut symbol = Symbol::new("INT_LINE");
+        symbol.add_line(Line::new(-30, 0, 30, 0));
+        let data = writer::encode_data_stream(&symbol).expect("encode");
+        let text = String::from_utf8_lossy(&data);
+        assert!(
+            !text.contains("_Frac"),
+            "integer line must emit no _Frac: {text}"
+        );
+
+        let mut decoded = Symbol::new("INT_LINE");
+        reader::parse_data_stream(&mut decoded, &data);
+        let l = &decoded.lines[0];
+        assert!((l.x1 - (-30.0)).abs() < 1e-9 && (l.x2 - 30.0).abs() < 1e-9);
+    }
 }

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -46,6 +46,7 @@
 //! | 44 | Implementation List | Start of model list |
 //! | 45 | Model | Footprint model reference |
 
+pub(crate) mod coord;
 pub mod primitives;
 pub mod reader;
 pub mod writer;

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -369,7 +369,7 @@ impl PinElectricalType {
 /// A rectangle shape.
 ///
 /// Coordinates are `f64` schematic units (integer part plus optional `…_Frac`,
-/// see [`super::coord`]); `Eq` is not derived (floats are only `PartialEq`).
+/// see `super::coord`); `Eq` is not derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rectangle {
     /// Left X coordinate.
@@ -445,7 +445,7 @@ impl Rectangle {
 /// A line segment.
 ///
 /// Coordinates are `f64` schematic units: Altium stores the integer part plus an
-/// optional `…_Frac` companion (see [`super::coord`]), so a line endpoint can sit
+/// optional `…_Frac` companion (see `super::coord`), so a line endpoint can sit
 /// off the integer grid. `Eq` is therefore not derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Line {
@@ -510,7 +510,7 @@ impl Line {
 
 /// A polyline (multiple connected line segments).
 ///
-/// Point coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is
+/// Point coordinates are `f64` schematic units (see `super::coord`); `Eq` is
 /// not derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Polyline {
@@ -548,7 +548,7 @@ pub struct Polyline {
 
 /// A filled polygon.
 ///
-/// Vertex coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is
+/// Vertex coordinates are `f64` schematic units (see `super::coord`); `Eq` is
 /// not derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Polygon {
@@ -631,7 +631,7 @@ const fn default_end_angle() -> f64 {
 /// - Control point 2 (x3, y3)
 /// - End point (x4, y4)
 ///
-/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// Coordinates are `f64` schematic units (see `super::coord`); `Eq` is not
 /// derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Bezier {
@@ -712,7 +712,7 @@ impl Bezier {
 
 /// An ellipse.
 ///
-/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// Coordinates are `f64` schematic units (see `super::coord`); `Eq` is not
 /// derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ellipse {
@@ -787,7 +787,7 @@ impl Ellipse {
 /// A rounded rectangle.
 ///
 /// Defined by two corner points and corner radii for rounding.
-/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// Coordinates are `f64` schematic units (see `super::coord`); `Eq` is not
 /// derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoundRect {
@@ -1047,7 +1047,7 @@ const fn default_justification() -> TextJustification {
 
 /// A component parameter (e.g., Value, Part Number).
 ///
-/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// Coordinates are `f64` schematic units (see `super::coord`); `Eq` is not
 /// derived (floats are only `PartialEq`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Parameter {

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -367,16 +367,23 @@ impl PinElectricalType {
 }
 
 /// A rectangle shape.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Coordinates are `f64` schematic units (integer part plus optional `…_Frac`,
+/// see [`super::coord`]); `Eq` is not derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rectangle {
     /// Left X coordinate.
-    pub x1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x1: f64,
     /// Bottom Y coordinate.
-    pub y1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y1: f64,
     /// Right X coordinate.
-    pub x2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x2: f64,
     /// Top Y coordinate.
-    pub y2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y2: f64,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -410,14 +417,19 @@ const fn default_line_width() -> u8 {
 }
 
 impl Rectangle {
-    /// Creates a new rectangle.
+    /// Creates a new rectangle. Accepts integer or float coordinates.
     #[must_use]
-    pub const fn new(x1: i32, y1: i32, x2: i32, y2: i32) -> Self {
+    pub fn new(
+        x1: impl Into<f64>,
+        y1: impl Into<f64>,
+        x2: impl Into<f64>,
+        y2: impl Into<f64>,
+    ) -> Self {
         Self {
-            x1,
-            y1,
-            x2,
-            y2,
+            x1: x1.into(),
+            y1: y1.into(),
+            x2: x2.into(),
+            y2: y2.into(),
             line_width: 1,
             line_color: 0x00_00_80, // Dark red (BGR)
             fill_color: 0xB0_FF_FF, // Light yellow (BGR), matches Altium's default AreaColor (11599871)
@@ -497,10 +509,13 @@ impl Line {
 }
 
 /// A polyline (multiple connected line segments).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Point coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is
+/// not derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Polyline {
     /// Points as (x, y) pairs.
-    pub points: Vec<(i32, i32)>,
+    pub points: Vec<(f64, f64)>,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -532,10 +547,13 @@ pub struct Polyline {
 }
 
 /// A filled polygon.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Vertex coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is
+/// not derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Polygon {
     /// Vertices as (x, y) pairs.
-    pub points: Vec<(i32, i32)>,
+    pub points: Vec<(f64, f64)>,
     /// Border line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -561,11 +579,14 @@ pub struct Polygon {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Arc {
     /// Centre X coordinate.
-    pub x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Centre Y coordinate.
-    pub y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// Radius.
-    pub radius: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub radius: f64,
     /// Whether the arc is marked not-accessible. Altium tags every arc
     /// `IsNotAccesible` (its own single-'s' spelling), so this defaults to true.
     #[serde(default = "default_true")]
@@ -609,24 +630,35 @@ const fn default_end_angle() -> f64 {
 /// - Control point 1 (x2, y2)
 /// - Control point 2 (x3, y3)
 /// - End point (x4, y4)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Bezier {
     /// Start point X.
-    pub x1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x1: f64,
     /// Start point Y.
-    pub y1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y1: f64,
     /// Control point 1 X.
-    pub x2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x2: f64,
     /// Control point 1 Y.
-    pub y2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y2: f64,
     /// Control point 2 X.
-    pub x3: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x3: f64,
     /// Control point 2 Y.
-    pub y3: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y3: f64,
     /// End point X.
-    pub x4: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x4: f64,
     /// End point Y.
-    pub y4: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y4: f64,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -650,25 +682,25 @@ impl Bezier {
     /// Creates a new Bezier curve.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
-    pub const fn new(
-        x1: i32,
-        y1: i32,
-        x2: i32,
-        y2: i32,
-        x3: i32,
-        y3: i32,
-        x4: i32,
-        y4: i32,
+    pub fn new(
+        x1: impl Into<f64>,
+        y1: impl Into<f64>,
+        x2: impl Into<f64>,
+        y2: impl Into<f64>,
+        x3: impl Into<f64>,
+        y3: impl Into<f64>,
+        x4: impl Into<f64>,
+        y4: impl Into<f64>,
     ) -> Self {
         Self {
-            x1,
-            y1,
-            x2,
-            y2,
-            x3,
-            y3,
-            x4,
-            y4,
+            x1: x1.into(),
+            y1: y1.into(),
+            x2: x2.into(),
+            y2: y2.into(),
+            x3: x3.into(),
+            y3: y3.into(),
+            x4: x4.into(),
+            y4: y4.into(),
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             is_not_accessible: true,
@@ -679,16 +711,23 @@ impl Bezier {
 }
 
 /// An ellipse.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ellipse {
     /// Centre X coordinate.
-    pub x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Centre Y coordinate.
-    pub y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// X radius (horizontal).
-    pub radius_x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub radius_x: f64,
     /// Y radius (vertical).
-    pub radius_y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub radius_y: f64,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -714,14 +753,19 @@ pub struct Ellipse {
 }
 
 impl Ellipse {
-    /// Creates a new ellipse.
+    /// Creates a new ellipse. Accepts integer or float coordinates.
     #[must_use]
-    pub const fn new(x: i32, y: i32, radius_x: i32, radius_y: i32) -> Self {
+    pub fn new(
+        x: impl Into<f64>,
+        y: impl Into<f64>,
+        radius_x: impl Into<f64>,
+        radius_y: impl Into<f64>,
+    ) -> Self {
         Self {
-            x,
-            y,
-            radius_x,
-            radius_y,
+            x: x.into(),
+            y: y.into(),
+            radius_x: radius_x.into(),
+            radius_y: radius_y.into(),
             line_width: 1,
             line_color: 0x00_00_80, // Dark red (BGR)
             fill_color: 0xB0_FF_FF, // Light yellow (BGR), matches Altium's default AreaColor (11599871)
@@ -734,7 +778,8 @@ impl Ellipse {
 
     /// Creates a new circle (equal radii).
     #[must_use]
-    pub const fn circle(x: i32, y: i32, radius: i32) -> Self {
+    pub fn circle(x: impl Into<f64>, y: impl Into<f64>, radius: impl Into<f64>) -> Self {
+        let (x, y, radius) = (x.into(), y.into(), radius.into());
         Self::new(x, y, radius, radius)
     }
 }
@@ -742,20 +787,28 @@ impl Ellipse {
 /// A rounded rectangle.
 ///
 /// Defined by two corner points and corner radii for rounding.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoundRect {
     /// Left/bottom X coordinate.
-    pub x1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x1: f64,
     /// Left/bottom Y coordinate.
-    pub y1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y1: f64,
     /// Right/top X coordinate.
-    pub x2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x2: f64,
     /// Right/top Y coordinate.
-    pub y2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y2: f64,
     /// Corner X radius (horizontal rounding).
-    pub corner_x_radius: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub corner_x_radius: f64,
     /// Corner Y radius (vertical rounding).
-    pub corner_y_radius: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub corner_y_radius: f64,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -787,21 +840,21 @@ impl RoundRect {
     /// Creates a new rounded rectangle.
     #[must_use]
     #[allow(clippy::similar_names)]
-    pub const fn new(
-        x1: i32,
-        y1: i32,
-        x2: i32,
-        y2: i32,
-        corner_x_radius: i32,
-        corner_y_radius: i32,
+    pub fn new(
+        x1: impl Into<f64>,
+        y1: impl Into<f64>,
+        x2: impl Into<f64>,
+        y2: impl Into<f64>,
+        corner_x_radius: impl Into<f64>,
+        corner_y_radius: impl Into<f64>,
     ) -> Self {
         Self {
-            x1,
-            y1,
-            x2,
-            y2,
-            corner_x_radius,
-            corner_y_radius,
+            x1: x1.into(),
+            y1: y1.into(),
+            x2: x2.into(),
+            y2: y2.into(),
+            corner_x_radius: corner_x_radius.into(),
+            corner_y_radius: corner_y_radius.into(),
             line_width: 1,
             line_color: 0x00_00_80, // Dark red (BGR)
             fill_color: 0xB0_FF_FF, // Light yellow (BGR), matches Altium's default AreaColor (11599871)
@@ -821,9 +874,11 @@ impl RoundRect {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EllipticalArc {
     /// Centre X coordinate.
-    pub x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Centre Y coordinate.
-    pub y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// Primary radius (horizontal).
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub radius: f64,
@@ -861,17 +916,17 @@ pub struct EllipticalArc {
 impl EllipticalArc {
     /// Creates a new elliptical arc.
     #[must_use]
-    pub const fn new(
-        x: i32,
-        y: i32,
+    pub fn new(
+        x: impl Into<f64>,
+        y: impl Into<f64>,
         radius: f64,
         secondary_radius: f64,
         start_angle: f64,
         end_angle: f64,
     ) -> Self {
         Self {
-            x,
-            y,
+            x: x.into(),
+            y: y.into(),
             radius,
             secondary_radius,
             start_angle,
@@ -886,7 +941,12 @@ impl EllipticalArc {
 
     /// Creates a full ellipse (0 to 360 degrees).
     #[must_use]
-    pub const fn full_ellipse(x: i32, y: i32, radius: f64, secondary_radius: f64) -> Self {
+    pub fn full_ellipse(
+        x: impl Into<f64>,
+        y: impl Into<f64>,
+        radius: f64,
+        secondary_radius: f64,
+    ) -> Self {
         Self::new(x, y, radius, secondary_radius, 0.0, 360.0)
     }
 }
@@ -895,9 +955,11 @@ impl EllipticalArc {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Label {
     /// X position.
-    pub x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Y position.
-    pub y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// Text content.
     pub text: String,
     /// Font ID (1-based index into library fonts).
@@ -934,9 +996,11 @@ pub struct Label {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Text {
     /// X position.
-    pub x: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Y position.
-    pub y: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// Text content.
     pub text: String,
     /// Font ID (1-based index into library fonts).
@@ -982,7 +1046,10 @@ const fn default_justification() -> TextJustification {
 }
 
 /// A component parameter (e.g., Value, Part Number).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Coordinates are `f64` schematic units (see [`super::coord`]); `Eq` is not
+/// derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Parameter {
     /// Parameter name (e.g., "Value", "Part Number").
     pub name: String,
@@ -990,11 +1057,11 @@ pub struct Parameter {
     #[serde(default)]
     pub value: String,
     /// X position.
-    #[serde(default)]
-    pub x: i32,
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub x: f64,
     /// Y position.
-    #[serde(default)]
-    pub y: i32,
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub y: f64,
     /// Font ID.
     #[serde(default = "default_font_id")]
     pub font_id: u8,
@@ -1026,8 +1093,8 @@ impl Parameter {
         Self {
             name: name.into(),
             value: value.into(),
-            x: 0,
-            y: 0,
+            x: 0.0,
+            y: 0.0,
             font_id: 1,
             color: 0x80_00_00, // Dark blue (BGR)
             hidden: false,

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -431,16 +431,24 @@ impl Rectangle {
 }
 
 /// A line segment.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Coordinates are `f64` schematic units: Altium stores the integer part plus an
+/// optional `…_Frac` companion (see [`super::coord`]), so a line endpoint can sit
+/// off the integer grid. `Eq` is therefore not derived (floats are only `PartialEq`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Line {
     /// Start X coordinate.
-    pub x1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x1: f64,
     /// Start Y coordinate.
-    pub y1: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y1: f64,
     /// End X coordinate.
-    pub x2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub x2: f64,
     /// End Y coordinate.
-    pub y2: i32,
+    #[serde(serialize_with = "crate::altium::serde_round::serialize")]
+    pub y2: f64,
     /// Line width.
     #[serde(default = "default_line_width")]
     pub line_width: u8,
@@ -464,14 +472,20 @@ pub struct Line {
 }
 
 impl Line {
-    /// Creates a new line.
+    /// Creates a new line. Accepts integer or float coordinates (`impl Into<f64>`),
+    /// so existing integer-literal call sites keep working.
     #[must_use]
-    pub const fn new(x1: i32, y1: i32, x2: i32, y2: i32) -> Self {
+    pub fn new(
+        x1: impl Into<f64>,
+        y1: impl Into<f64>,
+        x2: impl Into<f64>,
+        y2: impl Into<f64>,
+    ) -> Self {
         Self {
-            x1,
-            y1,
-            x2,
-            y2,
+            x1: x1.into(),
+            y1: y1.into(),
+            x2: x2.into(),
+            y2: y2.into(),
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             line_style: 0,

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -437,10 +437,11 @@ fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
 /// Parses a line from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_line(props: &HashMap<String, String>) -> Option<Line> {
-    let x1 = coord(props, "location.x");
-    let y1 = coord(props, "location.y");
-    let x2 = coord(props, "corner.x");
-    let y2 = coord(props, "corner.y");
+    // Each coordinate may carry a `…_Frac` companion (off-grid endpoints).
+    let x1 = crate::altium::schlib::coord::read(props, "location.x");
+    let y1 = crate::altium::schlib::coord::read(props, "location.y");
+    let x2 = crate::altium::schlib::coord::read(props, "corner.x");
+    let y2 = crate::altium::schlib::coord::read(props, "corner.y");
 
     let line_width = props
         .get("linewidth")

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -371,31 +371,13 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     })
 }
 
-/// Parses a numeric coordinate property, defaulting to zero when the key is
-/// absent or unparseable.
-///
-/// Altium omits zero-valued coordinates from a record's pipe-delimited text
-/// (`AddCoordParam` skips zeros), so a missing `Location.X` / `Corner.Y` /
-/// `Radius` / `X{n}` key means the value is zero — **not** a malformed record.
-/// Treating a missing key as fatal (the old `?` behaviour) silently dropped any
-/// shape that happened to sit on a zero coordinate.
-fn coord<T>(props: &HashMap<String, String>, key: &str) -> T
-where
-    T: std::str::FromStr + Default,
-{
-    props
-        .get(key)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_default()
-}
-
 /// Parses a rectangle from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
-    let x1 = coord(props, "location.x");
-    let y1 = coord(props, "location.y");
-    let x2 = coord(props, "corner.x");
-    let y2 = coord(props, "corner.y");
+    let x1 = crate::altium::schlib::coord::read(props, "location.x");
+    let y1 = crate::altium::schlib::coord::read(props, "location.y");
+    let x2 = crate::altium::schlib::coord::read(props, "corner.x");
+    let y2 = crate::altium::schlib::coord::read(props, "corner.y");
 
     let line_width = props
         .get("linewidth")
@@ -479,14 +461,8 @@ fn parse_parameter(props: &HashMap<String, String>) -> Option<Parameter> {
     let name = props.get("name")?.clone();
     let value = props.get("text").cloned().unwrap_or_default();
 
-    let x = props
-        .get("location.x")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let y = props
-        .get("location.y")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
     let font_id = props
         .get("fontid")
         .and_then(|s| s.parse().ok())
@@ -540,8 +516,8 @@ fn parse_polyline(props: &HashMap<String, String>) -> Option<Polyline> {
     for i in 1..=location_count {
         let x_key = format!("x{i}");
         let y_key = format!("y{i}");
-        let x = coord(props, &x_key);
-        let y = coord(props, &y_key);
+        let x = crate::altium::schlib::coord::read(props, &x_key);
+        let y = crate::altium::schlib::coord::read(props, &y_key);
         points.push((x, y));
     }
 
@@ -602,8 +578,8 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
     for i in 1..=location_count {
         let x_key = format!("x{i}");
         let y_key = format!("y{i}");
-        let x = coord(props, &x_key);
-        let y = coord(props, &y_key);
+        let x = crate::altium::schlib::coord::read(props, &x_key);
+        let y = crate::altium::schlib::coord::read(props, &y_key);
         points.push((x, y));
     }
 
@@ -636,14 +612,15 @@ fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> {
 /// Parses an ellipse from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
-    let x = coord(props, "location.x");
-    let y = coord(props, "location.y");
-    let radius_x = coord(props, "radius");
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
+    let radius_x = crate::altium::schlib::coord::read(props, "radius");
     // Secondary radius, defaults to radius for circles
-    let radius_y = props
-        .get("secondaryradius")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(radius_x);
+    let radius_y = if props.contains_key("secondaryradius") {
+        crate::altium::schlib::coord::read(props, "secondaryradius")
+    } else {
+        radius_x
+    };
 
     let line_width = props
         .get("linewidth")
@@ -679,9 +656,9 @@ fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> {
 /// Parses an arc from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
-    let x = coord(props, "location.x");
-    let y = coord(props, "location.y");
-    let radius = coord(props, "radius");
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
+    let radius = crate::altium::schlib::coord::read(props, "radius");
 
     let start_angle = props
         .get("startangle")
@@ -725,14 +702,14 @@ fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
     // Bezier curves have 4 control points: X1,Y1 through X4,Y4
-    let x1 = coord(props, "x1");
-    let y1 = coord(props, "y1");
-    let x2 = coord(props, "x2");
-    let y2 = coord(props, "y2");
-    let x3 = coord(props, "x3");
-    let y3 = coord(props, "y3");
-    let x4 = coord(props, "x4");
-    let y4 = coord(props, "y4");
+    let x1 = crate::altium::schlib::coord::read(props, "x1");
+    let y1 = crate::altium::schlib::coord::read(props, "y1");
+    let x2 = crate::altium::schlib::coord::read(props, "x2");
+    let y2 = crate::altium::schlib::coord::read(props, "y2");
+    let x3 = crate::altium::schlib::coord::read(props, "x3");
+    let y3 = crate::altium::schlib::coord::read(props, "y3");
+    let x4 = crate::altium::schlib::coord::read(props, "x4");
+    let y4 = crate::altium::schlib::coord::read(props, "y4");
 
     let line_width = props
         .get("linewidth")
@@ -768,19 +745,13 @@ fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
 #[allow(clippy::similar_names)]
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
-    let x1 = coord(props, "location.x");
-    let y1 = coord(props, "location.y");
-    let x2 = coord(props, "corner.x");
-    let y2 = coord(props, "corner.y");
+    let x1 = crate::altium::schlib::coord::read(props, "location.x");
+    let y1 = crate::altium::schlib::coord::read(props, "location.y");
+    let x2 = crate::altium::schlib::coord::read(props, "corner.x");
+    let y2 = crate::altium::schlib::coord::read(props, "corner.y");
 
-    let corner_x_radius = props
-        .get("cornerxradius")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let corner_y_radius = props
-        .get("corneryradius")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    let corner_x_radius = crate::altium::schlib::coord::read(props, "cornerxradius");
+    let corner_y_radius = crate::altium::schlib::coord::read(props, "corneryradius");
 
     let line_width = props
         .get("linewidth")
@@ -823,12 +794,8 @@ fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundRect> {
 /// Parses an elliptical arc from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc> {
-    let x = coord(props, "location.x");
-    // Location.Y may be omitted if it's 0
-    let y = props
-        .get("location.y")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
 
     // Primary radius with optional fractional part (`Radius` + `Radius_Frac`).
     let radius = crate::altium::schlib::coord::read(props, "radius");
@@ -882,8 +849,8 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
 /// Parses a label from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
-    let x = coord(props, "location.x");
-    let y = coord(props, "location.y");
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
     let text = props.get("text").cloned().unwrap_or_default();
 
     let font_id = props
@@ -924,8 +891,8 @@ fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
 /// Parses a text annotation from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_text(props: &HashMap<String, String>) -> Option<Text> {
-    let x = coord(props, "location.x");
-    let y = coord(props, "location.y");
+    let x = crate::altium::schlib::coord::read(props, "location.x");
+    let y = crate::altium::schlib::coord::read(props, "location.y");
     let text = props.get("text").cloned().unwrap_or_default();
 
     let font_id = props
@@ -1035,10 +1002,10 @@ mod tests {
             "|RECORD=14|Location.X=-10|Location.Y=-4|Corner.X=10|Corner.Y=4|LineWidth=1|",
         );
         let rect = parse_rectangle(&props).unwrap();
-        assert_eq!(rect.x1, -10);
-        assert_eq!(rect.y1, -4);
-        assert_eq!(rect.x2, 10);
-        assert_eq!(rect.y2, 4);
+        assert_eq!(
+            (rect.x1, rect.y1, rect.x2, rect.y2),
+            (-10.0, -4.0, 10.0, 4.0)
+        );
     }
 
     #[test]
@@ -1050,13 +1017,13 @@ mod tests {
             "|RECORD=14|Corner.X=10|Corner.Y=4|", // Location.X / Location.Y omitted (== 0)
         ))
         .expect("rectangle with omitted zero Location must not be dropped");
-        assert_eq!((rect.x1, rect.y1, rect.x2, rect.y2), (0, 0, 10, 4));
+        assert_eq!((rect.x1, rect.y1, rect.x2, rect.y2), (0.0, 0.0, 10.0, 4.0));
 
         let arc = parse_arc(&parse_properties(
             "|RECORD=12|Radius=20|StartAngle=0|EndAngle=90|", // Location.X / Location.Y omitted
         ))
         .expect("arc with omitted zero Location must not be dropped");
-        assert_eq!((arc.x, arc.y, arc.radius), (0, 0, 20));
+        assert_eq!((arc.x, arc.y, arc.radius), (0.0, 0.0, 20.0));
     }
 
     #[test]

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -829,24 +829,16 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
-    // Primary radius with optional fractional part
-    let radius_int: f64 = coord(props, "radius");
-    let radius_frac: f64 = props
-        .get("radius_frac")
-        .and_then(|s| s.parse::<u32>().ok())
-        .map_or(0.0, |f| f64::from(f) / 100_000.0);
-    let radius = radius_int + radius_frac;
+    // Primary radius with optional fractional part (`Radius` + `Radius_Frac`).
+    let radius = crate::altium::schlib::coord::read(props, "radius");
 
-    // Secondary radius with optional fractional part
-    let secondary_radius_int: f64 = props
-        .get("secondaryradius")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(radius_int);
-    let secondary_radius_frac: f64 = props
-        .get("secondaryradius_frac")
-        .and_then(|s| s.parse::<u32>().ok())
-        .map_or(0.0, |f| f64::from(f) / 100_000.0);
-    let secondary_radius = secondary_radius_int + secondary_radius_frac;
+    // Secondary radius with optional fractional part; defaults to the primary
+    // radius when absent (a circular arc).
+    let secondary_radius = if props.contains_key("secondaryradius") {
+        crate::altium::schlib::coord::read(props, "secondaryradius")
+    } else {
+        radius
+    };
 
     let start_angle = props
         .get("startangle")

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -19,6 +19,7 @@
 //! - `0x0000`: Text record (pipe-delimited key=value pairs)
 //! - `0x0001`: Binary pin record
 
+use super::coord;
 use super::primitives::{
     Arc, Bezier, Ellipse, EllipticalArc, FootprintModel, Label, Line, Parameter, Pin, Polygon,
     Polyline, Rectangle, RoundRect, Text, TextJustification,
@@ -579,20 +580,12 @@ fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
 }
 
 /// Encodes an elliptical arc record.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn encode_elliptical_arc(arc: &EllipticalArc, index: usize) -> String {
-    // Split each radius from a single rounded raw integer (`raw = round(r * 100_000)`)
-    // so a near-boundary value carries into the integer part exactly, matching
-    // AltiumSharp's `AddCoordParam` — rather than the old `trunc`/`fract` split, which
-    // clamped e.g. 4.999995 to `Radius=4|Radius_Frac=99999` instead of `Radius=5`.
-    // Radii are non-negative, so `raw % 100_000` is non-negative.
-    let radius_raw = (arc.radius * 100_000.0).round() as i64;
-    let radius_int = (radius_raw / 100_000) as i32;
-    let radius_frac = (radius_raw % 100_000) as u32;
-
-    let secondary_raw = (arc.secondary_radius * 100_000.0).round() as i64;
-    let secondary_radius_int = (secondary_raw / 100_000) as i32;
-    let secondary_radius_frac = (secondary_raw % 100_000) as u32;
+    // Split each radius into the integer part plus a non-negative `_Frac`
+    // companion (scaled by 100,000), carrying near-boundary values into the
+    // integer part. See [`super::coord`] for the shared encoding.
+    let (radius_int, radius_frac) = coord::split(arc.radius);
+    let (secondary_radius_int, secondary_radius_frac) = coord::split(arc.secondary_radius);
 
     format!(
         "|RECORD=11|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -328,15 +328,25 @@ fn encode_line(line: &Line, index: usize) -> String {
         ""
     };
     let line_style = nonzero("LineStyle", u32::from(line.line_style));
+    // Each coordinate is an integer part plus a non-negative `…_Frac` companion;
+    // the fraction is omitted when zero, so integer-grid lines stay byte-identical.
+    let (x1, x1_frac) = coord::split(line.x1);
+    let (y1, y1_frac) = coord::split(line.y1);
+    let (x2, x2_frac) = coord::split(line.x2);
+    let (y2, y2_frac) = coord::split(line.y2);
     format!(
-        "|RECORD=13|IndexInSheet={}|OwnerPartId={}{}|Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}|LineWidth={}{}{}|UniqueID={}",
+        "|RECORD=13|IndexInSheet={}|OwnerPartId={}{}|Location.X={}{}|Location.Y={}{}|Corner.X={}{}|Corner.Y={}{}|LineWidth={}{}{}|UniqueID={}",
         index,
         line.owner_part_id,
         not_accessible,
-        line.x1,
-        line.y1,
-        line.x2,
-        line.y2,
+        x1,
+        nonzero("Location.X_Frac", x1_frac),
+        y1,
+        nonzero("Location.Y_Frac", y1_frac),
+        x2,
+        nonzero("Corner.X_Frac", x2_frac),
+        y2,
+        nonzero("Corner.Y_Frac", y2_frac),
         line.line_width,
         nonzero("Color", line.color),
         line_style,
@@ -1314,5 +1324,39 @@ mod tests {
         );
         assert!(!s.contains("Color="), "zero text Color omitted: {s}");
         assert!(!s.contains("=F"), "text never emits a boolean =F: {s}");
+    }
+
+    #[test]
+    fn encode_line_omits_frac_for_integer_coords() {
+        // Byte-identity: an integer-grid line must emit its coordinates plainly
+        // with no `_Frac` companion, so existing files are unchanged by the
+        // f64 coordinate migration.
+        let s = encode_line(&Line::new(-10, 0, 10, 0), 1);
+        assert!(
+            s.contains("|Location.X=-10|"),
+            "integer X emitted plainly: {s}"
+        );
+        assert!(s.contains("|Corner.X=10|"), "integer corner X plainly: {s}");
+        assert!(
+            !s.contains("_Frac"),
+            "an integer-grid line must emit no _Frac token: {s}"
+        );
+    }
+
+    #[test]
+    fn encode_line_emits_frac_for_fractional_and_negative_coords() {
+        // Floor split: -28.995 -> Location.X=-29 with Location.X_Frac=500; the
+        // positive 7.5 -> 7 + 50000. This is the capability the integer field
+        // could not represent at all.
+        let mut line = Line::new(-28.995, 7.5, 0, 0);
+        line.unique_id = Some("ABCD1234".to_string());
+        let s = encode_line(&line, 1);
+        assert!(s.contains("|Location.X=-29|"), "floor integer part: {s}");
+        assert!(
+            s.contains("|Location.X_Frac=500|"),
+            "non-negative fractional part: {s}"
+        );
+        assert!(s.contains("|Location.Y=7|"), "Y integer part: {s}");
+        assert!(s.contains("|Location.Y_Frac=50000|"), "Y fractional: {s}");
     }
 }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -291,6 +291,33 @@ fn nonzero(key: &str, value: u32) -> String {
     }
 }
 
+/// Emits an Altium coordinate parameter: `|<key>=<int>` followed by
+/// `|<key>_Frac=<frac>` when the fractional part is non-zero (omitted otherwise,
+/// so integer-grid coordinates stay byte-identical to pre-fractional output).
+/// See [`super::coord`] for the integer/fraction split.
+fn coord_param(key: &str, value: f64) -> String {
+    let (int, frac) = coord::split(value);
+    format!("|{key}={int}{}", nonzero(&format!("{key}_Frac"), frac))
+}
+
+/// Pushes a numbered polyline/polygon vertex (`X{n}`/`Y{n}`) into a `parts`
+/// vector that is later joined by `|`, emitting `X{n}_Frac`/`Y{n}_Frac` only when
+/// the fractional part is non-zero. Mirrors [`coord_param`] for the list-style
+/// records that build their text from `parts.join("|")`.
+#[allow(clippy::similar_names)] // xi/yi/xf/yf are the obvious names for the split parts
+fn push_point(parts: &mut Vec<String>, n: usize, x: f64, y: f64) {
+    let (xi, xf) = coord::split(x);
+    let (yi, yf) = coord::split(y);
+    parts.push(format!("X{n}={xi}"));
+    if xf != 0 {
+        parts.push(format!("X{n}_Frac={xf}"));
+    }
+    parts.push(format!("Y{n}={yi}"));
+    if yf != 0 {
+        parts.push(format!("Y{n}_Frac={yf}"));
+    }
+}
+
 /// Encodes a rectangle record.
 fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
     let transparent = if rect.transparent { "T" } else { "F" };
@@ -301,14 +328,14 @@ fn encode_rectangle(rect: &Rectangle, index: usize) -> String {
     let line_style = nonzero("LineStyleExt", u32::from(rect.line_style));
     format!(
         "|RECORD=14|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
-         |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
+         {}{}{}{}\
          |LineWidth={}{}{}{}{}|Transparent={}|UniqueID={}",
         index,
         rect.owner_part_id,
-        rect.x1,
-        rect.y1,
-        rect.x2,
-        rect.y2,
+        coord_param("Location.X", rect.x1),
+        coord_param("Location.Y", rect.y1),
+        coord_param("Corner.X", rect.x2),
+        coord_param("Corner.Y", rect.y2),
         rect.line_width,
         nonzero("Color", rect.line_color),
         nonzero("AreaColor", rect.fill_color),
@@ -328,25 +355,15 @@ fn encode_line(line: &Line, index: usize) -> String {
         ""
     };
     let line_style = nonzero("LineStyle", u32::from(line.line_style));
-    // Each coordinate is an integer part plus a non-negative `…_Frac` companion;
-    // the fraction is omitted when zero, so integer-grid lines stay byte-identical.
-    let (x1, x1_frac) = coord::split(line.x1);
-    let (y1, y1_frac) = coord::split(line.y1);
-    let (x2, x2_frac) = coord::split(line.x2);
-    let (y2, y2_frac) = coord::split(line.y2);
     format!(
-        "|RECORD=13|IndexInSheet={}|OwnerPartId={}{}|Location.X={}{}|Location.Y={}{}|Corner.X={}{}|Corner.Y={}{}|LineWidth={}{}{}|UniqueID={}",
+        "|RECORD=13|IndexInSheet={}|OwnerPartId={}{}{}{}{}{}|LineWidth={}{}{}|UniqueID={}",
         index,
         line.owner_part_id,
         not_accessible,
-        x1,
-        nonzero("Location.X_Frac", x1_frac),
-        y1,
-        nonzero("Location.Y_Frac", y1_frac),
-        x2,
-        nonzero("Corner.X_Frac", x2_frac),
-        y2,
-        nonzero("Corner.Y_Frac", y2_frac),
+        coord_param("Location.X", line.x1),
+        coord_param("Location.Y", line.y1),
+        coord_param("Corner.X", line.x2),
+        coord_param("Corner.Y", line.y2),
         line.line_width,
         nonzero("Color", line.color),
         line_style,
@@ -359,16 +376,26 @@ fn encode_line(line: &Line, index: usize) -> String {
 /// Follows Altium's conventions: `IsHidden` is emitted only when hidden (never
 /// `=F`), `ReadOnlyState` / `ParamType` only when non-zero, `Text` only when
 /// non-empty, and the read `UniqueID` is preserved.
+#[allow(clippy::similar_names)] // px/py are the obvious names for the x/y integer parts
 fn encode_parameter(param: &Parameter, index: usize) -> String {
+    let (px, px_frac) = coord::split(param.x);
+    let (py, py_frac) = coord::split(param.y);
     let mut parts = vec![
         "RECORD=41".to_string(),
         format!("IndexInSheet={index}"),
         format!("OwnerPartId={}", param.owner_part_id),
-        format!("Location.X={}", param.x),
-        format!("Location.Y={}", param.y),
+        format!("Location.X={px}"),
+        format!("Location.Y={py}"),
         format!("Color={}", param.color),
         format!("FontID={}", param.font_id),
     ];
+    // Fractional companions (omitted when zero, so integer positions are unchanged).
+    if px_frac != 0 {
+        parts.push(format!("Location.X_Frac={px_frac}"));
+    }
+    if py_frac != 0 {
+        parts.push(format!("Location.Y_Frac={py_frac}"));
+    }
     if param.hidden {
         parts.push("IsHidden=T".to_string());
     }
@@ -418,8 +445,7 @@ fn encode_polyline(polyline: &Polyline, index: usize) -> String {
     ]);
 
     for (i, (x, y)) in polyline.points.iter().enumerate() {
-        parts.push(format!("X{}={}", i + 1, x));
-        parts.push(format!("Y{}={}", i + 1, y));
+        push_point(&mut parts, i + 1, *x, *y);
     }
 
     // Altium emits Transparent only when true; absent means opaque.
@@ -461,8 +487,7 @@ fn encode_polygon(polygon: &Polygon, index: usize) -> String {
     parts.push(format!("LocationCount={}", polygon.points.len()));
 
     for (i, (x, y)) in polygon.points.iter().enumerate() {
-        parts.push(format!("X{}={}", i + 1, x));
-        parts.push(format!("Y{}={}", i + 1, y));
+        push_point(&mut parts, i + 1, *x, *y);
     }
 
     parts.push(format!(
@@ -482,13 +507,13 @@ fn encode_arc(arc: &Arc, index: usize) -> String {
         ""
     };
     format!(
-        "|RECORD=12|IndexInSheet={}|OwnerPartId={}{}|Location.X={}|Location.Y={}|Radius={}|StartAngle={}|EndAngle={}|LineWidth={}{}{}|UniqueID={}",
+        "|RECORD=12|IndexInSheet={}|OwnerPartId={}{}{}{}{}|StartAngle={}|EndAngle={}|LineWidth={}{}{}|UniqueID={}",
         index,
         arc.owner_part_id,
         not_accessible,
-        arc.x,
-        arc.y,
-        arc.radius,
+        coord_param("Location.X", arc.x),
+        coord_param("Location.Y", arc.y),
+        coord_param("Radius", arc.radius),
         arc.start_angle,
         arc.end_angle,
         arc.line_width,
@@ -507,20 +532,20 @@ fn encode_bezier(bezier: &Bezier, index: usize) -> String {
         ""
     };
     format!(
-        "|RECORD=5|IndexInSheet={}|OwnerPartId={}{}|LineWidth={}{}|LocationCount=4|X1={}|Y1={}|X2={}|Y2={}|X3={}|Y3={}|X4={}|Y4={}|UniqueID={}",
+        "|RECORD=5|IndexInSheet={}|OwnerPartId={}{}|LineWidth={}{}|LocationCount=4{}{}{}{}{}{}{}{}|UniqueID={}",
         index,
         bezier.owner_part_id,
         not_accessible,
         bezier.line_width,
         nonzero("Color", bezier.color),
-        bezier.x1,
-        bezier.y1,
-        bezier.x2,
-        bezier.y2,
-        bezier.x3,
-        bezier.y3,
-        bezier.x4,
-        bezier.y4,
+        coord_param("X1", bezier.x1),
+        coord_param("Y1", bezier.y1),
+        coord_param("X2", bezier.x2),
+        coord_param("Y2", bezier.y2),
+        coord_param("X3", bezier.x3),
+        coord_param("Y3", bezier.y3),
+        coord_param("X4", bezier.x4),
+        coord_param("Y4", bezier.y4),
         bezier.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
@@ -536,13 +561,13 @@ fn encode_ellipse(ellipse: &Ellipse, index: usize) -> String {
         ""
     };
     format!(
-        "|RECORD=8|IndexInSheet={}|OwnerPartId={}|Location.X={}|Location.Y={}|Radius={}|SecondaryRadius={}|LineWidth={}{}{}{}{}|UniqueID={}",
+        "|RECORD=8|IndexInSheet={}|OwnerPartId={}{}{}{}{}|LineWidth={}{}{}{}{}|UniqueID={}",
         index,
         ellipse.owner_part_id,
-        ellipse.x,
-        ellipse.y,
-        ellipse.radius_x,
-        ellipse.radius_y,
+        coord_param("Location.X", ellipse.x),
+        coord_param("Location.Y", ellipse.y),
+        coord_param("Radius", ellipse.radius_x),
+        coord_param("SecondaryRadius", ellipse.radius_y),
         ellipse.line_width,
         nonzero("Color", ellipse.line_color),
         nonzero("AreaColor", ellipse.fill_color),
@@ -565,17 +590,17 @@ fn encode_round_rect(round_rect: &RoundRect, index: usize) -> String {
     };
     format!(
         "|RECORD=10|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
-         |Location.X={}|Location.Y={}|Corner.X={}|Corner.Y={}\
-         |CornerXRadius={}|CornerYRadius={}\
+         {}{}{}{}\
+         {}{}\
          |LineWidth={}{}{}{}{}{}|UniqueID={}",
         index,
         round_rect.owner_part_id,
-        round_rect.x1,
-        round_rect.y1,
-        round_rect.x2,
-        round_rect.y2,
-        round_rect.corner_x_radius,
-        round_rect.corner_y_radius,
+        coord_param("Location.X", round_rect.x1),
+        coord_param("Location.Y", round_rect.y1),
+        coord_param("Corner.X", round_rect.x2),
+        coord_param("Corner.Y", round_rect.y2),
+        coord_param("CornerXRadius", round_rect.corner_x_radius),
+        coord_param("CornerYRadius", round_rect.corner_y_radius),
         round_rect.line_width,
         nonzero("Color", round_rect.line_color),
         nonzero("AreaColor", round_rect.fill_color),
@@ -599,15 +624,15 @@ fn encode_elliptical_arc(arc: &EllipticalArc, index: usize) -> String {
 
     format!(
         "|RECORD=11|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T\
-         |Location.X={}|Location.Y={}\
+         {}{}\
          |Radius={}{}\
          |SecondaryRadius={}{}\
          |StartAngle={}|EndAngle={}\
          |LineWidth={}{}{}|UniqueID={}",
         index,
         arc.owner_part_id,
-        arc.x,
-        arc.y,
+        coord_param("Location.X", arc.x),
+        coord_param("Location.Y", arc.y),
         radius_int,
         nonzero("Radius_Frac", radius_frac),
         secondary_radius_int,
@@ -634,11 +659,11 @@ fn encode_label(label: &Label, index: usize) -> String {
     };
     let is_hidden = if label.is_hidden { "|IsHidden=T" } else { "" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|Location.X={}|Location.Y={}{}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
         index,
         label.owner_part_id,
-        label.x,
-        label.y,
+        coord_param("Location.X", label.x),
+        coord_param("Location.Y", label.y),
         nonzero("Color", label.color),
         label.font_id,
         orientation,
@@ -663,11 +688,11 @@ fn encode_text(text: &Text, index: usize) -> String {
     };
     let is_hidden = if text.is_hidden { "|IsHidden=T" } else { "" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T|Location.X={}|Location.Y={}{}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
         index,
         text.owner_part_id,
-        text.x,
-        text.y,
+        coord_param("Location.X", text.x),
+        coord_param("Location.Y", text.y),
         nonzero("Color", text.color),
         text.font_id,
         orientation,
@@ -1231,8 +1256,8 @@ mod tests {
     #[test]
     fn test_label_booleans_only_when_true() {
         let mut label = Label {
-            x: 0,
-            y: 0,
+            x: 0.0,
+            y: 0.0,
             text: "R".to_string(),
             font_id: 1,
             color: 0,
@@ -1261,9 +1286,9 @@ mod tests {
     #[test]
     fn test_arc_tags_is_not_accessible() {
         let arc = Arc {
-            x: 0,
-            y: 0,
-            radius: 10,
+            x: 0.0,
+            y: 0.0,
+            radius: 10.0,
             is_not_accessible: true,
             start_angle: 0.0,
             end_angle: 360.0,
@@ -1284,9 +1309,9 @@ mod tests {
     fn test_colour_omitted_when_zero() {
         // Altium omits Color / AreaColor when 0 (AddNonZero); emits them otherwise.
         let mut arc = Arc {
-            x: 0,
-            y: 0,
-            radius: 10,
+            x: 0.0,
+            y: 0.0,
+            radius: 10.0,
             is_not_accessible: true,
             start_angle: 0.0,
             end_angle: 360.0,
@@ -1308,8 +1333,8 @@ mod tests {
 
         let s = encode_text(
             &Text {
-                x: 0,
-                y: 0,
+                x: 0.0,
+                y: 0.0,
                 text: "hi".to_string(),
                 font_id: 1,
                 color: 0,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1032,14 +1032,15 @@ mod tests {
 
     #[test]
     fn validate_schlib_coordinate_boundary() {
-        assert!(McpServer::validate_schlib_coordinate(32000, "x").is_ok());
-        assert!(McpServer::validate_schlib_coordinate(-32000, "x").is_ok());
-        assert!(McpServer::validate_schlib_coordinate(32001, "x").is_err());
-        assert!(McpServer::validate_schlib_coordinate(-32001, "x").is_err());
-        // Extremes must be rejected without panicking: `value.abs()` overflowed
-        // on i32::MIN (panic in debug, wrap-negative bypass in release).
-        assert!(McpServer::validate_schlib_coordinate(i32::MIN, "x").is_err());
-        assert!(McpServer::validate_schlib_coordinate(i32::MAX, "x").is_err());
+        assert!(McpServer::validate_schlib_coordinate(32000.0, "x").is_ok());
+        assert!(McpServer::validate_schlib_coordinate(-32000.0, "x").is_ok());
+        assert!(McpServer::validate_schlib_coordinate(32001.0, "x").is_err());
+        assert!(McpServer::validate_schlib_coordinate(-32001.0, "x").is_err());
+        // Fractional in-range coordinate is accepted.
+        assert!(McpServer::validate_schlib_coordinate(-28.995, "x").is_ok());
+        // Non-finite coordinates must be rejected.
+        assert!(McpServer::validate_schlib_coordinate(f64::NAN, "x").is_err());
+        assert!(McpServer::validate_schlib_coordinate(f64::INFINITY, "x").is_err());
     }
 
     #[test]
@@ -1142,13 +1143,13 @@ mod tests {
 
             #[test]
             fn schlib_coordinate_in_range_always_accepts(v in -32000i32..=32000) {
-                prop_assert!(McpServer::validate_schlib_coordinate(v, "x").is_ok());
+                prop_assert!(McpServer::validate_schlib_coordinate(f64::from(v), "x").is_ok());
             }
 
             #[test]
             fn schlib_coordinate_out_of_range_always_rejects(v in 32001i32..i32::MAX) {
-                prop_assert!(McpServer::validate_schlib_coordinate(v, "x").is_err());
-                prop_assert!(McpServer::validate_schlib_coordinate(-v, "x").is_err());
+                prop_assert!(McpServer::validate_schlib_coordinate(f64::from(v), "x").is_err());
+                prop_assert!(McpServer::validate_schlib_coordinate(f64::from(-v), "x").is_err());
             }
         }
     }

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -421,10 +421,10 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x1": { "type": "integer", "description": "Left X coordinate" },
-                                                "y1": { "type": "integer", "description": "Bottom Y coordinate" },
-                                                "x2": { "type": "integer", "description": "Right X coordinate" },
-                                                "y2": { "type": "integer", "description": "Top Y coordinate" },
+                                                "x1": { "type": "number", "description": "Left X coordinate" },
+                                                "y1": { "type": "number", "description": "Bottom Y coordinate" },
+                                                "x2": { "type": "number", "description": "Right X coordinate" },
+                                                "y2": { "type": "number", "description": "Top Y coordinate" },
                                                 "line_width": { "type": "integer", "description": "Border width. Default: 1" },
                                                 "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
                                                 "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
@@ -440,12 +440,12 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x1": { "type": "integer", "description": "Left X coordinate" },
-                                                "y1": { "type": "integer", "description": "Bottom Y coordinate" },
-                                                "x2": { "type": "integer", "description": "Right X coordinate" },
-                                                "y2": { "type": "integer", "description": "Top Y coordinate" },
-                                                "corner_x_radius": { "type": "integer", "description": "Horizontal corner radius. Default: 0" },
-                                                "corner_y_radius": { "type": "integer", "description": "Vertical corner radius. Default: 0" },
+                                                "x1": { "type": "number", "description": "Left X coordinate" },
+                                                "y1": { "type": "number", "description": "Bottom Y coordinate" },
+                                                "x2": { "type": "number", "description": "Right X coordinate" },
+                                                "y2": { "type": "number", "description": "Top Y coordinate" },
+                                                "corner_x_radius": { "type": "number", "description": "Horizontal corner radius. Default: 0" },
+                                                "corner_y_radius": { "type": "number", "description": "Vertical corner radius. Default: 0" },
                                                 "line_width": { "type": "integer", "description": "Border width. Default: 1" },
                                                 "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
                                                 "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
@@ -461,10 +461,10 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x1": { "type": "integer", "description": "Start X coordinate" },
-                                                "y1": { "type": "integer", "description": "Start Y coordinate" },
-                                                "x2": { "type": "integer", "description": "End X coordinate" },
-                                                "y2": { "type": "integer", "description": "End Y coordinate" },
+                                                "x1": { "type": "number", "description": "Start X coordinate" },
+                                                "y1": { "type": "number", "description": "Start Y coordinate" },
+                                                "x2": { "type": "number", "description": "End X coordinate" },
+                                                "y2": { "type": "number", "description": "End Y coordinate" },
                                                 "line_width": { "type": "integer", "description": "Line width. Default: 1" },
                                                 "color": { "type": "integer", "description": "Line BGR colour. Default: 0x000080" },
                                                 "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" }
@@ -484,8 +484,8 @@ impl McpServer {
                                                     "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                            "x": { "type": "integer" },
-                                                            "y": { "type": "integer" }
+                                                            "x": { "type": "number" },
+                                                            "y": { "type": "number" }
                                                         },
                                                         "required": ["x", "y"]
                                                     }
@@ -505,9 +505,9 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x": { "type": "integer", "description": "Centre X coordinate" },
-                                                "y": { "type": "integer", "description": "Centre Y coordinate" },
-                                                "radius": { "type": "integer", "description": "Radius in schematic units" },
+                                                "x": { "type": "number", "description": "Centre X coordinate" },
+                                                "y": { "type": "number", "description": "Centre Y coordinate" },
+                                                "radius": { "type": "number", "description": "Radius in schematic units" },
                                                 "start_angle": { "type": "number", "description": "Start angle in degrees (0 = right, CCW). Default: 0" },
                                                 "end_angle": { "type": "number", "description": "End angle in degrees. Default: 360 (full circle)" },
                                                 "line_width": { "type": "integer", "description": "Line width. Default: 1" },
@@ -523,10 +523,10 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x": { "type": "integer", "description": "Centre X coordinate" },
-                                                "y": { "type": "integer", "description": "Centre Y coordinate" },
-                                                "radius_x": { "type": "integer", "description": "Horizontal radius" },
-                                                "radius_y": { "type": "integer", "description": "Vertical radius" },
+                                                "x": { "type": "number", "description": "Centre X coordinate" },
+                                                "y": { "type": "number", "description": "Centre Y coordinate" },
+                                                "radius_x": { "type": "number", "description": "Horizontal radius" },
+                                                "radius_y": { "type": "number", "description": "Vertical radius" },
                                                 "line_width": { "type": "integer", "description": "Border width. Default: 1" },
                                                 "line_color": { "type": "integer", "description": "Border BGR colour. Default: 0x000080" },
                                                 "fill_color": { "type": "integer", "description": "Fill BGR colour. Default: 0xB0FFFF (Altium light yellow)" },
@@ -542,8 +542,8 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x": { "type": "integer", "description": "X position" },
-                                                "y": { "type": "integer", "description": "Y position" },
+                                                "x": { "type": "number", "description": "X position" },
+                                                "y": { "type": "number", "description": "Y position" },
                                                 "text": { "type": "string", "description": "Text content" },
                                                 "font_id": { "type": "integer", "description": "Font ID. Default: 1" },
                                                 "color": { "type": "integer", "description": "BGR colour. Default: 0x000080" },
@@ -562,8 +562,8 @@ impl McpServer {
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "x": { "type": "integer", "description": "X position" },
-                                                "y": { "type": "integer", "description": "Y position" },
+                                                "x": { "type": "number", "description": "X position" },
+                                                "y": { "type": "number", "description": "Y position" },
                                                 "text": { "type": "string", "description": "Text content" },
                                                 "font_id": { "type": "integer", "description": "Font ID. Default: 1" },
                                                 "color": { "type": "integer", "description": "BGR colour. Default: 0x000080" },
@@ -584,8 +584,8 @@ impl McpServer {
                                             "properties": {
                                                 "name": { "type": "string", "description": "Parameter name (e.g., 'Value')" },
                                                 "value": { "type": "string", "description": "Parameter value (e.g., '10k'). Default: '*'" },
-                                                "x": { "type": "integer", "description": "X position. Default: 0" },
-                                                "y": { "type": "integer", "description": "Y position. Default: 0" },
+                                                "x": { "type": "number", "description": "X position. Default: 0" },
+                                                "y": { "type": "number", "description": "Y position. Default: 0" },
                                                 "font_id": { "type": "integer", "description": "Font ID. Default: 1" },
                                                 "color": { "type": "integer", "description": "BGR colour. Default: 0x800000 (dark red)" },
                                                 "hidden": { "type": "boolean", "description": "Whether hidden. Default: false" },

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -622,10 +622,10 @@ impl McpServer {
     pub(crate) fn parse_schlib_rectangle(json: &Value) -> Option<crate::altium::schlib::Rectangle> {
         use crate::altium::schlib::Rectangle;
 
-        let x1 = json_i32(json, "x1")?;
-        let y1 = json_i32(json, "y1")?;
-        let x2 = json_i32(json, "x2")?;
-        let y2 = json_i32(json, "y2")?;
+        let x1 = json_f64(json, "x1")?;
+        let y1 = json_f64(json, "y1")?;
+        let x2 = json_f64(json, "x2")?;
+        let y2 = json_f64(json, "y2")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let line_color = json
@@ -666,12 +666,12 @@ impl McpServer {
     ) -> Option<crate::altium::schlib::RoundRect> {
         use crate::altium::schlib::RoundRect;
 
-        let x1 = json_i32(json, "x1")?;
-        let y1 = json_i32(json, "y1")?;
-        let x2 = json_i32(json, "x2")?;
-        let y2 = json_i32(json, "y2")?;
-        let corner_x_radius = json_i32(json, "corner_x_radius").unwrap_or(0);
-        let corner_y_radius = json_i32(json, "corner_y_radius").unwrap_or(0);
+        let x1 = json_f64(json, "x1")?;
+        let y1 = json_f64(json, "y1")?;
+        let x2 = json_f64(json, "x2")?;
+        let y2 = json_f64(json, "y2")?;
+        let corner_x_radius = json_f64(json, "corner_x_radius").unwrap_or(0.0);
+        let corner_y_radius = json_f64(json, "corner_y_radius").unwrap_or(0.0);
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let line_color = json
@@ -748,8 +748,8 @@ impl McpServer {
             .unwrap_or("*")
             .to_string();
 
-        let x = json_i32(json, "x").unwrap_or(0);
-        let y = json_i32(json, "y").unwrap_or(0);
+        let x = json_f64(json, "x").unwrap_or(0.0);
+        let y = json_f64(json, "y").unwrap_or(0.0);
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;
         let color = json
             .get("color")
@@ -784,11 +784,11 @@ impl McpServer {
             .get("points")
             .or_else(|| json.get("vertices"))
             .and_then(Value::as_array)?;
-        let points: Vec<(i32, i32)> = points_json
+        let points: Vec<(f64, f64)> = points_json
             .iter()
             .filter_map(|p| {
-                let x = json_i32(p, "x")?;
-                let y = json_i32(p, "y")?;
+                let x = json_f64(p, "x")?;
+                let y = json_f64(p, "y")?;
                 Some((x, y))
             })
             .collect();
@@ -832,11 +832,11 @@ impl McpServer {
             .get("points")
             .or_else(|| json.get("vertices"))
             .and_then(Value::as_array)?;
-        let points: Vec<(i32, i32)> = points_json
+        let points: Vec<(f64, f64)> = points_json
             .iter()
             .filter_map(|p| {
-                let x = json_i32(p, "x")?;
-                let y = json_i32(p, "y")?;
+                let x = json_f64(p, "x")?;
+                let y = json_f64(p, "y")?;
                 Some((x, y))
             })
             .collect();
@@ -873,9 +873,9 @@ impl McpServer {
     pub(crate) fn parse_schlib_arc(json: &Value) -> Option<crate::altium::schlib::Arc> {
         use crate::altium::schlib::Arc;
 
-        let x = json_i32(json, "x")?;
-        let y = json_i32(json, "y")?;
-        let radius = json_i32(json, "radius")?;
+        let x = json_f64(json, "x")?;
+        let y = json_f64(json, "y")?;
+        let radius = json_f64(json, "radius")?;
         let start_angle = json
             .get("start_angle")
             .and_then(Value::as_f64)
@@ -911,10 +911,10 @@ impl McpServer {
     pub(crate) fn parse_schlib_ellipse(json: &Value) -> Option<crate::altium::schlib::Ellipse> {
         use crate::altium::schlib::Ellipse;
 
-        let x = json_i32(json, "x")?;
-        let y = json_i32(json, "y")?;
-        let radius_x = json_i32(json, "radius_x")?;
-        let radius_y = json_i32(json, "radius_y")?;
+        let x = json_f64(json, "x")?;
+        let y = json_f64(json, "y")?;
+        let radius_x = json_f64(json, "radius_x")?;
+        let radius_y = json_f64(json, "radius_y")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let line_color = json
@@ -948,8 +948,8 @@ impl McpServer {
     pub(crate) fn parse_schlib_label(json: &Value) -> Option<crate::altium::schlib::Label> {
         use crate::altium::schlib::{Label, TextJustification};
 
-        let x = json_i32(json, "x")?;
-        let y = json_i32(json, "y")?;
+        let x = json_f64(json, "x")?;
+        let y = json_f64(json, "y")?;
         let text = json.get("text").and_then(Value::as_str)?.to_string();
 
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;
@@ -1008,8 +1008,8 @@ impl McpServer {
     pub(crate) fn parse_schlib_text(json: &Value) -> Option<crate::altium::schlib::Text> {
         use crate::altium::schlib::{Text, TextJustification};
 
-        let x = json_i32(json, "x")?;
-        let y = json_i32(json, "y")?;
+        let x = json_f64(json, "x")?;
+        let y = json_f64(json, "y")?;
         let text = json.get("text").and_then(Value::as_str)?.to_string();
 
         let font_id = json.get("font_id").and_then(Value::as_u64).unwrap_or(1) as u8;

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -17,6 +17,16 @@ fn json_i32(json: &Value, field: &str) -> Option<i32> {
         .and_then(|v| i32::try_from(v).ok())
 }
 
+/// Reads a JSON number field as `f64`, accepting both integer and fractional
+/// JSON values and rejecting non-finite (NaN/∞) inputs. Schematic graphic
+/// coordinates use this so off-grid (fractional) positions survive instead of
+/// being dropped by the integer-only [`json_i32`].
+fn json_f64(json: &Value, field: &str) -> Option<f64> {
+    json.get(field)
+        .and_then(Value::as_f64)
+        .filter(|v| v.is_finite())
+}
+
 impl McpServer {
     // ==================== Primitive Parsing Helpers ====================
 
@@ -698,10 +708,12 @@ impl McpServer {
     pub(crate) fn parse_schlib_line(json: &Value) -> Option<crate::altium::schlib::Line> {
         use crate::altium::schlib::Line;
 
-        let x1 = json_i32(json, "x1")?;
-        let y1 = json_i32(json, "y1")?;
-        let x2 = json_i32(json, "x2")?;
-        let y2 = json_i32(json, "y2")?;
+        // Coordinates accept fractional values; integer-only `json_i32` would drop
+        // an off-grid endpoint like 3.75.
+        let x1 = json_f64(json, "x1")?;
+        let y1 = json_f64(json, "y1")?;
+        let x2 = json_f64(json, "x2")?;
+        let y2 = json_f64(json, "y2")?;
 
         let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
         let color = json
@@ -1049,5 +1061,43 @@ impl McpServer {
             owner_part_id,
             unique_id: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{json_f64, json_i32};
+    use crate::mcp::server::McpServer;
+    use serde_json::json;
+
+    #[test]
+    fn json_i32_drops_fractional_coordinate() {
+        // Demonstrates the original defect: the integer reader rejects an
+        // off-grid value, so a fractional coordinate was silently dropped while
+        // an integer one passed through.
+        assert_eq!(json_i32(&json!({ "x": 3.75 }), "x"), None);
+        assert_eq!(json_i32(&json!({ "x": 3 }), "x"), Some(3));
+    }
+
+    #[test]
+    fn json_f64_accepts_numbers_and_rejects_non_numeric() {
+        // The fix: accept fractional and integer JSON numbers; reject non-numeric.
+        assert_eq!(json_f64(&json!({ "x": 3.75 }), "x"), Some(3.75));
+        assert_eq!(json_f64(&json!({ "x": -28 }), "x"), Some(-28.0));
+        assert_eq!(json_f64(&json!({ "x": "nope" }), "x"), None);
+        assert_eq!(json_f64(&json!({}), "x"), None);
+    }
+
+    #[test]
+    fn parse_schlib_line_preserves_fractional_coords() {
+        // End-to-end: a fractional line now parses (instead of being dropped)
+        // and keeps its exact coordinates, including a negative fractional X.
+        let line = McpServer::parse_schlib_line(&json!({
+            "x1": -28.995, "y1": 7.5, "x2": 10.0, "y2": 0.0
+        }))
+        .expect("fractional line should parse");
+        assert!((line.x1 - (-28.995)).abs() < 1e-9, "x1 kept: {}", line.x1);
+        assert!((line.y1 - 7.5).abs() < 1e-9, "y1 kept: {}", line.y1);
+        assert!((line.x2 - 10.0).abs() < 1e-9, "x2 kept: {}", line.x2);
     }
 }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -67,6 +67,7 @@ const fn pin_tip(pin: &crate::altium::schlib::Pin) -> (i32, i32) {
 /// For each pin it reports the body-attach end, the computed connection tip, and
 /// the orientation; plus the symbol's bounding box. All values are in schematic
 /// units (10 = 1 grid square).
+#[allow(clippy::cast_possible_truncation)] // rectangle coords rounded onto the integer bbox grid
 fn symbol_geometry(symbol: &crate::altium::schlib::Symbol) -> Value {
     let mut xs: Vec<i32> = Vec::new();
     let mut ys: Vec<i32> = Vec::new();
@@ -89,10 +90,10 @@ fn symbol_geometry(symbol: &crate::altium::schlib::Symbol) -> Value {
         })
         .collect();
     for r in &symbol.rectangles {
-        xs.push(r.x1);
-        xs.push(r.x2);
-        ys.push(r.y1);
-        ys.push(r.y2);
+        xs.push(r.x1.round() as i32);
+        xs.push(r.x2.round() as i32);
+        ys.push(r.y1.round() as i32);
+        ys.push(r.y2.round() as i32);
     }
     let bounding_box = if xs.is_empty() {
         Value::Null

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -458,10 +458,13 @@ impl McpServer {
             if !matches_part(line.owner_part_id) {
                 continue;
             }
-            min_x = min_x.min(line.x1).min(line.x2);
-            max_x = max_x.max(line.x1).max(line.x2);
-            min_y = min_y.min(line.y1).min(line.y2);
-            max_y = max_y.max(line.y1).max(line.y2);
+            // Lines carry f64 coordinates; round to the integer ASCII grid.
+            let (lx1, ly1) = (line.x1.round() as i32, line.y1.round() as i32);
+            let (lx2, ly2) = (line.x2.round() as i32, line.y2.round() as i32);
+            min_x = min_x.min(lx1).min(lx2);
+            max_x = max_x.max(lx1).max(lx2);
+            min_y = min_y.min(ly1).min(ly2);
+            max_y = max_y.max(ly1).max(ly2);
         }
 
         // Calculate bounding box from polylines
@@ -593,8 +596,8 @@ impl McpServer {
             }
             Self::draw_line(
                 &mut canvas,
-                to_canvas(line.x1, line.y1),
-                to_canvas(line.x2, line.y2),
+                to_canvas(line.x1.round() as i32, line.y1.round() as i32),
+                to_canvas(line.x2.round() as i32, line.y2.round() as i32),
                 '-',
             );
         }

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -447,10 +447,12 @@ impl McpServer {
             if !matches_part(rect.owner_part_id) {
                 continue;
             }
-            min_x = min_x.min(rect.x1).min(rect.x2);
-            max_x = max_x.max(rect.x1).max(rect.x2);
-            min_y = min_y.min(rect.y1).min(rect.y2);
-            max_y = max_y.max(rect.y1).max(rect.y2);
+            let (rx1, ry1) = (rect.x1.round() as i32, rect.y1.round() as i32);
+            let (rx2, ry2) = (rect.x2.round() as i32, rect.y2.round() as i32);
+            min_x = min_x.min(rx1).min(rx2);
+            max_x = max_x.max(rx1).max(rx2);
+            min_y = min_y.min(ry1).min(ry2);
+            max_y = max_y.max(ry1).max(ry2);
         }
 
         // Calculate bounding box from lines
@@ -473,10 +475,11 @@ impl McpServer {
                 continue;
             }
             for &(x, y) in &polyline.points {
-                min_x = min_x.min(x);
-                max_x = max_x.max(x);
-                min_y = min_y.min(y);
-                max_y = max_y.max(y);
+                let (xi, yi) = (x.round() as i32, y.round() as i32);
+                min_x = min_x.min(xi);
+                max_x = max_x.max(xi);
+                min_y = min_y.min(yi);
+                max_y = max_y.max(yi);
             }
         }
 
@@ -485,10 +488,10 @@ impl McpServer {
             if !matches_part(arc.owner_part_id) {
                 continue;
             }
-            min_x = min_x.min(arc.x - arc.radius);
-            max_x = max_x.max(arc.x + arc.radius);
-            min_y = min_y.min(arc.y - arc.radius);
-            max_y = max_y.max(arc.y + arc.radius);
+            min_x = min_x.min((arc.x - arc.radius).round() as i32);
+            max_x = max_x.max((arc.x + arc.radius).round() as i32);
+            min_y = min_y.min((arc.y - arc.radius).round() as i32);
+            max_y = max_y.max((arc.y + arc.radius).round() as i32);
         }
 
         // Calculate bounding box from ellipses
@@ -496,10 +499,10 @@ impl McpServer {
             if !matches_part(ellipse.owner_part_id) {
                 continue;
             }
-            min_x = min_x.min(ellipse.x - ellipse.radius_x);
-            max_x = max_x.max(ellipse.x + ellipse.radius_x);
-            min_y = min_y.min(ellipse.y - ellipse.radius_y);
-            max_y = max_y.max(ellipse.y + ellipse.radius_y);
+            min_x = min_x.min((ellipse.x - ellipse.radius_x).round() as i32);
+            max_x = max_x.max((ellipse.x + ellipse.radius_x).round() as i32);
+            min_y = min_y.min((ellipse.y - ellipse.radius_y).round() as i32);
+            max_y = max_y.max((ellipse.y + ellipse.radius_y).round() as i32);
         }
 
         // Handle empty symbol
@@ -547,8 +550,8 @@ impl McpServer {
             if !matches_part(rect.owner_part_id) {
                 continue;
             }
-            let (x1, y1) = to_canvas(rect.x1, rect.y1);
-            let (x2, y2) = to_canvas(rect.x2, rect.y2);
+            let (x1, y1) = to_canvas(rect.x1.round() as i32, rect.y1.round() as i32);
+            let (x2, y2) = to_canvas(rect.x2.round() as i32, rect.y2.round() as i32);
             let (min_cx, max_cx) = (x1.min(x2), x1.max(x2));
             let (min_cy, max_cy) = (y1.min(y2), y1.max(y2));
 
@@ -610,7 +613,12 @@ impl McpServer {
             for i in 0..polyline.points.len().saturating_sub(1) {
                 let (x1, y1) = polyline.points[i];
                 let (x2, y2) = polyline.points[i + 1];
-                Self::draw_line(&mut canvas, to_canvas(x1, y1), to_canvas(x2, y2), '-');
+                Self::draw_line(
+                    &mut canvas,
+                    to_canvas(x1.round() as i32, y1.round() as i32),
+                    to_canvas(x2.round() as i32, y2.round() as i32),
+                    '-',
+                );
             }
         }
 
@@ -619,7 +627,7 @@ impl McpServer {
             if !matches_part(arc.owner_part_id) {
                 continue;
             }
-            let (cx, cy) = to_canvas(arc.x, arc.y);
+            let (cx, cy) = to_canvas(arc.x.round() as i32, arc.y.round() as i32);
             if cx < canvas_width && cy < canvas_height {
                 canvas[cy][cx] = 'o';
             }
@@ -630,7 +638,7 @@ impl McpServer {
             if !matches_part(ellipse.owner_part_id) {
                 continue;
             }
-            let (cx, cy) = to_canvas(ellipse.x, ellipse.y);
+            let (cx, cy) = to_canvas(ellipse.x.round() as i32, ellipse.y.round() as i32);
             if cx < canvas_width && cy < canvas_height {
                 canvas[cy][cx] = 'O';
             }

--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -206,19 +206,13 @@ impl McpServer {
                         if let Some(hidden) = arguments.get("hidden").and_then(Value::as_bool) {
                             param.hidden = hidden;
                         }
-                        if let Some(x) = arguments.get("x").and_then(Value::as_i64) {
-                            let Ok(x) = i32::try_from(x) else {
-                                return ToolCallResult::error("Parameter 'x' is out of range");
-                            };
+                        if let Some(x) = arguments.get("x").and_then(Value::as_f64) {
                             if let Err(e) = Self::validate_schlib_coordinate(x, "parameter x") {
                                 return ToolCallResult::error(e);
                             }
                             param.x = x;
                         }
-                        if let Some(y) = arguments.get("y").and_then(Value::as_i64) {
-                            let Ok(y) = i32::try_from(y) else {
-                                return ToolCallResult::error("Parameter 'y' is out of range");
-                            };
+                        if let Some(y) = arguments.get("y").and_then(Value::as_f64) {
                             if let Err(e) = Self::validate_schlib_coordinate(y, "parameter y") {
                                 return ToolCallResult::error(e);
                             }

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -133,6 +133,10 @@ impl McpServer {
     }
 
     /// Validates all coordinates in a symbol before writing.
+    // Graphic coordinates are f64; range-checking rounds them onto the integer
+    // schematic grid, so the f64→i32 cast is intentional (and saturates for
+    // absurd magnitudes, which the bound check then rejects).
+    #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn validate_symbol_coordinates(
         symbol: &crate::altium::schlib::Symbol,
     ) -> Result<(), String> {
@@ -167,10 +171,22 @@ impl McpServer {
         }
 
         for (i, line) in symbol.lines.iter().enumerate() {
-            Self::validate_schlib_coordinate(line.x1, &format!("Symbol '{name}' line {i} x1"))?;
-            Self::validate_schlib_coordinate(line.y1, &format!("Symbol '{name}' line {i} y1"))?;
-            Self::validate_schlib_coordinate(line.x2, &format!("Symbol '{name}' line {i} x2"))?;
-            Self::validate_schlib_coordinate(line.y2, &format!("Symbol '{name}' line {i} y2"))?;
+            Self::validate_schlib_coordinate(
+                line.x1.round() as i32,
+                &format!("Symbol '{name}' line {i} x1"),
+            )?;
+            Self::validate_schlib_coordinate(
+                line.y1.round() as i32,
+                &format!("Symbol '{name}' line {i} y1"),
+            )?;
+            Self::validate_schlib_coordinate(
+                line.x2.round() as i32,
+                &format!("Symbol '{name}' line {i} x2"),
+            )?;
+            Self::validate_schlib_coordinate(
+                line.y2.round() as i32,
+                &format!("Symbol '{name}' line {i} y2"),
+            )?;
         }
 
         for (i, polyline) in symbol.polylines.iter().enumerate() {

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -118,12 +118,13 @@ impl McpServer {
     /// `i16::MAX` = 32767, but we use 32000 as a conservative limit.
     const MAX_SCHLIB_COORDINATE: i32 = 32000;
 
-    /// Validates that a `SchLib` coordinate is within the safe range for i16.
-    pub(crate) fn validate_schlib_coordinate(value: i32, field_name: &str) -> Result<(), String> {
-        // Direct bound check, not `value.abs()`: `i32::MIN.abs()` overflows
-        // (panics in debug, wraps negative in release — silently passing the
-        // check), so a crafted coordinate could panic or bypass validation.
-        if !(-Self::MAX_SCHLIB_COORDINATE..=Self::MAX_SCHLIB_COORDINATE).contains(&value) {
+    /// Validates that a `SchLib` coordinate is within the safe range. Graphic
+    /// primitives carry f64 (off-grid) coordinates, so this takes f64 and also
+    /// rejects non-finite (NaN/∞) values. Pins pass their i32 coordinates via
+    /// `f64::from`.
+    pub(crate) fn validate_schlib_coordinate(value: f64, field_name: &str) -> Result<(), String> {
+        let max = f64::from(Self::MAX_SCHLIB_COORDINATE);
+        if !value.is_finite() || value < -max || value > max {
             return Err(format!(
                 "{field_name} value {value} exceeds the maximum safe range of ±{} units",
                 Self::MAX_SCHLIB_COORDINATE
@@ -133,20 +134,22 @@ impl McpServer {
     }
 
     /// Validates all coordinates in a symbol before writing.
-    // Graphic coordinates are f64; range-checking rounds them onto the integer
-    // schematic grid, so the f64→i32 cast is intentional (and saturates for
-    // absurd magnitudes, which the bound check then rejects).
-    #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn validate_symbol_coordinates(
         symbol: &crate::altium::schlib::Symbol,
     ) -> Result<(), String> {
         let name = &symbol.name;
 
         for (i, pin) in symbol.pins.iter().enumerate() {
-            Self::validate_schlib_coordinate(pin.x, &format!("Symbol '{name}' pin {i} x"))?;
-            Self::validate_schlib_coordinate(pin.y, &format!("Symbol '{name}' pin {i} y"))?;
             Self::validate_schlib_coordinate(
-                pin.length,
+                f64::from(pin.x),
+                &format!("Symbol '{name}' pin {i} x"),
+            )?;
+            Self::validate_schlib_coordinate(
+                f64::from(pin.y),
+                &format!("Symbol '{name}' pin {i} y"),
+            )?;
+            Self::validate_schlib_coordinate(
+                f64::from(pin.length),
                 &format!("Symbol '{name}' pin {i} length"),
             )?;
         }
@@ -171,22 +174,10 @@ impl McpServer {
         }
 
         for (i, line) in symbol.lines.iter().enumerate() {
-            Self::validate_schlib_coordinate(
-                line.x1.round() as i32,
-                &format!("Symbol '{name}' line {i} x1"),
-            )?;
-            Self::validate_schlib_coordinate(
-                line.y1.round() as i32,
-                &format!("Symbol '{name}' line {i} y1"),
-            )?;
-            Self::validate_schlib_coordinate(
-                line.x2.round() as i32,
-                &format!("Symbol '{name}' line {i} x2"),
-            )?;
-            Self::validate_schlib_coordinate(
-                line.y2.round() as i32,
-                &format!("Symbol '{name}' line {i} y2"),
-            )?;
+            Self::validate_schlib_coordinate(line.x1, &format!("Symbol '{name}' line {i} x1"))?;
+            Self::validate_schlib_coordinate(line.y1, &format!("Symbol '{name}' line {i} y1"))?;
+            Self::validate_schlib_coordinate(line.x2, &format!("Symbol '{name}' line {i} x2"))?;
+            Self::validate_schlib_coordinate(line.y2, &format!("Symbol '{name}' line {i} y2"))?;
         }
 
         for (i, polyline) in symbol.polylines.iter().enumerate() {

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -303,9 +303,9 @@ fn samples_schlib_arcs() {
     let circle = symbol
         .arcs
         .iter()
-        .find(|a| a.x == 0 && a.y == 0)
+        .find(|a| approx_eq(a.x, 0.0) && approx_eq(a.y, 0.0))
         .expect("full-circle arc at origin not found");
-    assert_eq!(circle.radius, 5, "circle radius");
+    assert!(approx_eq(circle.radius, 5.0), "circle radius");
     assert!(approx_eq(circle.start_angle, 0.0), "circle start angle");
     assert!(approx_eq(circle.end_angle, 360.0), "circle end angle");
 
@@ -313,9 +313,9 @@ fn samples_schlib_arcs() {
     let quarter = symbol
         .arcs
         .iter()
-        .find(|a| a.x == 0 && a.y == -20)
+        .find(|a| approx_eq(a.x, 0.0) && approx_eq(a.y, -20.0))
         .expect("quarter arc at (0,-20) not found");
-    assert_eq!(quarter.radius, 5, "quarter-arc radius");
+    assert!(approx_eq(quarter.radius, 5.0), "quarter-arc radius");
     assert!(
         approx_eq(quarter.start_angle, 0.0),
         "quarter-arc start angle"
@@ -410,26 +410,30 @@ fn samples_schlib_rects() {
     assert_eq!(symbol.rectangles.len(), 2, "RECTS has 2 rectangles");
 
     // Match by left edge (x1); both share line_color 0 / fill_color 65535.
-    let by_x1 = |x1: i32| -> &Rectangle {
+    let by_x1 = |x1: f64| -> &Rectangle {
         symbol
             .rectangles
             .iter()
-            .find(|r| r.x1 == x1)
+            .find(|r| approx_eq(r.x1, x1))
             .unwrap_or_else(|| panic!("rectangle with x1 = {x1} not found"))
     };
 
-    let filled = by_x1(-10);
-    assert_eq!(filled.y1, 0, "filled rect y1");
-    assert_eq!(filled.x2, 10, "filled rect x2");
-    assert_eq!(filled.y2, 10, "filled rect y2");
+    let filled = by_x1(-10.0);
+    assert_eq!(
+        (filled.y1, filled.x2, filled.y2),
+        (0.0, 10.0, 10.0),
+        "filled rect geometry"
+    );
     assert!(filled.filled, "filled rect is filled");
     assert_eq!(filled.fill_color, 65535, "filled rect fill_color");
     assert_eq!(filled.line_color, 0, "filled rect line_color");
 
-    let unfilled = by_x1(15);
-    assert_eq!(unfilled.y1, 0, "unfilled rect y1");
-    assert_eq!(unfilled.x2, 35, "unfilled rect x2");
-    assert_eq!(unfilled.y2, 10, "unfilled rect y2");
+    let unfilled = by_x1(15.0);
+    assert_eq!(
+        (unfilled.y1, unfilled.x2, unfilled.y2),
+        (0.0, 35.0, 10.0),
+        "unfilled rect geometry"
+    );
     assert!(!unfilled.filled, "unfilled rect is not filled");
     assert_eq!(unfilled.fill_color, 65535, "unfilled rect fill_color");
     assert_eq!(unfilled.line_color, 0, "unfilled rect line_color");
@@ -442,24 +446,28 @@ fn samples_schlib_ellipses() {
     assert_eq!(symbol.ellipses.len(), 2, "ELLIPSES has 2 ellipses");
 
     // Match by horizontal radius (radius_x), which is unique here.
-    let by_radius_x = |radius_x: i32| -> &Ellipse {
+    let by_radius_x = |radius_x: f64| -> &Ellipse {
         symbol
             .ellipses
             .iter()
-            .find(|e| e.radius_x == radius_x)
+            .find(|e| approx_eq(e.radius_x, radius_x))
             .unwrap_or_else(|| panic!("ellipse with radius_x = {radius_x} not found"))
     };
 
-    let circle = by_radius_x(5);
-    assert_eq!(circle.x, 0, "circle x");
-    assert_eq!(circle.y, 0, "circle y");
-    assert_eq!(circle.radius_y, 5, "circle radius_y");
+    let circle = by_radius_x(5.0);
+    assert_eq!(
+        (circle.x, circle.y, circle.radius_y),
+        (0.0, 0.0, 5.0),
+        "circle geometry"
+    );
     assert!(circle.filled, "circle is filled");
 
-    let ellipse = by_radius_x(8);
-    assert_eq!(ellipse.x, 20, "ellipse x");
-    assert_eq!(ellipse.y, 0, "ellipse y");
-    assert_eq!(ellipse.radius_y, 4, "ellipse radius_y");
+    let ellipse = by_radius_x(8.0);
+    assert_eq!(
+        (ellipse.x, ellipse.y, ellipse.radius_y),
+        (20.0, 0.0, 4.0),
+        "ellipse geometry"
+    );
     assert!(!ellipse.filled, "ellipse is not filled");
 }
 
@@ -472,7 +480,7 @@ fn samples_schlib_polylines() {
     let polyline = &symbol.polylines[0];
     assert_eq!(
         polyline.points,
-        vec![(0, 0), (10, 5), (0, 10)],
+        vec![(0.0, 0.0), (10.0, 5.0), (0.0, 10.0)],
         "polyline points",
     );
 }
@@ -484,12 +492,16 @@ fn samples_schlib_roundrects() {
     assert_eq!(symbol.round_rects.len(), 1, "ROUNDRECTS has 1 rounded rect");
 
     let rr: &RoundRect = &symbol.round_rects[0];
-    assert_eq!(rr.x1, -10, "round rect x1");
-    assert_eq!(rr.y1, 0, "round rect y1");
-    assert_eq!(rr.x2, 10, "round rect x2");
-    assert_eq!(rr.y2, 10, "round rect y2");
-    assert_eq!(rr.corner_x_radius, 2, "round rect corner_x_radius");
-    assert_eq!(rr.corner_y_radius, 2, "round rect corner_y_radius");
+    assert_eq!(
+        (rr.x1, rr.y1, rr.x2, rr.y2),
+        (-10.0, 0.0, 10.0, 10.0),
+        "round rect geometry"
+    );
+    assert_eq!(
+        (rr.corner_x_radius, rr.corner_y_radius),
+        (2.0, 2.0),
+        "round rect corner radii"
+    );
     assert!(rr.filled, "round rect is filled");
 }
 
@@ -500,26 +512,26 @@ fn samples_schlib_polygons() {
     assert_eq!(symbol.polygons.len(), 2, "POLYGONS has 2 polygons");
 
     // Both are 4-vertex boxes; match each by its first vertex x (unique here).
-    let by_first_x = |x: i32| -> &Polygon {
+    let by_first_x = |x: f64| -> &Polygon {
         symbol
             .polygons
             .iter()
-            .find(|p| p.points.first().is_some_and(|&(px, _)| px == x))
+            .find(|p| p.points.first().is_some_and(|&(px, _)| approx_eq(px, x)))
             .unwrap_or_else(|| panic!("polygon with first vertex x = {x} not found"))
     };
 
-    let left = by_first_x(-10);
+    let left = by_first_x(-10.0);
     assert_eq!(
         left.points,
-        vec![(-10, 0), (10, 0), (10, 10), (-10, 10)],
+        vec![(-10.0, 0.0), (10.0, 0.0), (10.0, 10.0), (-10.0, 10.0)],
         "left polygon points",
     );
     assert!(left.filled, "left polygon is filled");
 
-    let right = by_first_x(15);
+    let right = by_first_x(15.0);
     assert_eq!(
         right.points,
-        vec![(15, 0), (35, 0), (35, 10), (15, 10)],
+        vec![(15.0, 0.0), (35.0, 0.0), (35.0, 10.0), (15.0, 10.0)],
         "right polygon points",
     );
     assert!(right.filled, "right polygon is filled");

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -273,14 +273,21 @@ fn samples_schlib_lines() {
     let symbol = lib.get("LINES").expect("symbol LINES not found");
     assert_eq!(symbol.lines.len(), 3, "LINES has 3 lines");
 
-    // Match each line by its (x1, y1, x2, y2) endpoints (reader units).
-    for endpoints in [(0, 0, 10, 0), (0, 0, 0, 10), (0, 0, 10, 10)] {
+    // Match each line by its (x1, y1, x2, y2) endpoints (reader units). Coords are
+    // f64; the integer-grid sample reads back as exact whole values.
+    for endpoints in [
+        (0.0, 0.0, 10.0, 0.0),
+        (0.0, 0.0, 0.0, 10.0),
+        (0.0, 0.0, 10.0, 10.0),
+    ] {
         let (x1, y1, x2, y2) = endpoints;
         assert!(
-            symbol
-                .lines
-                .iter()
-                .any(|l| l.x1 == x1 && l.y1 == y1 && l.x2 == x2 && l.y2 == y2),
+            symbol.lines.iter().any(|l| {
+                (l.x1 - x1).abs() < 1e-9
+                    && (l.y1 - y1).abs() < 1e-9
+                    && (l.x2 - x2).abs() < 1e-9
+                    && (l.y2 - y2).abs() < 1e-9
+            }),
             "missing line {endpoints:?}",
         );
     }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -1345,10 +1345,10 @@ fn test_schlib_rename_component() {
     sym.description = "Test symbol".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -40,
-        x2: 40,
-        y2: 40,
+        x1: -40.0,
+        y1: -40.0,
+        x2: 40.0,
+        y2: 40.0,
         line_width: 1,
         line_color: 0x0000_0000,
         fill_color: 0x0000_FFFF,
@@ -1571,10 +1571,10 @@ fn test_schlib_copy_cross_library() {
     sym.description = "Source symbol".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -40,
-        x2: 40,
-        y2: 40,
+        x1: -40.0,
+        y1: -40.0,
+        x2: 40.0,
+        y2: 40.0,
         line_width: 1,
         line_color: 0x0000_0000,
         fill_color: 0x0000_FFFF,
@@ -1719,10 +1719,10 @@ fn test_schlib_json_roundtrip() {
     sym.description = "Test symbol for round-trip".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -40,
-        x2: 40,
-        y2: 40,
+        x1: -40.0,
+        y1: -40.0,
+        x2: 40.0,
+        y2: 40.0,
         line_width: 1,
         line_color: 0x0000_0000,
         fill_color: 0x0000_FFFF,
@@ -1984,10 +1984,10 @@ fn test_schlib_merge_libraries() {
     sym1.description = "Symbol A".to_string();
     sym1.designator = "U".to_string();
     sym1.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -40,
-        x2: 40,
-        y2: 40,
+        x1: -40.0,
+        y1: -40.0,
+        x2: 40.0,
+        y2: 40.0,
         line_width: 1,
         line_color: 0x0000_0000,
         fill_color: 0x0000_FFFF,
@@ -2169,10 +2169,10 @@ fn test_schlib_search() {
     let mut lib = SchLib::new();
     let mut sym1 = Symbol::new("LM7805");
     sym1.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -20,
-        x2: 40,
-        y2: 20,
+        x1: -40.0,
+        y1: -20.0,
+        x2: 40.0,
+        y2: 20.0,
         line_width: 1,
         line_color: 0,
         fill_color: 0,
@@ -2186,10 +2186,10 @@ fn test_schlib_search() {
 
     let mut sym2 = Symbol::new("LM7812");
     sym2.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -20,
-        x2: 40,
-        y2: 20,
+        x1: -40.0,
+        y1: -20.0,
+        x2: 40.0,
+        y2: 20.0,
         line_width: 1,
         line_color: 0,
         fill_color: 0,
@@ -2203,10 +2203,10 @@ fn test_schlib_search() {
 
     let mut sym3 = Symbol::new("NE555");
     sym3.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -40,
-        x2: 40,
-        y2: 40,
+        x1: -40.0,
+        y1: -40.0,
+        x2: 40.0,
+        y2: 40.0,
         line_width: 1,
         line_color: 0,
         fill_color: 0,
@@ -2301,10 +2301,10 @@ fn test_schlib_get_component() {
     let mut sym1 = Symbol::new("LM7805");
     sym1.description = "5V Regulator".to_string();
     sym1.rectangles.push(Rectangle {
-        x1: -40,
-        y1: -30,
-        x2: 40,
-        y2: 30,
+        x1: -40.0,
+        y1: -30.0,
+        x2: 40.0,
+        y2: 30.0,
         line_width: 1,
         line_color: 0,
         fill_color: 0,


### PR DESCRIPTION
## Description

SchLib graphic primitives were limited to integer schematic coordinates, so off-grid positions were impossible and a fractional coordinate sent to `write_schlib` (e.g. `3.75`) was silently dropped by the integer-only input parser.

This adds end-to-end fractional-coordinate support. Each coordinate encodes/decodes through a shared `schlib::coord` helper as an integer part plus a non-negative `<key>_Frac` companion (×100,000), reconstructed as `value = key + key_Frac / 100000`. The fraction is omitted when zero, so **integer-grid coordinates stay byte-identical on disk** — existing files and oracles are unaffected.

Covers every graphic primitive: Line, Rectangle, RoundRect, Arc, Ellipse, EllipticalArc, Polyline, Polygon, Bezier, Label, Text, Parameter. Pins remain integer (binary record). The negative-coordinate (floor) convention was confirmed against Altium: a floor-encoded `-10.5` line renders mirror-equal to `+10.5` (a truncate-magnitude decode would land at `-11.5`).

Commits are split by layer for review: shared helper → Line template → Altium-confirmed convention → all primitives (core read/write) → MCP boundary (parsing, schema, consumers) → docs.

## Related Issue

N/A — independent of #191/#192 (branched from `main`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — fractional input was dropped
- [x] New feature (non-breaking change that adds functionality) — off-grid coordinates
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Security improvement

## Standards Checklist

- [x] Primitive types maintain backwards compatibility (integer coords are byte-identical; constructors accept `impl Into<f64>` so integer-literal call sites are unchanged)
- [x] Altium file format compatibility is maintained (`<key>_Frac` is Altium's own convention; confirmed in Altium)
- [x] No breaking changes to existing MCP tool interfaces (coordinate fields widen from `integer` to `number`)

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove the fix/feature works
- [x] New and existing tests pass (`cargo test`)

New tests: bug-and-fix at the input layer (`json_i32` drops `3.75` / `json_f64` keeps it; end-to-end line preservation), byte-identity (integer primitives emit no `_Frac`), the negative-floor split, and `roundtrip_all_primitives_fractional_and_negative_coords` exercising every primitive through write→read.

## Code Quality

- [x] CI checks pass locally: `cargo build` (0 warnings), `cargo test` (10/10 suites), `cargo clippy --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all --check` (clean)
- [x] Documentation updated — `docs/SCHLIB_FORMAT.md` gains a "Fractional coordinates" section; stale elliptical-arc "clamped" note corrected to "carries"
- [x] CHANGELOG.md updated (Unreleased entry)

> Note: `markdownlint-cli2` was not available in my local environment; the doc edits follow `.markdownlint.json` (atx headings, dash lists, ≤170 cols, plain MD051 anchor) but the markdownlint CI step is the one gate I couldn't run locally.

## Additional Notes

The `_Frac` integer/fraction split lives in one place (`schlib::coord::split`), so the floor convention is a single-function decision if it ever needs revisiting. Pins are intentionally left integer-only (their binary record stores i16 coordinates and Altium keeps pins on-grid).