### PR TITLE
feat(pcblib): model Pad thermal-relief & power-plane connection (PR-6)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -44,8 +44,8 @@ use serde::{Deserialize, Serialize};
 
 pub use primitives::{
     Arc, ComponentBody, EmbeddedModel, Fill, HoleShape, Layer, MaskExpansionMode, Model3D, Pad,
-    PadShape, PadStackMode, PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track,
-    Vertex, Via,
+    PadShape, PadStackMode, PcbFlags, PowerPlaneConnectStyle, Region, StrokeFont, Text,
+    TextJustification, TextKind, Track, Vertex, Via,
 };
 
 use crate::altium::error::{AltiumError, AltiumResult};
@@ -591,6 +591,55 @@ mod tests {
         assert!(approx_eq(decoded.pads[1].x, 0.5, 0.001));
         assert!(approx_eq(decoded.pads[0].width, 0.6, 0.001));
         assert!(approx_eq(decoded.pads[0].height, 0.5, 0.001));
+    }
+
+    #[test]
+    fn binary_roundtrip_pad_thermal_relief() {
+        // A pad with NON-default thermal-relief / power-plane settings must survive
+        // encode -> decode with all six fields intact.
+        let mut original = Footprint::new("ROUNDTRIP_PAD_RELIEF");
+        let mut pad = Pad::through_hole("1", 0.0, 0.0, 1.6, 1.6, 0.8);
+        pad.power_plane_connect_style = PowerPlaneConnectStyle::Direct;
+        pad.relief_conductor_width = 0.3; // != 0.254 default
+        pad.relief_entries = 2; // != 4 default
+        pad.relief_air_gap = 0.2; // != 0.254 default
+        pad.power_plane_relief_expansion = 0.6; // != 0.508 default
+        pad.power_plane_clearance = 0.7; // != 0.508 default
+        original.add_pad(pad);
+
+        let data = writer::encode_data_stream(&original).expect("encoding should succeed");
+        let mut decoded = Footprint::new("ROUNDTRIP_PAD_RELIEF");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.pads.len(), 1);
+        let p = &decoded.pads[0];
+        assert_eq!(p.power_plane_connect_style, PowerPlaneConnectStyle::Direct);
+        assert!(approx_eq(p.relief_conductor_width, 0.3, 0.0001));
+        assert_eq!(p.relief_entries, 2);
+        assert!(approx_eq(p.relief_air_gap, 0.2, 0.0001));
+        assert!(approx_eq(p.power_plane_relief_expansion, 0.6, 0.0001));
+        assert!(approx_eq(p.power_plane_clearance, 0.7, 0.0001));
+    }
+
+    #[test]
+    fn pad_default_thermal_relief_byte_identical() {
+        // A pad created with default thermal-relief must produce byte-for-byte
+        // identical output regardless of whether the writer emits the struct
+        // fields or the old fixed template constants. We prove this by checking
+        // that the default field values map back to the canonical template raw
+        // values (style 0; conductor width / air gap 100000; entries 4; relief
+        // expansion / clearance 200000), so the oracle stays at 0 regressions.
+        let pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        assert_eq!(
+            pad.power_plane_connect_style,
+            PowerPlaneConnectStyle::Relief
+        );
+        assert_eq!(pad.power_plane_connect_style.to_id(), 0);
+        assert_eq!(units::from_mm(pad.relief_conductor_width), 100_000);
+        assert_eq!(pad.relief_entries, 4);
+        assert_eq!(units::from_mm(pad.relief_air_gap), 100_000);
+        assert_eq!(units::from_mm(pad.power_plane_relief_expansion), 200_000);
+        assert_eq!(units::from_mm(pad.power_plane_clearance), 200_000);
     }
 
     #[test]

--- a/src/altium/pcblib/primitives/mod.rs
+++ b/src/altium/pcblib/primitives/mod.rs
@@ -44,7 +44,10 @@ pub use layer::Layer;
 mod models3d;
 pub use models3d::{ComponentBody, EmbeddedModel, Model3D};
 mod pads;
