### PR TITLE
fix(schlib): decode %UTF8%Text for non-Win-1252 values (PR-16)

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -81,6 +81,53 @@ pub fn decode_windows1252(bytes: &[u8]) -> String {
     encoding_rs::WINDOWS_1252.decode(bytes).0.into_owned()
 }
 
+/// Returns `true` when `value` cannot be represented losslessly in Windows-1252,
+/// so it must be stored behind a `%UTF8%` key to avoid silent `?` corruption.
+///
+/// Altium stores a text value's plain `Text` key as Windows-1252; any character
+/// outside that code page (Cyrillic, CJK, Greek `Ω`, …) would be replaced with
+/// `?` on write. Altium (and `AltiumSharp`) detect this by re-encoding the value
+/// through Windows-1252 and checking it survives; when it does not, the value is
+/// emitted as `%UTF8%Text` instead. This mirrors that check exactly (the round
+/// trip is `WINDOWS_1252.decode(WINDOWS_1252.encode(value)) != value`).
+#[must_use]
+pub fn requires_utf8(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    decode_windows1252(&encode_windows1252(value)) != value
+}
+
+/// Encodes a Unicode `value` into the "one Windows-1252 char per UTF-8 byte"
+/// form Altium uses for a `%UTF8%`-prefixed value.
+///
+/// The surrounding parameter record is written as Windows-1252, so a value whose
+/// UTF-8 bytes are mapped one-per-char here is emitted on disk as its raw UTF-8
+/// byte sequence. This is the inverse of [`decode_utf8_param_value`]. The mapping
+/// is a byte bijection (every 0x00–0xFF Windows-1252 char round-trips through
+/// [`encode_windows1252`]), so no bytes are lost.
+#[must_use]
+pub fn encode_utf8_param_value(value: &str) -> String {
+    decode_windows1252(value.as_bytes())
+}
+
+/// Decodes a `%UTF8%`-prefixed value that was read back from a Windows-1252
+/// decoded record, recovering the original Unicode string.
+///
+/// The record was decoded as Windows-1252, so a UTF-8 value arrives as one char
+/// per raw byte ("mojibake"). Re-encoding those chars to Windows-1252 bytes
+/// recovers the original UTF-8 byte sequence, which is then decoded as UTF-8.
+/// Inverse of [`encode_utf8_param_value`]; matches `AltiumSharp`'s
+/// `DecodeUtf8ParameterValue`.
+#[must_use]
+pub fn decode_utf8_param_value(value: &str) -> String {
+    if value.is_empty() {
+        return String::new();
+    }
+    let bytes = encode_windows1252(value);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
 /// Generates a safe OLE storage name for a component.
 ///
 /// OLE Compound File names are limited to 31 characters. This function:

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -86,16 +86,35 @@ fn parse_text_record(symbol: &mut Symbol, data: &[u8]) {
     // Remove null terminator if present
     let data = data.split(|&b| b == 0).next().unwrap_or(data);
 
-    let text = std::str::from_utf8(data).map_or_else(
-        |_| {
-            // Decode as Windows-1252 (legacy Altium encoding)
-            let (decoded, _, _) = encoding_rs::WINDOWS_1252.decode(data);
-            decoded.into_owned()
-        },
-        str::to_string,
-    );
+    // A record carrying a `%UTF8%`-prefixed key (e.g. `%UTF8%Text`) stores that
+    // value as raw UTF-8 bytes inside an otherwise Windows-1252 record. Decode
+    // the whole record as Windows-1252 so the UTF-8 value arrives as deterministic
+    // one-char-per-byte "mojibake"; the field parser then re-decodes it as UTF-8
+    // (see `decode_utf8_param_value`). Without the `%UTF8%` marker the record is
+    // decoded exactly as before: UTF-8 when valid, else Windows-1252.
+    let text = if contains_utf8_marker(data) {
+        crate::altium::decode_windows1252(data)
+    } else {
+        std::str::from_utf8(data).map_or_else(
+            |_| {
+                // Decode as Windows-1252 (legacy Altium encoding)
+                let (decoded, _, _) = encoding_rs::WINDOWS_1252.decode(data);
+                decoded.into_owned()
+            },
+            str::to_string,
+        )
+    };
 
     parse_text_record_from_string(symbol, &text);
+}
+
+/// Returns `true` when the raw record bytes contain a `%UTF8%` key prefix
+/// (case-insensitive), signalling that at least one value is stored as raw UTF-8
+/// bytes and the record must be decoded as Windows-1252 to recover it.
+fn contains_utf8_marker(data: &[u8]) -> bool {
+    const MARKER: &[u8; 6] = b"%UTF8%";
+    data.windows(MARKER.len())
+        .any(|w| w.eq_ignore_ascii_case(MARKER))
 }
 
 /// Parses a text record from a decoded string.
@@ -157,9 +176,10 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
             }
         }
         34 => {
-            // Designator
-            if let Some(text) = props.get("text") {
-                symbol.designator.clone_from(text);
+            // Designator (a parameter record; its value uses the same
+            // `%UTF8%Text` convention as any other text field).
+            if let Some(text) = read_utf8_text_field(&props, "text") {
+                symbol.designator = text;
             }
         }
         41 => {
@@ -387,6 +407,22 @@ fn read_display_flags(props: &HashMap<String, String>) -> ShapeDisplayFlags {
     }
 }
 
+/// Reads a record's text value, preferring a `%UTF8%`-prefixed key when present.
+///
+/// Altium stores a text value that Windows-1252 cannot represent (Cyrillic, CJK,
+/// Greek `Ω`, …) under a `%UTF8%<Key>` key holding the raw UTF-8 bytes, instead
+/// of the lossy plain `<Key>`. When that key is present its value (mojibake from
+/// the Windows-1252 record decode) is re-decoded as UTF-8; otherwise the plain
+/// `<Key>` is read verbatim. `key` is the lower-cased field name (e.g. `"text"`),
+/// matching [`parse_properties`]'s lower-casing. Returns `None` when neither key
+/// is present so callers can distinguish an absent field from an empty one.
+fn read_utf8_text_field(props: &HashMap<String, String>, key: &str) -> Option<String> {
+    if let Some(raw) = props.get(&format!("%utf8%{key}")) {
+        return Some(crate::altium::decode_utf8_param_value(raw));
+    }
+    props.get(key).cloned()
+}
+
 /// Parses a rectangle from properties.
 #[allow(clippy::unnecessary_wraps)] // infallible (all coords default); Option kept for uniform parser dispatch
 fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectangle> {
@@ -477,7 +513,7 @@ fn parse_line(props: &HashMap<String, String>) -> Option<Line> {
 /// Parses a parameter from properties.
 fn parse_parameter(props: &HashMap<String, String>) -> Option<Parameter> {
     let name = props.get("name")?.clone();
-    let value = props.get("text").cloned().unwrap_or_default();
+    let value = read_utf8_text_field(props, "text").unwrap_or_default();
 
     let x = crate::altium::schlib::coord::read(props, "location.x");
     let y = crate::altium::schlib::coord::read(props, "location.y");
@@ -888,7 +924,7 @@ fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<EllipticalArc
 fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
     let x = crate::altium::schlib::coord::read(props, "location.x");
     let y = crate::altium::schlib::coord::read(props, "location.y");
-    let text = props.get("text").cloned().unwrap_or_default();
+    let text = read_utf8_text_field(props, "text").unwrap_or_default();
 
     let font_id = props
         .get("fontid")
@@ -931,7 +967,7 @@ fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
 fn parse_text(props: &HashMap<String, String>) -> Option<Text> {
     let x = crate::altium::schlib::coord::read(props, "location.x");
     let y = crate::altium::schlib::coord::read(props, "location.y");
-    let text = props.get("text").cloned().unwrap_or_default();
+    let text = read_utf8_text_field(props, "text").unwrap_or_default();
 
     let font_id = props
         .get("fontid")
@@ -1198,5 +1234,48 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(label.color, 0, "absent label Color must read as black");
+    }
+
+    #[test]
+    fn utf8_text_record_decodes_intact_from_raw_bytes() {
+        // Build the on-disk bytes for a Label whose value is Greek Ω (not in
+        // Windows-1252): the record is Windows-1252, with the Ω stored as its raw
+        // UTF-8 bytes behind `%UTF8%Text`. The reader must recover "10kΩ" exactly.
+        // A reader that only read a plain `Text=` (Windows-1252) would corrupt it.
+        let value = "10k\u{03A9}";
+        let utf8_form = crate::altium::encode_utf8_param_value(value);
+        let record = format!(
+            "|RECORD=4|Location.X=5|Location.Y=5|FontID=1|%UTF8%Text={utf8_form}|UniqueID=ABCD1234"
+        );
+        let bytes = crate::altium::encode_windows1252(&record);
+
+        let mut symbol = Symbol::new("L");
+        parse_text_record(&mut symbol, &bytes);
+        assert_eq!(
+            symbol.labels[0].text, value,
+            "%UTF8%Text label must decode to the true Unicode value, not ?-mangled"
+        );
+
+        // The same convention for a Parameter (RECORD=41).
+        let record = format!(
+            "|RECORD=41|Location.X=0|Location.Y=0|Color=0|FontID=1|%UTF8%Text={utf8_form}|Name=Value|UniqueID=ABCD1234"
+        );
+        let bytes = crate::altium::encode_windows1252(&record);
+        let mut symbol = Symbol::new("P");
+        parse_text_record(&mut symbol, &bytes);
+        assert_eq!(symbol.parameters[0].value, value);
+        assert_eq!(symbol.parameters[0].name, "Value");
+    }
+
+    #[test]
+    fn plain_win1252_text_record_reads_unchanged() {
+        // A record with no `%UTF8%` marker takes the unchanged decode path and
+        // reads the Windows-1252 value verbatim (here `µ`, byte 0xB5).
+        let bytes = crate::altium::encode_windows1252(
+            "|RECORD=41|Location.X=0|Location.Y=0|Color=0|FontID=1|Text=10\u{00B5}F|Name=Value|UniqueID=ABCD1234",
+        );
+        let mut symbol = Symbol::new("P");
+        parse_text_record(&mut symbol, &bytes);
+        assert_eq!(symbol.parameters[0].value, "10\u{00B5}F");
     }
 }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -279,6 +279,27 @@ fn encode_component_header(symbol: &Symbol) -> String {
     format!("|{}", parts.join("|"))
 }
 
+/// Formats a text field as `<key>=<value>`, promoting it to `%UTF8%<key>` when
+/// the value carries characters Windows-1252 cannot represent.
+///
+/// A pure-Windows-1252 value emits the plain `<key>=<value>` — byte-identical to
+/// the pre-UTF-8 output, so the common case (and everything in the golden library)
+/// is unchanged. A value with non-Windows-1252 characters (Cyrillic, CJK, Greek
+/// `Ω`, …) would otherwise be silently corrupted to `?` by the record's
+/// Windows-1252 encoder; instead it is emitted as `%UTF8%<key>=<utf8-bytes>` so
+/// the true value survives, matching Altium / `AltiumSharp`. Only one of the two
+/// keys is ever written (never both), mirroring `AltiumSharp`'s writer.
+fn text_field(key: &str, value: &str) -> String {
+    if crate::altium::requires_utf8(value) {
+        format!(
+            "%UTF8%{key}={}",
+            crate::altium::encode_utf8_param_value(value)
+        )
+    } else {
+        format!("{key}={value}")
+    }
+}
+
 /// Returns `"|Key=value"` when `value` is non-zero, or an empty string when it
 /// is zero. Altium omits zero-valued integer parameters such as `Color` and
 /// `AreaColor` from a record's text (its `AddNonZero` helper); our reader
@@ -472,7 +493,7 @@ fn encode_parameter(param: &Parameter, index: usize) -> String {
         parts.push("IsConfigurable=T".to_string());
     }
     if !param.value.is_empty() {
-        parts.push(format!("Text={}", param.value));
+        parts.push(text_field("Text", &param.value));
     }
     if !param.description.is_empty() {
         parts.push(format!("Description={}", param.description));
@@ -489,8 +510,8 @@ fn encode_parameter(param: &Parameter, index: usize) -> String {
 /// Encodes a designator record.
 fn encode_designator(designator: &str) -> String {
     format!(
-        "|RECORD=34|IndexInSheet=-1|OwnerPartId=-1|Location.Y=-6|Color=8388608|FontID=1|Text={}|Name=Designator|ReadOnlyState=1|UniqueID={}",
-        designator,
+        "|RECORD=34|IndexInSheet=-1|OwnerPartId=-1|Location.Y=-6|Color=8388608|FontID=1|{}|Name=Designator|ReadOnlyState=1|UniqueID={}",
+        text_field("Text", designator),
         generate_unique_id()
     )
 }
@@ -736,7 +757,7 @@ fn encode_label(label: &Label, index: usize) -> String {
     };
     let is_hidden = if label.is_hidden { "|IsHidden=T" } else { "" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}{}|Text={}|UniqueID={}",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}{}|{}|UniqueID={}",
         index,
         label.owner_part_id,
         coord_param("Location.X", label.x),
@@ -748,7 +769,7 @@ fn encode_label(label: &Label, index: usize) -> String {
         is_mirrored,
         is_hidden,
         write_display_flags(label.display_flags),
-        label.text,
+        text_field("Text", &label.text),
         label.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
@@ -766,7 +787,7 @@ fn encode_text(text: &Text, index: usize) -> String {
     };
     let is_hidden = if text.is_hidden { "|IsHidden=T" } else { "" };
     format!(
-        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}|Text={}|UniqueID={}",
+        "|RECORD=4|IndexInSheet={}|OwnerPartId={}|IsNotAccesible=T{}{}{}|FontID={}|Orientation={}|Justification={}{}{}|{}|UniqueID={}",
         index,
         text.owner_part_id,
         coord_param("Location.X", text.x),
@@ -777,7 +798,7 @@ fn encode_text(text: &Text, index: usize) -> String {
         justification,
         is_mirrored,
         is_hidden,
-        text.text,
+        text_field("Text", &text.text),
         text.unique_id.clone().unwrap_or_else(generate_unique_id)
     )
 }
@@ -1661,5 +1682,129 @@ mod tests {
         );
         assert!(s.contains("|Location.Y=7|"), "Y integer part: {s}");
         assert!(s.contains("|Location.Y_Frac=50000|"), "Y fractional: {s}");
+    }
+
+    #[test]
+    fn win1252_text_stays_byte_identical_no_utf8_key() {
+        // A pure-Windows-1252 value (the common case, and everything in the golden
+        // library) must emit the plain `Text=` key exactly as before the UTF-8 fix
+        // — no `%UTF8%Text` key, so the record bytes are unchanged (oracle-clean).
+        // `µ` (U+00B5) is representable in Windows-1252, so it stays plain.
+        let mut p = Parameter::new("Value", "10\u{00B5}F"); // "10µF"
+        p.unique_id = Some("ABCD1234".to_string());
+        let s = encode_parameter(&p, 1);
+        assert!(s.contains("|Text=10\u{00B5}F|"), "plain Text key: {s}");
+        assert!(
+            !s.contains("%UTF8%"),
+            "no %UTF8% key for Win-1252 value: {s}"
+        );
+
+        let mut label = Label {
+            x: 0.0,
+            y: 0.0,
+            text: "caf\u{00E9}".to_string(), // "café" — all Windows-1252
+            font_id: 1,
+            color: 0,
+            justification: TextJustification::BottomLeft,
+            rotation: 0.0,
+            is_mirrored: false,
+            is_hidden: false,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: Some("ABCD1234".to_string()),
+        };
+        let s = encode_label(&label, 1);
+        assert!(s.contains("|Text=caf\u{00E9}|"), "plain Text key: {s}");
+        assert!(
+            !s.contains("%UTF8%"),
+            "no %UTF8% key for Win-1252 label: {s}"
+        );
+
+        // And an ASCII label is byte-identical to the pre-change output.
+        label.text = "R".to_string();
+        let s = encode_label(&label, 1);
+        assert!(s.contains("|Text=R|"), "plain ASCII Text: {s}");
+        assert!(!s.contains("%UTF8%"), "no %UTF8% key for ASCII: {s}");
+    }
+
+    #[test]
+    fn non_win1252_text_emits_only_utf8_key() {
+        // Greek Ω (U+03A9) is NOT in Windows-1252. The writer must emit the value
+        // behind `%UTF8%Text` (never a lossy plain `Text=10k?`), matching Altium.
+        let mut p = Parameter::new("Value", "10k\u{03A9}"); // "10kΩ"
+        p.unique_id = Some("ABCD1234".to_string());
+        let s = encode_parameter(&p, 1);
+        assert!(s.contains("|%UTF8%Text="), "emit %UTF8%Text key: {s}");
+        // Exactly one Text key, and no lossy plain `Text=...?`.
+        assert!(
+            !s.contains("|Text="),
+            "must not also emit a lossy plain Text: {s}"
+        );
+        // The stored value is the UTF-8 byte sequence mapped one-char-per-byte.
+        let expected = crate::altium::encode_utf8_param_value("10k\u{03A9}");
+        assert!(
+            s.contains(&format!("|%UTF8%Text={expected}|")),
+            "stored UTF-8 form: {s}"
+        );
+    }
+
+    #[test]
+    fn non_latin_text_round_trips_intact_through_library() {
+        // The headline correctness fix: a Label and a Parameter whose values are
+        // NOT representable in Windows-1252 survive a full write -> read round-trip
+        // with the exact Unicode string intact — not the `?`-mangled corruption
+        // that today's plain-Text-only path produces.
+        for value in [
+            "10k\u{03A9}",
+            "\u{041F}\u{0440}\u{0438}\u{0432}\u{0435}\u{0442}",
+            "\u{6284}\u{6297}\u{5668}",
+        ] {
+            let mut symbol = Symbol::new("R");
+            let mut p = Parameter::new("Value", value);
+            p.unique_id = Some("WXYZ7890".to_string());
+            symbol.add_parameter(p);
+            symbol.add_label(Label {
+                x: 0.0,
+                y: 0.0,
+                text: value.to_string(),
+                font_id: 1,
+                color: 0,
+                justification: TextJustification::BottomLeft,
+                rotation: 0.0,
+                is_mirrored: false,
+                is_hidden: false,
+                owner_part_id: 1,
+                display_flags: ShapeDisplayFlags::default(),
+                unique_id: Some("ABCD1234".to_string()),
+            });
+            symbol.designator = value.to_string();
+
+            let mut lib = crate::altium::schlib::SchLib::new();
+            lib.add(symbol);
+            let mut buf = std::io::Cursor::new(Vec::new());
+            lib.write(&mut buf).expect("library should serialise");
+            buf.set_position(0);
+            let back_lib =
+                crate::altium::schlib::SchLib::read(buf).expect("library should deserialise");
+            let sym = back_lib.get("R").expect("symbol R round-trips");
+
+            let param = sym
+                .parameters
+                .iter()
+                .find(|q| q.name == "Value")
+                .expect("Value parameter round-trips");
+            assert_eq!(
+                param.value, value,
+                "parameter value must survive UTF-8 round-trip intact, not be ?-mangled"
+            );
+            assert_eq!(
+                sym.labels[0].text, value,
+                "label text must survive UTF-8 round-trip intact"
+            );
+            assert_eq!(
+                sym.designator, value,
+                "designator must survive UTF-8 round-trip intact"
+            );
+        }
     }
 }

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -20,6 +20,15 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from mcp_client import McpTestClient, TestRunner, find_binary  # noqa: E402
 
+# The UTF-8 round-trip test prints non-Latin values (Ω, Cyrillic, CJK); force
+# UTF-8 stdout so a legacy-code-page Windows console (e.g. cp1250) does not raise
+# UnicodeEncodeError while reporting results. No-op where stdout is already UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 
 def test_initialise(client, runner):
     print("\n=== Test: initialise ===")
@@ -1451,6 +1460,75 @@ def test_write_schlib_parameter_display_fields(client, runner, schlib_path):
     )
 
 
+def test_write_schlib_utf8_text(client, runner, schlib_path):
+    print("\n=== Test: write_schlib non-Latin (UTF-8) text round trip ===")
+    # Coverage PR-16 (correctness): a label / parameter / designator value with
+    # characters outside Windows-1252 (Greek Ω, Cyrillic, CJK) must survive a
+    # write -> read with the exact Unicode value intact. Before the fix the value
+    # was silently corrupted to '?' (Windows-1252 could not represent it); now the
+    # writer stores it behind `%UTF8%Text` and the reader decodes it back.
+    omega = "10kΩ"  # 10kΩ (Greek capital omega, not in Windows-1252)
+    cyrillic = "Привет"  # Привет
+    cjk = "抄抗器"  # CJK string
+    symbol = {
+        "name": "UTF8SYM",
+        "designator": cjk,
+        "pins": [
+            {
+                "designator": "1",
+                "name": "P1",
+                "x": -50,
+                "y": 0,
+                "length": 30,
+                "orientation": "left",
+            }
+        ],
+        "labels": [{"x": 0, "y": 40, "text": cyrillic}],
+        "parameters": [{"name": "Value", "value": omega}],
+    }
+
+    write = client.call_tool(
+        "write_schlib",
+        {"filepath": schlib_path, "symbols": [symbol], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"),
+        "write_schlib (UTF-8 text) succeeded",
+        actual=write,
+    )
+
+    read = client.call_tool("read_schlib", {"filepath": schlib_path})
+    runner.check(not read.get("_isError"), "read_schlib succeeded", actual=read)
+
+    symbols = {s.get("name"): s for s in read.get("symbols", [])}
+    sym = symbols.get("UTF8SYM", {})
+    runner.check(bool(sym), "UTF8SYM symbol present", actual=list(symbols))
+
+    params = {p.get("name"): p for p in sym.get("parameters", [])}
+    val = params.get("Value", {})
+    runner.check(
+        val.get("value") == omega,
+        "parameter Ω value survives UTF-8 round-trip intact",
+        actual=val.get("value"),
+        expected=omega,
+    )
+
+    labels = sym.get("labels", [])
+    runner.check(
+        any(l.get("text") == cyrillic for l in labels),
+        "label Cyrillic value survives UTF-8 round-trip intact",
+        actual=[l.get("text") for l in labels],
+        expected=cyrillic,
+    )
+
+    runner.check(
+        sym.get("designator") == cjk,
+        "designator CJK value survives UTF-8 round-trip intact",
+        actual=sym.get("designator"),
+        expected=cjk,
+    )
+
+
 def test_write_pcblib_text_font_style(client, runner, lib_path):
     print("\n=== Test: write_pcblib text mirror/bold/font/kind/justification round trip ===")
     # Coverage PR-10: the text primitive's mirror/bold/font_name plus the
@@ -1545,6 +1623,7 @@ def main():
         test_write_schlib_fields(client, runner, schlib_path)
         test_write_schlib_display_flags(client, runner, schlib_path)
         test_write_schlib_parameter_display_fields(client, runner, schlib_path)
+        test_write_schlib_utf8_text(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)
         test_unknown_tool(client, runner)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -27,6 +27,9 @@ for _stream in (sys.stdout, sys.stderr):
     try:
         _stream.reconfigure(encoding="utf-8")
     except (AttributeError, ValueError):
+        # Stream is already UTF-8, or cannot be reconfigured (redirected / older
+        # Python): safe to ignore — this only affects console reporting of the
+        # non-Latin PASS lines, never the test results themselves.
         pass
 
 

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -401,6 +401,36 @@ fn samples_schlib_params() {
 }
 
 #[test]
+fn samples_schlib_no_utf8_key_for_win1252_golden() {
+    // Every text value in the golden library is Windows-1252-representable, so the
+    // UTF-8 fix must NOT introduce a `%UTF8%` key anywhere: re-encoding each
+    // symbol's Data stream yields output with no `%UTF8%` marker, confirming the
+    // common case stays byte-identical (and the oracle sees zero regressions).
+    let lib = SchLib::open(sample("symbols.SchLib")).expect("failed to open symbols.SchLib");
+    for symbol in lib.iter() {
+        let data = altium_designer_mcp::altium::schlib::writer::encode_data_stream(symbol)
+            .expect("encode");
+        assert!(
+            !data.windows(6).any(|w| w == b"%UTF8%"),
+            "symbol {:?}: golden (all Windows-1252) must not gain a %UTF8% key",
+            symbol.name
+        );
+    }
+
+    // And the specific text-bearing symbols round-trip their values unchanged.
+    let labels = lib.get("LABELS").expect("LABELS symbol");
+    assert!(
+        labels.labels.iter().all(|l| l.text.is_ascii()),
+        "golden labels are ASCII, so their values must read back verbatim"
+    );
+    let params = lib.get("PARAMS").expect("PARAMS symbol");
+    assert!(
+        params.parameters.iter().any(|p| p.value == "10k"),
+        "golden Value parameter reads back as the plain Windows-1252 value"
+    );
+}
+
+#[test]
 fn samples_schlib_dualpart() {
     let lib = SchLib::open(sample("symbols.SchLib")).expect("failed to open symbols.SchLib");
     let symbol = lib.get("DUALPART").expect("symbol DUALPART not found");


### PR DESCRIPTION
**Coverage roadmap PR-16** — the last SchLib format PR: decode `%UTF8%Text` (a data-corruption fix).

When a SchLib text value contains characters outside Windows-1252 (Cyrillic, CJK, Greek `Ω`, …), Altium stores it UTF-8 under a `%UTF8%Text` key. Our readers read only the plain `Text=` as Windows-1252 — so `10kΩ` silently read back as `10k?`. **Data corruption, not just loss.**

## Fix
- **Reader** — `read_utf8_text_field` prefers the `%utf8%text` key (UTF-8-decoded) over the lossy Win-1252 `Text`; absent → plain `Text` as before.
- **Writer** — `text_field` emits plain `Text=<win1252>` when the value is Win-1252-representable (byte-identical), else `%UTF8%Text=<utf8>` — **only** that key. *(AltiumSharp investigation corrected the plan: Altium never writes a lossy plain `Text` alongside it, so I matched that.)*
- Shared `requires_utf8` / `encode`/`decode_utf8_param_value` in `altium/mod.rs`. Applied to all text-bearing records: **Parameter (41), Label (4), Text (3/4), Designator (34)**.

## Byte-identity
Pure-Windows-1252 values (incl. `µ`, `café`) emit **no** `%UTF8%` key — a golden test re-encodes every symbol and asserts none is introduced; **oracle 0 regressions**. Non-Latin values' bytes change — that's the fix (today's output is corrupt).

## Test
Reader corruption regression (raw bytes today's reader would mangle to `10k?`) + writer byte-identity + full-library non-Latin round-trip (`Ω`/Cyrillic/CJK) + golden no-`%UTF8%` + Python `test_write_schlib_utf8_text`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (342) / **integration 252/252** / **oracle 0 regressions**.

_Closes the SchLib format tier — both PcbLib and SchLib formats are now comprehensively modelled._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
