### PR TITLE
feat(mcp): write flags/solder_mask_expansion/keepout for PcbLib 2D primitives

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,7 +15,6 @@
         "ms-vscode.hexeditor",
         "ms-vscode.powershell",
         "alefragnani.pascal",
-        "github.copilot",
         "github.vscode-pull-request-github"
     ]
 }

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -196,7 +196,14 @@ impl McpServer {
                                                     "description": "Pad shape: rectangle (pin 1), rounded_rectangle (SMD default), round/circle (equivalent, for through-hole), oval, octagonal"
                                                 },
                                                 "layer": { "type": "string", "description": "Layer name: Top Layer, Bottom Layer, Multi-Layer (default for SMD)" },
-                                                "hole_size": { "type": "number", "description": "Hole diameter for through-hole pads (mm)" }
+                                                "hole_size": { "type": "number", "description": "Hole diameter for through-hole pads (mm)" },
+                                                "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion in mm (optional; omit to use the rule default)" },
+                                                "solder_mask_expansion_mode": {
+                                                    "type": "string",
+                                                    "enum": ["none", "from_rule", "manual"],
+                                                    "description": "Solder mask expansion mode. Default: from_rule"
+                                                },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["designator", "x", "y", "width", "height"]
                                         }
@@ -212,7 +219,10 @@ impl McpServer {
                                                 "x2": { "type": "number" },
                                                 "y2": { "type": "number" },
                                                 "width": { "type": "number", "description": "Line width in mm" },
-                                                "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Top Courtyard, Mechanical 1, etc." }
+                                                "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Top Courtyard, Mechanical 1, etc." },
+                                                "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
+                                                "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2", "width", "layer"]
                                         }
@@ -255,7 +265,8 @@ impl McpServer {
                                                 "layer": { "type": "string", "description": "Layer name (default Top Layer): Top Layer, Bottom Layer, Top Overlay, Mechanical 1, etc." },
                                                 "rotation": { "type": "number", "description": "Rotation in degrees. Default: 0" },
                                                 "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
-                                                "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" }
+                                                "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2"]
                                         }
@@ -272,7 +283,10 @@ impl McpServer {
                                                 "start_angle": { "type": "number", "description": "Start angle in degrees" },
                                                 "end_angle": { "type": "number", "description": "End angle in degrees" },
                                                 "width": { "type": "number", "description": "Line width in mm" },
-                                                "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Mechanical 1, etc." }
+                                                "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Mechanical 1, etc." },
+                                                "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
+                                                "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["x", "y", "radius", "start_angle", "end_angle", "width", "layer"]
                                         }
@@ -293,7 +307,8 @@ impl McpServer {
                                                         }
                                                     }
                                                 },
-                                                "layer": { "type": "string", "description": "Layer name: Top Courtyard, Top Assembly, Mechanical 1, etc." }
+                                                "layer": { "type": "string", "description": "Layer name: Top Courtyard, Top Assembly, Mechanical 1, etc." },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["vertices", "layer"]
                                         }
@@ -310,7 +325,8 @@ impl McpServer {
                                                 "height": { "type": "number", "description": "Text height in mm" },
                                                 "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Mechanical 1, etc." },
                                                 "rotation": { "type": "number", "description": "Rotation in degrees" },
-                                                "stroke_width": { "type": "number", "description": "Stroke line width in mm (optional; defaults to Altium's ~4 mil)" }
+                                                "stroke_width": { "type": "number", "description": "Stroke line width in mm (optional; defaults to Altium's ~4 mil)" },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["x", "y", "text", "height", "layer"]
                                         }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -27,6 +27,40 @@ fn json_f64(json: &Value, field: &str) -> Option<f64> {
         .filter(|v| v.is_finite())
 }
 
