### PR TITLE
feat(pcblib): Pad/Via slot-hole geometry & drill tolerances (PR-8)

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -53,8 +53,9 @@
 
 ### PR-8 — PcbLib: Pad/Via slot-hole geometry & drill tolerances (format)
 
-**Primitives:** Pad, Via. **Kind:** read+write+tool. **Missing:** HoleSlotLength + HoleRotation (currently hard-coded 0 in writer), HolePositiveTolerance/HoleNegativeTolerance (hard-coded 0x7FFFFFFF sentinel), DrillType (simple/pressfit).
+**Primitives:** Pad, Via. **Kind:** read+write+tool. **Missing:** HoleSlotLength + HoleRotation (currently hard-coded 0 in writer), HolePositiveTolerance/HoleNegativeTolerance (hard-coded 0x7FFFFFFF sentinel).
 **Fix:** Read slot length/rotation from the size-shape block and tolerances from extended-tail offsets 162/166 (Pad) / 291/295 (Via); add struct fields; replace the hard-coded writer values; expose in schema. Without this `hole_shape='slot'` produces a zero-length degenerate slot.
+**Deferred:** DrillType (simple/pressfit) — the `.PcbLib` binary has no verified offset (neither AltiumSharp nor pyaltiumlib serialise it, and every pad in AltiumSharp's test corpus is `Simple`). Deferred until a press-fit golden lets us locate the byte; a non-persisting write field would only mislead an AI.
 
 ### PR-9 — PcbLib: Region KIND / net / name (format)
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -643,6 +643,44 @@ mod tests {
     }
 
     #[test]
+    fn binary_roundtrip_pad_slot_hole_and_tolerances() {
+        // PR-8: a pad with a slot hole (non-zero slot length + rotation) and
+        // non-default drill tolerances must survive encode -> decode.
+        let mut original = Footprint::new("ROUNDTRIP_PAD_SLOT");
+        let mut pad = Pad::through_hole("1", 0.0, 0.0, 2.0, 1.2, 0.8);
+        pad.hole_shape = HoleShape::Slot;
+        pad.hole_slot_length = 1.5; // != 0 default
+        pad.hole_rotation = 45.0; // != 0 default
+        pad.hole_positive_tolerance = Some(0.05);
+        pad.hole_negative_tolerance = Some(0.02);
+        original.add_pad(pad);
+
+        let data = writer::encode_data_stream(&original).expect("encoding should succeed");
+        let mut decoded = Footprint::new("ROUNDTRIP_PAD_SLOT");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.pads.len(), 1);
+        let p = &decoded.pads[0];
+        assert_eq!(p.hole_shape, HoleShape::Slot);
+        assert!(approx_eq(p.hole_slot_length, 1.5, 0.0001));
+        assert!(approx_eq(p.hole_rotation, 45.0, 0.0001));
+        assert!(approx_eq(p.hole_positive_tolerance.unwrap(), 0.05, 0.0001));
+        assert!(approx_eq(p.hole_negative_tolerance.unwrap(), 0.02, 0.0001));
+    }
+
+    #[test]
+    fn pad_default_slot_hole_fields_byte_identical() {
+        // A default (round-hole, unset-tolerance) pad must map its new fields back to
+        // exactly the writer's previous hard-coded values so the oracle stays at 0
+        // regressions: slot length 0, rotation 0, tolerances -> 0x7FFFFFFF sentinel.
+        let pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        assert_eq!(units::from_mm(pad.hole_slot_length), 0); // writer hard-coded 0
+        assert!(approx_eq(pad.hole_rotation, 0.0, 1e-9)); // writer hard-coded 0.0
+        assert_eq!(pad.hole_positive_tolerance, None); // None -> sentinel
+        assert_eq!(pad.hole_negative_tolerance, None);
+    }
+
+    #[test]
     fn binary_roundtrip_tracks() {
         let mut original = Footprint::new("ROUNDTRIP_TRACK");
         original.add_track(Track::new(-1.0, -0.5, 1.0, -0.5, 0.15, Layer::TopOverlay));
@@ -1411,6 +1449,38 @@ mod tests {
         assert_eq!(&block[42..46], &200_000i32.to_le_bytes()); // relief expansion
         assert_eq!(&block[46..50], &200_000i32.to_le_bytes()); // plane clearance
         assert_eq!(&block[50..54], &0i32.to_le_bytes()); // paste-mask expansion
+                                                         // PR-8: default drill tolerances stay the 0x7FFFFFFF "unset" sentinel @291/@295.
+        assert_eq!(&block[291..295], &i32::MAX.to_le_bytes());
+        assert_eq!(&block[295..299], &i32::MAX.to_le_bytes());
+    }
+
+    #[test]
+    fn binary_roundtrip_via_tolerances() {
+        // PR-8: a via with non-default drill tolerances must survive encode -> decode.
+        // Vias carry no slot geometry.
+        let mut original = Footprint::new("VIA_TOL");
+        let mut via = Via::new(1.0, 2.0, 0.8, 0.4);
+        via.hole_positive_tolerance = Some(0.05);
+        via.hole_negative_tolerance = Some(0.02);
+        original.add_via(via);
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("VIA_TOL");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.vias.len(), 1);
+        let d = &decoded.vias[0];
+        assert!(approx_eq(d.hole_positive_tolerance.unwrap(), 0.05, 0.001));
+        assert!(approx_eq(d.hole_negative_tolerance.unwrap(), 0.02, 0.001));
+    }
+
+    #[test]
+    fn via_default_tolerances_unset() {
+        // A from-scratch via leaves both drill tolerances unset (None -> sentinel), so
+        // it serialises byte-identically to the template.
+        let via = Via::new(0.0, 0.0, 0.6, 0.3);
+        assert_eq!(via.hole_positive_tolerance, None);
+        assert_eq!(via.hole_negative_tolerance, None);
     }
 
     #[test]

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -71,6 +71,36 @@ pub struct Pad {
     #[serde(default, skip_serializing_if = "is_default_hole_shape")]
     pub hole_shape: HoleShape,
 
+    /// Slot length in mm for a `Slot` hole — size/shape block i32 @263.
+    /// Only meaningful when `hole_shape` is `Slot`. Default 0.0 (matches the
+    /// value the writer previously hard-coded).
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub hole_slot_length: f64,
+
+    /// Hole rotation in degrees — size/shape block f64 @267. Rotates a slot hole.
+    /// Default 0.0 (matches the value the writer previously hard-coded).
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub hole_rotation: f64,
+
+    /// Positive drill tolerance in mm — extended-tail i32 @162. `None` writes the
+    /// `0x7FFFFFFF` "unset" sentinel Altium uses (byte-identical to the template);
+    /// `Some(mm)` writes the raw tolerance.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub hole_positive_tolerance: Option<f64>,
+
+    /// Negative drill tolerance in mm — extended-tail i32 @166. `None` writes the
+    /// `0x7FFFFFFF` "unset" sentinel (byte-identical to the template).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub hole_negative_tolerance: Option<f64>,
+
     /// Rotation angle in degrees.
     #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
     pub rotation: f64,
@@ -239,6 +269,10 @@ impl Pad {
             layer: Layer::TopLayer,
             hole_size: None,
             hole_shape: HoleShape::Round,
+            hole_slot_length: 0.0,
+            hole_rotation: 0.0,
+            hole_positive_tolerance: None,
+            hole_negative_tolerance: None,
             rotation: 0.0,
             paste_mask_expansion: None,
             solder_mask_expansion: None,
@@ -281,6 +315,10 @@ impl Pad {
             layer: Layer::MultiLayer,
             hole_size: Some(hole_size),
             hole_shape: HoleShape::Round,
+            hole_slot_length: 0.0,
+            hole_rotation: 0.0,
+            hole_positive_tolerance: None,
+            hole_negative_tolerance: None,
             rotation: 0.0,
             paste_mask_expansion: None,
             solder_mask_expansion: None,
@@ -526,6 +564,25 @@ pub struct Via {
     )]
     pub solder_mask_expansion_back: Option<f64>,
 
+    /// Positive drill tolerance in mm — `SubRecord-1` i32 @291. `None` writes the
+    /// `0x7FFFFFFF` "unset" sentinel Altium uses (byte-identical to the template);
+    /// `Some(mm)` writes the raw tolerance.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub hole_positive_tolerance: Option<f64>,
+
+    /// Negative drill tolerance in mm — `SubRecord-1` i32 @295. `None` writes the
+    /// `0x7FFFFFFF` "unset" sentinel (byte-identical to the template).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::altium::serde_round::option"
+    )]
+    pub hole_negative_tolerance: Option<f64>,
+
     // Thermal relief settings (for polygon pours)
     /// Thermal relief air gap width in mm (default: 0.254mm = 10 mils).
     #[serde(
