### PR TITLE
fix(test): decode MCP server stdout as UTF-8 in the integration harness

### DIFF
--- a/tests/integration/mcp_client.py
+++ b/tests/integration/mcp_client.py
@@ -47,6 +47,7 @@ class McpTestClient:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,
+            encoding="utf-8",
         )
         self._reader = threading.Thread(target=self._read_lines, daemon=True)
         self._reader.start()


### PR DESCRIPTION
Fixes a latent bug in the integration test harness: `mcp_client.py` starts the server with `text=True` but no `encoding=`, so Python decodes the server's UTF-8 JSON-RPC stdout with the OS locale codec (cp1252 on Windows). Any non-ASCII byte the server emits then crashes the reader thread → `timeout waiting for server output`.

MCP / JSON-RPC is UTF-8 by spec, so the fix is one line: `encoding="utf-8"`.

Surfaced while reviewing #203 (whose new `initialize` `instructions` contain `≈`/`→`), but it's independent — any server output with non-cp1252 characters would trip it. Verified on current main with the fix: `test_mcp_tools.py` **131/131**, oracle **0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
