### PR TITLE
feat(pcblib): model Region KIND/net/name + param block (PR-9)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 
 pub use primitives::{
     Arc, ComponentBody, EmbeddedModel, Fill, HoleShape, Layer, MaskExpansionMode, Model3D, Pad,
-    PadShape, PadStackMode, PcbFlags, PowerPlaneConnectStyle, Region, StrokeFont, Text,
+    PadShape, PadStackMode, PcbFlags, PowerPlaneConnectStyle, Region, RegionKind, StrokeFont, Text,
     TextJustification, TextKind, Track, Vertex, Via,
 };
 
@@ -985,10 +985,8 @@ mod tests {
                     y: 1.016,
                 },
             ],
-            holes: Vec::new(),
             layer: Layer::TopAssembly,
-            flags: PcbFlags::empty(),
-            unique_id: None,
+            ..Region::default()
         });
 
         // Add a rectangular region

--- a/src/altium/pcblib/primitives/mod.rs
+++ b/src/altium/pcblib/primitives/mod.rs
@@ -49,7 +49,7 @@ pub use pads::{
     ViaStackMode,
 };
 mod shapes;
-pub use shapes::{Arc, Region, Track, Vertex};
+pub use shapes::{Arc, Region, RegionKind, Track, Vertex};
 mod text;
 pub use text::{Fill, StrokeFont, Text, TextJustification, TextKind};
 

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -177,6 +177,46 @@ impl Arc {
     }
 }
 
+/// The kind of a region, from the `KIND` key of its nested parameter block.
+///
+/// Altium serialises this as an integer (`KIND=0` for copper). We model the two
+/// documented values plus an `Other(i32)` catch-all so an unrecognised kind
+/// round-trips verbatim. `Copper` (=`KIND=0`) is the from-scratch default and the
+/// value the writer historically hard-coded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegionKind {
+    /// Copper pour / polygon fill (`KIND=0`). Altium's default.
+    #[default]
+    Copper,
+    /// Board / polygon cutout (`KIND=1`).
+    Cutout,
+    /// Any other `KIND` integer Altium may write; preserved for round-trip.
+    Other(i32),
+}
+
+impl RegionKind {
+    /// Creates from the Altium `KIND` integer (`0` = `Copper`, `1` = `Cutout`).
+    #[must_use]
+    pub const fn from_id(id: i32) -> Self {
+        match id {
+            0 => Self::Copper,
+            1 => Self::Cutout,
+            other => Self::Other(other),
+        }
+    }
+
+    /// Returns the Altium `KIND` integer.
+    #[must_use]
+    pub const fn to_id(self) -> i32 {
+        match self {
+            Self::Copper => 0,
+            Self::Cutout => 1,
+            Self::Other(other) => other,
+        }
+    }
+}
+
 /// A filled region (polygon).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Region {