@@ -616,6 +673,8 @@ impl Via {
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_back: None,
+            hole_positive_tolerance: None,
+            hole_negative_tolerance: None,
             paste_mask_expansion: 0.0,
             power_plane_connect_style: PowerPlaneConnectStyle::Relief,
             power_plane_relief_expansion: 0.508, // 20 mils
@@ -651,6 +710,8 @@ impl Via {
             solder_mask_expansion: 0.0,
             solder_mask_expansion_mode: MaskExpansionMode::FromRule,
             solder_mask_expansion_back: None,
+            hole_positive_tolerance: None,
+            hole_negative_tolerance: None,
             paste_mask_expansion: 0.0,
             power_plane_connect_style: PowerPlaneConnectStyle::Relief,
             power_plane_relief_expansion: 0.508, // 20 mils

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -141,6 +141,17 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         .filter(|d| d.len() >= 596)
         .map_or(HoleShape::Round, |d| hole_shape_from_id(d[262]));
 
+    // Slot length @263 (i32) and hole rotation @267 (f64) live in the same
+    // size/shape block; absent (plain simple pad) they default to 0.
+    let hole_slot_length = per_layer_data
+        .filter(|d| d.len() >= 596)
+        .and_then(|d| read_i32(d, 263))
+        .map_or(0.0, to_mm);
+    let hole_rotation = per_layer_data
+        .filter(|d| d.len() >= 596)
+        .and_then(|d| read_f64(d, 267))
+        .unwrap_or(0.0);
+
     // Stack mode - offset 62
     let stack_mode = if geometry.len() > 62 {
         pad_stack_mode_from_id(geometry[62])
@@ -188,6 +199,15 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
     let relief_air_gap = read_i32(geometry, 74).map_or(0.254, to_mm);
     let power_plane_relief_expansion = read_i32(geometry, 78).map_or(0.508, to_mm);
     let power_plane_clearance = read_i32(geometry, 82).map_or(0.508, to_mm);
+
+    // Drill tolerances @162 / @166 (i32). The 0x7FFFFFFF ("unset") sentinel and
+    // any absent (short pad) value read back as None.
+    let hole_positive_tolerance = read_i32(geometry, 162)
+        .filter(|&t| t != i32::MAX)
+        .map(to_mm);
+    let hole_negative_tolerance = read_i32(geometry, 166)
+        .filter(|&t| t != i32::MAX)
+        .map(to_mm);
 
     // Parse per-layer data when stack mode is not Simple
     // Per-layer data format:
@@ -257,6 +277,10 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         layer,
         hole_size,
         hole_shape,
+        hole_slot_length,
+        hole_rotation,
+        hole_positive_tolerance,
+        hole_negative_tolerance,
         rotation,
         paste_mask_expansion,
         solder_mask_expansion,
@@ -477,6 +501,11 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         .get(74)
         .map_or(ViaStackMode::Simple, |&b| via_stack_mode_from_id(b));
 
+    // Drill tolerances @291 / @295 (i32). The 0x7FFFFFFF ("unset") sentinel and
+    // any absent (short block) value read back as None.
+    let hole_positive_tolerance = read_i32(block, 291).filter(|&t| t != i32::MAX).map(to_mm);
+    let hole_negative_tolerance = read_i32(block, 295).filter(|&t| t != i32::MAX).map(to_mm);
+
     // Per-layer diameters: 32 x i32 from offset 75, only for a non-simple stack.
     let per_layer_diameters =
         if diameter_stack_mode != ViaStackMode::Simple && block.len() >= 75 + 32 * 4 {
@@ -499,6 +528,8 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         solder_mask_expansion,
         solder_mask_expansion_mode,
         solder_mask_expansion_back,
+        hole_positive_tolerance,
+        hole_negative_tolerance,
         paste_mask_expansion,
         power_plane_connect_style,
         power_plane_relief_expansion,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -479,8 +479,8 @@ fn encode_pad_size_shape_block(pad: &Pad) -> Vec<u8> {
     }
     b.push(0); // 261: reserved
     b.push(hole_shape_to_id(pad.hole_shape)); // 262: hole type
-    write_i32(&mut b, 0); // 263-266: hole slot length (not modelled)
-    write_f64(&mut b, 0.0); // 267-274: hole rotation
+    write_i32(&mut b, from_mm(pad.hole_slot_length)); // 263-266: hole slot length
+    write_f64(&mut b, pad.hole_rotation); // 267-274: hole rotation
     for _ in 0..32 {
         write_i32(&mut b, 0); // 275-402: per-layer X offsets
     }
@@ -616,6 +616,14 @@ fn build_pad_extended_tail(pad: &Pad) -> [u8; 141] {
     // 126-141 / 142-157: two per-pad identity GUIDs
     tail[126 - START..142 - START].copy_from_slice(&generate_guid());
     tail[142 - START..158 - START].copy_from_slice(&generate_guid());
+    // 162-165 / 166-169: drill tolerances. `None` leaves the template's
+    // 0x7FFFFFFF "unset" sentinel (byte-identical); `Some(mm)` writes the raw.
+    if let Some(tol) = pad.hole_positive_tolerance {
+        tail[162 - START..166 - START].copy_from_slice(&from_mm(tol).to_le_bytes());
+    }
+    if let Some(tol) = pad.hole_negative_tolerance {
+        tail[166 - START..170 - START].copy_from_slice(&from_mm(tol).to_le_bytes());
+    }
     // 185: reserved marker (0x03 for a standard PcbLib pad)
     tail[185 - START] = 0x03;
 
@@ -774,6 +782,15 @@ fn encode_via(data: &mut Vec<u8>, via: &Via) {
         .solder_mask_expansion_back
         .unwrap_or(via.solder_mask_expansion);
     block[242..246].copy_from_slice(&from_mm(back).to_le_bytes());
+
+    // Drill tolerances @291 / @295. `None` leaves the template's 0x7FFFFFFF
+    // "unset" sentinel (byte-identical); `Some(mm)` writes the raw tolerance.
+    if let Some(tol) = via.hole_positive_tolerance {
+        block[291..295].copy_from_slice(&from_mm(tol).to_le_bytes());
+    }
+    if let Some(tol) = via.hole_negative_tolerance {
+        block[295..299].copy_from_slice(&from_mm(tol).to_le_bytes());
+    }
 
     // Per-layer diameters: 32 x i32 from offset 75. A real stack uses the
     // per-layer array; a simple via repeats its diameter on every layer so it

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -202,6 +202,15 @@ impl McpServer {
                                                 },
                                                 "layer": { "type": "string", "description": "Layer name: Top Layer, Bottom Layer, Multi-Layer (default for SMD)" },
                                                 "hole_size": { "type": "number", "description": "Hole diameter for through-hole pads (mm)" },
+                                                "hole_shape": {
+                                                    "type": "string",
+                                                    "enum": ["round", "square", "slot"],
+                                                    "description": "Drill hole shape. Default: round. Use slot for oblong holes (set hole_slot_length)"
+                                                },
+                                                "hole_slot_length": { "type": "number", "description": "Slot length in mm for a slot hole (hole_shape=slot). Default: 0" },
+                                                "hole_rotation": { "type": "number", "description": "Hole rotation in degrees (rotates a slot hole). Default: 0" },
+                                                "hole_positive_tolerance": { "type": "number", "description": "Positive drill tolerance in mm (optional; omit to leave unset)" },
+                                                "hole_negative_tolerance": { "type": "number", "description": "Negative drill tolerance in mm (optional; omit to leave unset)" },
                                                 "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion in mm (optional; omit to use the rule default)" },
                                                 "solder_mask_expansion_mode": {
                                                     "type": "string",
@@ -272,6 +281,8 @@ impl McpServer {
                                                 "power_plane_clearance": { "type": "number", "description": "Power-plane (anti-pad) clearance in mm. Default: 0.508 (20 mil)" },
                                                 "paste_mask_expansion": { "type": "number", "description": "Paste-mask expansion in mm. Default: 0" },
                                                 "net_index": { "type": "integer", "description": "Net index into the board net list (0-65534; 65535 = no net). Default: 65535" },
+                                                "hole_positive_tolerance": { "type": "number", "description": "Positive drill tolerance in mm (optional; omit to leave unset)" },
+                                                "hole_negative_tolerance": { "type": "number", "description": "Negative drill tolerance in mm (optional; omit to leave unset)" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"TENTING_TOP\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Tenting covers the via with solder mask. Default: none" }
                                             },
                                             "required": ["x", "y", "diameter", "hole_size"]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -241,6 +241,20 @@ impl McpServer {
             .and_then(Value::as_f64)
             .unwrap_or(0.508);
 
+        // Slot geometry + drill tolerances. Absent keys keep the struct defaults
+        // (slot 0, rotation 0, tolerances unset), so an unspecified pad round-trips
+        // byte-identically.
+        let hole_slot_length = json
+            .get("hole_slot_length")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let hole_rotation = json
+            .get("hole_rotation")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let hole_positive_tolerance = json.get("hole_positive_tolerance").and_then(Value::as_f64);
+        let hole_negative_tolerance = json.get("hole_negative_tolerance").and_then(Value::as_f64);
+
         Ok(Pad {
             designator: designator.to_string(),
             x,
@@ -251,6 +265,10 @@ impl McpServer {
             layer,
             hole_size,
             hole_shape,
+            hole_slot_length,
+            hole_rotation,
+            hole_positive_tolerance,
+            hole_negative_tolerance,
             rotation,
             paste_mask_expansion,
             solder_mask_expansion,
@@ -570,6 +588,17 @@ impl McpServer {
         {
             via.net_index = v;
         }
+
+        // Drill tolerances (SubRecord-1 @291/@295). Absent keys keep the
+        // from-scratch defaults (tolerances unset), so an unspecified via
+        // round-trips byte-identically.
+        if let Some(v) = json.get("hole_positive_tolerance").and_then(Value::as_f64) {
+            via.hole_positive_tolerance = Some(v);
+        }
+        if let Some(v) = json.get("hole_negative_tolerance").and_then(Value::as_f64) {
+            via.hole_negative_tolerance = Some(v);
+        }
+
         via.flags = json_flags(json);
 
         Ok(via)

--- a/tests/integration/test_altium_readability.py
+++ b/tests/integration/test_altium_readability.py
@@ -100,9 +100,21 @@ def _generate(binary, out_dir):
             "pads": [
                 {"designator": "1", "x": -0.5, "y": 0.0, "width": 0.6, "height": 0.5},
                 {"designator": "2", "x": 0.5, "y": 0.0, "width": 0.6, "height": 0.5},
+                # PR-8: a slot-hole through-hole pad with drill tolerances so the
+                # oracle guards the slot length/rotation (@263/@267) and tolerance
+                # (@162/@166) bytes stay Altium-readable.
+                {"designator": "3", "x": 0.0, "y": 0.8, "width": 1.2, "height": 0.8,
+                 "hole_size": 0.5, "layer": "Multi-Layer", "hole_shape": "slot",
+                 "hole_slot_length": 0.6, "hole_rotation": 30.0,
+                 "hole_positive_tolerance": 0.05, "hole_negative_tolerance": 0.02},
             ],
-            # Via exercises the single-block via record (issue #113).
-            "vias": [{"x": 0.0, "y": -0.8, "diameter": 0.6, "hole_size": 0.3}],
+            # Via exercises the single-block via record (issue #113); the second via
+            # carries PR-8 drill tolerances (@291/@295) so the oracle guards them.
+            "vias": [
+                {"x": 0.0, "y": -0.8, "diameter": 0.6, "hole_size": 0.3},
+                {"x": 0.4, "y": -0.8, "diameter": 0.6, "hole_size": 0.3,
+                 "hole_positive_tolerance": 0.05, "hole_negative_tolerance": 0.02},
+            ],
             "tracks": [{"x1": -1, "y1": 0.5, "x2": 1, "y2": 0.5,
                         "width": 0.1, "layer": "Top Overlay"}],
             "arcs": [{"x": 0, "y": 0, "radius": 0.3, "start_angle": 0,

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -815,6 +815,132 @@ def test_write_pcblib_via_thermal_power_plane(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_pad_slot_hole(client, runner, lib_path):
+    print("\n=== Test: write_pcblib pad slot-hole / drill tolerances round trip ===")
+    # Coverage PR-8: a slot hole (length + rotation) and drill tolerances must be
+    # authorable via write_pcblib and round-trip through read_pcblib.
+    footprint = {
+        "name": "PAD_SLOT_RT",
+        "pads": [
+            {
+                "designator": "1",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 2.0,
+                "height": 1.2,
+                "hole_size": 0.8,
+                "layer": "Multi-Layer",
+                "hole_shape": "slot",
+                "hole_slot_length": 1.5,
+                "hole_rotation": 45.0,
+                "hole_positive_tolerance": 0.05,
+                "hole_negative_tolerance": 0.02,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_pcblib (pad slot) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("PAD_SLOT_RT", {})
+    runner.check(bool(fp), "PAD_SLOT_RT footprint present", actual=list(footprints))
+
+    # Coord fields carry sub-micron fixed-point quantisation; 1e-4 mm is well
+    # below any meaningful PCB tolerance.
+    tol = 1e-4
+    pads = fp.get("pads", [])
+    runner.check(len(pads) == 1, "1 pad survived", actual=len(pads))
+    if pads:
+        p = pads[0]
+        runner.check(
+            p.get("hole_shape") == "slot",
+            "pad hole_shape",
+            actual=p.get("hole_shape"),
+            expected="slot",
+        )
+        runner.check(
+            abs(p.get("hole_slot_length", 0) - 1.5) < tol,
+            "pad hole_slot_length",
+            actual=p.get("hole_slot_length"),
+            expected=1.5,
+        )
+        runner.check(
+            abs(p.get("hole_rotation", 0) - 45.0) < tol,
+            "pad hole_rotation",
+            actual=p.get("hole_rotation"),
+            expected=45.0,
+        )
+        runner.check(
+            abs(p.get("hole_positive_tolerance", 0) - 0.05) < tol,
+            "pad hole_positive_tolerance",
+            actual=p.get("hole_positive_tolerance"),
+            expected=0.05,
+        )
+        runner.check(
+            abs(p.get("hole_negative_tolerance", 0) - 0.02) < tol,
+            "pad hole_negative_tolerance",
+            actual=p.get("hole_negative_tolerance"),
+            expected=0.02,
+        )
+
+
+def test_write_pcblib_via_slot_tolerances(client, runner, lib_path):
+    print("\n=== Test: write_pcblib via drill tolerances round trip ===")
+    # Coverage PR-8: via drill tolerances must round-trip; vias carry no slot
+    # geometry.
+    footprint = {
+        "name": "VIA_TOL_RT",
+        "vias": [
+            {
+                "x": 1.0,
+                "y": 2.0,
+                "diameter": 0.8,
+                "hole_size": 0.4,
+                "hole_positive_tolerance": 0.05,
+                "hole_negative_tolerance": 0.02,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_pcblib (via tol) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("VIA_TOL_RT", {})
+    runner.check(bool(fp), "VIA_TOL_RT footprint present", actual=list(footprints))
+
+    tol = 1e-4
+    vias = fp.get("vias", [])
+    runner.check(len(vias) == 1, "1 via survived", actual=len(vias))
+    if vias:
+        v = vias[0]
+        runner.check(
+            abs(v.get("hole_positive_tolerance", 0) - 0.05) < tol,
+            "via hole_positive_tolerance",
+            actual=v.get("hole_positive_tolerance"),
+            expected=0.05,
+        )
+        runner.check(
+            abs(v.get("hole_negative_tolerance", 0) - 0.02) < tol,
+            "via hole_negative_tolerance",
+            actual=v.get("hole_negative_tolerance"),
+            expected=0.02,
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -989,6 +1115,8 @@ def main():
         test_write_pcblib_flags_mask_keepout(client, runner, lib_path)
         test_write_pcblib_pad_thermal_relief(client, runner, lib_path)
         test_write_pcblib_via_thermal_power_plane(client, runner, lib_path)
+        test_write_pcblib_pad_slot_hole(client, runner, lib_path)
+        test_write_pcblib_via_slot_tolerances(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -277,6 +277,25 @@ fn samples_pcblib_pad_holes() {
 
         assert_eq!(pad.hole_shape, hole_shape, "pad {designator} hole_shape");
     }
+
+    // The slot pad (designator "3") carries a non-zero slot length in its 651-byte
+    // size/shape block (@263 = 200000 raw = 0.508 mm); PR-8 now reads it. Round/square
+    // pads have a zero slot length.
+    let slot_pad = footprint.pads.iter().find(|p| p.designator == "3").unwrap();
+    assert!(
+        approx_eq(slot_pad.hole_slot_length, 0.508, 1e-3),
+        "slot pad hole_slot_length: expected ~0.508 mm, got {}",
+        slot_pad.hole_slot_length
+    );
+    assert!(
+        approx_eq(slot_pad.hole_rotation, 0.0, 1e-6),
+        "slot pad hole_rotation should be 0"
+    );
+    // Golden pads leave both drill tolerances at the 0x7FFFFFFF sentinel -> None.
+    for pad in &footprint.pads {
+        assert_eq!(pad.hole_positive_tolerance, None);
+        assert_eq!(pad.hole_negative_tolerance, None);
+    }
 }
 
 #[test]


### PR DESCRIPTION
**Coverage roadmap PR-8** — finish the Pad/Via hole story: slot-hole geometry + drill tolerances.

Today a `hole_shape='slot'` pad produces a **zero-length degenerate slot** — the reader skips slot length/rotation and the writer hard-codes them to 0. This adds them (and drill tolerances), read + written + tool-exposed, byte-identical for default holes.

## Fields
| Field | Primitive | Offset | Default |
|-------|-----------|--------|---------|
| `hole_slot_length` | Pad | @263 (size/shape block) | 0.0 mm |
| `hole_rotation` | Pad | @267 | 0.0° |
| `hole_positive_tolerance` / `hole_negative_tolerance` | Pad | @162 / @166 | unset (`0x7FFFFFFF`) |
| `hole_positive_tolerance` / `hole_negative_tolerance` | Via | @291 / @295 | unset |

Tolerances are `Option<f64>` — `None` writes the sentinel (byte-identical); `Some(mm)` the raw value.

## Byte-identity
Each default equals the writer's prior hard-coded value, so an unchanged pad/via serialises identically. The golden has a slot pad + vias, and the oracle now *also* generates a slot pad + tolerance-bearing primitives — **0 regressions** proves the new non-default bytes stay Altium-readable.

## Deferred
- **`drill_type`** — AltiumSharp declares `PcbPad.DrillType` but never serialises it (no verified binary offset; whole corpus is `Simple`). Exposing a write field that can't persist would mislead, so it's deferred (noted in `COVERAGE_AUDIT.md`) until a press-fit golden lets us locate the byte.
- Via slot geometry — vias are round; `ReadVia` has no slot length/rotation.

## Test
Rust round-trip + byte-identity + a golden slot-pad assertion; Python `test_write_pcblib_pad_slot_hole` + `test_write_pcblib_via_slot_tolerances`; oracle additions.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (327) / **integration 156/156** / **oracle 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