-pub use pads::{HoleShape, MaskExpansionMode, Pad, PadShape, PadStackMode, Via, ViaStackMode};
+pub use pads::{
+    HoleShape, MaskExpansionMode, Pad, PadShape, PadStackMode, PowerPlaneConnectStyle, Via,
+    ViaStackMode,
+};
 mod shapes;
 pub use shapes::{Arc, Region, Track, Vertex};
 mod text;

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -99,6 +99,48 @@ pub struct Pad {
     #[serde(default)]
     pub solder_mask_expansion_mode: MaskExpansionMode,
 
+    /// Power-plane connection style — extended-tail byte @67
+    /// (`Relief` / `Direct` / `NoConnect`). Altium's default is `Relief`.
+    #[serde(default)]
+    pub power_plane_connect_style: PowerPlaneConnectStyle,
+
+    /// Thermal-relief spoke (conductor) width in mm — extended-tail i32 @68.
+    /// Default: 0.254mm (10 mil), matching Altium's pad template.
+    #[serde(
+        default = "default_pad_relief_conductor_width",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub relief_conductor_width: f64,
+
+    /// Number of thermal-relief spokes (entries) — extended-tail i16 @72.
+    /// Default: 4.
+    #[serde(default = "default_pad_relief_entries")]
+    pub relief_entries: i16,
+
+    /// Thermal-relief air-gap width in mm — extended-tail i32 @74.
+    /// Default: 0.254mm (10 mil), matching Altium's pad template.
+    #[serde(
+        default = "default_pad_relief_air_gap",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub relief_air_gap: f64,
+
+    /// Power-plane relief expansion in mm — extended-tail i32 @78.
+    /// Default: 0.508mm (20 mil), matching Altium's pad template.
+    #[serde(
+        default = "default_pad_power_plane_relief_expansion",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub power_plane_relief_expansion: f64,
+
+    /// Power-plane (anti-pad) clearance to the plane in mm — extended-tail i32 @82.
+    /// Default: 0.508mm (20 mil), matching Altium's pad template.
+    #[serde(
+        default = "default_pad_power_plane_clearance",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub power_plane_clearance: f64,
+
     /// Corner radius as percentage of smaller pad dimension (0-100).
     /// Only applies to `RoundedRectangle` shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -158,6 +200,31 @@ fn is_default_hole_shape(shape: &HoleShape) -> bool {
     *shape == HoleShape::default()
 }
 
