### PR TITLE
feat(pcblib): model Via thermal-relief/power-plane/tenting/net (PR-7)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1345,6 +1345,75 @@ mod tests {
     }
 
     #[test]
+    fn via_thermal_power_plane_fields_round_trip() {
+        use super::primitives::PowerPlaneConnectStyle;
+
+        // PR-7: the via flag word (tenting/keepout/locked), power-plane connection,
+        // paste-mask expansion and net index all survive encode -> decode.
+        let mut original = Footprint::new("VIA_PP");
+        let mut via = Via::new(1.0, 2.0, 0.8, 0.4);
+        via.flags =
+            PcbFlags::TENTING_TOP | PcbFlags::TENTING_BOTTOM | PcbFlags::KEEPOUT | PcbFlags::LOCKED;
+        via.power_plane_connect_style = PowerPlaneConnectStyle::Direct;
+        via.power_plane_relief_expansion = 0.6;
+        via.power_plane_clearance = 0.7;
+        via.paste_mask_expansion = 0.05;
+        via.net_index = 42;
+        original.add_via(via);
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("VIA_PP");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.vias.len(), 1);
+        let d = &decoded.vias[0];
+        assert!(d.flags.contains(PcbFlags::TENTING_TOP));
+        assert!(d.flags.contains(PcbFlags::TENTING_BOTTOM));
+        assert!(d.flags.contains(PcbFlags::KEEPOUT));
+        assert!(d.flags.contains(PcbFlags::LOCKED));
+        assert_eq!(d.power_plane_connect_style, PowerPlaneConnectStyle::Direct);
+        assert!(approx_eq(d.power_plane_relief_expansion, 0.6, 0.001));
+        assert!(approx_eq(d.power_plane_clearance, 0.7, 0.001));
+        assert!(approx_eq(d.paste_mask_expansion, 0.05, 0.001));
+        assert_eq!(d.net_index, 42);
+    }
+
+    #[test]
+    fn default_via_defaults_match_template() {
+        use super::primitives::PowerPlaneConnectStyle;
+
+        // A from-scratch via must default to exactly the VIA_SR1_TEMPLATE constants
+        // so it serialises byte-identically (the readability oracle exercises vias).
+        let via = Via::new(0.0, 0.0, 0.6, 0.3);
+        assert_eq!(via.flags, PcbFlags::empty()); // flag word 0x000C (saved|unlocked)
+        assert_eq!(via.net_index, 0xFFFF); // @3-4 = 0xFFFF (no net)
+        assert_eq!(
+            via.power_plane_connect_style,
+            PowerPlaneConnectStyle::Relief // @31 = 0
+        );
+        assert!(approx_eq(via.power_plane_relief_expansion, 0.508, 1e-9)); // @42 = 200000
+        assert!(approx_eq(via.power_plane_clearance, 0.508, 1e-9)); // @46 = 200000
+        assert!(approx_eq(via.paste_mask_expansion, 0.0, 1e-9)); // @50 = 0
+
+        // Encode and confirm the SubRecord-1 bytes equal the template at each offset.
+        let mut fp = Footprint::new("VIA_TEMPLATE");
+        fp.add_via(via);
+        let data = writer::encode_data_stream(&fp).expect("encode");
+        let sig = [0x03u8, 0x41, 0x01, 0x00, 0x00];
+        let pos = data
+            .windows(sig.len())
+            .position(|w| w == sig)
+            .expect("via block");
+        let block = &data[pos + 5..pos + 5 + 321];
+        assert_eq!(&block[1..3], &[0x0C, 0x00]); // flags word
+        assert_eq!(&block[3..5], &[0xFF, 0xFF]); // net index
+        assert_eq!(block[31], 0x00); // power-plane connect style
+        assert_eq!(&block[42..46], &200_000i32.to_le_bytes()); // relief expansion
+        assert_eq!(&block[46..50], &200_000i32.to_le_bytes()); // plane clearance
+        assert_eq!(&block[50..54], &0i32.to_le_bytes()); // paste-mask expansion
+    }
+
+    #[test]
     fn pad_mask_expansion_mode_round_trips() {
         use super::primitives::MaskExpansionMode;
 

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -485,6 +485,37 @@ pub struct Via {
     #[serde(default)]
     pub solder_mask_expansion_mode: MaskExpansionMode,
 
+    /// Paste-mask expansion in mm — `SubRecord-1` i32 @50. Default: 0.0, matching
+    /// Altium's via template (a via has no paste by default).
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub paste_mask_expansion: f64,
+
+    /// Power-plane connection style — `SubRecord-1` byte @31
+    /// (`Relief` / `Direct` / `NoConnect`). Altium's default is `Relief`.
+    #[serde(default)]
+    pub power_plane_connect_style: PowerPlaneConnectStyle,
+
+    /// Power-plane relief expansion in mm — `SubRecord-1` i32 @42.
+    /// Default: 0.508mm (20 mil), matching Altium's via template.
+    #[serde(
+        default = "default_via_power_plane_relief_expansion",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub power_plane_relief_expansion: f64,
+
+    /// Power-plane (anti-pad) clearance to the plane in mm — `SubRecord-1` i32 @46.
+    /// Default: 0.508mm (20 mil), matching Altium's via template.
+    #[serde(
+        default = "default_via_power_plane_clearance",
+        serialize_with = "crate::altium::serde_round::serialize"
+    )]
+    pub power_plane_clearance: f64,
+
+    /// Net index into the board's net list — `SubRecord-1` u16 @3.
+    /// `0xFFFF` (65535) means "no net", the default for a footprint via.
+    #[serde(default = "default_via_net_index")]
+    pub net_index: u16,
+
     /// Bottom-face solder-mask expansion in mm (Altium geometry offset 242). `None`
     /// mirrors the front-face `solder_mask_expansion` (Altium's template encodes both
     /// faces equally), so a default via round-trips byte-identically.
