### PR TITLE
feat(pcblib): additional_parameters catch-all for Region/ComponentBody (PR-R5)

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -351,6 +351,29 @@ pub(crate) fn parse_pipe_params_raw(text: &str) -> std::collections::HashMap<Str
     map
 }
 
+/// Like [`parse_pipe_params_raw`] but preserves the original key order and every
+/// occurrence (no de-duplication), returning `(KEY, VALUE)` pairs in read order.
+///
+/// Parsing stops at the first NUL byte: `PcbLib` parameter blocks are
+/// NUL-terminated and (for a `ComponentBody`) followed by binary outline bytes,
+/// which must not be mistaken for further `KEY=VALUE` segments. Keys are kept in
+/// their native UPPERCASE form and values are trimmed of trailing NUL padding then
+/// surrounding whitespace, matching [`parse_pipe_params_raw`].
+///
+/// Used to capture the unmodelled Region / `ComponentBody` parameters into an
+/// order-preserving `additional_parameters` catch-all so a read-modify-write does
+/// not silently drop keys the typed model does not recognise.
+pub(crate) fn parse_pipe_params_ordered(text: &str) -> Vec<(String, String)> {
+    // Truncate at the NUL terminator so trailing binary (outline) bytes are ignored.
+    let text = text.split('\0').next().unwrap_or(text);
+    text.split('|')
+        .filter_map(|part| {
+            part.split_once('=')
+                .map(|(key, value)| (key.to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
 /// Builds a stable-reorder ranking function from a desired name order.
 ///
 /// The returned closure maps a name to its sort rank: its index in `new_order`,
@@ -387,6 +410,35 @@ mod tests {
     #[test]
     fn windows1252_ascii_is_identical_to_utf8() {
         assert_eq!(encode_windows1252("RESC0402"), b"RESC0402");
+    }
+
+    #[test]
+    fn parse_pipe_params_ordered_preserves_order_and_duplicates() {
+        // Order is preserved and repeated keys are kept (unlike the HashMap variant),
+        // so the region/body catch-all re-emits every occurrence in read order.
+        let pairs = parse_pipe_params_ordered("A=1|B=2|A=3");
+        assert_eq!(
+            pairs,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "2".to_string()),
+                ("A".to_string(), "3".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_pipe_params_ordered_stops_at_nul() {
+        // A ComponentBody param block is NUL-terminated and followed by binary
+        // outline bytes; segments after the NUL must be ignored.
+        let pairs = parse_pipe_params_ordered("A=1|B=2\0\u{7}garbage|C=3");
+        assert_eq!(
+            pairs,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "2".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1194,6 +1194,7 @@ mod tests {
             body_color_3d: 8_421_504,
             body_opacity_3d: 1.0,
             model_2d_rotation: 0.0,
+            additional_parameters: Vec::new(),
         };
         original.add_component_body(body);
 
@@ -1258,6 +1259,7 @@ mod tests {
                 body_color_3d: 8_421_504,
                 body_opacity_3d: 1.0,
                 model_2d_rotation: 0.0,
+                additional_parameters: Vec::new(),
             });
         }
 

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -176,6 +176,17 @@ pub struct ComponentBody {
     /// written with `{:.3}` so the default renders as `0.000` (byte-identity).
     #[serde(default)]
     pub model_2d_rotation: f64,
+
+    /// Unmodelled parameter keys read verbatim from the body's `KEY=VALUE|...`
+    /// block, in read order. An Altium body carries keys the typed model does not
+    /// recognise (e.g. `TEXTURE`, `TEXTURECENTERX`, `MODEL.2D.X`, `MODEL.2D.Y`,
+    /// `IDENTIFIER`, `MODEL.MODELTYPE`, `MODEL.MODELSOURCE`, `MODEL.EXTRUDED.MINZ`,
+    /// `CAVITYHEIGHT`, and the repeated `ARCRESOLUTION`). Capturing them here and
+    /// re-emitting them on write keeps a read-modify-write from silently dropping
+    /// keys we don't model. Empty from scratch, so the writer appends nothing and
+    /// the output stays byte-identical to the canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_parameters: Vec<(String, String)>,
 }
 
 const fn default_body_color() -> u32 {
@@ -221,6 +232,7 @@ impl ComponentBody {
             body_color_3d: default_body_color(),
             body_opacity_3d: default_opacity(),
             model_2d_rotation: 0.0,
+            additional_parameters: Vec::new(),
         }
     }
 }

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -271,6 +271,16 @@ pub struct Region {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Unmodelled parameter keys read verbatim from the nested `KEY=VALUE|...`
+    /// block, in read order. Altium regions carry board-region keys the typed
+    /// model does not recognise (e.g. `LAYER`, `KEEPOUT`, `ISBOARDCUTOUT`,
+    /// `KEEPOUTRESTRICTIONS`, `PADINDEX`, `OBJECTKIND`, `BENDINGLINECOUNT`,
+    /// `LOCKED3D`, `LAYERSTACKID`). Capturing them here and re-emitting them on
+    /// write keeps a read-modify-write from silently dropping keys we don't model.
+    /// Empty from scratch, so the writer appends nothing and the output stays
+    /// byte-identical to the canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_parameters: Vec<(String, String)>,
 }
 
 /// Default net index for a from-scratch region (`0xFFFF` = no net).
@@ -328,6 +338,7 @@ impl Default for Region {
             union_index: 0,
             is_shape_based: false,
             unique_id: None,
+            additional_parameters: Vec::new(),
         }
     }
 }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1098,6 +1098,14 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     let params_str = crate::altium::decode_windows1252(&props_block[22..param_end]);
     let params = crate::altium::parse_pipe_params_raw(&params_str);
 
+    // Capture every key the typed model does NOT consume, in read order, so a
+    // read-modify-write round-trips the board-region keys (LAYER, KEEPOUT, ...)
+    // Altium writes but we do not model. The writer re-emits these verbatim after
+    // its canonical key set. The modelled keys below are exactly those backed by a
+    // Region struct field (and thus re-emitted from that field); everything else
+    // is "additional".
+    let additional_parameters = capture_additional_params(&params_str, REGION_MODELLED_PARAM_KEYS);
+
     // Vertex data follows the parameter string.
     let vertex_offset = param_end;
 
@@ -1170,9 +1178,35 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         union_index,
         is_shape_based,
         unique_id: None,
+        additional_parameters,
     };
 
     Ok((region, current))
+}
+
+/// Region parameter keys the typed [`Region`] model consumes (each backed by a
+/// struct field). Every OTHER key in the nested block is captured verbatim into
+/// [`Region::additional_parameters`] so a read-modify-write does not drop it.
+const REGION_MODELLED_PARAM_KEYS: &[&str] = &[
+    "V7_LAYER",
+    "NAME",
+    "KIND",
+    "SUBPOLYINDEX",
+    "UNIONINDEX",
+    "ARCRESOLUTION",
+    "ISSHAPEBASED",
+    "CAVITYHEIGHT",
+    "NET",
+];
+
+/// Captures the parameters NOT in `modelled`, preserving read order and every
+/// occurrence. Shared by the Region and `ComponentBody` parsers to build their
+/// `additional_parameters` catch-all.
+fn capture_additional_params(params_str: &str, modelled: &[&str]) -> Vec<(String, String)> {
+    crate::altium::parse_pipe_params_ordered(params_str)
+        .into_iter()
+        .filter(|(key, _)| !modelled.contains(&key.as_str()))
+        .collect()
 }
 
 /// Parses a Fill primitive (filled rectangle).
@@ -1274,6 +1308,16 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
 
     // Find the parameter string (starts with V7_LAYER= or similar key)
     let params = parse_component_body_params(&block_str);
+
+    // Capture every key the typed model does NOT consume, in read order, so a
+    // read-modify-write round-trips the body keys Altium writes but we do not model
+    // (TEXTURE*, MODEL.2D.X/Y, IDENTIFIER, MODEL.MODELTYPE, MODEL.MODELSOURCE, the
+    // extrusion range, the repeated ARCRESOLUTION, CAVITYHEIGHT, ...). The writer
+    // re-emits these verbatim after its canonical key set. The modelled keys are
+    // exactly those backed by a ComponentBody struct field.
+    let additional_parameters = block_str.find("V7_LAYER").map_or_else(Vec::new, |start| {
+        capture_additional_params(&block_str[start..], BODY_MODELLED_PARAM_KEYS)
+    });
 
     // Extract key values
     let model_id = params.get("MODELID").cloned().unwrap_or_default();
@@ -1378,10 +1422,40 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         body_color_3d,
         body_opacity_3d,
         model_2d_rotation,
+        additional_parameters,
     };
 
     Ok((body, current))
 }
+
+/// `ComponentBody` parameter keys the typed [`ComponentBody`] model consumes (each
+/// backed by a struct field). Every OTHER key in the block — including the
+/// writer's hard-coded literals (`ARCRESOLUTION`, `CAVITYHEIGHT`, `IDENTIFIER`,
+/// `TEXTURE*`, `MODEL.2D.X/Y`, `MODEL.MODELTYPE`, `MODEL.MODELSOURCE`,
+/// `MODEL.EXTRUDED.*`) — is captured verbatim into
+/// [`ComponentBody::additional_parameters`] so a read-modify-write does not drop it.
+const BODY_MODELLED_PARAM_KEYS: &[&str] = &[
+    "V7_LAYER",
+    "NAME",
+    "KIND",
+    "SUBPOLYINDEX",
+    "UNIONINDEX",
+    "ISSHAPEBASED",
+    "STANDOFFHEIGHT",
+    "OVERALLHEIGHT",
+    "BODYPROJECTION",
+    "BODYCOLOR3D",
+    "BODYOPACITY3D",
+    "MODELID",
+    "MODEL.CHECKSUM",
+    "MODEL.EMBED",
+    "MODEL.NAME",
+    "MODEL.2D.ROTATION",
+    "MODEL.3D.ROTX",
+    "MODEL.3D.ROTY",
+    "MODEL.3D.ROTZ",
+    "MODEL.3D.DZ",
+];
 
 /// Parses the 2D outline polygon from a `ComponentBody` block.
 ///

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -170,6 +170,7 @@ impl PcbLib {
                 body_color_3d: 8_421_504,
                 body_opacity_3d: 1.0,
                 model_2d_rotation: 0.0,
+                additional_parameters: Vec::new(),
             });
 
             tracing::debug!(

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1160,6 +1160,11 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
         },
         cav = format_mil_coord(region.cavity_height),
     );