+/// Reads the optional `flags` field of a `PcbLib` 2D primitive.
+///
+/// `read_pcblib` serialises [`crate::altium::pcblib::PcbFlags`] (a `bitflags`
+/// set) via its serde impl, which in JSON is a string of `|`-separated flag
+/// names, e.g. `"LOCKED"` or `"LOCKED | KEEPOUT"`. The write side deserialises
+/// that exact form with serde so a value read from disk round-trips unchanged.
+/// For caller convenience a raw `u16` bitmask integer is also accepted
+/// (`1` = `LOCKED`, `4` = `KEEPOUT`, …). An absent or unparseable value yields
+/// the empty flag set rather than erroring, matching the lenient handling of the
+/// other optional tail fields.
+fn json_flags(json: &Value) -> crate::altium::pcblib::PcbFlags {
+    use crate::altium::pcblib::PcbFlags;
+    match json.get("flags") {
+        // Canonical round-trip shape: the bitflags serde string ("LOCKED | …").
+        Some(v @ Value::String(_)) => {
+            serde_json::from_value(v.clone()).unwrap_or_else(|_| PcbFlags::empty())
+        }
+        // Convenience shape: a raw bitmask integer.
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .and_then(|v| u16::try_from(v).ok())
+            .map_or_else(PcbFlags::empty, PcbFlags::from_bits_truncate),
+        _ => PcbFlags::empty(),
+    }
+}
+
+/// Reads the optional `keepout_restrictions` bitmask (`u8`) of a `PcbLib` 2D
+/// primitive, mirroring how `read_pcblib` serialises the `Option<u8>` field.
+fn json_keepout(json: &Value) -> Option<u8> {
+    json.get("keepout_restrictions")
+        .and_then(Value::as_u64)
+        .and_then(|v| u8::try_from(v).ok())
+}
+
 impl McpServer {
     // ==================== Primitive Parsing Helpers ====================
 
@@ -49,9 +83,7 @@ impl McpServer {
     /// Parses a pad from JSON.
     #[allow(clippy::too_many_lines)] // Pad has many fields requiring individual parsing
     pub(crate) fn parse_pad(json: &Value) -> Result<crate::altium::pcblib::Pad, String> {
-        use crate::altium::pcblib::{
-            Layer, MaskExpansionMode, Pad, PadShape, PadStackMode, PcbFlags,
-        };
+        use crate::altium::pcblib::{Layer, MaskExpansionMode, Pad, PadShape, PadStackMode};
 
         let designator = json
             .get("designator")
@@ -194,7 +226,7 @@ impl McpServer {
             per_layer_shapes: None,
             per_layer_corner_radii: None,
             per_layer_offsets: None,
-            flags: PcbFlags::empty(),
+            flags: json_flags(json),
             unique_id: None,
         })
     }
@@ -235,12 +267,18 @@ impl McpServer {
             None => Layer::TopOverlay, // Default for tracks is Top Overlay
         };
 
-        Ok(Track::new(x1, y1, x2, y2, width, layer))
+        let mut track = Track::new(x1, y1, x2, y2, width, layer);
+        // Optional EE tail (mirrors the modelled optionals; absent keys keep the
+        // `Track::new` defaults so a from-scratch track is byte-identical).
+        track.flags = json_flags(json);
+        track.solder_mask_expansion = json_f64(json, "solder_mask_expansion");
+        track.keepout_restrictions = json_keepout(json);
+        Ok(track)
     }
 
     /// Parses an arc from JSON.
     pub(crate) fn parse_arc(json: &Value) -> Result<crate::altium::pcblib::Arc, String> {
-        use crate::altium::pcblib::{Arc, Layer, PcbFlags};
+        use crate::altium::pcblib::{Arc, Layer};
 
         let x = json
             .get("x")
@@ -286,16 +324,18 @@ impl McpServer {
             end_angle,
             width,
             layer,
-            flags: PcbFlags::empty(),
+            flags: json_flags(json),
             unique_id: None,
-            solder_mask_expansion: None,
-            keepout_restrictions: None,
+            // Optional EE tail (mirrors the modelled optionals; absent keys keep
+            // the default `None` so a from-scratch arc is byte-identical).
+            solder_mask_expansion: json_f64(json, "solder_mask_expansion"),
+            keepout_restrictions: json_keepout(json),
         })
     }
 
     /// Parses a region from JSON.
     pub(crate) fn parse_region(json: &Value) -> Option<crate::altium::pcblib::Region> {
-        use crate::altium::pcblib::{Layer, PcbFlags, Region, Vertex};
+        use crate::altium::pcblib::{Layer, Region, Vertex};
 
         let vertices_json = json.get("vertices").and_then(Value::as_array)?;
         let layer = json
@@ -321,14 +361,14 @@ impl McpServer {
             vertices,
             holes: Vec::new(),
             layer,
-            flags: PcbFlags::empty(),
+            flags: json_flags(json),
             unique_id: None,
         })
     }
 
     /// Parses text from JSON.
     pub(crate) fn parse_text(json: &Value) -> Option<crate::altium::pcblib::Text> {
-        use crate::altium::pcblib::{Layer, PcbFlags, Text, TextJustification, TextKind};
+        use crate::altium::pcblib::{Layer, Text, TextJustification, TextKind};
 
         let x = json.get("x").and_then(Value::as_f64)?;
         let y = json.get("y").and_then(Value::as_f64)?;
@@ -358,7 +398,7 @@ impl McpServer {
             stroke_width,
             italic: false,
             justification: TextJustification::MiddleCenter,
-            flags: PcbFlags::empty(),
+            flags: json_flags(json),
             unique_id: None,
         })
     }