@@ -192,9 +232,65 @@ pub struct Region {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Region kind — the `KIND` param key. `Copper` (=`KIND=0`) is Altium's default
+    /// and the headline distinction between a copper pour and a cutout.
+    #[serde(default)]
+    pub kind: RegionKind,
+    /// Region name — the `NAME` param key. Empty (`NAME=`) from scratch.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub name: String,
+    /// Net index into the board's net list — common-header u16 @3 (and the optional
+    /// `NET` param). `0xFFFF` (65535) means "no net", the from-scratch default.
+    #[serde(default = "default_region_net_index")]
+    pub net_index: u16,
+    /// Polygon index this region belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_region_polygon_index")]
+    pub polygon_index: u16,
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_region_component_index")]
+    pub component_index: i32,
+    /// Arc-approximation resolution in mm — the `ARCRESOLUTION` param (Altium formats
+    /// it mil-suffixed, e.g. `0.5mil`). `0.0` (`0mil`) from scratch.
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub arc_resolution: f64,
+    /// Cavity height in mm for embedded components — the `CAVITYHEIGHT` param
+    /// (mil-suffixed). `0.0` (`0mil`) from scratch.
+    #[serde(default, serialize_with = "crate::altium::serde_round::serialize")]
+    pub cavity_height: f64,
+    /// Sub-polygon index — the `SUBPOLYINDEX` param. `-1` from scratch.
+    #[serde(default = "default_region_sub_poly_index")]
+    pub sub_poly_index: i32,
+    /// Union index for grouped primitives — the `UNIONINDEX` param. `0` from scratch.
+    #[serde(default)]
+    pub union_index: i32,
+    /// Whether the region is shape-based — the `ISSHAPEBASED` param. `false` from scratch.
+    #[serde(default)]
+    pub is_shape_based: bool,
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+}
+
+/// Default net index for a from-scratch region (`0xFFFF` = no net).
+const fn default_region_net_index() -> u16 {
+    0xFFFF
+}
+
+/// Default polygon index for a from-scratch region (`0xFFFF` = none).
+const fn default_region_polygon_index() -> u16 {
+    0xFFFF
+}
+
+/// Default component index for a from-scratch region (`-1` = free primitive).
+const fn default_region_component_index() -> i32 {
+    -1
+}
+
+/// Default sub-polygon index for a from-scratch region (`-1`).
+const fn default_region_sub_poly_index() -> i32 {
+    -1
 }
 
 impl Region {
@@ -208,9 +304,29 @@ impl Region {
                 Vertex { x: max_x, y: max_y },
                 Vertex { x: min_x, y: max_y },
             ],
-            holes: Vec::new(),
             layer,
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for Region {
+    fn default() -> Self {
+        Self {
+            vertices: Vec::new(),
+            holes: Vec::new(),
+            layer: Layer::default(),
             flags: PcbFlags::empty(),
+            kind: RegionKind::Copper,
+            name: String::new(),
+            net_index: default_region_net_index(),
+            polygon_index: default_region_polygon_index(),
+            component_index: default_region_component_index(),
+            arc_resolution: 0.0,
+            cavity_height: 0.0,
+            sub_poly_index: default_region_sub_poly_index(),
+            union_index: 0,
+            is_shape_based: false,
             unique_id: None,
         }
     }

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -28,8 +28,8 @@ use std::collections::HashMap;
 
 use super::primitives::{
     Arc, ComponentBody, Fill, HoleShape, Layer, MaskExpansionMode, Pad, PadShape, PadStackMode,
-    PcbFlags, PowerPlaneConnectStyle, Region, StrokeFont, Text, TextJustification, TextKind, Track,
-    Vertex, Via, ViaStackMode,
+    PcbFlags, PowerPlaneConnectStyle, Region, RegionKind, StrokeFont, Text, TextJustification,
+    TextKind, Track, Vertex, Via, ViaStackMode,
 };
 use super::Footprint;
 use crate::altium::bytes::{

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1007,10 +1007,17 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         ));
     }
 
-    // Common header (13 bytes)
+    // Common header (13 bytes): @0 layer, @1-2 flags, @3-4 net index (u16),
+    // @5-6 polygon index (u16), @7-8 component index (u16, 0xFFFF -> -1), @9-12 reserved.
     let layer_id = props_block[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(props_block);
+    let net_index = read_u16(props_block, 3).unwrap_or(0xFFFF);
+    let polygon_index = read_u16(props_block, 5).unwrap_or(0xFFFF);
+    let component_index = match read_u16(props_block, 7).unwrap_or(0xFFFF) {
+        0xFFFF => -1,
+        ci => i32::from(ci),
+    };
 
     // @13 reserved | @14-15 hole_count (u16) | @16-17 reserved. The trailing hole
     // contours (if any) follow the outline. A no-hole region reports 0 here.
@@ -1021,8 +1028,22 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         AltiumError::parse_error(offset + 18, "failed to read Region parameter string length")
     })? as usize;
 
