### PR TITLE
feat(pcblib): fix ComponentBody layer bug + expose authoring fields (PR-11)

### DIFF
--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1306,10 +1306,20 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         .and_then(|v| v.parse::<i64>().ok())
         .unwrap_or(0);
 
-    // Parse layer from V7_LAYER (e.g., "MECHANICAL6")
-    let layer = params
-        .get("V7_LAYER")
-        .and_then(|v| parse_v7_layer(v))
+    // The body's layer is the CommonPrimitiveData layer byte at block offset 0 — the
+    // authoritative source, exactly as AltiumSharp does (`result.Layer = layer`,
+    // PcbLibReader.ReadComponentBody). Previously we only decoded the `V7_LAYER`
+    // parameter string via the incomplete `parse_v7_layer` (MECHANICAL2-7 only) and
+    // fell back to `Top3DBody`, silently collapsing every other mechanical layer
+    // (e.g. MECHANICAL13 / id 69) to the top 3D-body layer on read. The header byte
+    // covers the full Mechanical1-32 range through `layer_from_id`, so a body authored
+    // on any layer now reads back on its true layer. The writer already emits the
+    // matching header byte and `V7_LAYER` token, so this is a read-only fix. When the
+    // header byte is absent (empty block) fall back to the `V7_LAYER` string.
+    let layer = block0
+        .first()
+        .map(|&id| layer_from_id(id))
+        .or_else(|| params.get("V7_LAYER").and_then(|v| parse_v7_layer(v)))
         .unwrap_or(Layer::Top3DBody);
 
     // Additive fields previously discarded. Each default matches the writer's
@@ -1424,17 +1434,22 @@ pub(super) fn parse_mil_value(s: Option<&str>) -> f64 {
     numeric.parse::<f64>().map_or(0.0, |v| v * MM_PER_MIL) // Convert mils to mm
 }
 