+    // Re-emit any unmodelled keys captured on read (board-region keys like LAYER /
+    // KEEPOUT / ISBOARDCUTOUT, etc.), verbatim and in read order, so a
+    // read-modify-write does not drop them. Empty for a from-scratch region, so
+    // nothing is appended and the output stays byte-identical to the canonical form.
+    let params = append_additional_params(params, &region.additional_parameters);
     let params_bytes = crate::altium::encode_windows1252(&params);
 
     let mut block = Vec::with_capacity(22 + params_bytes.len() + 4 + vertex_count * 16);
@@ -1457,7 +1462,28 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         params.push("MODEL.MODELSOURCE=Undefined".to_string());
     }
 
+    // Re-emit any unmodelled keys captured on read (TEXTURE*, MODEL.2D.X/Y,
+    // IDENTIFIER, MODEL.MODELTYPE, the extrusion range, etc.), verbatim and in read
+    // order, so a read-modify-write does not drop them. Empty for a from-scratch
+    // body, so nothing is appended and the output stays byte-identical.
+    for (key, value) in &body.additional_parameters {
+        params.push(format!("{key}={value}"));
+    }
+
     params.join("|")
+}
+
+/// Appends `additional` `KEY=VALUE` pairs to an already-built `|`-joined parameter
+/// string, verbatim and in order. Returns `params` unchanged when `additional` is
+/// empty (the from-scratch case), so the output stays byte-identical.
+fn append_additional_params(mut params: String, additional: &[(String, String)]) -> String {
+    for (key, value) in additional {
+        params.push('|');
+        params.push_str(key);
+        params.push('=');
+        params.push_str(value);
+    }
+    params
 }
 
 // =============================================================================