-    // Skip parameter string, vertex data follows
-    let vertex_offset = 22 + param_len;
+    // Parse the nested C-string parameter block (offsets 22..22+param_len). It carries
+    // KIND, NAME, ARCRESOLUTION, CAVITYHEIGHT, etc. in the canonical `KEY=VALUE|...`
+    // form (no leading pipe, Windows-1252, null-terminated). Historically skipped by
+    // length; now decoded into the region's typed fields.
+    let param_end = 22 + param_len;
+    if props_block.len() < param_end {
+        return Err(AltiumError::parse_error(
+            offset + 22,
+            format!("Region parameter block truncated: needs {param_end} bytes"),
+        ));
+    }
+    let params_str = crate::altium::decode_windows1252(&props_block[22..param_end]);
+    let params = crate::altium::parse_pipe_params_raw(&params_str);
+
+    // Vertex data follows the parameter string.
+    let vertex_offset = param_end;
 
     if props_block.len() < vertex_offset + 4 {
         return Err(AltiumError::parse_error(
@@ -1050,11 +1071,48 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     // places the next record's type byte immediately after this block, so `current`
     // already points at the next record. (We previously read a spurious second block,
     // which against a real Altium region would mis-read the next record's bytes.)
+    // Extract typed properties from the parsed parameter block. Missing keys fall
+    // back to the from-scratch defaults so a minimal region still round-trips.
+    let kind = params
+        .get("KIND")
+        .and_then(|v| v.parse::<i32>().ok())
+        .map_or(RegionKind::Copper, RegionKind::from_id);
+    let name = params.get("NAME").cloned().unwrap_or_default();
+    let sub_poly_index = params
+        .get("SUBPOLYINDEX")
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(-1);
+    let union_index = params
+        .get("UNIONINDEX")
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let is_shape_based = params
+        .get("ISSHAPEBASED")
+        .is_some_and(|v| v.eq_ignore_ascii_case("TRUE"));
+    let arc_resolution = parse_mil_value(params.get("ARCRESOLUTION").map(String::as_str));
+    let cavity_height = parse_mil_value(params.get("CAVITYHEIGHT").map(String::as_str));
+    // The `NET` param, when present, carries the numeric net index; otherwise the
+    // common-header index (@3) is authoritative.
+    let net_index = params
+        .get("NET")
+        .and_then(|v| v.parse::<u16>().ok())
+        .unwrap_or(net_index);
+
     let region = Region {
         vertices,
         holes,
         layer,
         flags,
+        kind,
+        name,
+        net_index,
+        polygon_index,
+        component_index,
+        arc_resolution,
+        cavity_height,
+        sub_poly_index,
+        union_index,
+        is_shape_based,
         unique_id: None,
     };
 

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1037,11 +1037,25 @@ fn region_v7_layer_token(layer: Layer) -> String {
     }
 }
 
+/// Formats a length (mm) as an Altium mil-suffixed string with trailing zeros
+/// trimmed (e.g. `0mil`, `0.5mil`, `19.685mil`). Mirrors `AltiumSharp`
+/// `FormatMilCoord` (`ToMils().ToString("0.######") + "mil"`). A `0.0` input
+/// yields exactly `0mil`, keeping the from-scratch region byte-identical.
+fn format_mil_coord(mm: f64) -> String {
+    let mils = mm_to_mil(mm);
+    // Round to 6 decimals and strip trailing zeros / a lone trailing dot.
+    let mut s = format!("{mils:.6}");
+    if s.contains('.') {
+        s = s.trim_end_matches('0').trim_end_matches('.').to_string();
+    }
+    format!("{s}mil")
+}
+
 /// Encodes the properties block for a region.
 ///
 /// Format (matching Altium):
 /// ```text
-/// [common_header:13]       // Layer, flags, padding
+/// [common_header:13]       // Layer, flags, net/poly/comp indices
 /// [reserved:1]             // @13 reserved (0)
 /// [hole_count:2 u16]       // @14-15 number of interior hole contours
 /// [reserved:2]             // @16-17 reserved (0)
@@ -1057,20 +1071,40 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
 
     // Parameter string in Altium's canonical key order. Unlike other Altium param
     // blocks, a region's nested block has NO leading pipe and carries the full
-    // canonical key set (matching AltiumSharp `BuildRegionParamText`); the values are
-    // the from-scratch defaults. Our reader skips this block by length, so the format
-    // only affects byte-fidelity with genuine Altium output.
+    // canonical key set (matching AltiumSharp `BuildRegionParamText`). Each value is
+    // now taken from the typed field; a default region reproduces the historical
+    // hard-coded string byte-for-byte (KIND=0, NAME=, ARCRESOLUTION=0mil, ...).
     let layer_name = region_v7_layer_token(region.layer);
     let params = format!(
-        "V7_LAYER={layer_name}|NAME=|KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0\
-         |ARCRESOLUTION=0mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil"
+        "V7_LAYER={layer_name}|NAME={name}|KIND={kind}|SUBPOLYINDEX={spi}|UNIONINDEX={uix}\
+         |ARCRESOLUTION={arc}|ISSHAPEBASED={shape}|CAVITYHEIGHT={cav}",
+        name = region.name,
+        kind = region.kind.to_id(),
+        spi = region.sub_poly_index,
+        uix = region.union_index,
+        arc = format_mil_coord(region.arc_resolution),
+        shape = if region.is_shape_based {
+            "TRUE"
+        } else {
+            "FALSE"
+        },
+        cav = format_mil_coord(region.cavity_height),
     );
     let params_bytes = crate::altium::encode_windows1252(&params);
 
     let mut block = Vec::with_capacity(22 + params_bytes.len() + 4 + vertex_count * 16);
 
-    // Common header (13 bytes)
+    // Common header (13 bytes): layer + flag word, then the net/polygon/component
+    // indices. `write_common_header` fills bytes 3-12 with 0xFF (a free primitive);
+    // we overlay the modelled indices. Defaults (net=0xFFFF, poly=0xFFFF,
+    // component=-1 -> 0xFFFF) leave the 0xFF bytes untouched, so a from-scratch
+    // region stays byte-identical.
     write_common_header(&mut block, region.layer, region.flags);
+    block[3..5].copy_from_slice(&region.net_index.to_le_bytes());
+    block[5..7].copy_from_slice(&region.polygon_index.to_le_bytes());
+    // -1 (free primitive) and any out-of-range value store as the 0xFFFF sentinel.
+    let component_word = u16::try_from(region.component_index).unwrap_or(0xFFFF);
+    block[7..9].copy_from_slice(&component_word.to_le_bytes());
 
     // @13 reserved | @14-15 hole_count (u16 LE) | @16-17 reserved. With no holes
     // this collapses to `00 00 00 00 00`, byte-identical to the previous output.
@@ -1828,10 +1862,8 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
-            holes: Vec::new(),
             layer: Layer::TopCourtyard,
-            flags: PcbFlags::default(),
-            unique_id: None,
+            ..Region::default()
         };
         let props = encode_region_properties(&region);
         let s = String::from_utf8_lossy(&props);
@@ -1853,10 +1885,8 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
-            holes: Vec::new(),
             layer: Layer::TopCourtyard,
-            flags: PcbFlags::default(),
-            unique_id: None,
+            ..Region::default()
         };
         let mut data = Vec::new();
         encode_region(&mut data, &region);
