### PR TITLE
fix(docs): silence MD013 in generated TOOLS.md

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -2,6 +2,9 @@
      Source of truth: src/mcp/tool_definitions.rs
      Regenerate: UPDATE_DOCS=1 cargo test --lib tools_md_in_sync -->
 
+<!-- markdownlint-disable MD013 -->
+<!-- Generated tables and inline JSON schemas legitimately exceed the line-length limit. -->
+
 # MCP Tools Reference
 
 Every tool the **altium-designer-mcp** server exposes, rendered from the tool

--- a/src/mcp/tool_docs.rs
+++ b/src/mcp/tool_docs.rs
@@ -22,6 +22,9 @@ const HEADER: &str = "<!-- GENERATED — do not edit by hand.
      Source of truth: src/mcp/tool_definitions.rs
      Regenerate: UPDATE_DOCS=1 cargo test --lib tools_md_in_sync -->
 
+<!-- markdownlint-disable MD013 -->
+<!-- Generated tables and inline JSON schemas legitimately exceed the line-length limit. -->
+
 # MCP Tools Reference
 
 Every tool the **altium-designer-mcp** server exposes, rendered from the tool


### PR DESCRIPTION
Follow-up to #203: its generated `docs/TOOLS.md` fails the repo's markdownlint gate (`MD013/line-length`, max 170) — parameter tables and inline JSON schemas legitimately run long (one line is 856 chars), so main's Quick Checks went red on merge.

Fix: the generator (`tool_docs.rs` `HEADER`) now emits `<!-- markdownlint-disable MD013 -->` at the top of the doc — the same call we make for `docs/COVERAGE_AUDIT.md`. Regenerated `TOOLS.md` so the drift guard (`tools_md_in_sync`) stays satisfied.

Verified: markdownlint `docs/TOOLS.md` + `docs/AGENT_GUIDE.md` **0 errors**, drift guard passes, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