-/// Parses `V7_LAYER` string (e.g., "MECHANICAL6") to Layer enum.
+/// Parses a `V7_LAYER` token (e.g., "MECHANICAL13") to a `Layer`.
+///
+/// Handles the full `MECHANICAL1`-`MECHANICAL32` range, inverting the writer's
+/// [`region_v7_layer_token`](super::super::writer) mapping via [`layer_from_id`]:
+/// `MECHANICAL{1..=16}` map to layer ids `57..=72` and `MECHANICAL{17..=32}` to
+/// `186..=201`. It previously mapped only `MECHANICAL2`-`MECHANICAL7`, returning
+/// `None` for every other mechanical layer. This is the fallback for a body whose
+/// header layer byte is missing; the primary layer source is the header byte.
 pub(super) fn parse_v7_layer(s: &str) -> Option<Layer> {
-    match s {
-        "MECHANICAL6" => Some(Layer::Top3DBody),
-        "MECHANICAL7" => Some(Layer::Bottom3DBody),
-        "MECHANICAL2" => Some(Layer::TopAssembly),
-        "MECHANICAL3" => Some(Layer::BottomAssembly),
-        "MECHANICAL4" => Some(Layer::TopCourtyard),
-        "MECHANICAL5" => Some(Layer::BottomCourtyard),
-        _ => None,
-    }
+    let n: u8 = s.strip_prefix("MECHANICAL")?.parse().ok()?;
+    let id = match n {
+        1..=16 => 56 + n,
+        17..=32 => 169 + n,
+        _ => return None,
+    };
+    Some(layer_from_id(id))
 }
 
 // =============================================================================

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -2134,6 +2134,9 @@ mod tests {
         body.is_shape_based = true;
         body.model_2d_rotation = 90.0;
         body.name = "BODY_A".into();
+        // Author on Mechanical 13 so the layer-reader fix (read the header layer byte,
+        // not just the incomplete V7_LAYER map) is exercised through encode -> decode.
+        body.layer = Layer::Mechanical13;
         original.add_component_body(body);
 
         let data = encode_data_stream(&original).expect("encode");
@@ -2150,6 +2153,7 @@ mod tests {
         assert!(b.is_shape_based);
         assert!((b.model_2d_rotation - 90.0).abs() < 1e-9);
         assert_eq!(b.name, "BODY_A");
+        assert_eq!(b.layer, Layer::Mechanical13, "body layer round-trips");
     }
 
     #[test]

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -428,7 +428,19 @@ impl McpServer {
                                                 "rotation_x": { "type": "number" },
                                                 "rotation_y": { "type": "number" },
                                                 "rotation_z": { "type": "number" },
-                                                "model_checksum": { "type": "integer", "description": "Altium MODEL.CHECKSUM; normally omitted (defaults to 0). Preserved verbatim on a read-modify-write round-trip." }
+                                                "model_checksum": { "type": "integer", "description": "Altium MODEL.CHECKSUM; normally omitted (defaults to 0). Preserved verbatim on a read-modify-write round-trip." },
+                                                "name": { "type": "string", "description": "Altium NAME. Default: \" \" (a single space, as template-default bodies emit)." },
+                                                "kind": { "type": "integer", "description": "Altium KIND (0=extruded, etc.). Default: 0" },
+                                                "sub_poly_index": { "type": "integer", "description": "Altium SUBPOLYINDEX; -1 when not a polygon sub-shape. Default: -1" },
+                                                "union_index": { "type": "integer", "description": "Altium UNIONINDEX for grouped primitives. Default: 0" },
+                                                "is_shape_based": { "type": "boolean", "description": "Altium ISSHAPEBASED (shape-based vs. model-based body). Default: false" },
+                                                "body_projection": { "type": "integer", "description": "Altium BODYPROJECTION (board side). Default: 0" },
+                                                "body_color_3d": { "type": "integer", "description": "3D body colour as decimal RGB (Altium BODYCOLOR3D). Default: 8421504 (0xE0E0E0, grey)" },
+                                                "body_opacity_3d": { "type": "number", "description": "3D body opacity, 0.0-1.0 (Altium BODYOPACITY3D). Default: 1.0" },
+                                                "model_2d_rotation": { "type": "number", "description": "2D placement rotation in degrees (Altium MODEL.2D.ROTATION). Default: 0" },
+                                                "model_id": { "type": "string", "description": "Model GUID referencing an embedded model (Altium MODELID). Default: \"\" (none)" },
+                                                "model_name": { "type": "string", "description": "Model filename or external path (Altium MODEL.NAME). Default: \"\" (none)" },
+                                                "embedded": { "type": "boolean", "description": "Whether the model is embedded in the library (Altium MODEL.EMBED). Default: false" }
                                             },
                                             "required": ["overall_height"]
                                         }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -769,10 +769,25 @@ impl McpServer {
                         })
                         .unwrap_or_default();
                     let f = |k: &str| body_json.get(k).and_then(Value::as_f64).unwrap_or(0.0);