@@ -528,6 +559,11 @@ pub struct Via {
     )]
     pub per_layer_diameters: Option<Vec<f64>>,
 
+    /// Primitive flags (locked, keepout, tenting top/bottom) — common-header word @1-2.
+    /// Tenting a via covers its pad with solder mask on the given face.
+    #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
+    pub flags: PcbFlags,
+
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -548,6 +584,21 @@ const fn default_thermal_relief_width() -> f64 {
     0.254
 }
 
+/// Default via power-plane relief expansion (20 mil = 0.508mm; raw 200000).
+const fn default_via_power_plane_relief_expansion() -> f64 {
+    0.508
+}
+
+/// Default via power-plane (anti-pad) clearance (20 mil = 0.508mm; raw 200000).
+const fn default_via_power_plane_clearance() -> f64 {
+    0.508
+}
+
+/// Default via net index (`0xFFFF` = no net).
+const fn default_via_net_index() -> u16 {
+    0xFFFF
+}
+
 impl Via {
     /// Creates a new via with default settings.
     ///
@@ -565,11 +616,17 @@ impl Via {
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_back: None,
-            thermal_relief_gap: 0.254, // 10 mils
+            paste_mask_expansion: 0.0,
+            power_plane_connect_style: PowerPlaneConnectStyle::Relief,
+            power_plane_relief_expansion: 0.508, // 20 mils
+            power_plane_clearance: 0.508,        // 20 mils
+            net_index: 0xFFFF,                   // no net
+            thermal_relief_gap: 0.254,           // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils
             diameter_stack_mode: ViaStackMode::Simple,
             per_layer_diameters: None,
+            flags: PcbFlags::empty(),
             unique_id: None,
         }
     }
@@ -594,11 +651,17 @@ impl Via {
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_back: None,
-            thermal_relief_gap: 0.254, // 10 mils
+            paste_mask_expansion: 0.0,
+            power_plane_connect_style: PowerPlaneConnectStyle::Relief,
+            power_plane_relief_expansion: 0.508, // 20 mils
+            power_plane_clearance: 0.508,        // 20 mils
+            net_index: 0xFFFF,                   // no net
+            thermal_relief_gap: 0.254,           // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils
             diameter_stack_mode: ViaStackMode::Simple,
             per_layer_diameters: None,
+            flags: PcbFlags::empty(),
             unique_id: None,
         }
     }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -441,11 +441,26 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
     let from_layer = layer_from_id(block[29]);
     let to_layer = layer_from_id(block[30]);
 