@@ -1882,10 +1912,8 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
-            holes: Vec::new(),
             layer: Layer::TopCourtyard,
-            flags: PcbFlags::default(),
-            unique_id: None,
+            ..Region::default()
         };
         let props = encode_region_properties(&region);
         assert_eq!(
@@ -1893,6 +1921,92 @@ mod tests {
             &[0x00, 0x00, 0x00, 0x00, 0x00],
             "no-hole region must keep the reserved @13-17 slot zeroed (hole_count=0)"
         );
+    }
+
+    #[test]
+    fn default_region_param_string_is_byte_identical() {
+        use crate::altium::pcblib::primitives::Vertex;
+        // Oracle-safety: a from-scratch region must serialize the exact historical
+        // canonical parameter string, and the common-header net/polygon/component
+        // index bytes (@3-8) must all be 0xFF (a free primitive, no net).
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            ..Region::default()
+        };
+        let props = encode_region_properties(&region);
+
+        // Header bytes 3-8 (net + polygon + component indices) are all 0xFF.
+        assert_eq!(
+            &props[3..9],
+            &[0xFF; 6],
+            "default region header net/polygon/component indices must be 0xFF"
+        );
+
+        // The nested parameter string must match the historical hard-coded string
+        // exactly (only V7_LAYER varies with the layer).
+        let param_len = u32::from_le_bytes(props[18..22].try_into().unwrap()) as usize;
+        let params = &props[22..22 + param_len];
+        let expected = b"V7_LAYER=MECHANICAL4|NAME=|KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0\
+                         |ARCRESOLUTION=0mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil\0";
+        assert_eq!(
+            params,
+            expected.as_slice(),
+            "default region param string drifted from the byte-identical canonical form: {}",
+            String::from_utf8_lossy(params)
+        );
+    }
+
+    #[test]
+    fn non_default_region_survives_roundtrip() {
+        use super::super::reader::parse_data_stream;
+        use crate::altium::pcblib::primitives::{RegionKind, Vertex};
+        // A region with non-default kind/name/cavity/arc values must survive an
+        // encode -> decode round-trip.
+        let mut fp = Footprint::new("R");
+        fp.add_region(Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            kind: RegionKind::Cutout,
+            name: "POUR1".to_string(),
+            cavity_height: 0.0254 * 10.0, // 10 mil in mm
+            arc_resolution: 0.0254 * 0.5, // 0.5 mil in mm
+            union_index: 3,
+            sub_poly_index: 2,
+            is_shape_based: true,
+            ..Region::default()
+        });
+
+        let data = encode_data_stream(&fp).expect("encode should succeed");
+        let mut decoded = Footprint::new("R");
+        parse_data_stream(&mut decoded, &data, None);
+        assert_eq!(decoded.regions.len(), 1);
+        let r = &decoded.regions[0];
+        assert_eq!(r.kind, RegionKind::Cutout);
+        assert_eq!(r.name, "POUR1");
+        assert!(
+            (r.cavity_height - 0.254).abs() < 1e-6,
+            "cav: {}",
+            r.cavity_height
+        );
+        assert!(
+            (r.arc_resolution - 0.0127).abs() < 1e-6,
+            "arc: {}",
+            r.arc_resolution
+        );
+        assert_eq!(r.union_index, 3);
+        assert_eq!(r.sub_poly_index, 2);
+        assert!(r.is_shape_based);
     }
 
     #[test]