+                    // Read each field from JSON, defaulting to the exact value the
+                    // handler used to hard-code, so a from-scratch body (none of these
+                    // keys supplied) is byte-identical to before (oracle 0 regressions).
+                    // These are all already modelled by `ComponentBody`, the reader and
+                    // the writer — only the tool boundary dropped them.
+                    let str_or = |k: &str, d: &str| {
+                        body_json
+                            .get(k)
+                            .and_then(Value::as_str)
+                            .unwrap_or(d)
+                            .to_string()
+                    };
                     footprint.add_component_body(ComponentBody {
-                        model_id: String::new(),
-                        model_name: String::new(),
-                        embedded: false,
+                        model_id: str_or("model_id", ""),
+                        model_name: str_or("model_name", ""),
+                        embedded: body_json
+                            .get("embedded")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false),
                         rotation_x: f("rotation_x"),
                         rotation_y: f("rotation_y"),
                         rotation_z: f("rotation_z"),
@@ -788,15 +803,44 @@ impl McpServer {
                             .get("model_checksum")
                             .and_then(Value::as_i64)
                             .unwrap_or(0),
-                        name: " ".to_string(),
-                        kind: 0,
-                        sub_poly_index: -1,
-                        union_index: 0,
-                        is_shape_based: false,
-                        body_projection: 0,
-                        body_color_3d: 8_421_504,
-                        body_opacity_3d: 1.0,
-                        model_2d_rotation: 0.0,
+                        name: str_or("name", " "),
+                        kind: body_json
+                            .get("kind")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u8::try_from(v).ok())
+                            .unwrap_or(0),
+                        sub_poly_index: body_json
+                            .get("sub_poly_index")
+                            .and_then(Value::as_i64)
+                            .and_then(|v| i32::try_from(v).ok())
+                            .unwrap_or(-1),
+                        union_index: body_json
+                            .get("union_index")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u32::try_from(v).ok())
+                            .unwrap_or(0),
+                        is_shape_based: body_json
+                            .get("is_shape_based")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false),
+                        body_projection: body_json
+                            .get("body_projection")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u8::try_from(v).ok())
+                            .unwrap_or(0),
+                        body_color_3d: body_json
+                            .get("body_color_3d")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u32::try_from(v).ok())
+                            .unwrap_or(8_421_504),
+                        body_opacity_3d: body_json
+                            .get("body_opacity_3d")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(1.0),
+                        model_2d_rotation: body_json
+                            .get("model_2d_rotation")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
                     });
                 }
             }

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -998,6 +998,102 @@ def test_write_pcblib_region_kind_net_name(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_component_body_fields(client, runner, lib_path):
+    print("\n=== Test: write_pcblib component body fields round trip ===")
+    # Coverage PR-11: the ComponentBody struct/reader/writer already model
+    # body_color_3d / body_opacity_3d / body_projection / model_2d_rotation /
+    # is_shape_based / kind / name, but the write handler used to hard-code them,
+    # so a caller could not author them. They must now be settable via
+    # component_bodies[] and round-trip through read_pcblib (proving the tool no
+    # longer resets them). The body is authored on Mechanical 13 to also exercise
+    # the layer-reader fix (header layer byte, not just the V7_LAYER string).
+    tol = 1e-4
+    footprint = {
+        "name": "BODY_FIELDS_RT",
+        "pads": [
+            {"designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+        ],
+        "component_bodies": [
+            {
+                "overall_height": 1.5,
+                "standoff_height": 0.2,
+                "layer": "Mechanical 13",
+                "outline": [
+                    {"x": -1.0, "y": -1.0},
+                    {"x": 1.0, "y": -1.0},
+                    {"x": 1.0, "y": 1.0},
+                    {"x": -1.0, "y": 1.0},
+                ],
+                "body_color_3d": 16711680,  # 0xFF0000 (red) — non-default
+                "body_opacity_3d": 0.5,
+                "body_projection": 1,
+                "model_2d_rotation": 90.0,
+                "is_shape_based": True,
+                "kind": 2,
+                "name": "BODY_A",
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(not write.get("_isError"), "write_pcblib (component body) succeeded", actual=write)
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("BODY_FIELDS_RT", {})
+    runner.check(bool(fp), "BODY_FIELDS_RT footprint present", actual=list(footprints))
+
+    bodies = fp.get("component_bodies", [])
+    runner.check(len(bodies) == 1, "1 component body survived", actual=len(bodies))
+    if bodies:
+        b = bodies[0]
+        runner.check(
+            b.get("layer") == "Mechanical 13",
+            "body layer (layer-reader fix)",
+            actual=b.get("layer"),
+            expected="Mechanical 13",
+        )
+        runner.check(
+            b.get("body_color_3d") == 16711680,
+            "body_color_3d",
+            actual=b.get("body_color_3d"),
+            expected=16711680,
+        )
+        runner.check(
+            abs(b.get("body_opacity_3d", 0) - 0.5) < tol,
+            "body_opacity_3d",
+            actual=b.get("body_opacity_3d"),
+            expected=0.5,
+        )
+        runner.check(
+            b.get("body_projection") == 1,
+            "body_projection",
+            actual=b.get("body_projection"),
+            expected=1,
+        )
+        runner.check(
+            abs(b.get("model_2d_rotation", 0) - 90.0) < tol,
+            "model_2d_rotation",
+            actual=b.get("model_2d_rotation"),
+            expected=90.0,
+        )
+        runner.check(
+            b.get("is_shape_based") is True,
+            "is_shape_based",
+            actual=b.get("is_shape_based"),
+            expected=True,
+        )
+        runner.check(
+            b.get("kind") == 2, "body kind", actual=b.get("kind"), expected=2
+        )
+        runner.check(
+            b.get("name") == "BODY_A", "body name", actual=b.get("name"), expected="BODY_A"
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -1223,6 +1319,7 @@ def main():
         test_write_pcblib_pad_slot_hole(client, runner, lib_path)
         test_write_pcblib_via_slot_tolerances(client, runner, lib_path)
         test_write_pcblib_region_kind_net_name(client, runner, lib_path)
+        test_write_pcblib_component_body_fields(client, runner, lib_path)
         test_write_pcblib_text_font_style(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -652,8 +652,9 @@ fn samples_pcblib_body3d() {
         "BODY3D has 1 component body",
     );
 
-    // A simple extruded 3D component body: a 100x60 mil rectangle authored on the
-    // top 3D-body layer, ~1 mm (40 mil) tall, sitting flush on the board (standoff 0).
+    // A simple extruded 3D component body: a 100x60 mil rectangle authored on
+    // Mechanical 13 (LayerUtils.MechanicalLayer(13) in the sample generator), ~1 mm
+    // (40 mil) tall, sitting flush on the board (standoff 0).
     let body = &footprint.component_bodies[0];
     assert!(
         approx_eq(body.overall_height, 1.016, 1e-2),
@@ -665,7 +666,12 @@ fn samples_pcblib_body3d() {
         "standoff_height: expected ~0, got {}",
         body.standoff_height,
     );
-    assert_eq!(body.layer, Layer::Top3DBody, "body layer");
+    // Layer-reader regression (PR-11): the body is authored on Mechanical 13
+    // (layer id 69). It was previously collapsed to Top3DBody because the reader
+    // decoded only the V7_LAYER string via an incomplete map (MECHANICAL2-7) and
+    // ignored the CommonPrimitiveData header layer byte. The reader now reads the
+    // header byte, so the true layer survives.
+    assert_eq!(body.layer, Layer::Mechanical13, "body layer");
 
     // Altium reorders the contour vertices on save, so we assert the vertex count
     // and the axis-aligned bounding box rather than an exact vertex order.


### PR DESCRIPTION
**Coverage roadmap PR-11** — the last format-EE PR: fix the ComponentBody layer bug + expose its authoring fields.

## 1. Layer reader bug (data loss)
`parse_component_body` derived the layer only from the `V7_LAYER` param via `parse_v7_layer`, which mapped just **MECHANICAL2-7** and collapsed everything else to `Top3DBody`. The golden BODY3D body is on **Mechanical13** (layer id 69) — so it silently read back as `Top3DBody`, losing its true layer.

**Fix:** read the CommonPrimitiveData header layer byte (via `layer_from_id`, covering Mechanical1-32) — matching AltiumSharp's `ReadComponentBody` (`result.Layer = layer byte`) — with `V7_LAYER` as fallback; `parse_v7_layer` also extended to MECHANICAL1-32. Read-only — the writer already emits the correct layer, so output bytes are unchanged.

## 2. De-hard-coded write handler
The `component_bodies` write branch hard-coded **12 fields** the struct/reader/writer already round-trip (`body_color_3d`, `body_opacity_3d`, `body_projection`, `model_2d_rotation`, `is_shape_based`, `kind`, `name`, `sub_poly_index`, `union_index`, `model_id`/`model_name`/`embedded`) — so an AI couldn't set them and a read-modify-write silently reset them. Now read from JSON, **each default = the exact prior hard-coded value** (byte-identical for a default body), all added to the `write_pcblib` schema.

## Byte-identity
Default body byte-identical. **Oracle 0 regressions.**

## Deferred
`cavity_height`, `model_2d_location`, `model_type`/`source`/`extruded_z`, `identifier`, texture, arc-resolution, net/comp index, flags, `AdditionalParameters` (need new struct fields).

## Test
`samples_pcblib_body3d` asserts the golden reads `Mechanical13` (was `Top3DBody`); `component_body_additive_fields_roundtrip` round-trips a Mechanical13 body; Python `test_write_pcblib_component_body_fields`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test / **integration 186/186** / **oracle 0 regressions**.

_Closes the format-EE tier — every PcbLib primitive (Pad, Via, Region, Text, ComponentBody) is now comprehensively modelled._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