@@ -2077,6 +2103,155 @@ mod tests {
         assert_eq!(r.union_index, 3);
         assert_eq!(r.sub_poly_index, 2);
         assert!(r.is_shape_based);
+    }
+
+    #[test]
+    fn region_additional_params_are_reemitted() {
+        use crate::altium::pcblib::primitives::Vertex;
+        // A region carrying unmodelled board-region keys must re-emit them verbatim
+        // after the canonical key set (round-trip fidelity — the reader captures them
+        // into `additional_parameters`).
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            additional_parameters: vec![
+                ("LAYER".to_string(), "TOP".to_string()),
+                ("KEEPOUT".to_string(), "TRUE".to_string()),
+                ("ISBOARDCUTOUT".to_string(), "FALSE".to_string()),
+            ],
+            ..Region::default()
+        };
+        let props = encode_region_properties(&region);
+        let param_len = u32::from_le_bytes(props[18..22].try_into().unwrap()) as usize;
+        let params = String::from_utf8_lossy(&props[22..22 + param_len]);
+        let params = params.trim_end_matches('\0');
+        // Canonical keys still present, and the extra keys appended (in order) after them.
+        assert!(params.contains("CAVITYHEIGHT=0mil"), "got: {params}");
+        assert!(
+            params.ends_with("|LAYER=TOP|KEEPOUT=TRUE|ISBOARDCUTOUT=FALSE"),
+            "extra keys must be appended verbatim after the canonical set: {params}"
+        );
+    }
+
+    #[test]
+    fn region_empty_additional_params_is_byte_identical() {
+        use crate::altium::pcblib::primitives::Vertex;
+        // The load-bearing property: a from-scratch region (empty additional_parameters)
+        // emits the EXACT canonical param string — the writer appends nothing.
+        let region = Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            ..Region::default()
+        };
+        assert!(region.additional_parameters.is_empty());
+        let props = encode_region_properties(&region);
+        let param_len = u32::from_le_bytes(props[18..22].try_into().unwrap()) as usize;
+        let params = &props[22..22 + param_len];
+        let expected = b"V7_LAYER=MECHANICAL4|NAME=|KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0\
+                         |ARCRESOLUTION=0mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil\0";
+        assert_eq!(
+            params,
+            expected.as_slice(),
+            "empty additional_parameters must not change the canonical param string: {}",
+            String::from_utf8_lossy(params)
+        );
+    }
+
+    #[test]
+    fn region_additional_params_survive_roundtrip() {
+        use super::super::reader::parse_data_stream;
+        use crate::altium::pcblib::primitives::Vertex;
+        // An unmodelled key captured on read must survive encode -> decode.
+        let mut fp = Footprint::new("R");
+        fp.add_region(Region {
+            vertices: vec![
+                Vertex { x: -1.0, y: -1.0 },
+                Vertex { x: 1.0, y: -1.0 },
+                Vertex { x: 1.0, y: 1.0 },
+                Vertex { x: -1.0, y: 1.0 },
+            ],
+            layer: Layer::TopCourtyard,
+            additional_parameters: vec![
+                ("LAYER".to_string(), "TOP".to_string()),
+                ("LAYERSTACKID".to_string(), "7".to_string()),
+            ],
+            ..Region::default()
+        });
+        let data = encode_data_stream(&fp).expect("encode should succeed");
+        let mut decoded = Footprint::new("R");
+        parse_data_stream(&mut decoded, &data, None);
+        assert_eq!(decoded.regions.len(), 1);
+        assert_eq!(
+            decoded.regions[0].additional_parameters,
+            vec![
+                ("LAYER".to_string(), "TOP".to_string()),
+                ("LAYERSTACKID".to_string(), "7".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn body_additional_params_are_reemitted_and_roundtrip() {
+        use super::super::reader;
+        // A body carrying unmodelled keys (TEXTURE, MODEL.2D.X) must re-emit them and
+        // survive encode -> decode into additional_parameters.
+        let mut model = ComponentBody::new("{G}", "part.step");
+        model.embedded = true;
+        model.additional_parameters = vec![
+            ("TEXTURE".to_string(), "wood".to_string()),
+            ("MODEL.2D.X".to_string(), "5mil".to_string()),
+        ];
+        let s = build_component_body_params(&model);
+        assert!(s.ends_with("|TEXTURE=wood|MODEL.2D.X=5mil"), "got: {s}");
+
+        let mut fp = Footprint::new("B");
+        fp.add_component_body(model);
+        let data = reader_encode_decode(&fp);
+        let mut decoded = Footprint::new("B");
+        reader::parse_data_stream(&mut decoded, &data, None);
+        let extra = &decoded.component_bodies[0].additional_parameters;
+        assert!(
+            extra.contains(&("TEXTURE".to_string(), "wood".to_string())),
+            "TEXTURE must round-trip, got: {extra:?}"
+        );
+        assert!(
+            extra.contains(&("MODEL.2D.X".to_string(), "5mil".to_string())),
+            "MODEL.2D.X must round-trip, got: {extra:?}"
+        );
+    }
+
+    #[test]
+    fn body_empty_additional_params_is_byte_identical() {
+        // A from-scratch body (empty additional_parameters) must emit the exact
+        // canonical param string — the writer appends nothing.
+        let mut model = ComponentBody::new("{G}", "part.step");
+        model.embedded = true;
+        assert!(model.additional_parameters.is_empty());
+        let s = build_component_body_params(&model);
+        let expected = "V7_LAYER=MECHANICAL6|NAME= |KIND=0|SUBPOLYINDEX=-1|UNIONINDEX=0|\
+            ARCRESOLUTION=0.5mil|ISSHAPEBASED=FALSE|CAVITYHEIGHT=0mil|STANDOFFHEIGHT=0mil|\
+            OVERALLHEIGHT=0mil|BODYPROJECTION=0|ARCRESOLUTION=0.5mil|BODYCOLOR3D=8421504|\
+            BODYOPACITY3D=1.000|IDENTIFIER=|TEXTURE=|TEXTURECENTERX=0mil|TEXTURECENTERY=0mil|\
+            TEXTURESIZEX=0.0001mil|TEXTURESIZEY=0.0001mil|TEXTUREROTATION= 0.00000000000000E+0000|\
+            MODELID={G}|MODEL.CHECKSUM=0|MODEL.EMBED=TRUE|MODEL.NAME=part.step|MODEL.2D.X=0mil|\
+            MODEL.2D.Y=0mil|MODEL.2D.ROTATION=0.000|MODEL.3D.ROTX=0.000|MODEL.3D.ROTY=0.000|\
+            MODEL.3D.ROTZ=0.000|MODEL.3D.DZ=0mil|MODEL.MODELTYPE=1|MODEL.MODELSOURCE=Undefined";
+        assert_eq!(s, expected);
+    }
+
+    /// Encodes then returns the data stream for a footprint (test helper).
+    fn reader_encode_decode(fp: &Footprint) -> Vec<u8> {
+        encode_data_stream(fp).expect("encode should succeed")
     }
 
     #[test]

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -368,6 +368,7 @@ impl McpServer {
                                                     }
                                                 },
                                                 "unique_id": { "type": "string", "description": "Unique ID (optional, 8-char alphanumeric). Default: none" },
+                                                "additional_parameters": { "type": "array", "description": "Unmodelled region parameter keys captured verbatim on read (e.g. board-region keys like LAYER, KEEPOUT, ISBOARDCUTOUT). Each entry is a [key, value] string pair. Round-tripped so a read-modify-write does not drop keys the tool does not model. Normally omitted; supply only the pairs read_pcblib returned.", "items": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 } },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
                                             "required": ["vertices", "layer"]
@@ -447,7 +448,8 @@ impl McpServer {
                                                 "model_id": { "type": "string", "description": "Model GUID referencing an embedded model (Altium MODELID). Default: \"\" (none)" },
                                                 "model_name": { "type": "string", "description": "Model filename or external path (Altium MODEL.NAME). Default: \"\" (none)" },
                                                 "embedded": { "type": "boolean", "description": "Whether the model is embedded in the library (Altium MODEL.EMBED). Default: false" },
-                                                "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" }
+                                                "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
+                                                "additional_parameters": { "type": "array", "description": "Unmodelled body parameter keys captured verbatim on read (e.g. TEXTURE, MODEL.2D.X, IDENTIFIER, MODEL.MODELTYPE, MODEL.MODELSOURCE, the extrusion range). Each entry is a [key, value] string pair. Round-tripped so a read-modify-write does not drop keys the tool does not model. Normally omitted; supply only the pairs read_pcblib returned.", "items": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 } }
                                             },
                                             "required": ["overall_height"]
                                         }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -509,6 +509,12 @@ impl McpServer {
             .and_then(Value::as_str)
             .map(str::to_string);
 
+        // Round-trip unmodelled board-region keys captured on read (a `read_pcblib`
+        // emits `additional_parameters` as an array of `[key, value]` pairs; accept
+        // that verbatim so a modify-write preserves them). Absent -> empty -> the
+        // writer appends nothing (byte-identical to a from-scratch region).
+        let additional_parameters = Self::parse_additional_parameters(json);
+
         Some(Region {
             vertices,
             holes,
@@ -519,8 +525,30 @@ impl McpServer {
             net_index,
             cavity_height,
             unique_id,
+            additional_parameters,
             ..Region::default()
         })
+    }
+
+    /// Parses an `additional_parameters` catch-all from a primitive's JSON: an
+    /// array of `[key, value]` string pairs (the shape `read_pcblib` emits for the
+    /// `Vec<(String, String)>` field). Missing/malformed entries yield an empty
+    /// vector, so a from-scratch primitive re-emits nothing.
+    pub(crate) fn parse_additional_parameters(json: &Value) -> Vec<(String, String)> {
+        json.get("additional_parameters")
+            .and_then(Value::as_array)
+            .map(|pairs| {
+                pairs
+                    .iter()
+                    .filter_map(|pair| {
+                        let arr = pair.as_array()?;
+                        let key = arr.first()?.as_str()?;
+                        let value = arr.get(1)?.as_str()?;
+                        Some((key.to_string(), value.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Parses text from JSON.
@@ -1700,6 +1728,36 @@ mod tests {
         }))
         .expect("region should parse");
         assert!(region.flags.contains(PcbFlags::KEEPOUT));
+    }
+
+    #[test]
+    fn parse_region_reads_additional_parameters() {
+        // PR-R5: the read DTO's `additional_parameters` (an array of [key, value]
+        // pairs) must land on the struct so a read-modify-write preserves them.
+        let region = McpServer::parse_region(&json!({
+            "layer": "Top Courtyard",
+            "vertices": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0}, {"x": 0.0, "y": 1.0}],
+            "additional_parameters": [["LAYER", "TOP"], ["LAYERSTACKID", "7"]],
+        }))
+        .expect("region should parse");
+        assert_eq!(
+            region.additional_parameters,
+            vec![
+                ("LAYER".to_string(), "TOP".to_string()),
+                ("LAYERSTACKID".to_string(), "7".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_region_additional_parameters_default_empty() {
+        // Absent -> empty, so a from-scratch region re-emits nothing (byte-identical).
+        let region = McpServer::parse_region(&json!({
+            "layer": "Top Courtyard",
+            "vertices": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.0}, {"x": 0.0, "y": 1.0}],
+        }))
+        .expect("region should parse");
+        assert!(region.additional_parameters.is_empty());
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -625,7 +625,8 @@ impl McpServer {
                             "net_index",
                             "cavity_height",
                             "holes",
-                            "unique_id"
+                            "unique_id",
+                            "additional_parameters"
                         ]
                     );
                     if let Some(region) = Self::parse_region(region_json) {
@@ -736,6 +737,7 @@ impl McpServer {
                             body_color_3d: 8_421_504,
                             body_opacity_3d: 1.0,
                             model_2d_rotation: 0.0,
+                            additional_parameters: Vec::new(),
                         });
                     }
                 }
@@ -845,6 +847,10 @@ impl McpServer {
                             .get("model_2d_rotation")
                             .and_then(Value::as_f64)
                             .unwrap_or(0.0),
+                        // Round-trip unmodelled body keys (TEXTURE*, MODEL.2D.X/Y,
+                        // etc.) captured on read. Absent -> empty -> the writer
+                        // appends nothing (byte-identical to a from-scratch body).
+                        additional_parameters: Self::parse_additional_parameters(body_json),
                     });
                 }
             }