@@ -2108,10 +2222,8 @@ mod tests {
                 Vertex { x: 1.0, y: 1.0 },
                 Vertex { x: -1.0, y: 1.0 },
             ],
-            holes: Vec::new(),
             layer: Layer::TopCourtyard,
-            flags: PcbFlags::default(),
-            unique_id: None,
+            ..Region::default()
         };
         let block = encode_region_properties(&region);
         let param_len = u32::from_le_bytes([block[18], block[19], block[20], block[21]]) as usize;

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -329,7 +329,7 @@ impl McpServer {
                                     },
                                     "regions": {
                                         "type": "array",
-                                        "description": "Filled region definitions (courtyard, etc.)",
+                                        "description": "Filled region definitions (courtyard, copper pour, cutout, etc.)",
                                         "items": {
                                             "type": "object",
                                             "properties": {
@@ -344,6 +344,25 @@ impl McpServer {
                                                     }
                                                 },
                                                 "layer": { "type": "string", "description": "Layer name: Top Courtyard, Top Assembly, Mechanical 1, etc." },
+                                                "kind": { "type": ["string", "integer"], "description": "Region kind (optional). \"copper\" (default) for a copper pour/fill, \"cutout\" for a board/polygon cutout, or a raw Altium KIND integer. Default: copper" },
+                                                "name": { "type": "string", "description": "Region name (the NAME parameter, optional). Default: empty" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (optional). 65535 = no net. Default: 65535" },
+                                                "cavity_height": { "type": "number", "description": "Cavity height in mm for embedded components (optional). Default: 0" },
+                                                "holes": {
+                                                    "type": "array",
+                                                    "description": "Interior hole/cutout contours (optional). Each hole is an array of {x,y} vertices subtracted from the outline.",
+                                                    "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "x": { "type": "number" },
+                                                                "y": { "type": "number" }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "unique_id": { "type": "string", "description": "Unique ID (optional, 8-char alphanumeric). Default: none" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["vertices", "layer"]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -395,7 +395,7 @@ impl McpServer {
 
     /// Parses a region from JSON.
     pub(crate) fn parse_region(json: &Value) -> Option<crate::altium::pcblib::Region> {
-        use crate::altium::pcblib::{Layer, Region, Vertex};
+        use crate::altium::pcblib::{Layer, Region, RegionKind, Vertex};
 
         let vertices_json = json.get("vertices").and_then(Value::as_array)?;
         let layer = json
@@ -417,12 +417,75 @@ impl McpServer {
             return None; // Need at least 3 vertices for a polygon
         }
 
+        // `kind` accepts a name ("copper"/"cutout") or a raw KIND integer.
+        let parse_kind_str = |s: &str| match s.to_ascii_lowercase().as_str() {
+            "cutout" => RegionKind::Cutout,
+            "copper" => RegionKind::Copper,
+            other => other
+                .parse::<i32>()
+                .map_or(RegionKind::Copper, RegionKind::from_id),
+        };
+        let kind = match json.get("kind") {
+            Some(v) if v.is_string() => parse_kind_str(v.as_str().unwrap_or("copper")),
+            Some(v) => v
+                .as_i64()
+                .and_then(|i| i32::try_from(i).ok())
+                .map_or(RegionKind::Copper, RegionKind::from_id),
+            None => RegionKind::Copper,
+        };
+        let name = json
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let net_index = json
+            .get("net_index")
+            .and_then(Value::as_u64)
+            .and_then(|n| u16::try_from(n).ok())
+            .unwrap_or(0xFFFF);
+        let cavity_height = json
+            .get("cavity_height")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+
+        // Optional interior hole contours: an array of vertex arrays (each >= 3 pts).
+        let holes: Vec<Vec<Vertex>> = json
+            .get("holes")
+            .and_then(Value::as_array)
+            .map(|contours| {
+                contours
+                    .iter()
+                    .filter_map(Value::as_array)
+                    .map(|contour| {
+                        contour
+                            .iter()
+                            .filter_map(|v| {
+                                let x = v.get("x").and_then(Value::as_f64)?;
+                                let y = v.get("y").and_then(Value::as_f64)?;
+                                Some(Vertex { x, y })
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let unique_id = json
+            .get("unique_id")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+
         Some(Region {
             vertices,
-            holes: Vec::new(),
+            holes,
             layer,
             flags: json_flags(json),
-            unique_id: None,
+            kind,
+            name,
+            net_index,
+            cavity_height,
+            unique_id,
+            ..Region::default()
         })
     }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -614,7 +614,20 @@ impl McpServer {
             // Parse regions
             if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
                 for region_json in regions {
-                    check_keys!(region_json, &["layer", "vertices", "flags"]);
+                    check_keys!(
+                        region_json,
+                        &[
+                            "layer",
+                            "vertices",
+                            "flags",
+                            "kind",
+                            "name",
+                            "net_index",
+                            "cavity_height",
+                            "holes",
+                            "unique_id"
+                        ]
+                    );
                     if let Some(region) = Self::parse_region(region_json) {
                         footprint.add_region(region);
                     }

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -941,6 +941,63 @@ def test_write_pcblib_via_slot_tolerances(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_region_kind_net_name(client, runner, lib_path):
+    print("\n=== Test: write_pcblib region kind/net/name/cavity round trip ===")
+    # Coverage PR-9: the region's nested parameter block is now parsed and written,
+    # so KIND (copper vs cutout), NAME, net_index, and cavity_height must be
+    # authorable via write_pcblib and round-trip through read_pcblib.
+    tol = 1e-4
+    footprint = {
+        "name": "REGION_FIELDS_RT",
+        "regions": [
+            {
+                "vertices": [
+                    {"x": -1.0, "y": -1.0},
+                    {"x": 1.0, "y": -1.0},
+                    {"x": 1.0, "y": 1.0},
+                    {"x": -1.0, "y": 1.0},
+                ],
+                "layer": "Top Layer",
+                "kind": "cutout",
+                "name": "POUR_A",
+                "net_index": 7,
+                "cavity_height": 0.254,  # 10 mil in mm
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(not write.get("_isError"), "write_pcblib (region) succeeded", actual=write)
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("REGION_FIELDS_RT", {})
+    runner.check(bool(fp), "REGION_FIELDS_RT footprint present", actual=list(footprints))
+
+    regions = fp.get("regions", [])
+    runner.check(len(regions) == 1, "1 region survived", actual=len(regions))
+    if regions:
+        rg = regions[0]
+        runner.check(
+            rg.get("kind") == "cutout", "region kind=cutout", actual=rg.get("kind"), expected="cutout"
+        )
+        runner.check(
+            rg.get("name") == "POUR_A", "region name", actual=rg.get("name"), expected="POUR_A"
+        )
+        runner.check(
+            rg.get("net_index") == 7, "region net_index", actual=rg.get("net_index"), expected=7
+        )
+        runner.check(
+            abs(rg.get("cavity_height", 0) - 0.254) < tol,
+            "region cavity_height",
+            actual=rg.get("cavity_height"),
+            expected=0.254,
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -1117,6 +1174,7 @@ def main():
         test_write_pcblib_via_thermal_power_plane(client, runner, lib_path)
         test_write_pcblib_pad_slot_hole(client, runner, lib_path)
         test_write_pcblib_via_slot_tolerances(client, runner, lib_path)
+        test_write_pcblib_region_kind_net_name(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -6,7 +6,7 @@
 //! writer's output, as `file_io_roundtrip.rs` does).
 
 use altium_designer_mcp::altium::pcblib::{
-    HoleShape, Layer, PadShape, PadStackMode, PcbLib, TextKind,
+    HoleShape, Layer, PadShape, PadStackMode, PcbLib, RegionKind, TextKind,
 };
 use std::path::PathBuf;
 
@@ -422,7 +422,9 @@ fn samples_pcblib_regions() {
     assert_eq!(footprint.regions.len(), 2, "REGIONS has 2 regions");
 
     // Each region is a 4-vertex box; one is on the Top Layer, the other on
-    // Mechanical 1.
+    // Mechanical 1. The reader now parses the nested parameter block, so KIND,
+    // NAME, and ARCRESOLUTION are populated from the golden's real Altium values
+    // (`KIND=0`, `NAME= ` -> empty, `ARCRESOLUTION=0.5mil`).
     for region in &footprint.regions {
         assert_eq!(
             region.vertices.len(),
@@ -431,6 +433,20 @@ fn samples_pcblib_regions() {
             region.vertices.len(),
             region.layer,
         );
+        assert_eq!(region.kind, RegionKind::Copper, "golden regions are copper");
+        assert!(
+            region.name.is_empty(),
+            "golden region NAME is blank, got {:?}",
+            region.name
+        );
+        // ARCRESOLUTION=0.5mil = 0.0127 mm.
+        assert!(
+            approx_eq(region.arc_resolution, 0.5 * 0.0254, 1e-6),
+            "golden region ARCRESOLUTION should be 0.5mil (0.0127mm), got {}",
+            region.arc_resolution
+        );
+        assert_eq!(region.sub_poly_index, -1, "golden SUBPOLYINDEX=-1");
+        assert!(!region.is_shape_based, "golden ISSHAPEBASED=FALSE");
     }
 
     assert!(

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -354,10 +354,8 @@ fn test_complex_region() {
             Vertex { x: 1.0, y: 2.0 },
             Vertex { x: 0.0, y: 2.0 },
         ],
-        holes: Vec::new(),
         layer: Layer::TopCourtyard,
-        flags: PcbFlags::default(),
-        unique_id: None,
+        ..Region::default()
     };
     fp.add_region(region);
 
@@ -393,10 +391,8 @@ fn test_region_with_many_vertices() {
 
     let region = Region {
         vertices,
-        holes: Vec::new(),
         layer: Layer::TopCourtyard,
-        flags: PcbFlags::default(),
-        unique_id: None,
+        ..Region::default()
     };
     fp.add_region(region);
 


### PR DESCRIPTION
**Coverage roadmap PR-9** — model the Region's parameter block: `KIND` / net / name + round-trip params.

The Region's nested C-string param block was **skipped by length** on read and emitted as a **fixed hard-coded string** on write — so `KIND` (copper vs cutout, the defining region property) was invisible, and **any non-copper region read from Altium silently became copper**.

## Change
- New `RegionKind` enum (`Copper` / `Cutout` / `Other(i32)` catch-all so unknown KIND ints round-trip), string-serialised.
- Fields parsed from the param block / common header: `name`, `net_index` (@3-4), `polygon_index` (@5-6), `component_index` (@7-8), `arc_resolution`, `cavity_height`, `sub_poly_index`, `union_index`, `is_shape_based`.
- `parse_region` now parses the `|KEY=VAL|` block; `encode_region_properties` builds it from the struct (new `format_mil_coord` matches Altium's `Xmil` formatting).
- `write_pcblib` region schema + `parse_region` accept `kind` (name or int) / `name` / `net_index` / `cavity_height` (+ `holes`/`unique_id`); the region `check_keys!` allow-list extended.

## Byte-identity
Every default equals the writer's current hard-coded value, so a from-scratch default region emits the identical canonical string (`KIND=0|NAME=|…|ARCRESOLUTION=0mil|…`) + 0xFF header bytes — pinned by `default_region_param_string_is_byte_identical`. **Oracle 0 regressions.** The reader now populates the golden's *real* values (`KIND=copper`, `ARCRESOLUTION=0.5mil`).

## Deferred
`AdditionalParameters` catch-all (arbitrary unmodelled keys), vertex sub-coord precision, raw-flags-word preservation.

## Test
Byte-identity + non-default round-trip + golden-region assertions + Python `test_write_pcblib_region_kind_net_name`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (329) / **integration 164/164** / **oracle 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