+/// Default pad thermal-relief conductor width (10 mil = 0.254mm; raw 100000).
+const fn default_pad_relief_conductor_width() -> f64 {
+    0.254
+}
+
+/// Default pad thermal-relief spoke count (matches Altium's pad template).
+const fn default_pad_relief_entries() -> i16 {
+    4
+}
+
+/// Default pad thermal-relief air gap (10 mil = 0.254mm; raw 100000).
+const fn default_pad_relief_air_gap() -> f64 {
+    0.254
+}
+
+/// Default pad power-plane relief expansion (20 mil = 0.508mm; raw 200000).
+const fn default_pad_power_plane_relief_expansion() -> f64 {
+    0.508
+}
+
+/// Default pad power-plane (anti-pad) clearance (20 mil = 0.508mm; raw 200000).
+const fn default_pad_power_plane_clearance() -> f64 {
+    0.508
+}
+
 impl Pad {
     /// Creates a new SMD pad on the top layer.
     #[must_use]
@@ -177,6 +244,12 @@ impl Pad {
             solder_mask_expansion: None,
             paste_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
+            power_plane_connect_style: PowerPlaneConnectStyle::Relief,
+            relief_conductor_width: default_pad_relief_conductor_width(),
+            relief_entries: default_pad_relief_entries(),
+            relief_air_gap: default_pad_relief_air_gap(),
+            power_plane_relief_expansion: default_pad_power_plane_relief_expansion(),
+            power_plane_clearance: default_pad_power_plane_clearance(),
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,
@@ -213,6 +286,12 @@ impl Pad {
             solder_mask_expansion: None,
             paste_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
+            power_plane_connect_style: PowerPlaneConnectStyle::Relief,
+            relief_conductor_width: default_pad_relief_conductor_width(),
+            relief_entries: default_pad_relief_entries(),
+            relief_air_gap: default_pad_relief_air_gap(),
+            power_plane_relief_expansion: default_pad_power_plane_relief_expansion(),
+            power_plane_clearance: default_pad_power_plane_clearance(),
             corner_radius_percent: None,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,
@@ -324,6 +403,45 @@ impl MaskExpansionMode {
             Self::None => 0,
             Self::FromRule => 1,
             Self::Manual => 2,
+        }
+    }
+}
+
+/// Power-plane connection style for a pad (Altium `TPlaneConnectStyle`).
+///
+/// Controls how a pad connects to an internal power plane: with a thermal-relief
+/// spoke pattern, a solid (direct) copper connection, or no connection at all.
+/// Stored as a single byte at extended-tail offset 67.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PowerPlaneConnectStyle {
+    /// Thermal-relief connection (spokes). Altium's default.
+    #[default]
+    Relief,
+    /// Solid/direct copper connection to the plane.
+    Direct,
+    /// No connection to the plane.
+    NoConnect,
+}
+
+impl PowerPlaneConnectStyle {
+    /// Creates from the Altium byte (`0` = `Relief`, `1` = `Direct`, `2` = `NoConnect`).
+    #[must_use]
+    pub const fn from_id(id: u8) -> Self {
+        match id {
+            1 => Self::Direct,
+            2 => Self::NoConnect,
+            _ => Self::Relief,
+        }
+    }
+
+    /// Returns the Altium connection-style byte.
+    #[must_use]
+    pub const fn to_id(self) -> u8 {
+        match self {
+            Self::Relief => 0,
+            Self::Direct => 1,
+            Self::NoConnect => 2,
         }
     }
 }

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -28,13 +28,13 @@ use std::collections::HashMap;
 
 use super::primitives::{
     Arc, ComponentBody, Fill, HoleShape, Layer, MaskExpansionMode, Pad, PadShape, PadStackMode,
-    PcbFlags, Region, StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via,
-    ViaStackMode,
+    PcbFlags, PowerPlaneConnectStyle, Region, StrokeFont, Text, TextJustification, TextKind, Track,
+    Vertex, Via, ViaStackMode,
 };
 use super::Footprint;
 use crate::altium::bytes::{
-    read_f64_le as read_f64, read_i32_le as read_i32, read_u16_le as read_u16,
-    read_u32_le as read_u32,
+    read_f64_le as read_f64, read_i16_le as read_i16, read_i32_le as read_i32,
+    read_u16_le as read_u16, read_u32_le as read_u32,
 };
 use crate::altium::error::AltiumError;
 

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -174,6 +174,21 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         MaskExpansionMode::from_id(b)
     });
 
+    // Thermal-relief / power-plane connection fields (extended tail). Each
+    // falls back to the from-scratch default (= Altium's pad template constant)
+    // when the byte is absent, so a short or older pad round-trips faithfully.
+    // 67: connection style; 68-71/74-77/78-81/82-85: i32 coords; 72-73: i16 count.
+    let power_plane_connect_style = geometry
+        .get(67)
+        .map_or(PowerPlaneConnectStyle::Relief, |&b| {
+            PowerPlaneConnectStyle::from_id(b)
+        });
+    let relief_conductor_width = read_i32(geometry, 68).map_or(0.254, to_mm);
+    let relief_entries = read_i16(geometry, 72).unwrap_or(4);
+    let relief_air_gap = read_i32(geometry, 74).map_or(0.254, to_mm);
+    let power_plane_relief_expansion = read_i32(geometry, 78).map_or(0.508, to_mm);
+    let power_plane_clearance = read_i32(geometry, 82).map_or(0.508, to_mm);
+
     // Parse per-layer data when stack mode is not Simple
     // Per-layer data format:
     // - 32 size entries (width, height as i32 pairs) = 256 bytes
@@ -247,6 +262,12 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         solder_mask_expansion,
         paste_mask_expansion_mode,
         solder_mask_expansion_mode,
