### PR TITLE
feat(mcp): self-documenting tools — generated TOOLS.md, drift guard, initialize instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,8 @@ jobs:
                 cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
                 cp README.md LICENCE CHANGELOG.md dist/
                 cp config/example-config.json dist/
+                mkdir -p dist/docs
+                cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
                 cd dist
                 tar -czvf ../${{ matrix.artifact }}.tar.gz *
 
@@ -159,6 +161,8 @@ jobs:
                 cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
                 cp README.md LICENCE CHANGELOG.md dist/
                 cp config/example-config.json dist/
+                mkdir -p dist/docs
+                cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
                 cd dist
                 7z a -tzip ../${{ matrix.artifact }}.zip *
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,55 @@
+# Using altium-designer-mcp
+
+Invariants for an agent driving this server. For the per-tool parameter schema
+and a worked example of every tool, call `tools/list` (the schema travels with
+the server) or read `docs/TOOLS.md`. This guide covers only the conventions that
+the per-tool schema does not.
+
+## Responsibility split
+
+The **agent** supplies the intelligence — it computes footprint land patterns,
+pin positions, and symbol geometry (from datasheets, IPC-7351, etc.). The
+**tool** only validates and writes those primitives to the Altium binary
+format. The server never invents geometry; pass it exact, finished numbers.
+
+## Coordinate units (this trips up most callers)
+
+- **`.PcbLib` (footprints):** millimetres. Pad/track/arc/region coordinates and
+  sizes are all mm.
+- **`.SchLib` (symbols):** schematic units where **10 units = 1 grid square**
+  (≈ 100 mil). These are *not* millimetres. Graphic primitives accept fractional
+  values; pin coordinates are integers.
+
+## Pin geometry (the counter-intuitive one)
+
+For a schematic pin, `(x, y)` is the **body-attach (inner) end** — the end that
+touches the symbol body — **not** the connection tip. `orientation` is the
+direction the pin **points outward**:
+
+- `left`  → tip at `x - length` (pin sits on the body's left edge)
+- `right` → tip at `x + length` (right edge)
+- `up`    → tip at `y + length` (top edge)
+- `down`  → tip at `y - length` (bottom edge)
+
+So a left-side pin uses `"left"` with its `(x, y)` on the left edge of the body
+rectangle; the tip extends further left. The `write_schlib` response echoes each
+pin's computed `body_end`/`tip` so you can verify placement without opening
+Altium.
+
+## Filesystem sandbox
+
+Only paths inside the configured `allowed_paths` (see `config.json`) can be read
+or written. Requests outside the sandbox are rejected. Writes create a timestamped
+`.bak` of any existing file first.
+
+## Typical build flow
+
+1. Gather the real pinout/dimensions (datasheet, land-pattern drawing).
+2. Compute geometry (the agent's job).
+3. `write_pcblib` for footprints, `write_schlib` for symbols.
+4. Link each symbol to its footprint(s) via the symbol's `footprints` field
+   (`name` + optional `library_path`).
+5. `write_libpkg` to group the `.SchLib` + `.PcbLib` for compilation.
+
+Compiling to an `.IntLib` is a one-click step inside Altium; this server only
+produces the source documents.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,1327 +1,1064 @@
+<!-- GENERATED — do not edit by hand.
+     Source of truth: src/mcp/tool_definitions.rs
+     Regenerate: UPDATE_DOCS=1 cargo test --lib tools_md_in_sync -->
+
 # MCP Tools Reference
 
-Complete reference for every tool the **altium-designer-mcp** server exposes — parameters, behaviour, and examples. For a categorised overview, see [README § MCP Tools](../README.md#mcp-tools).
+Every tool the **altium-designer-mcp** server exposes, rendered from the tool
+definitions served over `tools/list`. Coordinates are millimetres for `.PcbLib`
+footprints and schematic units (10 units = 1 grid square) for `.SchLib` symbols.
+
+_34 tools._
 
 ## `read_pcblib`
 
-Read footprints from an Altium `.PcbLib` file. All coordinates are in millimetres.
+Read an Altium .PcbLib file and return its contents including footprints with their primitives (pads, tracks, arcs, regions, text). Returns structured data that can be used to understand existing footprint styles. All coordinates and dimensions are in millimetres (mm). For large libraries, use component_name to fetch specific footprints, or use limit/offset for pagination.
+
+**Example**
 
 ```json
 {
-    "name": "read_pcblib",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib"
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "read_pcblib"
 }
 ```
 
-**Pagination options** (for large libraries):
+**Parameters**
 
-```json
-{
-    "name": "read_pcblib",
-    "arguments": {
-        "filepath": "./LargeLibrary.PcbLib",
-        "component_name": "RESC1608X55N",
-        "limit": 10,
-        "offset": 0,
-        "compact": true
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `component_name` | Fetch only this specific footprint |
-| `limit` | Maximum footprints to return |
-| `offset` | Skip first N footprints |
-| `compact` | Omit redundant per-layer pad data when uniform (default: `true`) |
-
-## `write_pcblib`
-
-Write footprints to an Altium `.PcbLib` file. The AI provides primitive definitions.
-
-```json
-{
-    "name": "write_pcblib",
-    "arguments": {
-        "filepath": "./Passives.PcbLib",
-        "footprints": [{
-            "name": "RESC1608X55N",
-            "description": "Chip resistor, 0603 (1608 metric)",
-            "pads": [
-                { "designator": "1", "x": -0.75, "y": 0, "width": 0.9, "height": 0.95 },
-                { "designator": "2", "x": 0.75, "y": 0, "width": 0.9, "height": 0.95 }
-            ],
-            "tracks": [
-                { "x1": -0.8, "y1": -0.425, "x2": 0.8, "y2": -0.425, "width": 0.12, "layer": "Top Overlay" },
-                { "x1": -0.8, "y1": 0.425, "x2": 0.8, "y2": 0.425, "width": 0.12, "layer": "Top Overlay" }
-            ],
-            "regions": [
-                { "vertices": [{"x": -1.45, "y": -0.73}, {"x": 1.45, "y": -0.73}, {"x": 1.45, "y": 0.73}, {"x": -1.45, "y": 0.73}], "layer": "Top Courtyard" }
-            ]
-        }],
-        "append": false
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `append` | If `true`, add footprints to existing file; if `false`, create new file (default: `false`) |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `compact` | boolean | no | If true (default), omit per-layer pad data when stack_mode is Simple. Set to false for full output. |
+| `component_name` | string | no | Optional: fetch only this specific footprint by name |
+| `filepath` | string | yes | Path to the .PcbLib file |
+| `limit` | integer | no | Optional: maximum number of footprints to return (default: all) |
+| `offset` | integer | no | Optional: skip first N footprints (default: 0) |
 
 ## `read_schlib`
 
-Read symbols from an Altium `.SchLib` file. Coordinates are in schematic units (10 units = 1 grid).
+Read an Altium .SchLib file and return its contents including symbols with their primitives (pins, rectangles, lines, text). Coordinates are in schematic units (10 units = 1 grid square, not mm). For large libraries, use component_name to fetch specific symbols, or use limit/offset for pagination.
+
+**Example**
 
 ```json
 {
-    "name": "read_schlib",
-    "arguments": {
-        "filepath": "./MySymbols.SchLib"
-    }
+  "arguments": {
+    "filepath": "./MySymbols.SchLib"
+  },
+  "name": "read_schlib"
 }
 ```
 
-**Pagination options** (for large libraries):
+**Parameters**
 
-```json
-{
-    "name": "read_schlib",
-    "arguments": {
-        "filepath": "./LargeLibrary.SchLib",
-        "component_name": "RES_0603",
-        "limit": 10,
-        "offset": 0
-    }
-}
-```
-
-## `write_schlib`
-
-Write symbols to an Altium `.SchLib` file. The AI provides primitive definitions.
-
-```json
-{
-    "name": "write_schlib",
-    "arguments": {
-        "filepath": "./MySymbols.SchLib",
-        "symbols": [...],
-        "append": false
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `append` | If `true`, add symbols to existing file; if `false`, create new file (default: `false`) |
-
-**Symbol properties:**
-
-| Property | Description |
-|----------|-------------|
-| `name` | Symbol name (required) |
-| `description` | Symbol description |
-| `designator_prefix` | Designator prefix (e.g., "R", "U", "C") |
-| `part_count` | Number of parts for multi-part symbols (default: 1) |
-| `pins` | Array of pin definitions |
-
-**Pin properties:**
-
-| Property | Description |
-|----------|-------------|
-| `designator` | Pin number (required) |
-| `name` | Pin name (required) |
-| `x`, `y` | Position in schematic units (required) |
-| `length` | Pin length (required) |
-| `orientation` | `left`, `right`, `up`, `down` (required) |
-| `electrical_type` | `input`, `output`, `bidirectional`, `passive`, `power` |
-| `owner_part_id` | Part number for multi-part symbols (1-based, default: 1) |
-| `symbol_inner_edge` | Pin symbol at inner edge: `none`, `dot`, `clock`, `schmitt`, etc. |
-| `symbol_outer_edge` | Pin symbol at outer edge: `none`, `dot`, `active_low_input`, etc. |
-| `symbol_inside` | Pin symbol inside: `none`, `dot`, `clock`, etc. |
-| `symbol_outside` | Pin symbol outside: `none`, `dot`, `clock`, etc. |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | no | Optional: fetch only this specific symbol by name |
+| `filepath` | string | yes | Path to the .SchLib file |
+| `limit` | integer | no | Optional: maximum number of symbols to return (default: all) |
+| `offset` | integer | no | Optional: skip first N symbols (default: 0) |
 
 ## `list_components`
 
-List component names in an Altium library file. Supports pagination for large libraries.
+List all component/footprint names in an Altium library file (.PcbLib or .SchLib). Supports pagination with limit/offset for large libraries. Use include_metadata for additional details like part_count and pin_count.
+
+**Example**
 
 ```json
 {
-    "name": "list_components",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "limit": 50,
-        "offset": 0,
-        "include_metadata": true
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib",
+    "include_metadata": true,
+    "limit": 50,
+    "offset": 0
+  },
+  "name": "list_components"
 }
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the library file |
-| `limit` | No | Maximum number of components to return (default: all) |
-| `offset` | No | Number of components to skip (default: 0) |
-| `include_metadata` | No | Include component metadata like pad/pin counts (default: `false`) |
+**Parameters**
 
-**Response includes:**
-
-- `total_count`: Total number of components in the library
-- `returned_count`: Number of components in this response
-- `offset`: Current offset
-- `has_more`: Whether more components are available
-
-**With `include_metadata: true` (PcbLib):**
-
-```json
-{
-    "components": [
-        { "name": "RESC0603", "pad_count": 2, "track_count": 4, "has_3d_model": true }
-    ]
-}
-```
-
-**With `include_metadata: true` (SchLib):**
-
-```json
-{
-    "components": [
-        { "name": "RESISTOR", "part_count": 1, "pin_count": 2, "footprint_count": 1 }
-    ]
-}
-```
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath` | string | yes | Path to the library file |
+| `include_metadata` | boolean | no | If true, return objects with metadata (part_count, pin_count, etc.) instead of just names. Default: false |
+| `limit` | integer | no | Maximum number of components to return (optional, default: all) |
+| `offset` | integer | no | Number of components to skip (optional, default: 0) |
 
 ## `extract_style`
 
-Extract styling information from an existing library.
+Extract style information from an existing Altium library file. Returns statistics about track widths, colours, pin lengths, layer usage, and other styling parameters. Use this to learn from existing libraries and create consistent new components.
+
+**Example**
 
 ```json
 {
-    "name": "extract_style",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib"
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "extract_style"
 }
 ```
 
-Returns statistics about track widths, pad shapes, pin lengths, colours, and layer usage.
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
+
+## `write_pcblib`
+
+Write footprints to an Altium .PcbLib file. Each footprint is defined by its primitives: pads (with position, size, shape, layer), tracks, vias, fills, arcs, regions, and text. The AI is responsible for calculating correct positions and sizes based on IPC-7351B or other standards. All coordinates and dimensions must be in millimetres (mm). The response 'bodies' array echoes each footprint's 3D body height and source; a footprint with no STEP model and no component body reports source 'none'. Set 'auto_3d_body': true to have an extruded placeholder body (default height 1.0 mm, flagged 'assumed_height': true) added to such footprints, then confirm or override it by supplying 'component_bodies' explicitly. The response also includes a 'warnings' array flagging silkscreen (overlay) tracks that overlap a pad (silk-on-pad) so you can move them clear.
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "append": false,
+    "filepath": "./Passives.PcbLib",
+    "footprints": [
+      {
+        "description": "Chip resistor, 0603 (1608 metric)",
+        "name": "RESC1608X55N",
+        "pads": [
+          {
+            "designator": "1",
+            "height": 0.95,
+            "width": 0.9,
+            "x": -0.75,
+            "y": 0
+          },
+          {
+            "designator": "2",
+            "height": 0.95,
+            "width": 0.9,
+            "x": 0.75,
+            "y": 0
+          }
+        ],
+        "regions": [
+          {
+            "layer": "Top Courtyard",
+            "vertices": [
+              {
+                "x": -1.45,
+                "y": -0.73
+              },
+              {
+                "x": 1.45,
+                "y": -0.73
+              },
+              {
+                "x": 1.45,
+                "y": 0.73
+              },
+              {
+                "x": -1.45,
+                "y": 0.73
+              }
+            ]
+          }
+        ],
+        "tracks": [
+          {
+            "layer": "Top Overlay",
+            "width": 0.12,
+            "x1": -0.8,
+            "x2": 0.8,
+            "y1": -0.425,
+            "y2": -0.425
+          },
+          {
+            "layer": "Top Overlay",
+            "width": 0.12,
+            "x1": -0.8,
+            "x2": 0.8,
+            "y1": 0.425,
+            "y2": 0.425
+          }
+        ]
+      }
+    ]
+  },
+  "name": "write_pcblib"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `append` | boolean | no | If true, append to existing file; if false, create new file |
+| `auto_3d_body` | boolean | no | If true, footprints with pads but no STEP model and no component body get a placeholder extruded 3D body (1.0 mm tall, flagged assumed_height). Default false: nothing is added unless you ask, since many footprints (fiducials, test points, mounting holes) legitimately have no body. Prefer supplying real heights via component_bodies. |
+| `filepath` | string | yes | Path to the .PcbLib file to create/modify |
+| `footprints` | array<object> | yes | Array of footprint definitions |
+
+## `write_schlib`
+
+Write schematic symbols to an Altium .SchLib file. Each symbol is defined by its primitives: pins, rectangles, round_rects, lines, polylines, polygons, arcs, ellipses, labels, and text. Coordinates must be in schematic units (10 units = 1 grid square, not mm).
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "filepath": "./MyLibrary.SchLib",
+    "symbols": [
+      {
+        "designator_prefix": "R",
+        "footprints": [
+          {
+            "library_path": "./MyLibrary.PcbLib",
+            "name": "R0402"
+          }
+        ],
+        "name": "R",
+        "parameters": [
+          {
+            "name": "Value",
+            "value": "10k"
+          }
+        ],
+        "pins": [
+          {
+            "designator": "1",
+            "electrical_type": "passive",
+            "length": 20,
+            "name": "1",
+            "orientation": "left",
+            "x": -50,
+            "y": 0
+          },
+          {
+            "designator": "2",
+            "electrical_type": "passive",
+            "length": 20,
+            "name": "2",
+            "orientation": "right",
+            "x": 50,
+            "y": 0
+          }
+        ],
+        "rectangles": [
+          {
+            "x1": -50,
+            "x2": 50,
+            "y1": -20,
+            "y2": 20
+          }
+        ]
+      }
+    ]
+  },
+  "name": "write_schlib"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `append` | boolean | no | If true, append to existing file; if false, create new file |
+| `filepath` | string | yes | Path to the .SchLib file to create/modify |
+| `symbols` | array<object> | yes | Array of symbol definitions |
+
+## `write_libpkg`
+
+Write an Altium Library Package (.LibPkg) project file that groups source library documents (.SchLib and .PcbLib) so they can be compiled into an Integrated Library (.IntLib). Member documents are referenced by their path relative to the .LibPkg. This generates only the project source; compiling to a binary .IntLib is a one-click operation inside Altium Designer (Project > Compile Integrated Library).
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "documents": [
+      "MyLibrary.SchLib",
+      "MyLibrary.PcbLib"
+    ],
+    "filepath": "./MyLibrary.LibPkg"
+  },
+  "name": "write_libpkg"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `documents` | array<string> | yes | Member document paths (.SchLib / .PcbLib). Each is referenced relative to the .LibPkg location; same-folder files become bare names. |
+| `filepath` | string | yes | Path to the .LibPkg file to create |
 
 ## `delete_component`
 
-Delete one or more components from an Altium library file. Works with both `.PcbLib` and `.SchLib` files.
-Use `dry_run=true` to preview changes without modifying the file.
+Delete one or more components from an Altium library file (.PcbLib or .SchLib). The file type is auto-detected from the extension. Returns status for each component: deleted, not_found, or error. Use dry_run=true to preview changes without modifying the file.
+
+**Example**
 
 ```json
 {
-    "name": "delete_component",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_names": ["OLD_FOOTPRINT", "UNUSED_COMPONENT"],
-        "dry_run": false
-    }
+  "arguments": {
+    "component_names": [
+      "OLD_FOOTPRINT",
+      "UNUSED_COMPONENT"
+    ],
+    "dry_run": false,
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "delete_component"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `component_names` | Array of component names to delete |
-| `dry_run` | If `true`, show what would be deleted without modifying the file (default: `false`) |
+**Parameters**
 
-Returns per-component status (`deleted` or `not_found`) and updated component counts.
-
-A backup is automatically created before deletion (see the `list_backups` and `restore_backup` tools).
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_names` | array<string> | yes | Names of components to delete |
+| `dry_run` | boolean | no | If true, show what would be deleted without actually modifying the file (default: `false`) |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
 
 ## `validate_library`
 
-Validate an Altium library file for common issues. Works with both `.PcbLib` and `.SchLib` files.
+Validate an Altium library file for common issues. Checks for: empty components (no pads/pins), duplicate designators, invalid coordinates, zero-size primitives, and other integrity problems. Returns a list of warnings and errors.
+
+**Example**
 
 ```json
 {
-    "name": "validate_library",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib"
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "validate_library"
 }
 ```
 
-Checks for:
+**Parameters**
 
-- Empty components (no pads/pins)
-- Duplicate designators within a component
-- Invalid coordinates (NaN, Infinity)
-- Zero or negative dimensions
-- Missing body graphics (SchLib)
-
-Returns status (`valid`, `warnings`, or `invalid`) with a list of issues found.
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
 
 ## `export_library`
 
-Export an Altium library to JSON or CSV format for version control, backup, or external processing.
+Export an Altium library to JSON or CSV format for version control, backup, or external processing. JSON includes full component data; CSV provides a summary table of component names and basic info.
+
+**Example**
 
 ```json
 {
-    "name": "export_library",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "format": "json",
-        "compact": true
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `format` | Export format: `json` for full data, `csv` for summary table |
-| `compact` | Omit redundant per-layer pad data when uniform (default: `true`) |
-
-**JSON format** returns complete component data including all primitives.
-
-**CSV format** returns a summary table with columns: name, description, pad/pin count, etc.
-
-## `extract_step_model`
-
-Extract embedded STEP 3D models from an Altium .PcbLib file. Models are stored compressed inside the library;
-this tool extracts them to standalone .step files. Supports multiple extraction modes and pagination.
-
-```json
-{
-    "name": "extract_step_model",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "output_path": "./extracted_model.step",
-        "model": "RESC1005X04L.step",
-        "mode": "auto"
-    }
-}
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the .PcbLib file containing embedded 3D models |
-| `output_path` | No | Path where the extracted .step file will be saved. If omitted, returns base64-encoded data. |
-| `model` | No | Model name (e.g., `RESC1005X04L.step`) or GUID to extract. If omitted and only one model exists, extracts it automatically. If multiple models exist and no model specified, lists available models. |
-| `mode` | No | Extraction mode: `auto` (default), `list`, `extract_all`, `extract_by_footprint` |
-| `footprint_name` | No | Footprint name (required for `extract_by_footprint` mode) |
-| `limit` | No | Maximum number of models to list (default: all) |
-| `offset` | No | Number of models to skip when listing (default: 0) |
-
-**Extraction Modes:**
-
-| Mode | Description |
-|------|-------------|
-| `auto` | Default behaviour — extract single model, or list if multiple exist |
-| `list` | List all available models without extracting |
-| `extract_all` | Extract all models to a directory (requires `output_path` to be a directory) |
-| `extract_by_footprint` | Extract models used by a specific footprint (requires `footprint_name`) |
-
-**Response (listing models):**
-
-```json
-{
-    "status": "list",
+  "arguments": {
+    "compact": true,
     "filepath": "./MyLibrary.PcbLib",
-    "message": "Multiple models found. Specify 'model' parameter with name or ID to extract.",
-    "total_count": 50,
-    "returned_count": 10,
-    "offset": 0,
-    "has_more": true,
-    "models": [
-        { "id": "{GUID...}", "name": "model1.step", "size_bytes": 12345 },
-        { "id": "{GUID...}", "name": "model2.step", "size_bytes": 67890 }
-    ]
+    "format": "json"
+  },
+  "name": "export_library"
 }
 ```
 
-**Response (extraction success):**
+**Parameters**
 
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
-    "output_path": "./extracted_model.step",
-    "model_id": "{GUID...}",
-    "model_name": "RESC1005X04L.step",
-    "size_bytes": 12345,
-    "message": "STEP model extracted to './extracted_model.step'"
-}
-```
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `compact` | boolean | no | For PcbLib JSON export: if true (default), omit per-layer pad data when stack_mode is Simple |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
+| `format` | enum | yes | Export format: 'json' for full data, 'csv' for summary table (one of: json, csv) |
 
 ## `import_library`
 
-Import components into an Altium library from JSON data. This is the inverse of `export_library` —
-it accepts the same JSON format that `export_library` produces, enabling round-trip workflows.
+Import components from JSON data into an Altium library file. Accepts JSON in the format produced by export_library, enabling round-trip workflows. Auto-detects library type (PcbLib/SchLib) from the JSON data.
+
+**Example**
 
 ```json
 {
-    "name": "import_library",
-    "arguments": {
-        "output_path": "./NewLibrary.PcbLib",
-        "json_data": {
-            "file_type": "PcbLib",
-            "footprints": [...]
-        },
-        "append": false
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `output_path` | Path for the output library file (.PcbLib or .SchLib) |
-| `json_data` | JSON object containing the library data (same format as `export_library` output) |
-| `append` | If `true`, add components to existing file; if `false`, create new file (default: `false`) |
-
-**JSON format (PcbLib):**
-
-```json
-{
-    "file_type": "PcbLib",
-    "footprints": [
+  "arguments": {
+    "json_data": {
+      "file_type": "PcbLib",
+      "footprints": [
         {
-            "name": "RESC1608X55N",
-            "description": "Chip resistor, 0603",
-            "pads": [...],
-            "tracks": [...],
-            "regions": [...]
+          "name": "R0402",
+          "pads": []
         }
-    ]
+      ]
+    },
+    "output_path": "./MyLibrary.PcbLib"
+  },
+  "name": "import_library"
 }
 ```
 
-**JSON format (SchLib):**
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `append` | boolean | no | If true, append to existing library instead of overwriting. Default: false |
+| `json_data` | object | yes | JSON data containing components to import. Should have 'file_type' (PcbLib/SchLib) and 'footprints' or 'symbols' array. |
+| `output_path` | string | yes | Path where the new library file will be created (.PcbLib or .SchLib) |
+
+## `extract_step_model`
+
+Extract embedded STEP 3D models from an Altium .PcbLib file. Models are stored compressed inside the library and this tool extracts them to standalone .step files. Supports multiple modes: 'auto' (default), 'list', 'extract_all', or 'extract_by_footprint'.
+
+**Example**
 
 ```json
 {
-    "file_type": "SchLib",
-    "symbols": [
-        {
-            "name": "RESISTOR",
-            "description": "Generic resistor",
-            "pins": [...]
-        }
-    ]
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib",
+    "mode": "auto",
+    "model": "RESC1005X04L.step",
+    "output_path": "./extracted_model.step"
+  },
+  "name": "extract_step_model"
 }
 ```
 
-The library type is determined from:
+**Parameters**
 
-1. The `file_type` field in the JSON data (preferred)
-2. The output file extension (.PcbLib or .SchLib)
-
-**Use cases:**
-
-- Round-trip editing: export → modify JSON → import
-- Version control: store libraries as JSON, import when needed
-- Migration: convert between formats or merge data from external sources
-- Backup restoration: recreate libraries from JSON backups
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath` | string | yes | Path to the .PcbLib file containing embedded 3D models |
+| `footprint_name` | string | no | Footprint name to extract models for (required for 'extract_by_footprint' mode) |
+| `limit` | integer | no | Maximum number of models to list (for 'list' mode) |
+| `mode` | enum | no | Extraction mode: 'auto' (default) extracts single model or lists if multiple; 'list' always lists models; 'extract_all' extracts all models to output_dir; 'extract_by_footprint' extracts models used by specified footprint (one of: auto, list, extract_all, extract_by_footprint) |
+| `model` | string | no | Model name (e.g., 'RESC1005X04L.step') or GUID to extract (for 'auto' mode) |
+| `offset` | integer | no | Number of models to skip when listing (for 'list' mode) |
+| `output_path` | string | no | For single extraction: file path for .step file. For extract_all: directory path for all models. |
 
 ## `diff_libraries`
 
-Compare two Altium library files and report differences. Both files must be the same type.
+Compare two Altium library files and report differences. Shows added, removed, and modified components. Both files must be the same type (.PcbLib or .SchLib).
+
+**Example**
 
 ```json
 {
-    "name": "diff_libraries",
-    "arguments": {
-        "filepath_a": "./OldLibrary.PcbLib",
-        "filepath_b": "./NewLibrary.PcbLib"
-    }
+  "arguments": {
+    "filepath_a": "./OldLibrary.PcbLib",
+    "filepath_b": "./NewLibrary.PcbLib"
+  },
+  "name": "diff_libraries"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `filepath_a` | Path to the first (base/old) library |
-| `filepath_b` | Path to the second (new/changed) library |
+**Parameters**
 
-Returns:
-
-- **added**: Components in B but not in A
-- **removed**: Components in A but not in B
-- **modified**: Components in both with changes (count differences, description changes)
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath_a` | string | yes | Path to the first (base/old) library file |
+| `filepath_b` | string | yes | Path to the second (new/changed) library file |
 
 ## `batch_update`
 
-Perform batch updates across all components in an Altium library file. Supports PcbLib
-operations (track width updates, layer renames) and SchLib operations (parameter updates).
+Perform batch updates across all components in an Altium library file. For PcbLib: update track widths, rename layers. For SchLib: update parameter values across symbols. Use dry_run=true to preview changes without modifying the file.
+
+**Example**
 
 ```json
 {
-    "name": "batch_update",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "operation": "update_track_width",
-        "parameters": {
-            "from_width": 0.2,
-            "to_width": 0.25,
-            "tolerance": 0.001
-        }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib",
+    "operation": "update_track_width",
+    "parameters": {
+      "from_width": 0.2,
+      "to_width": 0.25,
+      "tolerance": 0.001
     }
+  },
+  "name": "batch_update"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the PcbLib or SchLib file |
-| `operation` | One of: `update_track_width`, `rename_layer`, `update_parameters` |
-| `parameters` | Operation-specific parameters |
+**Parameters**
 
-**PcbLib Operations:**
-
-| Operation | Parameters | Description |
-|-----------|------------|-------------|
-| `update_track_width` | `from_width`, `to_width`, `tolerance` | Update all tracks matching `from_width` (±tolerance) to `to_width` |
-| `rename_layer` | `from_layer`, `to_layer` | Change all primitives from one layer to another |
-
-**SchLib Operations:**
-
-| Operation | Parameters | Description |
-|-----------|------------|-------------|
-| `update_parameters` | `param_name`, `param_value`, `symbol_filter`?, `add_if_missing`? | Update parameter values across symbols |
-
-**Example: Rename layer (PcbLib)**
-
-```json
-{
-    "name": "batch_update",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "operation": "rename_layer",
-        "parameters": {
-            "from_layer": "Mechanical 1",
-            "to_layer": "Mechanical 2"
-        }
-    }
-}
-```
-
-Layer names accept both spaced format (`Top Layer`) and camelCase (`TopLayer`).
-
-**Example: Update parameters across symbols (SchLib)**
-
-```json
-{
-    "name": "batch_update",
-    "arguments": {
-        "filepath": "./MySymbols.SchLib",
-        "operation": "update_parameters",
-        "parameters": {
-            "param_name": "Manufacturer",
-            "param_value": "Acme Corp",
-            "symbol_filter": "^RES.*",
-            "add_if_missing": true
-        }
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `param_name` | Name of the parameter to update |
-| `param_value` | New value for the parameter |
-| `symbol_filter` | Optional regex to filter which symbols to update |
-| `add_if_missing` | If true, add the parameter to symbols that don't have it (default: false) |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dry_run` | boolean | no | If true, show what would be updated without actually modifying the file (default: `false`) |
+| `filepath` | string | yes | Path to the Altium library file (.PcbLib or .SchLib) |
+| `operation` | enum | yes | The batch operation to perform. PcbLib: update_track_width, rename_layer. SchLib: update_parameters. (one of: update_track_width, rename_layer, update_parameters) |
+| `parameters` | object | yes | Operation-specific parameters |
 
 ## `copy_component`
 
-Copy/duplicate a component within an Altium library file. Creates a new component with a
-different name but identical primitives. Useful for creating variants.
+Copy/duplicate a component within an Altium library file. Creates a new component with a different name but identical primitives. Useful for creating variants.
+
+**Example**
 
 ```json
 {
-    "name": "copy_component",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "source_name": "RESC0603_IPC_MEDIUM",
-        "target_name": "RESC0603_IPC_MEDIUM_V2",
-        "description": "0603 resistor variant 2"
-    }
+  "arguments": {
+    "description": "0603 resistor variant 2",
+    "filepath": "./MyLibrary.PcbLib",
+    "source_name": "RESC0603_IPC_MEDIUM",
+    "target_name": "RESC0603_IPC_MEDIUM_V2"
+  },
+  "name": "copy_component"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the library file (.PcbLib or .SchLib) |
-| `source_name` | Name of the component to copy |
-| `target_name` | Name for the new copied component |
-| `description` | Optional description for the new component |
+**Parameters**
 
-Returns the new component count after copying.
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `description` | string | no | Optional description for the new component (defaults to source description) |
+| `dry_run` | boolean | no | If true, validate the operation without modifying the file. Default: false |
+| `filepath` | string | yes | Path to the Altium library file (.PcbLib or .SchLib) |
+| `source_name` | string | yes | Name of the component to copy |
+| `target_name` | string | yes | Name for the new copied component |
 
 ## `rename_component`
 
-Rename a component within an Altium library file. This is an atomic operation that changes
-the component's name while preserving all primitives and properties. More efficient than
-copy + delete for simple renames.
+Rename a component within an Altium library file. This is an atomic operation that changes the component's name while preserving all primitives and properties. More efficient than copy + delete for simple renames.
+
+**Example**
 
 ```json
 {
-    "name": "rename_component",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "old_name": "RESC0603_OLD",
-        "new_name": "RESC0603_NEW"
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib",
+    "new_name": "RESC0603_NEW",
+    "old_name": "RESC0603_OLD"
+  },
+  "name": "rename_component"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the library file (.PcbLib or .SchLib) |
-| `old_name` | Current name of the component to rename |
-| `new_name` | New name for the component |
+**Parameters**
 
-Returns the component count after renaming (unchanged).
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dry_run` | boolean | no | If true, validate the operation without modifying the file. Default: false |
+| `filepath` | string | yes | Path to the Altium library file (.PcbLib or .SchLib) |
+| `new_name` | string | yes | New name for the component |
+| `old_name` | string | yes | Current name of the component to rename |
 
 ## `copy_component_cross_library`
 
-Copy a component from one Altium library to another. Both libraries must be the same type
-(PcbLib to PcbLib, or SchLib to SchLib). Useful for consolidating libraries or sharing
-components between projects.
+Copy a component from one Altium library to another. Both libraries must be the same type (PcbLib to PcbLib, or SchLib to SchLib). Useful for consolidating libraries or sharing components between projects.
+
+**Example**
 
 ```json
 {
-    "name": "copy_component_cross_library",
-    "arguments": {
-        "source_filepath": "./SourceLibrary.PcbLib",
-        "target_filepath": "./TargetLibrary.PcbLib",
-        "component_name": "RESC0603_IPC_MEDIUM",
-        "new_name": "RESC0603_COPIED",
-        "description": "Copied from SourceLibrary",
-        "ignore_missing_models": false,
-        "preserve_external_paths": false
-    }
+  "arguments": {
+    "component_name": "RESC0603_IPC_MEDIUM",
+    "description": "Copied from SourceLibrary",
+    "ignore_missing_models": false,
+    "new_name": "RESC0603_COPIED",
+    "preserve_external_paths": false,
+    "source_filepath": "./SourceLibrary.PcbLib",
+    "target_filepath": "./TargetLibrary.PcbLib"
+  },
+  "name": "copy_component_cross_library"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `source_filepath` | Path to the source library file (.PcbLib or .SchLib) |
-| `target_filepath` | Path to the target library file (must be same type as source) |
-| `component_name` | Name of the component to copy from the source library |
-| `new_name` | Optional new name for the component in the target library (defaults to original name) |
-| `description` | Optional new description for the component (defaults to original description) |
-| `ignore_missing_models` | If `true`, copy the component even if referenced embedded 3D models are missing (PcbLib only). The component body references will be removed. (default: `false`) |
-| `preserve_external_paths` | If `true`, keep external 3D model file path references (default: `false` — external paths are removed as they are not portable) |
+**Parameters**
 
-**Behaviour:**
-
-- If the target file does not exist, it will be created
-- If the target file exists, the component will be added to it
-- If a component with the same name already exists in the target, an error is returned
-- Embedded 3D models are copied along with the component (if present and valid)
-- External STEP file references are removed by default (paths are not portable); use `preserve_external_paths: true` to keep them
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the component to copy from the source library |
+| `description` | string | no | Optional new description for the component (defaults to original description) |
+| `ignore_missing_models` | boolean | no | If true, copy the component even if referenced embedded 3D models are missing (PcbLib only). The component body references will be removed. Defaults to false. |
+| `new_name` | string | no | Optional new name for the component in the target library (defaults to original name) |
+| `preserve_external_paths` | boolean | no | If true, preserve external 3D model paths (model_3d field) instead of removing them. The path may need manual adjustment in the target location. Defaults to false. |
+| `source_filepath` | string | yes | Path to the source library file (.PcbLib or .SchLib) |
+| `target_filepath` | string | yes | Path to the target library file (must be same type as source) |
 
 ## `merge_libraries`
 
-Merge multiple Altium libraries into a single library. All source libraries must be the same
-type (all PcbLib or all SchLib). Components are copied from each source into the target library.
+Merge multiple Altium libraries into a single library. All source libraries must be the same type (all PcbLib or all SchLib). Components are copied from each source into the target library. Use dry_run=true to preview what would be merged.
+
+**Example**
 
 ```json
 {
-    "name": "merge_libraries",
-    "arguments": {
-        "source_filepaths": [
-            "./LibraryA.PcbLib",
-            "./LibraryB.PcbLib",
-            "./LibraryC.PcbLib"
-        ],
-        "target_filepath": "./MergedLibrary.PcbLib",
-        "on_duplicate": "skip"
-    }
+  "arguments": {
+    "on_duplicate": "skip",
+    "source_filepaths": [
+      "./LibraryA.PcbLib",
+      "./LibraryB.PcbLib",
+      "./LibraryC.PcbLib"
+    ],
+    "target_filepath": "./MergedLibrary.PcbLib"
+  },
+  "name": "merge_libraries"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `source_filepaths` | Array of paths to source library files (.PcbLib or .SchLib) |
-| `target_filepath` | Path to the target library file (will be created or appended to) |
-| `on_duplicate` | How to handle duplicate names: `skip` (ignore), `error` (fail), `rename` (auto-suffix). Default: `error` |
+**Parameters**
 
-**Behaviour:**
-
-- If the target file does not exist, it will be created
-- If the target file exists, components will be appended to it
-- Duplicate handling options:
-    - `error`: Fail immediately if a duplicate is found (default)
-    - `skip`: Silently ignore duplicates, keeping the first occurrence
-    - `rename`: Auto-rename duplicates with `_1`, `_2`, etc. suffixes
-
-**Example Response:**
-
-```json
-{
-    "status": "success",
-    "target_filepath": "./MergedLibrary.PcbLib",
-    "file_type": "PcbLib",
-    "sources_count": 3,
-    "merged_count": 45,
-    "skipped_count": 2,
-    "renamed_count": 0,
-    "final_count": 45,
-    "message": "Merged 45 components from 3 sources into './MergedLibrary.PcbLib' (total: 45)"
-}
-```
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dry_run` | boolean | no | If true, show what would be merged without actually modifying any files (default: `false`) |
+| `on_duplicate` | enum | no | How to handle duplicate component names: 'skip' (ignore duplicates), 'error' (fail on duplicates), 'rename' (auto-rename with suffix). Default: 'error' (one of: skip, error, rename) |
+| `source_filepaths` | array<string> | yes | Array of paths to source library files (.PcbLib or .SchLib) |
+| `target_filepath` | string | yes | Path to the target library file (will be created or appended to) |
 
 ## `reorder_components`
 
-Reorder components in an Altium library file (.PcbLib or .SchLib). Specify the desired order as
-a list of component names. Components not in the list are placed at the end in their original
-relative order.
+Reorder components in an Altium library file (.PcbLib or .SchLib). Specify the desired order as a list of component names. Components not in the list are placed at the end in their original relative order.
+
+**Example**
 
 ```json
 {
-    "name": "reorder_components",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_order": ["RESC1608X55N", "RESC0805X40N", "RESC0402X20N"]
-    }
+  "arguments": {
+    "component_order": [
+      "RESC1608X55N",
+      "RESC0805X40N",
+      "RESC0402X20N"
+    ],
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "reorder_components"
 }
 ```
 
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the .PcbLib or .SchLib file |
-| `component_order` | Component names in desired order |
+**Parameters**
 
-**Behaviour:**
-
-- Components listed in `component_order` appear first, in the specified order
-- Components not in the list are appended at the end in their original relative order
-- Names in `component_order` that don't exist in the library are ignored
-
-**Example Response:**
-
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
-    "component_count": 5,
-    "original_order": ["CAPC0402X20N", "RESC1608X55N", "RESC0805X40N", "RESC0402X20N", "INDC1005X55N"],
-    "new_order": ["RESC1608X55N", "RESC0805X40N", "RESC0402X20N", "CAPC0402X20N", "INDC1005X55N"],
-    "not_in_library": [],
-    "appended_at_end": ["CAPC0402X20N", "INDC1005X55N"],
-    "message": "Reordered 5 components in './MyLibrary.PcbLib' (2 components appended at end)"
-}
-```
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_order` | array<string> | yes | Component names in desired order |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
 
 ## `update_component`
 
-Update a component in-place within an Altium library file, preserving its position. For PcbLib
-files, provide a `footprint` object. For SchLib files, provide a `symbol` object. The component
-is matched by the `component_name` parameter.
+Update a component in-place within an Altium library file, preserving its position. For PcbLib, provide a footprint object. For SchLib, provide a symbol object. The component is matched by name. Use dry_run=true to preview changes without modifying.
+
+**Example**
 
 ```json
 {
-    "name": "update_component",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_name": "RESC0402X20N",
-        "footprint": {
-            "name": "RESC0402X20N",
-            "description": "Updated resistor 0402",
-            "pads": [
-                {"designator": "1", "x": -0.5, "y": 0, "width": 0.5, "height": 0.5, "layer": "TopLayer"},
-                {"designator": "2", "x": 0.5, "y": 0, "width": 0.5, "height": 0.5, "layer": "TopLayer"}
-            ]
-        }
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the .PcbLib or .SchLib file |
-| `component_name` | Name of the component to update (must exist) |
-| `footprint` | For PcbLib: footprint data (same format as `write_pcblib`) |
-| `symbol` | For SchLib: symbol data (same format as `write_schlib`) |
-
-**Example Response:**
-
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
-    "file_type": "PcbLib",
+  "arguments": {
     "component_name": "RESC0402X20N",
-    "new_name": "RESC0402X20N",
-    "renamed": false,
-    "component_count": 5,
-    "message": "Updated component 'RESC0402X20N' in './MyLibrary.PcbLib'"
+    "filepath": "./MyLibrary.PcbLib",
+    "footprint": {
+      "description": "Updated resistor 0402",
+      "name": "RESC0402X20N",
+      "pads": [
+        {
+          "designator": "1",
+          "height": 0.5,
+          "layer": "TopLayer",
+          "width": 0.5,
+          "x": -0.5,
+          "y": 0
+        },
+        {
+          "designator": "2",
+          "height": 0.5,
+          "layer": "TopLayer",
+          "width": 0.5,
+          "x": 0.5,
+          "y": 0
+        }
+      ]
+    }
+  },
+  "name": "update_component"
 }
 ```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the component to update (must exist in library) |
+| `dry_run` | boolean | no | If true, show what would be updated without actually modifying the file (default: `false`) |
+| `filepath` | string | yes | Path to the .PcbLib or .SchLib file |
+| `footprint` | object | no | For PcbLib: footprint data (same format as write_pcblib) |
+| `symbol` | object | no | For SchLib: symbol data (same format as write_schlib) |
 
 ## `search_components`
 
-Search for components across multiple Altium libraries using regex or glob patterns. Returns
-matching component names with their source library paths. Supports both `.PcbLib` (footprints)
-and `.SchLib` (symbols) files.
+Search for components across multiple Altium libraries using regex or glob patterns. Returns matching component names with their source library paths. Supports both `.PcbLib` (footprints) and `.SchLib` (symbols) files.
+
+**Example**
 
 ```json
 {
-    "name": "search_components",
-    "arguments": {
-        "filepaths": [
-            "./Resistors.PcbLib",
-            "./Capacitors.PcbLib",
-            "./ICs.PcbLib"
-        ],
-        "pattern": "SOIC-*",
-        "pattern_type": "glob"
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepaths` | Array of library file paths to search (.PcbLib or .SchLib) |
-| `pattern` | Search pattern to match component names |
-| `pattern_type` | Pattern type: `glob` (wildcards like `*` and `?`) or `regex`. Default: `glob` |
-
-**Glob Patterns:**
-
-- `*` matches any number of characters
-- `?` matches a single character
-- Search is case-insensitive
-
-**Example Response:**
-
-```json
-{
-    "status": "success",
-    "pattern": "SOIC-*",
-    "pattern_type": "glob",
-    "libraries_searched": 3,
-    "components_searched": 150,
-    "matches_found": 5,
-    "matches": [
-        { "name": "SOIC-8", "library": "./ICs.PcbLib", "type": "PcbLib" },
-        { "name": "SOIC-14", "library": "./ICs.PcbLib", "type": "PcbLib" },
-        { "name": "SOIC-16", "library": "./ICs.PcbLib", "type": "PcbLib" }
+  "arguments": {
+    "filepaths": [
+      "./Resistors.PcbLib",
+      "./Capacitors.PcbLib",
+      "./ICs.PcbLib"
     ],
-    "message": "Found 5 matches for 'SOIC-*' across 3 libraries (150 components searched)"
+    "pattern": "SOIC-*",
+    "pattern_type": "glob"
+  },
+  "name": "search_components"
 }
 ```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepaths` | array<string> | yes | Array of library file paths to search (.PcbLib or .SchLib) |
+| `pattern` | string | yes | Search pattern to match component names |
+| `pattern_type` | enum | no | Pattern type: 'glob' (wildcards like * and ?) or 'regex' (regular expressions). Default: 'glob' (one of: glob, regex) |
 
 ## `get_component`
 
-Get a single component by name from an Altium library. Returns the full component data
-(footprint or symbol) without needing to read and filter the entire library. Supports both
-`.PcbLib` (footprints) and `.SchLib` (symbols) files.
+Get a single component by name from an Altium library. Returns the full component data (footprint or symbol) without needing to read and filter the entire library. Supports both `.PcbLib` (footprints) and `.SchLib` (symbols) files.
+
+**Example**
 
 ```json
 {
-    "name": "get_component",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_name": "SOIC-8"
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the Altium library file (.PcbLib or .SchLib) |
-| `component_name` | Exact name of the component to retrieve |
-
-**Example Response (PcbLib):**
-
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
+  "arguments": {
     "component_name": "SOIC-8",
-    "type": "PcbLib",
-    "units": "mm",
-    "component": {
-        "name": "SOIC-8",
-        "description": "8-pin SOIC package",
-        "pads": [...],
-        "tracks": [...]
-    },
-    "message": "Retrieved footprint 'SOIC-8' from './MyLibrary.PcbLib'"
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "get_component"
 }
 ```
 
-**Error Response (component not found):**
+**Parameters**
 
-```json
-{
-    "isError": true,
-    "content": [{
-        "type": "text",
-        "text": "Component 'SOIC-99' not found in library. Available components: SOIC-8, SOIC-14, SOIC-16 ... and 5 more"
-    }]
-}
-```
-
-## `compare_components`
-
-Compare two specific components in detail, showing differences in primitives, parameters, and
-properties. Components can be from the same library or different libraries. Returns detailed
-primitive-level differences (pads, tracks, pins, etc.).
-
-```json
-{
-    "name": "compare_components",
-    "arguments": {
-        "filepath_a": "./LibraryA.PcbLib",
-        "component_a": "RESC0603_V1",
-        "filepath_b": "./LibraryB.PcbLib",
-        "component_b": "RESC0603_V2",
-        "include_geometry": true,
-        "tolerance": 0.001
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath_a` | Path to the first library file (.PcbLib or .SchLib) |
-| `component_a` | Name of the first component |
-| `filepath_b` | Path to the second library file (can be same as `filepath_a`) |
-| `component_b` | Name of the second component |
-| `include_geometry` | Include detailed geometry comparisons (default: `true`) |
-| `tolerance` | Tolerance for floating-point comparisons in mm (default: `0.001`) |
-
-**Example Response:**
-
-```json
-{
-    "status": "different",
-    "summary": {
-        "identical": false,
-        "pad_differences": 2,
-        "track_differences": 1,
-        "description_changed": true
-    },
-    "differences": {
-        "pads": [
-            { "designator": "1", "field": "width", "a": 0.9, "b": 1.0 }
-        ]
-    }
-}
-```
-
-## `render_footprint`
-
-Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks,
-and other primitives in a simple text format for quick preview.
-
-```json
-{
-    "name": "render_footprint",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_name": "RESC0603_IPC_MEDIUM",
-        "scale": 2.0,
-        "max_width": 80,
-        "max_height": 40
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the PcbLib file |
-| `component_name` | Name of the footprint to render |
-| `scale` | Characters per mm (default: 2.0) |
-| `max_width` | Maximum width in characters (default: 80) |
-| `max_height` | Maximum height in characters (default: 40) |
-
-Returns ASCII art with pad designators shown in full (e.g., "1", "10", "A01"). Legend: `#` = pad area, `-` = track, `o` = arc, `+` = origin.
-
-## `render_symbol`
-
-Render an ASCII art visualisation of a schematic symbol from a SchLib file. Shows pins,
-rectangles, lines, and other primitives in a simple text format for quick preview.
-
-```json
-{
-    "name": "render_symbol",
-    "arguments": {
-        "filepath": "./MyLibrary.SchLib",
-        "component_name": "LM358",
-        "scale": 1.0,
-        "max_width": 80,
-        "max_height": 40,
-        "part_id": 1
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the SchLib file |
-| `component_name` | Name of the symbol to render |
-| `scale` | Characters per 10 schematic units (default: 1.0) |
-| `max_width` | Maximum width in characters (default: 80) |
-| `max_height` | Maximum height in characters (default: 40) |
-| `part_id` | Part ID for multi-part symbols (default: 1, use 0 for all parts) |
-
-Returns ASCII art with pin designators shown in full (e.g., "1", "10", "VCC"). Legend: `|-+` = rectangle, `~` = pin line, `o` = arc, `O` = ellipse, `+` = origin.
-
-## `manage_schlib_parameters`
-
-Manage component parameters in Altium SchLib files. Supports listing, getting, setting,
-adding, and deleting parameters like Value, Manufacturer, Part Number, etc.
-
-```json
-{
-    "name": "manage_schlib_parameters",
-    "arguments": {
-        "filepath": "./MyLibrary.SchLib",
-        "component_name": "LM358",
-        "operation": "set",
-        "parameter_name": "Value",
-        "value": "LM358D"
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the SchLib file |
-| `component_name` | Name of the symbol |
-| `operation` | Operation: `list`, `get`, `set`, `add`, `delete` |
-| `parameter_name` | Parameter name (required for get/set/add/delete) |
-| `value` | Parameter value (required for set/add) |
-| `hidden` | Whether parameter is hidden (optional for set/add) |
-| `x`, `y` | Position in schematic units (optional for add) |
-
-**Operations:**
-
-| Operation | Description |
-|-----------|-------------|
-| `list` | Returns all parameters for a symbol |
-| `get` | Returns a single parameter by name |
-| `set` | Updates an existing parameter's value |
-| `add` | Creates a new parameter |
-| `delete` | Removes a parameter |
-
-## `manage_schlib_footprints`
-
-Manage footprint links in Altium SchLib symbols. Supports listing, adding, and removing
-footprint references that link schematic symbols to PCB footprints.
-
-```json
-{
-    "name": "manage_schlib_footprints",
-    "arguments": {
-        "filepath": "./MyLibrary.SchLib",
-        "component_name": "LM358",
-        "operation": "add",
-        "footprint_name": "SOIC-8_3.9x4.9mm"
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the SchLib file |
-| `component_name` | Name of the symbol |
-| `operation` | Operation: `list`, `add`, `remove` |
-| `footprint_name` | Footprint name (required for add/remove) |
-| `description` | Footprint description (optional for add) |
-
-**Operations:**
-
-| Operation | Description |
-|-----------|-------------|
-| `list` | Returns all linked footprints for a symbol |
-| `add` | Links a new footprint to the symbol |
-| `remove` | Removes a footprint link from the symbol |
-
-## `repair_library`
-
-Repair a library file by removing orphaned data. For PcbLib files, this removes component body
-references that point to non-existent embedded STEP models. This fixes libraries where 3D model
-data was corrupted or incompletely deleted.
-
-```json
-{
-    "name": "repair_library",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "dry_run": true
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the library file (.PcbLib) |
-| `dry_run` | If `true`, report what would be removed without modifying the file (default: `false`) |
-
-**Example Response:**
-
-```json
-{
-    "library_type": "PcbLib",
-    "footprints_checked": 5,
-    "orphaned_references_removed": [
-        { "footprint_name": "RESC0603", "removed_count": 2 }
-    ],
-    "total_removed": 2,
-    "dry_run": false
-}
-```
-
-## `bulk_rename`
-
-Rename multiple components in a library using pattern matching. Supports glob patterns and
-regex with capture groups for flexible bulk renaming operations.
-
-```json
-{
-    "name": "bulk_rename",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "pattern": "^RESC(.*)$",
-        "replacement": "RES_$1",
-        "pattern_type": "regex",
-        "dry_run": true
-    }
-}
-```
-
-| Parameter | Description |
-|-----------|-------------|
-| `filepath` | Path to the library file (.PcbLib or .SchLib) |
-| `pattern` | Pattern to match component names |
-| `replacement` | Replacement string (use `$1`, `$2`, etc. for regex capture groups) |
-| `pattern_type` | Pattern type: `glob` or `regex` (default: `glob`) |
-| `dry_run` | If `true`, preview changes without modifying the file (default: `false`) |
-
-**Example Response:**
-
-```json
-{
-    "renamed": [
-        { "old_name": "RESC0402", "new_name": "RES_0402" },
-        { "old_name": "RESC0603", "new_name": "RES_0603" }
-    ],
-    "skipped": [],
-    "conflicts": [],
-    "dry_run": true
-}
-```
-
-**Pattern Examples:**
-
-| Pattern Type | Pattern | Replacement | Input | Output |
-|--------------|---------|-------------|-------|--------|
-| glob | `RESC*` | `RES_` | `RESC0603` | `RES_0603` (suffix preserved) |
-| regex | `^RESC(.*)$` | `RES_$1` | `RESC0603` | `RES_0603` |
-| regex | `^(.*)_V(\d+)$` | `$1_REV$2` | `CAP_V2` | `CAP_REV2` |
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Exact name of the component to retrieve |
+| `filepath` | string | yes | Path to the Altium library file (.PcbLib or .SchLib) |
 
 ## `component_exists`
 
-Check if one or more components exist in an Altium library. Useful for validating references
-before performing operations like copy or merge.
+Check if one or more components exist in an Altium library. Use this to validate component names before operations like rename, copy, or delete. Supports both `.PcbLib` and `.SchLib` files.
+
+**Example**
 
 ```json
 {
-    "name": "component_exists",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_names": ["RESC0603", "CAPC0402", "MISSING_COMPONENT"]
-    }
-}
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the library file (.PcbLib or .SchLib) |
-| `component_names` | Yes | Array of component names to check |
-
-**Response:**
-
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
-    "file_type": "PcbLib",
-    "results": [
-        { "name": "RESC0603", "exists": true },
-        { "name": "CAPC0402", "exists": true },
-        { "name": "MISSING_COMPONENT", "exists": false }
+  "arguments": {
+    "component_names": [
+      "RESC0603",
+      "CAPC0402",
+      "MISSING_COMPONENT"
     ],
-    "all_exist": false,
-    "found_count": 2,
-    "missing_count": 1
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "component_exists"
 }
 ```
 
-## `update_pad`
+**Parameters**
 
-Update specific properties of a pad in a PcbLib footprint without replacing the entire component.
-Find the pad by designator and update only the specified properties.
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_names` | array<string> | yes | List of component names to check |
+| `filepath` | string | yes | Path to the Altium library file (.PcbLib or .SchLib) |
+
+## `render_footprint`
+
+Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks, and other primitives in a simple text format for quick preview.
+
+**Example**
 
 ```json
 {
-    "name": "update_pad",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_name": "RESC0603",
-        "designator": "1",
-        "updates": {
-            "width": 1.0,
-            "height": 0.9,
-            "shape": "rectangle"
-        },
-        "dry_run": false
-    }
+  "arguments": {
+    "component_name": "RESC0603_IPC_MEDIUM",
+    "filepath": "./MyLibrary.PcbLib",
+    "max_height": 40,
+    "max_width": 80,
+    "scale": 2.0
+  },
+  "name": "render_footprint"
 }
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the PcbLib file |
-| `component_name` | Yes | Name of the footprint |
-| `designator` | Yes | Pad designator to update (e.g., "1", "A1") |
-| `updates` | Yes | Object with properties to update |
-| `dry_run` | No | Preview changes without modifying the file (default: `false`) |
+**Parameters**
 
-**Updatable Pad Properties:**
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the footprint to render |
+| `filepath` | string | yes | Path to the Altium PcbLib file |
+| `max_height` | integer | no | Maximum height in characters (default: 40) |
+| `max_width` | integer | no | Maximum width in characters (default: 80) |
+| `scale` | number | no | Characters per mm (default: 2.0). Higher = more detail |
 
-| Property | Description |
-|----------|-------------|
-| `x`, `y` | Position in mm |
-| `width`, `height` | Pad dimensions in mm |
-| `shape` | Pad shape: `rectangle`, `round`, `oval`, `rounded_rectangle` |
-| `rotation` | Rotation angle in degrees |
-| `hole_size` | Hole diameter in mm (for through-hole pads) |
+## `render_symbol`
 
-**Response:**
+Render an ASCII art visualisation of a schematic symbol from a SchLib file. Shows pins, rectangles, lines, and other primitives in a simple text format for quick preview. Coordinates are in schematic units (10 units = 1 grid).
+
+**Example**
 
 ```json
 {
-    "status": "success",
-    "component_name": "RESC0603",
-    "designator": "1",
-    "changes": [
-        { "property": "width", "old": 0.9, "new": 1.0 },
-        { "property": "height", "old": 0.95, "new": 0.9 },
-        { "property": "shape", "old": "RoundedRectangle", "new": "rectangle" }
-    ]
+  "arguments": {
+    "component_name": "LM358",
+    "filepath": "./MyLibrary.SchLib",
+    "max_height": 40,
+    "max_width": 80,
+    "part_id": 1,
+    "scale": 1.0
+  },
+  "name": "render_symbol"
 }
 ```
 
-## `update_primitive`
+**Parameters**
 
-Update specific properties of a primitive (track, arc, text, fill, region) in a PcbLib footprint.
-Find the primitive by type and index, and update only the specified properties.
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the symbol to render |
+| `filepath` | string | yes | Path to the Altium SchLib file |
+| `max_height` | integer | no | Maximum height in characters (default: 40) |
+| `max_width` | integer | no | Maximum width in characters (default: 80) |
+| `part_id` | integer | no | Part ID for multi-part symbols (default: 1, shows all parts if 0) |
+| `scale` | number | no | Characters per 10 schematic units (default: 1.0). Higher = more detail |
+
+## `manage_schlib_parameters`
+
+Manage component parameters in Altium SchLib files. Supports listing, getting, setting, adding, and deleting parameters like Value, Manufacturer, Part Number, etc.
+
+**Example**
 
 ```json
 {
-    "name": "update_primitive",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "component_name": "RESC0603",
-        "primitive_type": "track",
-        "index": 0,
-        "updates": {
-            "width": 0.15,
-            "layer": "Top Overlay"
-        },
-        "dry_run": false
-    }
+  "arguments": {
+    "component_name": "LM358",
+    "filepath": "./MyLibrary.SchLib",
+    "operation": "set",
+    "parameter_name": "Value",
+    "value": "LM358D"
+  },
+  "name": "manage_schlib_parameters"
 }
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the PcbLib file |
-| `component_name` | Yes | Name of the footprint |
-| `primitive_type` | Yes | Type: `track`, `arc`, `text`, `fill`, `region` |
-| `index` | Yes | Zero-based index of the primitive in its type array |
-| `updates` | Yes | Object with properties to update |
-| `dry_run` | No | Preview changes without modifying the file (default: `false`) |
+**Parameters**
 
-**Updatable Properties by Type:**
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the symbol to manage parameters for |
+| `filepath` | string | yes | Path to the Altium SchLib file |
+| `hidden` | boolean | no | Whether the parameter is hidden (optional for set, add) |
+| `operation` | enum | yes | Operation to perform: list (all parameters), get (single parameter), set (update value), add (new parameter), delete (remove parameter) (one of: list, get, set, add, delete) |
+| `parameter_name` | string | no | Name of the parameter (required for get, set, add, delete) |
+| `value` | string | no | Parameter value (required for set, add) |
+| `x` | integer | no | X position in schematic units (optional for add) |
+| `y` | integer | no | Y position in schematic units (optional for add) |
 
-| Type | Properties |
-|------|------------|
-| `track` | `x1`, `y1`, `x2`, `y2`, `width`, `layer` |
-| `arc` | `x`, `y`, `radius`, `start_angle`, `end_angle`, `width`, `layer` |
-| `text` | `x`, `y`, `text`, `height`, `rotation`, `layer` |
-| `fill` | `x1`, `y1`, `x2`, `y2`, `rotation`, `layer` |
-| `region` | `layer` |
+## `manage_schlib_footprints`
+
+Manage footprint links in Altium SchLib symbols. Supports listing, adding, and removing footprint references that link schematic symbols to PCB footprints.
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "component_name": "LM358",
+    "filepath": "./MyLibrary.SchLib",
+    "footprint_name": "SOIC-8_3.9x4.9mm",
+    "operation": "add"
+  },
+  "name": "manage_schlib_footprints"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the symbol to manage footprints for |
+| `description` | string | no | Footprint description (optional for add) |
+| `filepath` | string | yes | Path to the Altium SchLib file |
+| `footprint_name` | string | no | Footprint name (required for add, remove) |
+| `library_path` | string | no | Optional (add): absolute path to the .PcbLib containing the footprint, written as ModelDatafile0 so Altium can resolve and preview the model. Omit to link by name only (requires the library to be installed/in the project, else 'footprint not found'). |
+| `operation` | enum | yes | Operation to perform: list (all footprints), add (new footprint link), remove (delete footprint link) (one of: list, add, remove) |
+
+## `compare_components`
+
+Compare two specific components in detail, showing differences in primitives, parameters, and properties. Components can be from the same library or different libraries. Returns detailed primitive-level differences (pads, tracks, pins, etc.).
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "component_a": "RESC0603_V1",
+    "component_b": "RESC0603_V2",
+    "filepath_a": "./LibraryA.PcbLib",
+    "filepath_b": "./LibraryB.PcbLib",
+    "include_geometry": true,
+    "tolerance": 0.001
+  },
+  "name": "compare_components"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_a` | string | yes | Name of the first component |
+| `component_b` | string | yes | Name of the second component |
+| `filepath_a` | string | yes | Path to the first library file (.PcbLib or .SchLib) |
+| `filepath_b` | string | yes | Path to the second library file (can be same as filepath_a) |
+| `include_geometry` | boolean | no | Include detailed geometry comparisons for primitives (default: true) |
+| `tolerance` | number | no | Tolerance for floating-point comparisons in mm (default: 0.001) |
+
+## `repair_library`
+
+Repair a library by removing orphaned references. For PcbLib files, this removes: (1) embedded models not referenced by any footprint, and (2) component body references that point to non-existent models. This fixes libraries where STEP model data is missing but references remain.
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "dry_run": true,
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "repair_library"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dry_run` | boolean | no | If true, report what would be fixed without making changes (default: false) |
+| `filepath` | string | yes | Path to the library file (.PcbLib) |
 
 ## `list_backups`
 
-List available backup files for an Altium library. Backups are created automatically before
-destructive operations.
+List available backup files for an Altium library. Shows timestamped .bak files that were automatically created before write operations.
+
+**Example**
 
 ```json
 {
-    "name": "list_backups",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib"
-    }
+  "arguments": {
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "list_backups"
 }
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the library file |
+**Parameters**
 
-**Response:**
-
-```json
-{
-    "status": "success",
-    "filepath": "./MyLibrary.PcbLib",
-    "backups": [
-        {
-            "filename": "MyLibrary.PcbLib.20260126_143022.bak",
-            "path": "./MyLibrary.PcbLib.20260126_143022.bak",
-            "timestamp": "2026-01-26T14:30:22",
-            "size_bytes": 45678
-        },
-        {
-            "filename": "MyLibrary.PcbLib.20260125_091500.bak",
-            "path": "./MyLibrary.PcbLib.20260125_091500.bak",
-            "timestamp": "2026-01-25T09:15:00",
-            "size_bytes": 44123
-        }
-    ],
-    "backup_count": 2
-}
-```
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `filepath` | string | yes | Path to the library file (.PcbLib or .SchLib) |
 
 ## `restore_backup`
 
-Restore an Altium library from a backup file. If no specific backup is specified, restores
-from the most recent backup.
+Restore an Altium library file from a backup. If no specific backup is specified, restores from the most recent backup.
+
+**Example**
 
 ```json
 {
-    "name": "restore_backup",
-    "arguments": {
-        "filepath": "./MyLibrary.PcbLib",
-        "backup_filename": "MyLibrary.PcbLib.20260125_091500.bak"
-    }
+  "arguments": {
+    "backup_path": "MyLibrary.PcbLib.20260125_091500.bak",
+    "filepath": "./MyLibrary.PcbLib"
+  },
+  "name": "restore_backup"
 }
 ```
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `filepath` | Yes | Path to the library file to restore |
-| `backup_filename` | No | Specific backup filename to restore (default: most recent) |
+**Parameters**
 
-**Response:**
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `backup_path` | string | no | Optional: specific backup file to restore from. If not provided, uses most recent backup. |
+| `filepath` | string | yes | Path to the library file to restore |
+
+## `bulk_rename`
+
+Rename multiple components in a library using regex pattern matching. Supports capture groups for flexible renaming (e.g., 'RESC(.*)' -> 'RES_$1').
+
+**Example**
 
 ```json
 {
-    "status": "success",
+  "arguments": {
+    "dry_run": true,
     "filepath": "./MyLibrary.PcbLib",
-    "restored_from": "MyLibrary.PcbLib.20260125_091500.bak",
-    "backup_timestamp": "2026-01-25T09:15:00",
-    "message": "Restored './MyLibrary.PcbLib' from backup 'MyLibrary.PcbLib.20260125_091500.bak'"
+    "pattern": "^RESC(.*)$",
+    "replacement": "RES_$1"
+  },
+  "name": "bulk_rename"
 }
 ```
 
----
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dry_run` | boolean | no | If true, show what would be renamed without making changes (default: false) |
+| `filepath` | string | yes | Path to the library file (.PcbLib or .SchLib) |
+| `pattern` | string | yes | Regex pattern to match component names (e.g., '^RESC(.*)$') |
+| `replacement` | string | yes | Replacement string with optional capture groups (e.g., 'RES_$1') |
+
+## `update_pad`
+
+Update specific properties of a pad in a PcbLib footprint without replacing the entire component. Find pad by designator and apply only the specified updates.
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "component_name": "RESC0603",
+    "designator": "1",
+    "dry_run": false,
+    "filepath": "./MyLibrary.PcbLib",
+    "updates": {
+      "height": 0.9,
+      "shape": "rectangle",
+      "width": 1.0
+    }
+  },
+  "name": "update_pad"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the footprint containing the pad |
+| `designator` | string | yes | Pad designator (e.g., '1', '2', 'A1') |
+| `dry_run` | boolean | no | If true, show what would change without saving (default: false) |
+| `filepath` | string | yes | Path to the .PcbLib file |
+| `updates` | object | yes | Properties to update (only specified properties are changed) |
+
+## `update_primitive`
+
+Update specific properties of a primitive (track, arc, region, or text) in a PcbLib footprint. Find primitive by type and index, apply only specified updates.
+
+**Example**
+
+```json
+{
+  "arguments": {
+    "component_name": "RESC0603",
+    "dry_run": false,
+    "filepath": "./MyLibrary.PcbLib",
+    "index": 0,
+    "primitive_type": "track",
+    "updates": {
+      "layer": "Top Overlay",
+      "width": 0.15
+    }
+  },
+  "name": "update_primitive"
+}
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component_name` | string | yes | Name of the footprint containing the primitive |
+| `dry_run` | boolean | no | If true, show what would change without saving (default: false) |
+| `filepath` | string | yes | Path to the .PcbLib file |
+| `index` | integer | yes | Zero-based index of the primitive within its type array |
+| `primitive_type` | enum | yes | Type of primitive to update (one of: track, arc, region, text, fill) |
+| `updates` | object | yes | Properties to update (only specified properties are changed). Valid properties depend on primitive_type. |

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -29,6 +29,8 @@
 pub mod protocol;
 pub mod server;
 mod tool_definitions;
+#[cfg(test)]
+mod tool_docs;
 mod tools;
 pub mod transport;
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -119,6 +119,11 @@ pub struct ToolDefinition {
     pub description: Option<String>,
     /// JSON Schema for the tool's input parameters.
     pub input_schema: Value,
+    /// Representative `tools/call` example, rendered into `docs/TOOLS.md` by the
+    /// doc generator. Internal only — `#[serde(skip)]` keeps it off the
+    /// `tools/list` wire response (it is not part of the MCP tool schema).
+    #[serde(skip)]
+    pub example: Option<Value>,
 }
 
 /// Parameters for tools/call request.
@@ -712,6 +717,12 @@ impl McpServer {
             "protocolVersion": negotiated_version,
             "capabilities": ServerCapabilities::default(),
             "serverInfo": ServerInfo::default(),
+            // MCP `instructions`: surfaced to the model by the client so an agent
+            // learns the conventions (units, pin geometry, sandbox, build flow)
+            // without reading the source. Embedded from docs/AGENT_GUIDE.md so
+            // there is a single source of truth; per-tool detail stays in the
+            // tools/list schema.
+            "instructions": include_str!("../../docs/AGENT_GUIDE.md"),
         });
 
         Ok(JsonRpcResponse::success(req.id.clone(), result))
@@ -1668,6 +1679,40 @@ mod tests {
         let arc = &sym.arcs[0];
         assert!((arc.radius - 10.0).abs() < 1e-9);
         assert!((arc.end_angle - 180.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn initialize_sends_agent_instructions() {
+        // The MCP `instructions` field is how a client teaches the model the
+        // conventions; it must be sent and must be the embedded AGENT_GUIDE so
+        // the doc stays the single source.
+        let dir = test_temp_dir();
+        let mut server = McpServer::new(vec![dir.path().to_path_buf()]);
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: RequestId::Number(1),
+            method: "initialize".to_string(),
+            params: Some(json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0.0" }
+            })),
+        };
+        let resp = server.handle_initialize(&req).expect("initialize ok");
+        let instructions = resp
+            .result
+            .get("instructions")
+            .and_then(|v| v.as_str())
+            .expect("initialize result includes `instructions`");
+        assert!(
+            !instructions.trim().is_empty(),
+            "instructions must be non-empty"
+        );
+        assert_eq!(
+            instructions,
+            include_str!("../../docs/AGENT_GUIDE.md"),
+            "instructions must be the embedded AGENT_GUIDE.md"
+        );
     }
 
     #[test]

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -19,6 +19,7 @@ impl McpServer {
             // === Library Reading ===
             ToolDefinition {
                 name: "read_pcblib".to_string(),
+                example: Some(serde_json::json!({"name": "read_pcblib", "arguments": {"filepath": "./MyLibrary.PcbLib"}})),
                 description: Some(
                     "Read an Altium .PcbLib file and return its contents including footprints \
                      with their primitives (pads, tracks, arcs, regions, text). Returns structured \
@@ -57,6 +58,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "read_schlib".to_string(),
+                example: Some(serde_json::json!({"name": "read_schlib", "arguments": {"filepath": "./MySymbols.SchLib"}})),
                 description: Some(
                     "Read an Altium .SchLib file and return its contents including symbols \
                      with their primitives (pins, rectangles, lines, text). \
@@ -90,6 +92,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "list_components".to_string(),
+                example: Some(serde_json::json!({"name": "list_components", "arguments": {"filepath": "./MyLibrary.PcbLib", "limit": 50, "offset": 0, "include_metadata": true}})),
                 description: Some(
                     "List all component/footprint names in an Altium library file (.PcbLib or .SchLib). \
                      Supports pagination with limit/offset for large libraries. Use include_metadata \
@@ -122,6 +125,7 @@ impl McpServer {
             // === Style Extraction ===
             ToolDefinition {
                 name: "extract_style".to_string(),
+                example: Some(serde_json::json!({"name": "extract_style", "arguments": {"filepath": "./MyLibrary.PcbLib"}})),
                 description: Some(
                     "Extract style information from an existing Altium library file. Returns \
                      statistics about track widths, colours, pin lengths, layer usage, and other \
@@ -143,6 +147,7 @@ impl McpServer {
             // === Library Writing ===
             ToolDefinition {
                 name: "write_pcblib".to_string(),
+                example: Some(serde_json::json!({"name": "write_pcblib", "arguments": {"filepath": "./Passives.PcbLib", "footprints": [{"name": "RESC1608X55N", "description": "Chip resistor, 0603 (1608 metric)", "pads": [{"designator": "1", "x": -0.75, "y": 0, "width": 0.9, "height": 0.95}, {"designator": "2", "x": 0.75, "y": 0, "width": 0.9, "height": 0.95}], "tracks": [{"x1": -0.8, "y1": -0.425, "x2": 0.8, "y2": -0.425, "width": 0.12, "layer": "Top Overlay"}, {"x1": -0.8, "y1": 0.425, "x2": 0.8, "y2": 0.425, "width": 0.12, "layer": "Top Overlay"}], "regions": [{"vertices": [{"x": -1.45, "y": -0.73}, {"x": 1.45, "y": -0.73}, {"x": 1.45, "y": 0.73}, {"x": -1.45, "y": 0.73}], "layer": "Top Courtyard"}]}], "append": false}})),
                 description: Some(
                     "Write footprints to an Altium .PcbLib file. Each footprint is defined by \
                      its primitives: pads (with position, size, shape, layer), tracks, vias, \
@@ -399,6 +404,23 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "write_schlib".to_string(),
+                example: Some(serde_json::json!({
+                    "name": "write_schlib",
+                    "arguments": {
+                        "filepath": "./MyLibrary.SchLib",
+                        "symbols": [{
+                            "name": "R",
+                            "designator_prefix": "R",
+                            "pins": [
+                                {"designator": "1", "name": "1", "x": -50, "y": 0, "length": 20, "orientation": "left", "electrical_type": "passive"},
+                                {"designator": "2", "name": "2", "x": 50, "y": 0, "length": 20, "orientation": "right", "electrical_type": "passive"}
+                            ],
+                            "rectangles": [{"x1": -50, "y1": -20, "x2": 50, "y2": 20}],
+                            "parameters": [{"name": "Value", "value": "10k"}],
+                            "footprints": [{"name": "R0402", "library_path": "./MyLibrary.PcbLib"}]
+                        }]
+                    }
+                })),
                 description: Some(
                     "Write schematic symbols to an Altium .SchLib file. Each symbol is defined by \
                      its primitives: pins, rectangles, round_rects, lines, polylines, polygons, \
@@ -697,6 +719,13 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "write_libpkg".to_string(),
+                example: Some(serde_json::json!({
+                    "name": "write_libpkg",
+                    "arguments": {
+                        "filepath": "./MyLibrary.LibPkg",
+                        "documents": ["MyLibrary.SchLib", "MyLibrary.PcbLib"]
+                    }
+                })),
                 description: Some(
                     "Write an Altium Library Package (.LibPkg) project file that groups source \
                      library documents (.SchLib and .PcbLib) so they can be compiled into an \
@@ -725,6 +754,7 @@ impl McpServer {
             // === Library Management ===
             ToolDefinition {
                 name: "delete_component".to_string(),
+                example: Some(serde_json::json!({"name": "delete_component", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_names": ["OLD_FOOTPRINT", "UNUSED_COMPONENT"], "dry_run": false}})),
                 description: Some(
                     "Delete one or more components from an Altium library file (.PcbLib or .SchLib). \
                      The file type is auto-detected from the extension. Returns status for each \
@@ -755,6 +785,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "validate_library".to_string(),
+                example: Some(serde_json::json!({"name": "validate_library", "arguments": {"filepath": "./MyLibrary.PcbLib"}})),
                 description: Some(
                     "Validate an Altium library file for common issues. Checks for: empty components \
                      (no pads/pins), duplicate designators, invalid coordinates, zero-size primitives, \
@@ -774,6 +805,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "export_library".to_string(),
+                example: Some(serde_json::json!({"name": "export_library", "arguments": {"filepath": "./MyLibrary.PcbLib", "format": "json", "compact": true}})),
                 description: Some(
                     "Export an Altium library to JSON or CSV format for version control, backup, \
                      or external processing. JSON includes full component data; CSV provides a \
@@ -802,6 +834,16 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "import_library".to_string(),
+                example: Some(serde_json::json!({
+                    "name": "import_library",
+                    "arguments": {
+                        "output_path": "./MyLibrary.PcbLib",
+                        "json_data": {
+                            "file_type": "PcbLib",
+                            "footprints": [{"name": "R0402", "pads": []}]
+                        }
+                    }
+                })),
                 description: Some(
                     "Import components from JSON data into an Altium library file. Accepts JSON \
                      in the format produced by export_library, enabling round-trip workflows. \
@@ -829,6 +871,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "extract_step_model".to_string(),
+                example: Some(serde_json::json!({"name": "extract_step_model", "arguments": {"filepath": "./MyLibrary.PcbLib", "output_path": "./extracted_model.step", "model": "RESC1005X04L.step", "mode": "auto"}})),
                 description: Some(
                     "Extract embedded STEP 3D models from an Altium .PcbLib file. \
                      Models are stored compressed inside the library and this tool extracts \
@@ -874,6 +917,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "diff_libraries".to_string(),
+                example: Some(serde_json::json!({"name": "diff_libraries", "arguments": {"filepath_a": "./OldLibrary.PcbLib", "filepath_b": "./NewLibrary.PcbLib"}})),
                 description: Some(
                     "Compare two Altium library files and report differences. Shows added, removed, \
                      and modified components. Both files must be the same type (.PcbLib or .SchLib)."
@@ -896,6 +940,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "batch_update".to_string(),
+                example: Some(serde_json::json!({"name": "batch_update", "arguments": {"filepath": "./MyLibrary.PcbLib", "operation": "update_track_width", "parameters": {"from_width": 0.2, "to_width": 0.25, "tolerance": 0.001}}})),
                 description: Some(
                     "Perform batch updates across all components in an Altium library file. \
                      For PcbLib: update track widths, rename layers. \
@@ -968,6 +1013,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "copy_component".to_string(),
+                example: Some(serde_json::json!({"name": "copy_component", "arguments": {"filepath": "./MyLibrary.PcbLib", "source_name": "RESC0603_IPC_MEDIUM", "target_name": "RESC0603_IPC_MEDIUM_V2", "description": "0603 resistor variant 2"}})),
                 description: Some(
                     "Copy/duplicate a component within an Altium library file. Creates a new component \
                      with a different name but identical primitives. Useful for creating variants."
@@ -1002,6 +1048,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "rename_component".to_string(),
+                example: Some(serde_json::json!({"name": "rename_component", "arguments": {"filepath": "./MyLibrary.PcbLib", "old_name": "RESC0603_OLD", "new_name": "RESC0603_NEW"}})),
                 description: Some(
                     "Rename a component within an Altium library file. This is an atomic operation \
                      that changes the component's name while preserving all primitives and properties. \
@@ -1033,6 +1080,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "copy_component_cross_library".to_string(),
+                example: Some(serde_json::json!({"name": "copy_component_cross_library", "arguments": {"source_filepath": "./SourceLibrary.PcbLib", "target_filepath": "./TargetLibrary.PcbLib", "component_name": "RESC0603_IPC_MEDIUM", "new_name": "RESC0603_COPIED", "description": "Copied from SourceLibrary", "ignore_missing_models": false, "preserve_external_paths": false}})),
                 description: Some(
                     "Copy a component from one Altium library to another. Both libraries must be \
                      the same type (PcbLib to PcbLib, or SchLib to SchLib). Useful for consolidating \
@@ -1076,6 +1124,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "merge_libraries".to_string(),
+                example: Some(serde_json::json!({"name": "merge_libraries", "arguments": {"source_filepaths": ["./LibraryA.PcbLib", "./LibraryB.PcbLib", "./LibraryC.PcbLib"], "target_filepath": "./MergedLibrary.PcbLib", "on_duplicate": "skip"}})),
                 description: Some(
                     "Merge multiple Altium libraries into a single library. All source libraries must \
                      be the same type (all PcbLib or all SchLib). Components are copied from each \
@@ -1110,6 +1159,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "reorder_components".to_string(),
+                example: Some(serde_json::json!({"name": "reorder_components", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_order": ["RESC1608X55N", "RESC0805X40N", "RESC0402X20N"]}})),
                 description: Some(
                     "Reorder components in an Altium library file (.PcbLib or .SchLib). Specify the \
                      desired order as a list of component names. Components not in the list are placed \
@@ -1134,6 +1184,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "update_component".to_string(),
+                example: Some(serde_json::json!({"name": "update_component", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "RESC0402X20N", "footprint": {"name": "RESC0402X20N", "description": "Updated resistor 0402", "pads": [{"designator": "1", "x": -0.5, "y": 0, "width": 0.5, "height": 0.5, "layer": "TopLayer"}, {"designator": "2", "x": 0.5, "y": 0, "width": 0.5, "height": 0.5, "layer": "TopLayer"}]}}})),
                 description: Some(
                     "Update a component in-place within an Altium library file, preserving its position. \
                      For PcbLib, provide a footprint object. For SchLib, provide a symbol object. The \
@@ -1170,6 +1221,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "search_components".to_string(),
+                example: Some(serde_json::json!({"name": "search_components", "arguments": {"filepaths": ["./Resistors.PcbLib", "./Capacitors.PcbLib", "./ICs.PcbLib"], "pattern": "SOIC-*", "pattern_type": "glob"}})),
                 description: Some(
                     "Search for components across multiple Altium libraries using regex or glob patterns. \
                      Returns matching component names with their source library paths. Supports both \
@@ -1199,6 +1251,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "get_component".to_string(),
+                example: Some(serde_json::json!({"name": "get_component", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "SOIC-8"}})),
                 description: Some(
                     "Get a single component by name from an Altium library. Returns the full component \
                      data (footprint or symbol) without needing to read and filter the entire library. \
@@ -1222,6 +1275,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "component_exists".to_string(),
+                example: Some(serde_json::json!({"name": "component_exists", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_names": ["RESC0603", "CAPC0402", "MISSING_COMPONENT"]}})),
                 description: Some(
                     "Check if one or more components exist in an Altium library. Use this to validate \
                      component names before operations like rename, copy, or delete. Supports both \
@@ -1246,6 +1300,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "render_footprint".to_string(),
+                example: Some(serde_json::json!({"name": "render_footprint", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "RESC0603_IPC_MEDIUM", "scale": 2.0, "max_width": 80, "max_height": 40}})),
                 description: Some(
                     "Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, \
                      tracks, and other primitives in a simple text format for quick preview."
@@ -1280,6 +1335,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "render_symbol".to_string(),
+                example: Some(serde_json::json!({"name": "render_symbol", "arguments": {"filepath": "./MyLibrary.SchLib", "component_name": "LM358", "scale": 1.0, "max_width": 80, "max_height": 40, "part_id": 1}})),
                 description: Some(
                     "Render an ASCII art visualisation of a schematic symbol from a SchLib file. \
                      Shows pins, rectangles, lines, and other primitives in a simple text format \
@@ -1320,6 +1376,7 @@ impl McpServer {
             // manage_schlib_parameters - Manage symbol parameters (Value, Manufacturer, etc.)
             ToolDefinition {
                 name: "manage_schlib_parameters".to_string(),
+                example: Some(serde_json::json!({"name": "manage_schlib_parameters", "arguments": {"filepath": "./MyLibrary.SchLib", "component_name": "LM358", "operation": "set", "parameter_name": "Value", "value": "LM358D"}})),
                 description: Some(
                     "Manage component parameters in Altium SchLib files. Supports listing, \
                      getting, setting, adding, and deleting parameters like Value, Manufacturer, \
@@ -1369,6 +1426,7 @@ impl McpServer {
             // manage_schlib_footprints - Manage footprint links in symbols
             ToolDefinition {
                 name: "manage_schlib_footprints".to_string(),
+                example: Some(serde_json::json!({"name": "manage_schlib_footprints", "arguments": {"filepath": "./MyLibrary.SchLib", "component_name": "LM358", "operation": "add", "footprint_name": "SOIC-8_3.9x4.9mm"}})),
                 description: Some(
                     "Manage footprint links in Altium SchLib symbols. Supports listing, adding, \
                      and removing footprint references that link schematic symbols to PCB footprints."
@@ -1408,6 +1466,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "compare_components".to_string(),
+                example: Some(serde_json::json!({"name": "compare_components", "arguments": {"filepath_a": "./LibraryA.PcbLib", "component_a": "RESC0603_V1", "filepath_b": "./LibraryB.PcbLib", "component_b": "RESC0603_V2", "include_geometry": true, "tolerance": 0.001}})),
                 description: Some(
                     "Compare two specific components in detail, showing differences in primitives, \
                      parameters, and properties. Components can be from the same library or different \
@@ -1447,6 +1506,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "repair_library".to_string(),
+                example: Some(serde_json::json!({"name": "repair_library", "arguments": {"filepath": "./MyLibrary.PcbLib", "dry_run": true}})),
                 description: Some(
                     "Repair a library by removing orphaned references. For PcbLib files, this removes: \
                      (1) embedded models not referenced by any footprint, and \
@@ -1471,6 +1531,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "list_backups".to_string(),
+                example: Some(serde_json::json!({"name": "list_backups", "arguments": {"filepath": "./MyLibrary.PcbLib"}})),
                 description: Some(
                     "List available backup files for an Altium library. Shows timestamped .bak files \
                      that were automatically created before write operations."
@@ -1489,6 +1550,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "restore_backup".to_string(),
+                example: Some(serde_json::json!({"name": "restore_backup", "arguments": {"filepath": "./MyLibrary.PcbLib", "backup_path": "MyLibrary.PcbLib.20260125_091500.bak"}})),
                 description: Some(
                     "Restore an Altium library file from a backup. If no specific backup is specified, \
                      restores from the most recent backup."
@@ -1511,6 +1573,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "bulk_rename".to_string(),
+                example: Some(serde_json::json!({"name": "bulk_rename", "arguments": {"filepath": "./MyLibrary.PcbLib", "pattern": "^RESC(.*)$", "replacement": "RES_$1", "dry_run": true}})),
                 description: Some(
                     "Rename multiple components in a library using regex pattern matching. \
                      Supports capture groups for flexible renaming (e.g., 'RESC(.*)' -> 'RES_$1')."
@@ -1541,6 +1604,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "update_pad".to_string(),
+                example: Some(serde_json::json!({"name": "update_pad", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "RESC0603", "designator": "1", "updates": {"width": 1.0, "height": 0.9, "shape": "rectangle"}, "dry_run": false}})),
                 description: Some(
                     "Update specific properties of a pad in a PcbLib footprint without replacing \
                      the entire component. Find pad by designator and apply only the specified updates."
@@ -1584,6 +1648,7 @@ impl McpServer {
             },
             ToolDefinition {
                 name: "update_primitive".to_string(),
+                example: Some(serde_json::json!({"name": "update_primitive", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "RESC0603", "primitive_type": "track", "index": 0, "updates": {"width": 0.15, "layer": "Top Overlay"}, "dry_run": false}})),
                 description: Some(
                     "Update specific properties of a primitive (track, arc, region, or text) in a \
                      PcbLib footprint. Find primitive by type and index, apply only specified updates."

--- a/src/mcp/tool_docs.rs
+++ b/src/mcp/tool_docs.rs
@@ -1,0 +1,234 @@
+//! Generates `docs/TOOLS.md` from [`McpServer::get_tool_definitions`], so the
+//! human-readable tool reference cannot drift from the schema the server
+//! actually serves over `tools/list`.
+//!
+//! The committed `docs/TOOLS.md` is a build artifact of the tool definitions:
+//! a unit test ([`tests::tools_md_in_sync`]) fails if the file is out of date,
+//! and `UPDATE_DOCS=1 cargo test --lib tools_md_in_sync` regenerates it. Tool
+//! descriptions, parameter schemas, and the per-tool `example` all live in
+//! `tool_definitions.rs` (the single source of truth); nothing here is authored
+//! by hand.
+
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+use crate::mcp::server::McpServer;
+
+/// Path to the generated doc, relative to the crate manifest dir.
+const TOOLS_MD_REL: &str = "docs/TOOLS.md";
+
+const HEADER: &str = "<!-- GENERATED — do not edit by hand.
+     Source of truth: src/mcp/tool_definitions.rs
+     Regenerate: UPDATE_DOCS=1 cargo test --lib tools_md_in_sync -->
+
+# MCP Tools Reference
+
+Every tool the **altium-designer-mcp** server exposes, rendered from the tool
+definitions served over `tools/list`. Coordinates are millimetres for `.PcbLib`
+footprints and schematic units (10 units = 1 grid square) for `.SchLib` symbols.
+";
+
+/// Renders the full Markdown reference for every registered tool.
+pub fn render_tools_markdown() -> String {
+    let mut out = String::from(HEADER);
+    let tools = McpServer::get_tool_definitions();
+    let _ = writeln!(out, "\n_{} tools._", tools.len());
+
+    for tool in &tools {
+        let _ = writeln!(out, "\n## `{}`", tool.name);
+        if let Some(desc) = &tool.description {
+            let _ = writeln!(out, "\n{}", desc.trim());
+        }
+        if let Some(example) = &tool.example {
+            out.push_str("\n**Example**\n\n```json\n");
+            out.push_str(&serde_json::to_string_pretty(example).unwrap_or_default());
+            out.push_str("\n```\n");
+        }
+        out.push_str(&render_params(&tool.input_schema));
+    }
+    out
+}
+
+/// Renders the parameter table for one tool's input schema.
+fn render_params(schema: &Value) -> String {
+    let props = schema.get("properties").and_then(Value::as_object);
+    let Some(props) = props else {
+        return "\n_No parameters._\n".to_string();
+    };
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    // Sort property names so the table is deterministic regardless of the
+    // serde_json map backing (BTreeMap vs preserve_order IndexMap).
+    let mut names: Vec<&String> = props.keys().collect();
+    names.sort();
+
+    let mut out = String::from(
+        "\n**Parameters**\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n",
+    );
+    for name in names {
+        let p = &props[name];
+        let req = if required.contains(&name.as_str()) {
+            "yes"
+        } else {
+            "no"
+        };
+        let _ = writeln!(
+            out,
+            "| `{}` | {} | {} | {} |",
+            name,
+            schema_type(p),
+            req,
+            describe(p)
+        );
+    }
+    out
+}
+
+/// Human-readable type for a schema property (`string`, `array<object>`, …).
+fn schema_type(p: &Value) -> String {
+    if p.get("enum").is_some() {
+        return "enum".to_string();
+    }
+    match p.get("type").and_then(Value::as_str) {
+        Some("array") => {
+            let item = p
+                .get("items")
+                .and_then(|i| i.get("type"))
+                .and_then(Value::as_str)
+                .unwrap_or("any");
+            format!("array<{item}>")
+        }
+        Some(t) => t.to_string(),
+        None => "any".to_string(),
+    }
+}
+
+/// Description cell: the schema `description`, with enum values and any default
+/// appended so the table is self-contained.
+fn describe(p: &Value) -> String {
+    let mut s = p
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .replace('\n', " ")
+        .replace('|', "\\|");
+    if let Some(vals) = p.get("enum").and_then(Value::as_array) {
+        let joined = vals
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !joined.is_empty() {
+            let _ = write!(s, " (one of: {joined})");
+        }
+    }
+    if let Some(def) = p.get("default") {
+        let _ = write!(s, " (default: `{def}`)");
+    }
+    s.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_tools_markdown, TOOLS_MD_REL};
+    use crate::mcp::server::McpServer;
+    use serde_json::Value;
+
+    /// Every per-tool `example` must be a valid call for that tool: it must name
+    /// the right tool, use only documented top-level arguments (the same
+    /// contract the strict-deserialization allow-lists enforce at runtime), and
+    /// supply every required argument. A stale or hand-typo'd example would
+    /// otherwise ship in docs/TOOLS.md and mislead an agent.
+    #[test]
+    fn examples_are_schema_valid() {
+        let mut problems: Vec<String> = Vec::new();
+        for tool in McpServer::get_tool_definitions() {
+            let Some(example) = &tool.example else {
+                continue;
+            };
+            let t = &tool.name;
+            if example.get("name").and_then(Value::as_str) != Some(t.as_str()) {
+                problems.push(format!(
+                    "{t}: example names the wrong tool (or omits `name`)"
+                ));
+            }
+            let Some(args) = example.get("arguments").and_then(Value::as_object) else {
+                problems.push(format!("{t}: example has no `arguments` object"));
+                continue;
+            };
+            let Some(props) = tool
+                .input_schema
+                .get("properties")
+                .and_then(Value::as_object)
+            else {
+                continue;
+            };
+            for key in args.keys() {
+                if !props.contains_key(key) {
+                    problems.push(format!("{t}: argument `{key}` is not in the input schema"));
+                }
+            }
+            if let Some(required) = tool.input_schema.get("required").and_then(Value::as_array) {
+                for req in required.iter().filter_map(Value::as_str) {
+                    if !args.contains_key(req) {
+                        problems.push(format!("{t}: missing required argument `{req}`"));
+                    }
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "tool examples disagree with their schemas:\n  {}",
+            problems.join("\n  ")
+        );
+    }
+
+    /// The internal `example` must never leak onto the `tools/list` wire — it is
+    /// not part of the MCP tool schema. Guards the `#[serde(skip)]`.
+    #[test]
+    fn example_field_is_not_serialized() {
+        let tool = McpServer::get_tool_definitions()
+            .into_iter()
+            .find(|t| t.example.is_some())
+            .expect("at least one tool carries an example");
+        let wire = serde_json::to_value(&tool).expect("serialize ToolDefinition");
+        assert!(
+            wire.get("example").is_none(),
+            "`example` must be #[serde(skip)] — it leaked into tools/list output"
+        );
+        assert!(
+            wire.get("inputSchema").is_some(),
+            "the real schema is still serialized (camelCase)"
+        );
+    }
+
+    /// Guards `docs/TOOLS.md` against drift from `tool_definitions.rs`. If a
+    /// tool's schema, description, or example changes and the doc isn't
+    /// regenerated, this fails. Regenerate with:
+    ///   `UPDATE_DOCS=1 cargo test --lib tools_md_in_sync`
+    #[test]
+    fn tools_md_in_sync() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(TOOLS_MD_REL);
+        let generated = render_tools_markdown();
+
+        if std::env::var_os("UPDATE_DOCS").is_some() {
+            std::fs::write(&path, &generated).expect("write docs/TOOLS.md");
+            return;
+        }
+
+        let committed = std::fs::read_to_string(&path)
+            .unwrap_or_default()
+            .replace("\r\n", "\n");
+        assert_eq!(
+            generated.replace("\r\n", "\n"),
+            committed,
+            "docs/TOOLS.md is out of date with tool_definitions.rs. \
+             Regenerate: UPDATE_DOCS=1 cargo test --lib tools_md_in_sync"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Agents that consume a **release** have no source tree, and the MCP surface today is tools-only — so the conventions that aren't per-tool (coordinate units, the pin body-attach/orientation rule, the path sandbox, the build flow) lived only in `docs/`/source, and agents reached straight for the source to answer API questions. This adds two **self-updating** channels, both sourced from code so neither can drift, plus tests that enforce that.

### 1. `docs/TOOLS.md` is now generated from the tool definitions
Rendered from `get_tool_definitions()` — the same defs served over `tools/list` — so the human-readable reference can't disagree with the schema. Each `ToolDefinition` carries an optional `example` (`#[serde(skip)]`, internal-only) rendered with its description and a parameter table derived from the input schema.

- Regenerate: `UPDATE_DOCS=1 cargo test --lib tools_md_in_sync`
- A unit test (`tools_md_in_sync`) fails if the committed doc is stale — same guarantee `tools/list` has. This also removes the drift risk in the previously hand-maintained `TOOLS.md`.

### 2. `initialize` now sends MCP `instructions`
Embedded via `include_str!` from a new `docs/AGENT_GUIDE.md` (invariants only — it points at `tools/list` for per-tool detail, so adding a tool needs no edit there). Clients surface this to the model automatically, which is the protocol's designated "how to use me" channel.

### 3. Release bundles the agent docs
`release.yml` now ships `docs/AGENT_GUIDE.md` + `docs/TOOLS.md` in `dist/docs/`, so a downloaded release teaches the consuming agent without the source tree.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD changes (release artifact contents)

## Testing

- [x] `tools_md_in_sync` — generated doc vs committed `TOOLS.md`
- [x] `examples_are_schema_valid` — every example names its tool, uses only documented args, supplies required args. **Caught two stale examples** harvested from the old hand-written doc: `restore_backup` used `backup_filename` (real param `backup_path`); `bulk_rename` referenced a nonexistent `pattern_type`. Both fixed.
- [x] `example_field_is_not_serialized` — the internal `example` stays off the `tools/list` wire
- [x] `initialize_sends_agent_instructions` — `initialize` returns the embedded `AGENT_GUIDE.md`
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (319 unit) green
- [x] Integration `tests/integration/test_mcp_tools.py` 131/131; `ORACLE_REQUIRE_DEPS=1 .../test_altium_readability.py` 0 regressions

## Notes

The `example` data is compiled into the binary but `#[serde(skip)]` and only read by the (test-only) doc generator — it never reaches `tools/list` and has no runtime effect. The `release.yml` doc-copy only exercises on a tag build; the referenced paths were verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)