-    // Extended SubRecord-1 fields (offsets 32-74). A short block falls back to
+    // Common-header flag word @1-2 (locked/keepout/tenting top+bottom). Tenting a
+    // via is the highest-value property here — it covers the pad with solder mask.
+    let flags = read_flags(block);
+    // Net index @3-4 (u16; 0xFFFF = no net). Read-only surface for footprint vias.
+    let net_index = read_u16(block, 3).unwrap_or(0xFFFF);
+
+    // Extended SubRecord-1 fields (offsets 31-74). A short block falls back to
     // the same defaults the Via struct uses.
+    // Power-plane connection style @31 (0=Relief, 1=Direct, 2=NoConnect).
+    let power_plane_connect_style = block.get(31).map_or(PowerPlaneConnectStyle::Relief, |&b| {
+        PowerPlaneConnectStyle::from_id(b)
+    });
     let thermal_relief_gap = read_i32(block, 32).map_or(0.254, to_mm);
     let thermal_relief_conductors = block.get(36).copied().unwrap_or(4);
     let thermal_relief_width = read_i32(block, 38).map_or(0.254, to_mm);
+    // Power-plane relief expansion @42, plane clearance @46 (i32 -> mm).
+    let power_plane_relief_expansion = read_i32(block, 42).map_or(0.508, to_mm);
+    let power_plane_clearance = read_i32(block, 46).map_or(0.508, to_mm);
+    // Paste-mask expansion @50 (i32 -> mm).
+    let paste_mask_expansion = read_i32(block, 50).map_or(0.0, to_mm);
     let solder_mask_expansion = read_i32(block, 54).map_or(0.0, to_mm);
     // Offset 66 is a tri-state mode byte (0=None, 1=FromRule, 2=Manual), not a bool.
     let solder_mask_expansion_mode = block.get(66).map_or(MaskExpansionMode::FromRule, |&b| {
@@ -484,11 +499,17 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         solder_mask_expansion,
         solder_mask_expansion_mode,
         solder_mask_expansion_back,
+        paste_mask_expansion,
+        power_plane_connect_style,
+        power_plane_relief_expansion,
+        power_plane_clearance,
+        net_index,
         thermal_relief_gap,
         thermal_relief_conductors,
         thermal_relief_width,
         diameter_stack_mode,
         per_layer_diameters,
+        flags,
         unique_id: None,
     };
 

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -732,10 +732,15 @@ const VIA_SR1_TEMPLATE: [u8; 321] = [
 fn encode_via(data: &mut Vec<u8>, via: &Via) {
     let mut block = VIA_SR1_TEMPLATE;
 
-    // Common header (offsets 0-12): MultiLayer + default (saved + unlocked) flags.
+    // Common header (offsets 0-12): MultiLayer + the via's flag word
+    // (locked/keepout/tenting top+bottom).
     let mut header = Vec::with_capacity(13);
-    write_common_header(&mut header, Layer::MultiLayer, PcbFlags::empty());
+    write_common_header(&mut header, Layer::MultiLayer, via.flags);
     block[0..13].copy_from_slice(&header);
+
+    // Net index @3-4 (u16; 0xFFFF = no net). Overlays the header's 0xFF bytes; a
+    // default via keeps 0xFFFF so the template bytes are reproduced unchanged.
+    block[3..5].copy_from_slice(&via.net_index.to_le_bytes());
 
     // Geometry (offsets 13-30).
     block[13..17].copy_from_slice(&from_mm(via.x).to_le_bytes());
@@ -745,10 +750,18 @@ fn encode_via(data: &mut Vec<u8>, via: &Via) {
     block[29] = layer_to_id(via.from_layer);
     block[30] = layer_to_id(via.to_layer);
 
+    // Power-plane connection style @31 (0=Relief, 1=Direct, 2=NoConnect).
+    block[31] = via.power_plane_connect_style.to_id();
+
     // Thermal relief (air gap @32, conductor count @36, conductor width @38).
     block[32..36].copy_from_slice(&from_mm(via.thermal_relief_gap).to_le_bytes());
     block[36] = via.thermal_relief_conductors;
     block[38..42].copy_from_slice(&from_mm(via.thermal_relief_width).to_le_bytes());
+
+    // Power-plane relief expansion @42, plane clearance @46, paste-mask @50.
+    block[42..46].copy_from_slice(&from_mm(via.power_plane_relief_expansion).to_le_bytes());
+    block[46..50].copy_from_slice(&from_mm(via.power_plane_clearance).to_le_bytes());
+    block[50..54].copy_from_slice(&from_mm(via.paste_mask_expansion).to_le_bytes());
 
     // Solder mask expansion @54, its mode @66, diameter stack mode @74.
     block[54..58].copy_from_slice(&from_mm(via.solder_mask_expansion).to_le_bytes());

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -262,7 +262,17 @@ impl McpServer {
                                                 },
                                                 "thermal_relief_gap": { "type": "number", "description": "Thermal relief air-gap width in mm. Default: 0.254 (10 mil)" },
                                                 "thermal_relief_conductors": { "type": "integer", "description": "Number of thermal relief conductors. Default: 4" },
-                                                "thermal_relief_width": { "type": "number", "description": "Thermal relief conductor width in mm. Default: 0.254 (10 mil)" }
+                                                "thermal_relief_width": { "type": "number", "description": "Thermal relief conductor width in mm. Default: 0.254 (10 mil)" },
+                                                "power_plane_connect_style": {
+                                                    "type": "string",
+                                                    "enum": ["relief", "direct", "no_connect"],
+                                                    "description": "How the via connects to an internal power plane. Default: relief (thermal spokes)"
+                                                },
+                                                "power_plane_relief_expansion": { "type": "number", "description": "Power-plane relief expansion in mm. Default: 0.508 (20 mil)" },
+                                                "power_plane_clearance": { "type": "number", "description": "Power-plane (anti-pad) clearance in mm. Default: 0.508 (20 mil)" },
+                                                "paste_mask_expansion": { "type": "number", "description": "Paste-mask expansion in mm. Default: 0" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (0-65534; 65535 = no net). Default: 65535" },
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"TENTING_TOP\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Tenting covers the via with solder mask. Default: none" }
                                             },
                                             "required": ["x", "y", "diameter", "hole_size"]
                                         }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -451,8 +451,9 @@ impl McpServer {
     /// `to_layer` fields and reuses [`crate::altium::pcblib::MaskExpansionMode`]
     /// string parsing for the mask mode. Optionals default exactly as
     /// [`crate::altium::pcblib::Via::new`] does when absent.
+    #[allow(clippy::too_many_lines)] // Via has many optional fields requiring individual parsing
     pub(crate) fn parse_via(json: &Value) -> Result<crate::altium::pcblib::Via, String> {
-        use crate::altium::pcblib::{Layer, MaskExpansionMode, Via};
+        use crate::altium::pcblib::{Layer, MaskExpansionMode, PowerPlaneConnectStyle, Via};
 
         let x = json
             .get("x")
@@ -536,6 +537,40 @@ impl McpServer {
         if let Some(v) = json.get("thermal_relief_width").and_then(Value::as_f64) {
             via.thermal_relief_width = v;
         }
+
+        // Power-plane connection (SubRecord-1 @31/@42/@46) + paste-mask @50 +
+        // net index @3. Absent keys keep the from-scratch defaults (= Altium's
+        // via template), so an unspecified via round-trips byte-identically.
+        if let Some(s) = json
+            .get("power_plane_connect_style")
+            .and_then(Value::as_str)
+        {
+            via.power_plane_connect_style = match s.to_lowercase().as_str() {
+                "direct" => PowerPlaneConnectStyle::Direct,
+                "no_connect" | "noconnect" => PowerPlaneConnectStyle::NoConnect,
+                _ => PowerPlaneConnectStyle::Relief,
+            };
+        }
+        if let Some(v) = json
+            .get("power_plane_relief_expansion")
+            .and_then(Value::as_f64)
+        {
+            via.power_plane_relief_expansion = v;
+        }
+        if let Some(v) = json.get("power_plane_clearance").and_then(Value::as_f64) {
+            via.power_plane_clearance = v;
+        }
+        if let Some(v) = json.get("paste_mask_expansion").and_then(Value::as_f64) {
+            via.paste_mask_expansion = v;
+        }
+        if let Some(v) = json
+            .get("net_index")
+            .and_then(Value::as_u64)
+            .and_then(|v| u16::try_from(v).ok())
+        {
+            via.net_index = v;
+        }
+        via.flags = json_flags(json);
 
         Ok(via)
     }
@@ -1365,6 +1400,51 @@ mod tests {
         assert!((pad.relief_air_gap - 0.254).abs() < 1e-9);
         assert!((pad.power_plane_relief_expansion - 0.508).abs() < 1e-9);
         assert!((pad.power_plane_clearance - 0.508).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_via_reads_power_plane_and_flags() {
+        use crate::altium::pcblib::{PcbFlags, PowerPlaneConnectStyle};
+        // PR-7: power-plane connection, paste-mask, net index and flags parse in.
+        let via = McpServer::parse_via(&json!({
+            "x": 0.0, "y": 0.0, "diameter": 0.8, "hole_size": 0.4,
+            "power_plane_connect_style": "direct",
+            "power_plane_relief_expansion": 0.6,
+            "power_plane_clearance": 0.7,
+            "paste_mask_expansion": 0.05,
+            "net_index": 42,
+            "flags": "TENTING_TOP | LOCKED",
+        }))
+        .expect("via should parse");
+        assert_eq!(
+            via.power_plane_connect_style,
+            PowerPlaneConnectStyle::Direct
+        );
+        assert!((via.power_plane_relief_expansion - 0.6).abs() < 1e-9);
+        assert!((via.power_plane_clearance - 0.7).abs() < 1e-9);
+        assert!((via.paste_mask_expansion - 0.05).abs() < 1e-9);
+        assert_eq!(via.net_index, 42);
+        assert!(via.flags.contains(PcbFlags::TENTING_TOP));
+        assert!(via.flags.contains(PcbFlags::LOCKED));
+    }
+
+    #[test]
+    fn parse_via_defaults_match_template() {
+        use crate::altium::pcblib::{PcbFlags, PowerPlaneConnectStyle};
+        // Absent keys keep the from-scratch defaults (= Altium's via template).
+        let via = McpServer::parse_via(&json!({
+            "x": 0.0, "y": 0.0, "diameter": 0.8, "hole_size": 0.4,
+        }))
+        .expect("via should parse");
+        assert_eq!(
+            via.power_plane_connect_style,
+            PowerPlaneConnectStyle::Relief
+        );
+        assert!((via.power_plane_relief_expansion - 0.508).abs() < 1e-9);
+        assert!((via.power_plane_clearance - 0.508).abs() < 1e-9);
+        assert!((via.paste_mask_expansion - 0.0).abs() < 1e-9);
+        assert_eq!(via.net_index, 0xFFFF);
+        assert_eq!(via.flags, PcbFlags::empty());
     }
 
     #[test]

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -729,6 +729,92 @@ def test_write_pcblib_pad_thermal_relief(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_via_thermal_power_plane(client, runner, lib_path):
+    print("\n=== Test: write_pcblib via thermal / power-plane / tenting round trip ===")
+    # Coverage PR-7: the via flag word (tenting/keepout/locked), power-plane
+    # connection style/expansion/clearance, paste-mask expansion and net index
+    # must be authorable via write_pcblib and round-trip through read_pcblib.
+    footprint = {
+        "name": "VIA_RELIEF_RT",
+        "vias": [
+            {
+                "x": 1.0,
+                "y": 2.0,
+                "diameter": 0.8,
+                "hole_size": 0.4,
+                "from_layer": "Top Layer",
+                "to_layer": "Bottom Layer",
+                "power_plane_connect_style": "direct",
+                "power_plane_relief_expansion": 0.6,
+                "power_plane_clearance": 0.7,
+                "paste_mask_expansion": 0.05,
+                "net_index": 42,
+                "flags": "TENTING_TOP | TENTING_BOTTOM | KEEPOUT | LOCKED",
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_pcblib (via relief) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("VIA_RELIEF_RT", {})
+    runner.check(bool(fp), "VIA_RELIEF_RT footprint present", actual=list(footprints))
+
+    # Coord fields carry sub-micron fixed-point quantisation; 1e-4 mm is well
+    # below any meaningful PCB tolerance.
+    tol = 1e-4
+    vias = fp.get("vias", [])
+    runner.check(len(vias) == 1, "1 via survived", actual=len(vias))
+    if vias:
+        v = vias[0]
+        runner.check(
+            v.get("power_plane_connect_style") == "direct",
+            "via power_plane_connect_style",
+            actual=v.get("power_plane_connect_style"),
+            expected="direct",
+        )
+        runner.check(
+            abs(v.get("power_plane_relief_expansion", 0) - 0.6) < tol,
+            "via power_plane_relief_expansion",
+            actual=v.get("power_plane_relief_expansion"),
+            expected=0.6,
+        )
+        runner.check(
+            abs(v.get("power_plane_clearance", 0) - 0.7) < tol,
+            "via power_plane_clearance",
+            actual=v.get("power_plane_clearance"),
+            expected=0.7,
+        )
+        runner.check(
+            abs(v.get("paste_mask_expansion", 0) - 0.05) < tol,
+            "via paste_mask_expansion",
+            actual=v.get("paste_mask_expansion"),
+            expected=0.05,
+        )
+        runner.check(
+            v.get("net_index") == 42,
+            "via net_index",
+            actual=v.get("net_index"),
+            expected=42,
+        )
+        # read_pcblib serialises PcbFlags as the bitflags name string; order is
+        # canonical (LOCKED before KEEPOUT before tenting). Assert each bit is set.
+        flags = v.get("flags", "")
+        runner.check(
+            all(f in flags for f in ("LOCKED", "KEEPOUT", "TENTING_TOP", "TENTING_BOTTOM")),
+            "via flags (tenting/keepout/locked)",
+            actual=flags,
+            expected="LOCKED | KEEPOUT | TENTING_TOP | TENTING_BOTTOM",
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -902,6 +988,7 @@ def main():
         test_write_pcblib_via_fill(client, runner, lib_path)
         test_write_pcblib_flags_mask_keepout(client, runner, lib_path)
         test_write_pcblib_pad_thermal_relief(client, runner, lib_path)
+        test_write_pcblib_via_thermal_power_plane(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)


### PR DESCRIPTION
**Coverage roadmap PR-7** — model the Via's thermal-relief / power-plane / tenting / net format fields (mirrors PR-6 on the Via).

These bytes already exist in the Via's SubRecord-1, but the reader skipped them and the writer emitted `VIA_SR1_TEMPLATE` constants — so an AI couldn't read or set a via's tenting, plane connection, paste-mask, or net.

## Fields (Via SubRecord-1 offsets)
| Field | Offset | Default |
|-------|--------|---------|
| `flags` (tenting top/bottom, keepout, locked) | 1-2 (flag word) | none |
| `net_index` | 3-4 | 0xFFFF (no net) |
| `power_plane_connect_style` (relief/direct/no_connect) | 31 | relief |
| `power_plane_relief_expansion` | 42 | 0.508 mm |
| `power_plane_clearance` | 46 | 0.508 mm |
| `paste_mask_expansion` | 50 | 0 mm |

**Tenting is the headline** — whether each via face is covered by solder mask.

## Byte-identity
Each default equals the template constant it replaces, so a default via serialises byte-for-byte identically. The golden `footprints.PcbLib` contains vias, so **oracle 0 regressions** proves it.

## Change
- **Struct**: 6 fields on the Via (`flags: PcbFlags` mirrors the Pad; `power_plane_connect_style` reuses PR-6's enum).
- **Reader** `parse_via` decodes offsets 1-2/3-4/31/42/46/50; **writer** `encode_via` overlays them (was hardcoded `PcbFlags::empty()`).
- **Tool**: `parse_via` reads the keys; `write_pcblib` via schema documents them.

Deferred to later PRs: drill tolerances, drill-pair-type, test-point/fab flags, per-via identity GUIDs, solder-mask-from-hole-edge.

## Test
Rust round-trip (non-default via survives) + byte-identity (default via bytes == template); Python `test_write_pcblib_via_thermal_power_plane`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (321) / **integration 141/141** / **oracle 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