+        power_plane_connect_style,
+        relief_conductor_width,
+        relief_entries,
+        relief_air_gap,
+        power_plane_relief_expansion,
+        power_plane_clearance,
         corner_radius_percent,
         stack_mode,
         per_layer_sizes,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -583,6 +583,25 @@ fn build_pad_extended_tail(pad: &Pad) -> [u8; 141] {
 
     // 62: pad stack mode
     tail[62 - START] = pad_stack_mode_to_id(pad.stack_mode);
+    // Thermal-relief / power-plane connection fields. Each default equals the
+    // template constant at its offset (style 0; conductor width / air gap
+    // 100000 = 0.254mm; entries 4; relief expansion / clearance 200000 =
+    // 0.508mm), so a default pad stays byte-identical. See
+    // PAD_EXTENDED_TAIL_TEMPLATE.
+    // 67: power-plane connection style (0=Relief, 1=Direct, 2=NoConnect)
+    tail[67 - START] = pad.power_plane_connect_style.to_id();
+    // 68-71: thermal-relief conductor (spoke) width
+    tail[68 - START..72 - START]
+        .copy_from_slice(&from_mm(pad.relief_conductor_width).to_le_bytes());
+    // 72-73: thermal-relief spoke count (i16)
+    tail[72 - START..74 - START].copy_from_slice(&pad.relief_entries.to_le_bytes());
+    // 74-77: thermal-relief air gap
+    tail[74 - START..78 - START].copy_from_slice(&from_mm(pad.relief_air_gap).to_le_bytes());
+    // 78-81: power-plane relief expansion
+    tail[78 - START..82 - START]
+        .copy_from_slice(&from_mm(pad.power_plane_relief_expansion).to_le_bytes());
+    // 82-85: power-plane (anti-pad) clearance
+    tail[82 - START..86 - START].copy_from_slice(&from_mm(pad.power_plane_clearance).to_le_bytes());
     // 86-89 / 90-93: paste & solder mask expansion
     tail[86 - START..90 - START]
         .copy_from_slice(&from_mm(pad.paste_mask_expansion.unwrap_or(0.0)).to_le_bytes());

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -203,6 +203,16 @@ impl McpServer {
                                                     "enum": ["none", "from_rule", "manual"],
                                                     "description": "Solder mask expansion mode. Default: from_rule"
                                                 },
+                                                "power_plane_connect_style": {
+                                                    "type": "string",
+                                                    "enum": ["relief", "direct", "no_connect"],
+                                                    "description": "How the pad connects to an internal power plane. Default: relief (thermal spokes)"
+                                                },
+                                                "relief_conductor_width": { "type": "number", "description": "Thermal-relief spoke (conductor) width in mm. Default: 0.254 (10 mil)" },
+                                                "relief_entries": { "type": "integer", "description": "Number of thermal-relief spokes. Default: 4" },
+                                                "relief_air_gap": { "type": "number", "description": "Thermal-relief air-gap width in mm. Default: 0.254 (10 mil)" },
+                                                "power_plane_relief_expansion": { "type": "number", "description": "Power-plane relief expansion in mm. Default: 0.508 (20 mil)" },
+                                                "power_plane_clearance": { "type": "number", "description": "Power-plane (anti-pad) clearance to the plane in mm. Default: 0.508 (20 mil)" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["designator", "x", "y", "width", "height"]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -83,7 +83,9 @@ impl McpServer {
     /// Parses a pad from JSON.
     #[allow(clippy::too_many_lines)] // Pad has many fields requiring individual parsing
     pub(crate) fn parse_pad(json: &Value) -> Result<crate::altium::pcblib::Pad, String> {
-        use crate::altium::pcblib::{Layer, MaskExpansionMode, Pad, PadShape, PadStackMode};
+        use crate::altium::pcblib::{
+            Layer, MaskExpansionMode, Pad, PadShape, PadStackMode, PowerPlaneConnectStyle,
+        };
 
         let designator = json
             .get("designator")
@@ -205,6 +207,40 @@ impl McpServer {
             .and_then(|v| u8::try_from(v).ok())
             .filter(|&v| v <= 100);
 
+        // Thermal-relief / power-plane connection fields. Absent keys keep the
+        // from-scratch defaults (= Altium's pad template), so an unspecified pad
+        // round-trips byte-identically.
+        let power_plane_connect_style = json
+            .get("power_plane_connect_style")
+            .and_then(Value::as_str)
+            .map(|s| match s.to_lowercase().as_str() {
+                "direct" => PowerPlaneConnectStyle::Direct,
+                "no_connect" | "noconnect" => PowerPlaneConnectStyle::NoConnect,
+                _ => PowerPlaneConnectStyle::Relief,
+            })
+            .unwrap_or_default();
+        let relief_conductor_width = json
+            .get("relief_conductor_width")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.254);
+        let relief_entries = json
+            .get("relief_entries")
+            .and_then(Value::as_i64)
+            .and_then(|v| i16::try_from(v).ok())
+            .unwrap_or(4);
+        let relief_air_gap = json
+            .get("relief_air_gap")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.254);
+        let power_plane_relief_expansion = json
+            .get("power_plane_relief_expansion")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.508);
+        let power_plane_clearance = json
+            .get("power_plane_clearance")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.508);
+
         Ok(Pad {
             designator: designator.to_string(),
             x,
@@ -220,6 +256,12 @@ impl McpServer {
             solder_mask_expansion,
             paste_mask_expansion_mode,
             solder_mask_expansion_mode,
+            power_plane_connect_style,
+            relief_conductor_width,
+            relief_entries,
+            relief_air_gap,
+            power_plane_relief_expansion,
+            power_plane_clearance,
             corner_radius_percent,
             stack_mode: PadStackMode::Simple,
             per_layer_sizes: None,
@@ -1279,6 +1321,50 @@ mod tests {
         assert!(pad.flags.contains(PcbFlags::LOCKED));
         assert_eq!(pad.solder_mask_expansion, Some(0.05));
         assert_eq!(pad.solder_mask_expansion_mode, MaskExpansionMode::Manual);
+    }
+
+    #[test]
+    fn parse_pad_reads_thermal_relief_fields() {
+        use crate::altium::pcblib::PowerPlaneConnectStyle;
+        // Non-default thermal-relief / power-plane keys parse into the model.
+        let pad = McpServer::parse_pad(&json!({
+            "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
+            "power_plane_connect_style": "direct",
+            "relief_conductor_width": 0.3,
+            "relief_entries": 2,
+            "relief_air_gap": 0.2,
+            "power_plane_relief_expansion": 0.6,
+            "power_plane_clearance": 0.7,
+        }))
+        .expect("pad should parse");
+        assert_eq!(
+            pad.power_plane_connect_style,
+            PowerPlaneConnectStyle::Direct
+        );
+        assert!((pad.relief_conductor_width - 0.3).abs() < 1e-9);
+        assert_eq!(pad.relief_entries, 2);
+        assert!((pad.relief_air_gap - 0.2).abs() < 1e-9);
+        assert!((pad.power_plane_relief_expansion - 0.6).abs() < 1e-9);
+        assert!((pad.power_plane_clearance - 0.7).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_pad_thermal_relief_defaults() {
+        use crate::altium::pcblib::PowerPlaneConnectStyle;
+        // Absent keys keep the from-scratch defaults (= Altium's pad template).
+        let pad = McpServer::parse_pad(&json!({
+            "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
+        }))
+        .expect("pad should parse");
+        assert_eq!(
+            pad.power_plane_connect_style,
+            PowerPlaneConnectStyle::Relief
+        );
+        assert!((pad.relief_conductor_width - 0.254).abs() < 1e-9);
+        assert_eq!(pad.relief_entries, 4);
+        assert!((pad.relief_air_gap - 0.254).abs() < 1e-9);
+        assert!((pad.power_plane_relief_expansion - 0.508).abs() < 1e-9);
+        assert!((pad.power_plane_clearance - 0.508).abs() < 1e-9);
     }
 
     #[test]

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -646,6 +646,89 @@ def test_write_pcblib_flags_mask_keepout(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_pad_thermal_relief(client, runner, lib_path):
+    print("\n=== Test: write_pcblib pad thermal-relief / power-plane round trip ===")
+    # Coverage PR-6: the six pad thermal-relief / power-plane connection fields
+    # must be authorable via write_pcblib and round-trip through read_pcblib.
+    footprint = {
+        "name": "PAD_RELIEF_RT",
+        "pads": [
+            {
+                "designator": "1",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 1.6,
+                "height": 1.6,
+                "hole_size": 0.8,
+                "layer": "Multi-Layer",
+                "power_plane_connect_style": "direct",
+                "relief_conductor_width": 0.3,
+                "relief_entries": 2,
+                "relief_air_gap": 0.2,
+                "power_plane_relief_expansion": 0.6,
+                "power_plane_clearance": 0.7,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_pcblib (pad relief) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("PAD_RELIEF_RT", {})
+    runner.check(bool(fp), "PAD_RELIEF_RT footprint present", actual=list(footprints))
+
+    # Coord fields carry sub-micron fixed-point quantisation; 1e-4 mm is well
+    # below any meaningful PCB tolerance.
+    tol = 1e-4
+    pads = fp.get("pads", [])
+    runner.check(len(pads) == 1, "1 pad survived", actual=len(pads))
+    if pads:
+        p = pads[0]
+        runner.check(
+            p.get("power_plane_connect_style") == "direct",
+            "pad power_plane_connect_style",
+            actual=p.get("power_plane_connect_style"),
+            expected="direct",
+        )
+        runner.check(
+            abs(p.get("relief_conductor_width", 0) - 0.3) < tol,
+            "pad relief_conductor_width",
+            actual=p.get("relief_conductor_width"),
+            expected=0.3,
+        )
+        runner.check(
+            p.get("relief_entries") == 2,
+            "pad relief_entries",
+            actual=p.get("relief_entries"),
+            expected=2,
+        )
+        runner.check(
+            abs(p.get("relief_air_gap", 0) - 0.2) < tol,
+            "pad relief_air_gap",
+            actual=p.get("relief_air_gap"),
+            expected=0.2,
+        )
+        runner.check(
+            abs(p.get("power_plane_relief_expansion", 0) - 0.6) < tol,
+            "pad power_plane_relief_expansion",
+            actual=p.get("power_plane_relief_expansion"),
+            expected=0.6,
+        )
+        runner.check(
+            abs(p.get("power_plane_clearance", 0) - 0.7) < tol,
+            "pad power_plane_clearance",
+            actual=p.get("power_plane_clearance"),
+            expected=0.7,
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -818,6 +901,7 @@ def main():
         test_write_pcblib_auto_3d_body_opt_in(client, runner, lib_path)
         test_write_pcblib_via_fill(client, runner, lib_path)
         test_write_pcblib_flags_mask_keepout(client, runner, lib_path)
+        test_write_pcblib_pad_thermal_relief(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)


### PR DESCRIPTION
**Coverage roadmap PR-6** — the first **format-EE** PR: model the Pad's thermal-relief & power-plane connection.

These 6 fields already exist in the pad's extended tail, but our reader skipped them and the writer emitted fixed template constants — so an AI couldn't read or set how a through-hole pad connects to a power/ground plane (direct vs thermal-relief vs no-connect, spoke width/count, air gap, plane clearance).

## Fields (extended-tail offsets)
| Field | Offset | Default |
|-------|--------|---------|
| `power_plane_connect_style` (relief/direct/no_connect) | 67 | relief |
| `relief_conductor_width` | 68 | 0.254 mm |
| `relief_entries` (spoke count) | 72 | 4 |
| `relief_air_gap` | 74 | 0.254 mm |
| `power_plane_relief_expansion` | 78 | 0.508 mm |
| `power_plane_clearance` | 82 | 0.508 mm |

## Byte-identity (the safety property)
Each default is matched to the template's exact raw constant (`from_mm(0.254)=100000`, `from_mm(0.508)=200000`), so a pad with default thermal-relief serialises byte-for-byte identically. **Oracle: 0 regressions** confirms it.

## Change
- **Struct** (`pads.rs`): 6 fields + new `PowerPlaneConnectStyle` enum (mirrors `MaskExpansionMode`); constructors set defaults; read DTO exposes them via serde.
- **Reader** reads the 6 offsets; **writer** `build_pad_extended_tail` overlays the struct values over the template.
- **Tool**: `parse_pad` reads the keys; `write_pcblib` pad schema documents them.

Mirrors how Via already models thermal-relief, for consistency.

## Test
Rust round-trip (non-default pad survives) + byte-identity (defaults → canonical raw values); Python `test_write_pcblib_pad_thermal_relief`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (315) / **integration 131/131** / **oracle 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