@@ -922,6 +928,7 @@ impl McpServer {
                     body_color_3d: 8_421_504,
                     body_opacity_3d: 1.0,
                     model_2d_rotation: 0.0,
+                    additional_parameters: Vec::new(),
                 });
                 true
             } else {
@@ -2201,6 +2208,7 @@ mod tests {
             body_color_3d: 8_421_504,
             body_opacity_3d: 1.0,
             model_2d_rotation: 0.0,
+            additional_parameters: Vec::new(),
         };
 
         // Explicit extruded body: reports its height, not assumed.

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1106,6 +1106,82 @@ def test_write_pcblib_component_body_fields(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_additional_parameters_roundtrip(client, runner, lib_path):
+    print("\n=== Test: write_pcblib region/body additional_parameters round trip ===")
+    # Coverage PR-R5: Region and ComponentBody carry unmodelled |KEY=VAL| keys the
+    # typed model does not recognise. They must be authorable via
+    # additional_parameters (an array of [key, value] pairs) and round-trip through
+    # read_pcblib so a read-modify-write does not silently drop them.
+    region_extra = [["LAYER", "TOP"], ["ISBOARDCUTOUT", "FALSE"], ["LAYERSTACKID", "7"]]
+    body_extra = [["TEXTURE", "wood"], ["MODEL.2D.X", "5mil"]]
+    footprint = {
+        "name": "ADDL_PARAMS_RT",
+        "pads": [
+            {"designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
+        ],
+        "regions": [
+            {
+                "vertices": [
+                    {"x": -1.0, "y": -1.0},
+                    {"x": 1.0, "y": -1.0},
+                    {"x": 1.0, "y": 1.0},
+                    {"x": -1.0, "y": 1.0},
+                ],
+                "layer": "Top Layer",
+                "additional_parameters": region_extra,
+            }
+        ],
+        "component_bodies": [
+            {
+                "overall_height": 1.0,
+                "layer": "Top 3D Body",
+                "additional_parameters": body_extra,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"),
+        "write_pcblib (additional_parameters) succeeded",
+        actual=write,
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("ADDL_PARAMS_RT", {})
+    runner.check(bool(fp), "ADDL_PARAMS_RT footprint present", actual=list(footprints))
+
+    # The value is not DROPPING the keys; order/interleaving with Altium's own keys
+    # is not asserted (Altium's reader is order-independent), so we compare as sets.
+    regions = fp.get("regions", [])
+    runner.check(len(regions) == 1, "1 region survived", actual=len(regions))
+    if regions:
+        got = {(k, v) for k, v in regions[0].get("additional_parameters", [])}
+        want = {tuple(pair) for pair in region_extra}
+        runner.check(
+            want.issubset(got),
+            "region additional_parameters preserved",
+            actual=sorted(got),
+            expected=sorted(want),
+        )
+
+    bodies = fp.get("component_bodies", [])
+    runner.check(len(bodies) == 1, "1 component body survived", actual=len(bodies))
+    if bodies:
+        got = {(k, v) for k, v in bodies[0].get("additional_parameters", [])}
+        want = {tuple(pair) for pair in body_extra}
+        runner.check(
+            want.issubset(got),
+            "body additional_parameters preserved",
+            actual=sorted(got),
+            expected=sorted(want),
+        )
+
+
 def test_write_schlib_fields(client, runner, schlib_path):
     print("\n=== Test: write_schlib field-completeness round trip ===")
     # Coverage PR-12/PR-13: every primitive field the read tool round-trips must
@@ -1774,6 +1850,7 @@ def main():
         test_write_pcblib_via_slot_tolerances(client, runner, lib_path)
         test_write_pcblib_region_kind_net_name(client, runner, lib_path)
         test_write_pcblib_component_body_fields(client, runner, lib_path)
+        test_write_pcblib_additional_parameters_roundtrip(client, runner, lib_path)
         test_write_pcblib_text_font_style(client, runner, lib_path)
         test_write_pcblib_unique_id_roundtrip(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -447,6 +447,13 @@ fn samples_pcblib_regions() {
         );
         assert_eq!(region.sub_poly_index, -1, "golden SUBPOLYINDEX=-1");
         assert!(!region.is_shape_based, "golden ISSHAPEBASED=FALSE");
+        // These simple copper regions carry only the modelled keys, so the
+        // unmodelled-parameter catch-all is empty (PR-R5).
+        assert!(
+            region.additional_parameters.is_empty(),
+            "golden copper region has no unmodelled keys, got {:?}",
+            region.additional_parameters
+        );
     }
 
     assert!(
@@ -714,4 +721,30 @@ fn samples_pcblib_body3d() {
         approx_eq(max_y, 0.762, 1e-2),
         "outline max y: expected ~0.762 mm, got {max_y}",
     );
+
+    // PR-R5: the body's unmodelled keys (TEXTURE*, IDENTIFIER, the repeated
+    // ARCRESOLUTION, etc.) are captured verbatim into `additional_parameters` so a
+    // read-modify-write does not drop them. The golden carries these, so the map is
+    // non-empty and the keys the typed model consumes are NOT present in it.
+    let extra = &body.additional_parameters;
+    assert!(
+        !extra.is_empty(),
+        "golden body carries unmodelled keys; additional_parameters must not be empty",
+    );
+    let keys: Vec<&str> = extra.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(
+        keys.contains(&"TEXTURE"),
+        "expected TEXTURE captured, got {keys:?}"
+    );
+    assert!(
+        keys.contains(&"IDENTIFIER"),
+        "expected IDENTIFIER captured, got {keys:?}"
+    );
+    // Modelled keys must be excluded from the catch-all (they round-trip via fields).
+    for modelled in ["V7_LAYER", "NAME", "OVERALLHEIGHT", "MODELID", "MODEL.NAME"] {
+        assert!(
+            !keys.contains(&modelled),
+            "modelled key {modelled} must not appear in additional_parameters, got {keys:?}"
+        );
+    }
 }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -843,6 +843,7 @@ fn test_component_body_roundtrip() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);
 
@@ -898,6 +899,7 @@ fn test_component_body_with_rotation() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);
 
@@ -2708,6 +2710,7 @@ fn test_component_body_external_model_reference() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);
 


### PR DESCRIPTION
**Coverage roadmap PR-R5** (round-trip tier) — `additional_parameters` catch-all for Region + ComponentBody.

PcbLib Region + ComponentBody carry `|KEY=VAL|` param keys our model doesn't recognise (Region board-region keys `LAYER`/`KEEPOUT`/`OBJECTKIND`/`LAYERSTACKID`/…; ComponentBody `TEXTURE`/`MODEL.2D.X-Y`/`IDENTIFIER`/…). The reader dropped them and the writer emitted a fixed canonical string — so a **read-modify-write of a real Altium file silently lost them**.

## Change
- New `additional_parameters: Vec<(String, String)>` (order-preserving, keeps duplicate keys) on Region + ComponentBody.
- New shared `parse_pipe_params_ordered` iterates the `|KEY=VAL|` block in read order, **stopping at the NUL terminator** so trailing binary outline bytes aren't mis-parsed.
- Reader captures every key not matched to a modelled field; writer re-emits them after the canonical modelled keys.
- Tool round-trip: read DTO serde-automatic; `parse_region` + the `component_bodies` handler read it; schemas + region allow-list extended.

## Byte-identity
A from-scratch primitive has an **empty** map → the writer appends nothing → **byte-identical** to today (asserted by exact-canonical-string tests; **oracle 0 regressions**). Verified against the golden BODY3D — it now preserves `TEXTURE`/`IDENTIFIER`/`ARCRESOLUTION`/etc. (Altium's reader is order-independent, so a re-written file's key order needn't match — the point is not dropping them.)

## Deferred
ComponentBody raw-outline sub-coordinate precision (i32 vertex quantisation).

## Test
Ordered-parser (order/duplicates/NUL) + region/body re-emit + round-trip + byte-identity + golden assertions + Python `test_write_pcblib_additional_parameters_roundtrip`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (358) / **integration 275/275** / **oracle 0 regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