@@ -499,12 +539,10 @@ impl McpServer {
         if let Some(r) = json.get("rotation").and_then(Value::as_f64) {
             fill.rotation = r;
         }
-        // Optional mask/keepout tail (mirrors the modelled optionals).
+        // Optional flags + mask/keepout tail (mirrors the modelled optionals).
+        fill.flags = json_flags(json);
         fill.solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
-        fill.keepout_restrictions = json
-            .get("keepout_restrictions")
-            .and_then(Value::as_u64)
-            .and_then(|v| u8::try_from(v).ok());
+        fill.keepout_restrictions = json_keepout(json);
 
         Ok(fill)
     }
@@ -1115,5 +1153,133 @@ mod tests {
         assert!((line.x1 - (-28.995)).abs() < 1e-9, "x1 kept: {}", line.x1);
         assert!((line.y1 - 7.5).abs() < 1e-9, "y1 kept: {}", line.y1);
         assert!((line.x2 - 10.0).abs() < 1e-9, "x2 kept: {}", line.x2);
+    }
+
+    // --- PR-4: flags / solder_mask_expansion / keepout_restrictions on the
+    // write (JSON -> primitive) path. The `flags` JSON shape is the raw u16
+    // bitmask that `read_pcblib` serialises (PcbFlags is #[serde(transparent)]),
+    // so the values these tests feed in are the same ones a read would emit.
+
+    #[test]
+    fn json_flags_reads_read_dto_string_form() {
+        use crate::altium::pcblib::PcbFlags;
+        // Canonical round-trip shape: the bitflags serde string read_pcblib emits.
+        let flags = super::json_flags(&json!({ "flags": "LOCKED | KEEPOUT" }));
+        assert!(flags.contains(PcbFlags::LOCKED));
+        assert!(flags.contains(PcbFlags::KEEPOUT));
+        let single = super::json_flags(&json!({ "flags": "LOCKED" }));
+        assert!(single.contains(PcbFlags::LOCKED));
+        assert!(!single.contains(PcbFlags::KEEPOUT));
+        // Convenience shape: a raw bitmask integer (LOCKED 1 | KEEPOUT 4 = 5).
+        let int_flags = super::json_flags(&json!({ "flags": 5 }));
+        assert!(int_flags.contains(PcbFlags::LOCKED));
+        assert!(int_flags.contains(PcbFlags::KEEPOUT));
+        // Absent key -> empty (default), matching the read-side skip_serializing_if.
+        assert!(super::json_flags(&json!({})).is_empty());
+    }
+
+    #[test]
+    fn pcbflags_write_then_read_dto_round_trip() {
+        use crate::altium::pcblib::PcbFlags;
+        // The string the read DTO serialises must parse back to the same flags on
+        // the write path — guards the read/write shape reconciliation.
+        let original = PcbFlags::LOCKED | PcbFlags::KEEPOUT;
+        let dto = serde_json::to_value(original).expect("serialise flags");
+        let parsed = super::json_flags(&json!({ "flags": dto }));
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn parse_pad_reads_flags_and_solder_mask() {
+        use crate::altium::pcblib::{MaskExpansionMode, PcbFlags};
+        let pad = McpServer::parse_pad(&json!({
+            "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
+            "flags": "LOCKED",
+            "solder_mask_expansion": 0.05,
+            "solder_mask_expansion_mode": "manual",
+        }))
+        .expect("pad should parse");
+        assert!(pad.flags.contains(PcbFlags::LOCKED));
+        assert_eq!(pad.solder_mask_expansion, Some(0.05));
+        assert_eq!(pad.solder_mask_expansion_mode, MaskExpansionMode::Manual);
+    }
+
+    #[test]
+    fn parse_track_reads_flags_solder_mask_keepout() {
+        use crate::altium::pcblib::PcbFlags;
+        let track = McpServer::parse_track(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.15,
+            "layer": "Top Overlay",
+            "flags": "KEEPOUT",
+            "solder_mask_expansion": 0.1,
+            "keepout_restrictions": 3,
+        }))
+        .expect("track should parse");
+        assert!(track.flags.contains(PcbFlags::KEEPOUT));
+        assert_eq!(track.solder_mask_expansion, Some(0.1));
+        assert_eq!(track.keepout_restrictions, Some(3));
+        // Absent keys leave the Track::new defaults untouched.
+        let bare = McpServer::parse_track(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.15, "layer": "Top Overlay"
+        }))
+        .expect("bare track should parse");
+        assert!(bare.flags.is_empty());
+        assert_eq!(bare.solder_mask_expansion, None);
+        assert_eq!(bare.keepout_restrictions, None);
+    }
+
+    #[test]
+    fn parse_arc_reads_flags_solder_mask_keepout() {
+        use crate::altium::pcblib::PcbFlags;
+        let arc = McpServer::parse_arc(&json!({
+            "x": 0.0, "y": 0.0, "radius": 1.0,
+            "start_angle": 0.0, "end_angle": 90.0, "width": 0.15,
+            "layer": "Top Overlay",
+            "flags": "LOCKED",
+            "solder_mask_expansion": 0.2,
+            "keepout_restrictions": 5,
+        }))
+        .expect("arc should parse");
+        assert!(arc.flags.contains(PcbFlags::LOCKED));
+        assert_eq!(arc.solder_mask_expansion, Some(0.2));
+        assert_eq!(arc.keepout_restrictions, Some(5));
+    }
+
+    #[test]
+    fn parse_region_reads_flags() {
+        use crate::altium::pcblib::PcbFlags;
+        let region = McpServer::parse_region(&json!({
+            "layer": "Top Courtyard",
+            "vertices": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0}, {"x": 0.0, "y": 1.0}],
+            "flags": "KEEPOUT",
+        }))
+        .expect("region should parse");
+        assert!(region.flags.contains(PcbFlags::KEEPOUT));
+    }
+
+    #[test]
+    fn parse_fill_reads_flags() {
+        use crate::altium::pcblib::PcbFlags;
+        let fill = McpServer::parse_fill(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0, "layer": "Top Layer",
+            "flags": "LOCKED",
+            "solder_mask_expansion": 0.05,
+            "keepout_restrictions": 2,
+        }))
+        .expect("fill should parse");
+        assert!(fill.flags.contains(PcbFlags::LOCKED));
+        assert_eq!(fill.solder_mask_expansion, Some(0.05));
+        assert_eq!(fill.keepout_restrictions, Some(2));
+    }
+
+    #[test]
+    fn parse_text_reads_flags() {
+        use crate::altium::pcblib::PcbFlags;
+        let text = McpServer::parse_text(&json!({
+            "x": 0.0, "y": 0.0, "text": "REF", "height": 0.5, "layer": "Top Overlay",
+            "flags": "LOCKED",
+        }))
+        .expect("text should parse");
+        assert!(text.flags.contains(PcbFlags::LOCKED));
     }
 }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -614,7 +614,7 @@ impl McpServer {
             // Parse regions
             if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
                 for region_json in regions {
-                    check_keys!(region_json, &["layer", "vertices"]);
+                    check_keys!(region_json, &["layer", "vertices", "flags"]);
                     if let Some(region) = Self::parse_region(region_json) {
                         footprint.add_region(region);
                     }
@@ -627,6 +627,7 @@ impl McpServer {
                     check_keys!(
                         text_json,
                         &[
+                            "flags",
                             "height",
                             "layer",
                             "rotation",

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -448,6 +448,204 @@ def test_write_pcblib_via_fill(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_flags_mask_keepout(client, runner, lib_path):
+    print("\n=== Test: write_pcblib flags + solder_mask + keepout round trip ===")
+    # Coverage PR-4: the three EE-meaningful fields — flags, solder_mask_expansion,
+    # and keepout_restrictions — must be authorable via write_pcblib for every 2D
+    # primitive that carries them, and round-trip through read_pcblib. `flags` is
+    # serialised by read_pcblib as the bitflags name string (PcbFlags' serde impl),
+    # e.g. "LOCKED" or "LOCKED | KEEPOUT" — the write path accepts that same shape.
+    LOCKED = "LOCKED"
+    KEEPOUT = "KEEPOUT"
+    footprint = {
+        "name": "FLAGS_RT",
+        "pads": [
+            {
+                "designator": "1",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1.0,
+                "height": 1.0,
+                "flags": LOCKED,
+                "solder_mask_expansion": 0.05,
+                "solder_mask_expansion_mode": "manual",
+            }
+        ],
+        "tracks": [
+            {
+                "x1": -1.0,
+                "y1": 0.0,
+                "x2": 1.0,
+                "y2": 0.0,
+                "width": 0.15,
+                "layer": "Top Overlay",
+                "flags": LOCKED,
+                "solder_mask_expansion": 0.1,
+                "keepout_restrictions": 3,
+            }
+        ],
+        "arcs": [
+            {
+                "x": 0.0,
+                "y": 2.0,
+                "radius": 0.5,
+                "start_angle": 0.0,
+                "end_angle": 90.0,
+                "width": 0.15,
+                "layer": "Top Overlay",
+                "flags": LOCKED,
+                "solder_mask_expansion": 0.2,
+                "keepout_restrictions": 5,
+            }
+        ],
+        "regions": [
+            {
+                "vertices": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 1.0, "y": 0.0},
+                    {"x": 0.0, "y": 1.0},
+                ],
+                "layer": "Top Courtyard",
+                "flags": KEEPOUT,
+            }
+        ],
+        "fills": [
+            {
+                "x1": -1.0,
+                "y1": -1.0,
+                "x2": 1.0,
+                "y2": 1.0,
+                "layer": "Top Layer",
+                "flags": LOCKED,
+                "solder_mask_expansion": 0.05,
+                "keepout_restrictions": 2,
+            }
+        ],
+        "text": [
+            {
+                "x": 0.0,
+                "y": 3.0,
+                "text": "REF",
+                "height": 0.5,
+                "layer": "Top Overlay",
+                "flags": LOCKED,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(not write.get("_isError"), "write_pcblib (flags) succeeded", actual=write)
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("FLAGS_RT", {})
+    runner.check(bool(fp), "FLAGS_RT footprint present", actual=list(footprints))
+
+    # Tolerance: Altium stores mask values as fixed-point internal units, so a
+    # round-trip carries sub-micron quantisation error. 1e-4 mm is well below any
+    # meaningful PCB tolerance.
+    tol = 1e-4
+
+    def has_flag(value, name):
+        # read_pcblib serialises PcbFlags as a "|"-joined name string, e.g.
+        # "LOCKED" or "LOCKED | KEEPOUT". Assert set membership of the bit we set.
+        parts = {p.strip() for p in str(value or "").split("|")}
+        return name in parts
+
+    pads = fp.get("pads", [])
+    runner.check(len(pads) == 1, "1 pad survived", actual=len(pads))
+    if pads:
+        p = pads[0]
+        runner.check(has_flag(p.get("flags"), LOCKED), "pad flags LOCKED", actual=p.get("flags"))
+        runner.check(
+            abs(p.get("solder_mask_expansion", 0) - 0.05) < tol,
+            "pad solder_mask_expansion",
+            actual=p.get("solder_mask_expansion"),
+            expected=0.05,
+        )
+        runner.check(
+            p.get("solder_mask_expansion_mode") == "manual",
+            "pad solder_mask_expansion_mode",
+            actual=p.get("solder_mask_expansion_mode"),
+            expected="manual",
+        )
+
+    tracks = fp.get("tracks", [])
+    runner.check(len(tracks) == 1, "1 track survived", actual=len(tracks))
+    if tracks:
+        t = tracks[0]
+        runner.check(has_flag(t.get("flags"), LOCKED), "track flags LOCKED", actual=t.get("flags"))
+        runner.check(
+            abs(t.get("solder_mask_expansion", 0) - 0.1) < tol,
+            "track solder_mask_expansion",
+            actual=t.get("solder_mask_expansion"),
+            expected=0.1,
+        )
+        runner.check(
+            t.get("keepout_restrictions") == 3,
+            "track keepout_restrictions",
+            actual=t.get("keepout_restrictions"),
+            expected=3,
+        )
+
+    arcs = fp.get("arcs", [])
+    runner.check(len(arcs) == 1, "1 arc survived", actual=len(arcs))
+    if arcs:
+        a = arcs[0]
+        runner.check(has_flag(a.get("flags"), LOCKED), "arc flags LOCKED", actual=a.get("flags"))
+        runner.check(
+            abs(a.get("solder_mask_expansion", 0) - 0.2) < tol,
+            "arc solder_mask_expansion",
+            actual=a.get("solder_mask_expansion"),
+            expected=0.2,
+        )
+        runner.check(
+            a.get("keepout_restrictions") == 5,
+            "arc keepout_restrictions",
+            actual=a.get("keepout_restrictions"),
+            expected=5,
+        )
+
+    regions = fp.get("regions", [])
+    runner.check(len(regions) == 1, "1 region survived", actual=len(regions))
+    if regions:
+        rg = regions[0]
+        runner.check(has_flag(rg.get("flags"), KEEPOUT), "region flags KEEPOUT", actual=rg.get("flags"))
+
+    fills = fp.get("fills", [])
+    runner.check(len(fills) == 1, "1 fill survived", actual=len(fills))
+    if fills:
+        fl = fills[0]
+        runner.check(has_flag(fl.get("flags"), LOCKED), "fill flags LOCKED", actual=fl.get("flags"))
+        runner.check(
+            abs(fl.get("solder_mask_expansion", 0) - 0.05) < tol,
+            "fill solder_mask_expansion",
+            actual=fl.get("solder_mask_expansion"),
+            expected=0.05,
+        )
+        runner.check(
+            fl.get("keepout_restrictions") == 2,
+            "fill keepout_restrictions",
+            actual=fl.get("keepout_restrictions"),
+            expected=2,
+        )
+
+    # The writer may inject an auto designator/comment text, so locate the
+    # one we authored by content rather than asserting an exact count.
+    texts = fp.get("text", [])
+    ref_text = next((t for t in texts if t.get("text") == "REF"), None)
+    runner.check(ref_text is not None, "REF text survived", actual=[t.get("text") for t in texts])
+    if ref_text:
+        runner.check(
+            has_flag(ref_text.get("flags"), LOCKED),
+            "text flags LOCKED",
+            actual=ref_text.get("flags"),
+        )
+
+
 def main():
     binary = find_binary()
     print(f"Using binary: {binary}")
@@ -482,6 +680,7 @@ def main():
         test_write_read_roundtrip(client, runner, lib_path)
         test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path)
         test_write_pcblib_via_fill(client, runner, lib_path)
+        test_write_pcblib_flags_mask_keepout(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)


### PR DESCRIPTION
**Coverage roadmap PR-4** — expose `flags`, `solder_mask_expansion` (+mode), and `keepout_restrictions` on write for all PcbLib 2D primitives.

`read_pcblib` already serialises these (serde on the structs), but the write parsers dropped them — `flags` was never read for any primitive, and `track`/`arc` lost `solder_mask_expansion` + `keepout_restrictions` (arc hard-coded them to `None`).

## Change
- New `json_flags` helper parses `PcbFlags` from the read DTO's canonical `|`-joined name string (e.g. `"LOCKED | KEEPOUT"`); also accepts a raw bitmask integer. Wired into `parse_pad/track/arc/region/fill/text`.
- `track` + `arc` now parse `solder_mask_expansion` (+ `keepout_restrictions`); arc's hard-coded `None`s removed. (pad/via/fill already parsed mask; text/region carry only `flags`.)
- `write_pcblib` schema documents the new fields (`flags` as `string|integer`).
- Strict-deser allow-lists: `+flags` on region and text (their per-item `check_keys!`); pad/track/arc/via/fill are permissive at item level.

**Round-trip note:** `PcbFlags` serialises as a `|`-joined name string, not a raw int — `json_flags` round-trips that exact form (plus accepts an int for convenience).

## Test
`test_write_pcblib_flags_mask_keepout` sets `flags` (+ mask/keepout where supported) on pad/track/arc/region/fill/text and reads each back; plus `parsing.rs` unit tests.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (302+) / **integration 93/93** / **oracle 0 regressions**.

_Also includes one unrelated chore commit dropping `github.copilot` from `.vscode/extensions.json` recommendations (was staged locally)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
