### PR TITLE
docs: symbol pin conventions (overbar + multi-part), cited to coffeenmusic

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -36,6 +36,21 @@ rectangle; the tip extends further left. The `write_schlib` response echoes each
 pin's computed `body_end`/`tip` so you can verify placement without opening
 Altium.
 
+## Overbar / active-low names
+
+Pin, net, and parameter names are stored verbatim, so use Altium's overbar
+convention: a backslash **after** each character to bar it. `R\E\S\E\T\` renders
+as an overbarred RESET; `RW\` bars only the `W`. Only the barred characters take a
+trailing `\`.
+
+## Multi-part symbols
+
+For a multi-unit component (dual/quad op-amp, gate array), set the symbol's
+`part_count` and give each pin an `owner_part_id` = its 1-based part number. The
+`DUALPART` sample shows pins split across two parts.
+
+*Overbar + multi-part conventions per [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp).*
+
 ## Filesystem sandbox
 
 Only paths inside the configured `allowed_paths` (see `config.json`) can be read

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -168,6 +168,28 @@ and the standard Altium layer names are documented in the reference — see
 **[docs/TOOLS.md](TOOLS.md)** and [README § Primitive Types](../README.md#primitive-types).
 This guide covers the *workflow* of assembling them, not the field-by-field reference.
 
+## Symbol Pin Conventions
+
+Conventions the per-tool schema can't express — adapted from
+[coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp):
+
+### Active-low pins (overbar)
+
+Pin names are written verbatim, so Altium's overbar convention works directly: put a
+backslash **after** each character that should carry a bar.
+
+| Intended rendering | Pin `name` |
+|--------------------|------------|
+| `RESET`, fully overbarred | `R\E\S\E\T\` |
+| `CS`, both letters barred | `C\S\` |
+| `RW`, bar the `W` only | `RW\` |
+
+### Multi-part symbols
+
+For multi-unit parts (dual / quad op-amps, gate arrays): set `part_count` on the symbol
+and tag each pin with `owner_part_id` (the 1-based part it belongs to). The `DUALPART`
+sample demonstrates a two-part symbol with pins split across parts 1 and 2.
+
 ## Working with Large Libraries
 
 For libraries with many components, use pagination to avoid output limits:


### PR DESCRIPTION
Adds two AI-facing symbol/pin conventions the per-tool schema can't express, **adapted from [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp)** (cited in both docs):

- **Overbar / active-low pins** — pin names are stored verbatim (`encode_windows1252` → `write_pascal_string` on write, `read_pascal_string` on read, no escaping), so Altium's `\`-per-character overbar convention works directly: `R\E\S\E\T\` renders as an overbarred RESET. *(Verified by code inspection — the name path is an opaque Windows-1252 pascal string.)*
- **Multi-part symbols** — `part_count` + per-pin `owner_part_id` (1-based); the `DUALPART` sample demonstrates it.

`AGENT_GUIDE.md` (the MCP `initialize` instructions the model sees) gets a concise version; `AI_WORKFLOW.md` a fuller treatment with an overbar table.

markdownlint clean; `initialize_sends_agent_instructions` + full `cargo test --lib` (323) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
