### PR TITLE
feat(pcblib): common-header net/polygon/component indices (PR-R4)

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -811,6 +811,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
         original.add_text(Text {
@@ -829,6 +832,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::TopLeft,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
 
@@ -875,6 +881,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
 
@@ -909,6 +918,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
 
@@ -943,6 +955,9 @@ mod tests {
             // BottomLeft is the from-scratch default; it encodes to the template's 0x03.
             justification: TextJustification::BottomLeft,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
         assert_eq!(
@@ -989,6 +1004,9 @@ mod tests {
             font_name: "Times New Roman".to_string(),
             justification: TextJustification::TopRight,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
 
@@ -1031,6 +1049,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::LOCKED | PcbFlags::TENTING_TOP,
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         });
 
@@ -1041,6 +1062,80 @@ mod tests {
         assert_eq!(decoded.text.len(), 1);
         assert!(decoded.text[0].flags.contains(PcbFlags::LOCKED));
         assert!(decoded.text[0].flags.contains(PcbFlags::TENTING_TOP));
+    }
+
+    #[test]
+    fn binary_roundtrip_common_indices() {
+        // A board-context Track and Text carrying a net/component association must
+        // survive encode -> decode via the common-header indices (@3 net, @5
+        // polygon, @7 component). Previously these header bytes were dropped on
+        // read and hard-coded to 0xFF on write, so the association was lost.
+        let mut original = Footprint::new("ROUNDTRIP_INDICES");
+
+        let mut track = Track::new(-1.0, 0.0, 1.0, 0.0, 0.25, Layer::TopLayer);
+        track.net_index = 5;
+        track.polygon_index = 2;
+        track.component_index = 3;
+        original.add_track(track);
+
+        original.add_text(Text {
+            x: 0.0,
+            y: 1.0,
+            text: "NET".to_string(),
+            height: 0.8,
+            layer: Layer::TopOverlay,
+            rotation: 0.0,
+            kind: TextKind::Stroke,
+            stroke_font: None,
+            stroke_width: None,
+            italic: false,
+            bold: false,
+            mirror: false,
+            font_name: "Arial".to_string(),
+            justification: TextJustification::MiddleCenter,
+            flags: PcbFlags::empty(),
+            net_index: 9,
+            polygon_index: 0xFFFF,
+            component_index: 4,
+            unique_id: None,
+        });
+
+        let data = writer::encode_data_stream(&original).expect("encoding should succeed");
+        let mut decoded = Footprint::new("ROUNDTRIP_INDICES");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.tracks.len(), 1);
+        assert_eq!(decoded.tracks[0].net_index, 5, "track net index");
+        assert_eq!(decoded.tracks[0].polygon_index, 2, "track polygon index");
+        assert_eq!(
+            decoded.tracks[0].component_index, 3,
+            "track component index"
+        );
+
+        assert_eq!(decoded.text.len(), 1);
+        assert_eq!(decoded.text[0].net_index, 9, "text net index");
+        assert_eq!(
+            decoded.text[0].polygon_index, 0xFFFF,
+            "text polygon stays none"
+        );
+        assert_eq!(decoded.text[0].component_index, 4, "text component index");
+    }
+
+    #[test]
+    fn binary_roundtrip_default_indices_are_none() {
+        // A from-scratch primitive reads back the "none" defaults (net/polygon
+        // 0xFFFF, component -1), confirming the 0xFF header bytes decode correctly.
+        let mut original = Footprint::new("DEFAULT_INDICES");
+        original.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::TopOverlay));
+
+        let data = writer::encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("DEFAULT_INDICES");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        assert_eq!(decoded.tracks.len(), 1);
+        assert_eq!(decoded.tracks[0].net_index, 0xFFFF);
+        assert_eq!(decoded.tracks[0].polygon_index, 0xFFFF);
+        assert_eq!(decoded.tracks[0].component_index, -1);
     }
 
     #[test]
@@ -1107,6 +1202,9 @@ mod tests {
             layer: Layer::BottomPaste,
             rotation: 45.0,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,
@@ -1194,6 +1292,9 @@ mod tests {
             body_color_3d: 8_421_504,
             body_opacity_3d: 1.0,
             model_2d_rotation: 0.0,
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             additional_parameters: Vec::new(),
         };
         original.add_component_body(body);
@@ -1259,6 +1360,9 @@ mod tests {
                 body_color_3d: 8_421_504,
                 body_opacity_3d: 1.0,
                 model_2d_rotation: 0.0,
+                net_index: 0xFFFF,
+                polygon_index: 0xFFFF,
+                component_index: -1,
                 additional_parameters: Vec::new(),
             });
         }

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -177,6 +177,21 @@ pub struct ComponentBody {
     #[serde(default)]
     pub model_2d_rotation: f64,
 
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+
+    /// Polygon index this body belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
+
     /// Unmodelled parameter keys read verbatim from the body's `KEY=VALUE|...`
     /// block, in read order. An Altium body carries keys the typed model does not
     /// recognise (e.g. `TEXTURE`, `TEXTURECENTERX`, `MODEL.2D.X`, `MODEL.2D.Y`,
@@ -191,6 +206,24 @@ pub struct ComponentBody {
 
 const fn default_body_color() -> u32 {
     8_421_504
+}
+
+/// Default net index for a from-scratch body (`0xFFFF` = no net). The
+/// common-header connectivity indices default to "none" so a free library
+/// body writes the same `0xFF` header bytes as before (byte-identity).
+const fn default_net_index() -> u16 {
+    0xFFFF
+}
+
+/// Default polygon index for a from-scratch body (`0xFFFF` = none).
+const fn default_polygon_index() -> u16 {
+    0xFFFF
+}
+
+/// Default component index for a from-scratch body (`-1` = free primitive,
+/// stored as the `0xFFFF` common-header sentinel).
+const fn default_component_index() -> i32 {
+    -1
 }
 
 const fn default_opacity() -> f64 {
@@ -232,6 +265,9 @@ impl ComponentBody {
             body_color_3d: default_body_color(),
             body_opacity_3d: default_opacity(),
             model_2d_rotation: 0.0,
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             additional_parameters: Vec::new(),
         }
     }

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -219,6 +219,21 @@ pub struct Pad {
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
 
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+
+    /// Polygon index this pad belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
+
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -228,6 +243,24 @@ pub struct Pad {
 #[allow(clippy::trivially_copy_pass_by_ref)] // serde requires reference
 fn is_default_hole_shape(shape: &HoleShape) -> bool {
     *shape == HoleShape::default()
+}
+
+/// Default net index for a from-scratch pad/via (`0xFFFF` = no net). The
+/// common-header connectivity indices default to "none" so a free library
+/// primitive writes the same `0xFF` header bytes as before (byte-identity).
+const fn default_net_index() -> u16 {
+    0xFFFF
+}
+
+/// Default polygon index for a from-scratch pad/via (`0xFFFF` = none).
+const fn default_polygon_index() -> u16 {
+    0xFFFF
+}
+
+/// Default component index for a from-scratch pad/via (`-1` = free primitive,
+/// stored as the `0xFFFF` common-header sentinel).
+const fn default_component_index() -> i32 {
+    -1
 }
 
 /// Default pad thermal-relief conductor width (10 mil = 0.254mm; raw 100000).
@@ -291,6 +324,9 @@ impl Pad {
             per_layer_corner_radii: None,
             per_layer_offsets: None,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             unique_id: None,
         }
     }
@@ -337,6 +373,9 @@ impl Pad {
             per_layer_corner_radii: None,
             per_layer_offsets: None,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             unique_id: None,
         }
     }
@@ -554,6 +593,16 @@ pub struct Via {
     #[serde(default = "default_via_net_index")]
     pub net_index: u16,
 
+    /// Polygon index this via belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
+
     /// Bottom-face solder-mask expansion in mm (Altium geometry offset 242). `None`
     /// mirrors the front-face `solder_mask_expansion` (Altium's template encodes both
     /// faces equally), so a default via round-trips byte-identically.
@@ -680,6 +729,8 @@ impl Via {
             power_plane_relief_expansion: 0.508, // 20 mils
             power_plane_clearance: 0.508,        // 20 mils
             net_index: 0xFFFF,                   // no net
+            polygon_index: 0xFFFF,               // none
+            component_index: -1,                 // free primitive
             thermal_relief_gap: 0.254,           // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils
@@ -717,6 +768,8 @@ impl Via {
             power_plane_relief_expansion: 0.508, // 20 mils
             power_plane_clearance: 0.508,        // 20 mils
             net_index: 0xFFFF,                   // no net
+            polygon_index: 0xFFFF,               // none
+            component_index: -1,                 // free primitive
             thermal_relief_gap: 0.254,           // 10 mils
             thermal_relief_conductors: 4,
             thermal_relief_width: 0.254, // 10 mils

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -3,6 +3,24 @@
 #[allow(clippy::wildcard_imports)] // sibling primitive types
 use super::*;
 
+/// Default net index for a from-scratch primitive (`0xFFFF` = no net). The
+/// common-header connectivity indices default to "none" so a free library
+/// primitive writes the same `0xFF` header bytes as before (byte-identity).
+pub(super) const fn default_net_index() -> u16 {
+    0xFFFF
+}
+
+/// Default polygon index for a from-scratch primitive (`0xFFFF` = none).
+pub(super) const fn default_polygon_index() -> u16 {
+    0xFFFF
+}
+
+/// Default component index for a from-scratch primitive (`-1` = free primitive,
+/// stored as the `0xFFFF` common-header sentinel).
+pub(super) const fn default_component_index() -> i32 {
+    -1
+}
+
 /// A track (line segment) on a layer.
 ///
 /// Tracks are used to draw silkscreen outlines, keepout boundaries, and other
@@ -45,6 +63,18 @@ pub struct Track {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+    /// Polygon index this track belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -73,6 +103,9 @@ impl Track {
             width,
             layer,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             unique_id: None,
             solder_mask_expansion: None,
             keepout_restrictions: None,
@@ -111,6 +144,9 @@ impl Track {
 ///     width: 0.15,
 ///     layer: Layer::TopOverlay,
 ///     flags: Default::default(),
+///     net_index: 0xFFFF,
+///     polygon_index: 0xFFFF,
+///     component_index: -1,
 ///     unique_id: None,
 ///     solder_mask_expansion: None,
 ///     keepout_restrictions: None,
@@ -141,6 +177,18 @@ pub struct Arc {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+    /// Polygon index this arc belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -170,6 +218,9 @@ impl Arc {
             width,
             layer,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             unique_id: None,
             solder_mask_expansion: None,
             keepout_restrictions: None,

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -57,6 +57,24 @@ fn default_font_name() -> String {
     "Arial".to_string()
 }
 
+/// Default net index for a from-scratch text/fill (`0xFFFF` = no net). The
+/// common-header connectivity indices default to "none" so a free library
+/// primitive writes the same `0xFF` header bytes as before (byte-identity).
+const fn default_net_index() -> u16 {
+    0xFFFF
+}
+
+/// Default polygon index for a from-scratch text/fill (`0xFFFF` = none).
+const fn default_polygon_index() -> u16 {
+    0xFFFF
+}
+
+/// Default component index for a from-scratch text/fill (`-1` = free primitive,
+/// stored as the `0xFFFF` common-header sentinel).
+const fn default_component_index() -> i32 {
+    -1
+}
+
 /// A text string on a layer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Text {
@@ -119,6 +137,18 @@ pub struct Text {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+    /// Polygon index this text belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
@@ -147,6 +177,18 @@ pub struct Fill {
     /// Primitive flags (locked, keepout, etc.).
     #[serde(default, skip_serializing_if = "PcbFlags::is_empty")]
     pub flags: PcbFlags,
+    /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
+    /// (65535) means "no net", the from-scratch default (round-trip fidelity).
+    #[serde(default = "default_net_index")]
+    pub net_index: u16,
+    /// Polygon index this fill belongs to — common-header u16 @5. `0xFFFF`
+    /// (none) from scratch, matching the historical writer output.
+    #[serde(default = "default_polygon_index")]
+    pub polygon_index: u16,
+    /// Component index into the board's component list — common-header u16 @7
+    /// (`0xFFFF` stored, exposed as `-1`). `-1` (free primitive) from scratch.
+    #[serde(default = "default_component_index")]
+    pub component_index: i32,
     /// Solder-mask expansion override in mm (geometry offset 37). `None` uses the
     /// rule default; round-trips like the Track/Arc extended tail.
     #[serde(
@@ -175,6 +217,9 @@ impl Fill {
             layer,
             rotation: 0.0,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,
@@ -194,6 +239,9 @@ impl Fill {
             layer,
             rotation: 0.0,
             flags: PcbFlags::empty(),
+            net_index: default_net_index(),
+            polygon_index: default_polygon_index(),
+            component_index: default_component_index(),
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -3,6 +3,25 @@
 #[allow(clippy::wildcard_imports)] // tightly-coupled reader split
 use super::*;
 
+/// Reads the common-header connectivity indices from a primitive block/header:
+/// net index (u16 @3-4), polygon index (u16 @5-6) and component index (u16 @7-8,
+/// exposed as `i32` with the `0xFFFF` sentinel mapped to `-1`).
+///
+/// These live in the `CommonPrimitiveData` header shared by every `PcbLib`
+/// primitive. A missing byte (short header) or the `0xFFFF` sentinel reads back as the
+/// from-scratch "none" default (`0xFFFF` / `0xFFFF` / `-1`). Inverse of
+/// [`super::super::writer`]'s `write_common_indices`; factored so every parser
+/// shares one implementation (mirrors how `parse_region` already reads @3/@5/@7).
+fn read_common_indices(header: &[u8]) -> (u16, u16, i32) {
+    let net_index = read_u16(header, 3).unwrap_or(0xFFFF);
+    let polygon_index = read_u16(header, 5).unwrap_or(0xFFFF);
+    let component_index = match read_u16(header, 7).unwrap_or(0xFFFF) {
+        0xFFFF => -1,
+        ci => i32::from(ci),
+    };
+    (net_index, polygon_index, component_index)
+}
+
 /// Parses a Pad primitive.
 /// Returns the parsed `Pad` and the new offset on success.
 ///
@@ -86,6 +105,8 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
     let layer_id = geometry[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(geometry);
+    // Common-header connectivity indices @3-8 (net/polygon/component).
+    let (net_index, polygon_index, component_index) = read_common_indices(geometry);
 
     // Location (X, Y) - offsets 13-20
     let x =
@@ -298,6 +319,9 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         per_layer_shapes,
         per_layer_corner_radii,
         per_layer_offsets,
+        net_index,
+        polygon_index,
+        component_index,
         flags,
         unique_id: None,
     };
@@ -468,8 +492,9 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
     // Common-header flag word @1-2 (locked/keepout/tenting top+bottom). Tenting a
     // via is the highest-value property here — it covers the pad with solder mask.
     let flags = read_flags(block);
-    // Net index @3-4 (u16; 0xFFFF = no net). Read-only surface for footprint vias.
-    let net_index = read_u16(block, 3).unwrap_or(0xFFFF);
+    // Common-header connectivity indices @3-8 (net/polygon/component). Read-only
+    // surface for footprint vias (a free via keeps the 0xFFFF/none defaults).
+    let (net_index, polygon_index, component_index) = read_common_indices(block);
 
     // Extended SubRecord-1 fields (offsets 31-74). A short block falls back to
     // the same defaults the Via struct uses.
@@ -535,6 +560,8 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         power_plane_relief_expansion,
         power_plane_clearance,
         net_index,
+        polygon_index,
+        component_index,
         thermal_relief_gap,
         thermal_relief_conductors,
         thermal_relief_width,
@@ -577,6 +604,8 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
     let layer_id = block[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(block);
+    // Common-header connectivity indices @3-8 (net/polygon/component).
+    let (net_index, polygon_index, component_index) = read_common_indices(block);
 
     // Start coordinates (X, Y) - offsets 13-20
     let x1 = to_mm(read_i32(block, 13).ok_or_else(|| {
@@ -614,6 +643,9 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
         width,
         layer,
         flags,
+        net_index,
+        polygon_index,
+        component_index,
         unique_id: None,
         solder_mask_expansion,
         keepout_restrictions,
@@ -643,6 +675,8 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
     let layer_id = block[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(block);
+    // Common-header connectivity indices @3-8 (net/polygon/component).
+    let (net_index, polygon_index, component_index) = read_common_indices(block);
 
     // Centre coordinates (X, Y) - offsets 13-20
     let x =
@@ -683,6 +717,9 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
         width,
         layer,
         flags,
+        net_index,
+        polygon_index,
+        component_index,
         unique_id: None,
         solder_mask_expansion,
         keepout_restrictions,
@@ -738,6 +775,8 @@ pub(super) fn parse_text(
     // Decode the lock/tenting/keepout flag word like every other primitive does,
     // rather than discarding it (the write side already encodes these correctly).
     let flags = read_flags(geometry_block);
+    // Common-header connectivity indices @3-8 (net/polygon/component).
+    let (net_index, polygon_index, component_index) = read_common_indices(geometry_block);
 
     // The authoritative text kind lives at offset 160 in the 252-byte record
     // (0 = Stroke, 1 = TrueType, 2 = BarCode).
@@ -841,6 +880,9 @@ pub(super) fn parse_text(
         font_name,
         justification,
         flags,
+        net_index,
+        polygon_index,
+        component_index,
         unique_id: None,
     };
 
@@ -1068,12 +1110,7 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     let layer_id = props_block[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(props_block);
-    let net_index = read_u16(props_block, 3).unwrap_or(0xFFFF);
-    let polygon_index = read_u16(props_block, 5).unwrap_or(0xFFFF);
-    let component_index = match read_u16(props_block, 7).unwrap_or(0xFFFF) {
-        0xFFFF => -1,
-        ci => i32::from(ci),
-    };
+    let (net_index, polygon_index, component_index) = read_common_indices(props_block);
 
     // @13 reserved | @14-15 hole_count (u16) | @16-17 reserved. The trailing hole
     // contours (if any) follow the outline. A no-hole region reports 0 here.
@@ -1245,6 +1282,8 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
     let layer_id = block[0];
     let layer = layer_from_id(layer_id);
     let flags = read_flags(block);
+    // Common-header connectivity indices @3-8 (net/polygon/component).
+    let (net_index, polygon_index, component_index) = read_common_indices(block);
 
     // Coordinates at offset 13
     let x1 = to_mm(read_i32(block, 13).ok_or_else(|| {
@@ -1277,6 +1316,9 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
         layer,
         rotation,
         flags,
+        net_index,
+        polygon_index,
+        component_index,
         solder_mask_expansion,
         keepout_restrictions,
         unique_id: None,
@@ -1366,6 +1408,11 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         .or_else(|| params.get("V7_LAYER").and_then(|v| parse_v7_layer(v)))
         .unwrap_or(Layer::Top3DBody);
 
+    // Common-header connectivity indices @3-8 (net/polygon/component). The body's
+    // block starts with the layer byte @0, the 0x0C/0x00 record-type marker @1-2,
+    // then the net/polygon/component words @3-8 (0xFF padding for a free body).
+    let (net_index, polygon_index, component_index) = read_common_indices(block0);
+
     // Additive fields previously discarded. Each default matches the writer's
     // hard-coded literal default so a default body round-trips byte-identically.
     let name = params
@@ -1422,6 +1469,9 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         body_color_3d,
         body_opacity_3d,
         model_2d_rotation,
+        net_index,
+        polygon_index,
+        component_index,
         additional_parameters,
     };
 

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -170,6 +170,9 @@ impl PcbLib {
                 body_color_3d: 8_421_504,
                 body_opacity_3d: 1.0,
                 model_2d_rotation: 0.0,
+                net_index: 0xFFFF,
+                polygon_index: 0xFFFF,
+                component_index: -1,
                 additional_parameters: Vec::new(),
             });
 

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -258,6 +258,31 @@ fn write_common_header(data: &mut Vec<u8>, layer: Layer, flags: PcbFlags) {
     data.extend_from_slice(&[0xFF; 10]);
 }
 
+/// Overlays the common-header connectivity indices onto the `0xFF` fill
+/// [`write_common_header`] writes: net index (u16 @3-4), polygon index
+/// (u16 @5-6) and component index (i32 modelled, stored as u16 @7-8 with
+/// `-1` -> the `0xFFFF` sentinel).
+///
+/// The from-scratch "none" defaults — `net = 0xFFFF`, `polygon = 0xFFFF`,
+/// `component = -1` (-> `0xFFFF`) — reproduce the header's `0xFF FF` bytes exactly,
+/// so a default primitive stays byte-identical to the previous hard-coded output
+/// (the oracle depends on this). `block` must be at least 9 bytes long.
+///
+/// Mirrors how [`encode_region_properties`] / [`encode_via`] already overlay these
+/// bytes; factored so every primitive encoder shares one implementation.
+fn write_common_indices(
+    block: &mut [u8],
+    net_index: u16,
+    polygon_index: u16,
+    component_index: i32,
+) {
+    block[3..5].copy_from_slice(&net_index.to_le_bytes());
+    block[5..7].copy_from_slice(&polygon_index.to_le_bytes());
+    // -1 (free primitive) and any out-of-range value store as the 0xFFFF sentinel.
+    let component_word = u16::try_from(component_index).unwrap_or(0xFFFF);
+    block[7..9].copy_from_slice(&component_word.to_le_bytes());
+}
+
 /// Encodes footprint primitives to binary format.
 ///
 /// # Errors
@@ -638,8 +663,14 @@ fn build_pad_extended_tail(pad: &Pad) -> [u8; 141] {
 fn encode_pad_geometry(pad: &Pad) -> Vec<u8> {
     let mut block = Vec::with_capacity(PAD_MAIN_BLOCK_LEN);
 
-    // Common header (13 bytes) - offsets 0-12
+    // Common header (13 bytes) - offsets 0-12 + connectivity indices @3-8.
     write_common_header(&mut block, pad.layer, pad.flags);
+    write_common_indices(
+        &mut block,
+        pad.net_index,
+        pad.polygon_index,
+        pad.component_index,
+    );
 
     // Location (X, Y) - offsets 13-20
     write_i32(&mut block, from_mm(pad.x));
@@ -748,9 +779,15 @@ fn encode_via(data: &mut Vec<u8>, via: &Via) {
     write_common_header(&mut header, Layer::MultiLayer, via.flags);
     block[0..13].copy_from_slice(&header);
 
-    // Net index @3-4 (u16; 0xFFFF = no net). Overlays the header's 0xFF bytes; a
-    // default via keeps 0xFFFF so the template bytes are reproduced unchanged.
-    block[3..5].copy_from_slice(&via.net_index.to_le_bytes());
+    // Connectivity indices @3-8 (net/polygon/component). Overlays the header's
+    // 0xFF bytes; a default via keeps 0xFFFF/none so the template bytes are
+    // reproduced unchanged (byte-identity).
+    write_common_indices(
+        &mut block,
+        via.net_index,
+        via.polygon_index,
+        via.component_index,
+    );
 
     // Geometry (offsets 13-30).
     block[13..17].copy_from_slice(&from_mm(via.x).to_le_bytes());
@@ -904,8 +941,14 @@ const fn stroke_font_to_id(font: StrokeFont) -> u16 {
 fn encode_track(data: &mut Vec<u8>, track: &Track) {
     let mut block = Vec::with_capacity(64);
 
-    // Common header (13 bytes)
+    // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
     write_common_header(&mut block, track.layer, track.flags);
+    write_common_indices(
+        &mut block,
+        track.net_index,
+        track.polygon_index,
+        track.component_index,
+    );
 
     // Start coordinates (X, Y) - offsets 13-20
     write_i32(&mut block, from_mm(track.x1));
@@ -937,8 +980,14 @@ fn encode_track(data: &mut Vec<u8>, track: &Track) {
 fn encode_arc(data: &mut Vec<u8>, arc: &Arc) {
     let mut block = Vec::with_capacity(64);
 
-    // Common header (13 bytes)
+    // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
     write_common_header(&mut block, arc.layer, arc.flags);
+    write_common_indices(
+        &mut block,
+        arc.net_index,
+        arc.polygon_index,
+        arc.component_index,
+    );
 
     // Centre coordinates (X, Y) - offsets 13-20
     write_i32(&mut block, from_mm(arc.x));
@@ -1024,6 +1073,16 @@ pub fn encode_text_geometry(text: &Text) -> Vec<u8> {
     let mut header = Vec::with_capacity(13);
     write_common_header(&mut header, text.layer, text.flags);
     block[..13].copy_from_slice(&header);
+
+    // Connectivity indices @3-8 (net/polygon/component). Overlays the header's
+    // 0xFF bytes; defaults keep 0xFFFF/none so a from-scratch text stays
+    // byte-identical to the template.
+    write_common_indices(
+        &mut block,
+        text.net_index,
+        text.polygon_index,
+        text.component_index,
+    );
 
     // Position and height (offsets 13-24).
     block[13..17].copy_from_slice(&from_mm(text.x).to_le_bytes());
@@ -1171,15 +1230,16 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
 
     // Common header (13 bytes): layer + flag word, then the net/polygon/component
     // indices. `write_common_header` fills bytes 3-12 with 0xFF (a free primitive);
-    // we overlay the modelled indices. Defaults (net=0xFFFF, poly=0xFFFF,
-    // component=-1 -> 0xFFFF) leave the 0xFF bytes untouched, so a from-scratch
-    // region stays byte-identical.
+    // `write_common_indices` overlays the modelled indices. Defaults (net=0xFFFF,
+    // poly=0xFFFF, component=-1 -> 0xFFFF) leave the 0xFF bytes untouched, so a
+    // from-scratch region stays byte-identical.
     write_common_header(&mut block, region.layer, region.flags);
-    block[3..5].copy_from_slice(&region.net_index.to_le_bytes());
-    block[5..7].copy_from_slice(&region.polygon_index.to_le_bytes());
-    // -1 (free primitive) and any out-of-range value store as the 0xFFFF sentinel.
-    let component_word = u16::try_from(region.component_index).unwrap_or(0xFFFF);
-    block[7..9].copy_from_slice(&component_word.to_le_bytes());
+    write_common_indices(
+        &mut block,
+        region.net_index,
+        region.polygon_index,
+        region.component_index,
+    );
 
     // @13 reserved | @14-15 hole_count (u16 LE) | @16-17 reserved. With no holes
     // this collapses to `00 00 00 00 00`, byte-identical to the previous output.
@@ -1240,8 +1300,14 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
     // Total block size: 13 + 16 + 8 + 13 = 50 bytes
     let mut block = Vec::with_capacity(50);
 
-    // Common header (13 bytes)
+    // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
     write_common_header(&mut block, fill.layer, fill.flags);
+    write_common_indices(
+        &mut block,
+        fill.net_index,
+        fill.polygon_index,
+        fill.component_index,
+    );
 
     // Corner coordinates (16 bytes)
     write_i32(&mut block, from_mm(fill.x1));
@@ -1301,8 +1367,18 @@ fn encode_component_body_block(body: &ComponentBody, outline: &[(f64, f64)]) -> 
     block.push(0x0C);
     block.push(0x00);
 
-    // 0xFF padding (10 bytes)
+    // 0xFF padding (10 bytes) @3-12: net/polygon/component indices + reserved.
     block.extend_from_slice(&[0xFF; 10]);
+
+    // Connectivity indices @3-8 (net/polygon/component). Overlays the 0xFF
+    // padding; defaults keep 0xFFFF/none so a from-scratch body's header bytes
+    // are reproduced unchanged (byte-identity).
+    write_common_indices(
+        &mut block,
+        body.net_index,
+        body.polygon_index,
+        body.component_index,
+    );
 
     // Zeros (5 bytes)
     block.extend_from_slice(&[0x00; 5]);
@@ -1832,6 +1908,99 @@ mod tests {
         assert_eq!(&b[628..632], &1i32.to_le_bytes(), "tail entry count = 1");
         assert_eq!(&b[632..636], &15i32.to_le_bytes(), "tail entry stride = 15");
         assert_eq!(b[649], 50, "tail entry corner is a fixed 50");
+    }
+
+    #[test]
+    fn common_indices_default_to_ff_bytes() {
+        // Byte-identity guard (oracle): a from-scratch primitive's connectivity
+        // indices default to "none" (net=0xFFFF, polygon=0xFFFF, component=-1 ->
+        // 0xFFFF), which must reproduce the header fill's `0xFF FF` bytes @3-8
+        // exactly. Any drift here re-introduces a byte diff the oracle would flag.
+        let mut block = vec![0u8; 13];
+        write_common_header(&mut block, Layer::TopLayer, PcbFlags::empty());
+        // A from-scratch track/arc/etc. uses these defaults.
+        write_common_indices(&mut block, 0xFFFF, 0xFFFF, -1);
+        assert_eq!(
+            &block[3..9],
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+            "default indices must reproduce the 0xFF header fill @3-8"
+        );
+    }
+
+    #[test]
+    fn common_indices_overlay_modelled_values() {
+        // A set net/polygon/component overlays the header fill at the right offsets
+        // in LE, with component `-1` mapping to the 0xFFFF sentinel.
+        let mut block = vec![0u8; 13];
+        write_common_header(&mut block, Layer::TopLayer, PcbFlags::empty());
+        write_common_indices(&mut block, 0x1234, 0x5678, 42);
+        assert_eq!(&block[3..5], &0x1234u16.to_le_bytes(), "net @3-4");
+        assert_eq!(&block[5..7], &0x5678u16.to_le_bytes(), "polygon @5-6");
+        assert_eq!(&block[7..9], &42u16.to_le_bytes(), "component @7-8");
+    }
+
+    #[test]
+    fn track_from_scratch_header_bytes_byte_identical() {
+        // A default Track encodes the same 0xFF header bytes @3-8 as before the
+        // indices were modelled (byte-identity for the oracle).
+        let track = Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::TopOverlay);
+        let mut data = Vec::new();
+        encode_track(&mut data, &track);
+        // Skip the 4-byte block length prefix; header is @0 of the block body.
+        let block = &data[4..];
+        assert_eq!(
+            &block[3..9],
+            &[0xFF; 6],
+            "from-scratch track must keep the 0xFF net/polygon/component bytes"
+        );
+    }
+
+    #[test]
+    fn text_from_scratch_header_bytes_byte_identical() {
+        use crate::altium::TextJustification;
+        // A default Text's geometry block keeps the template's 0xFF header bytes @3-8.
+        let text = Text {
+            x: 0.0,
+            y: 0.0,
+            text: "X".to_string(),
+            height: 1.0,
+            layer: Layer::TopOverlay,
+            rotation: 0.0,
+            kind: TextKind::Stroke,
+            stroke_font: None,
+            stroke_width: None,
+            italic: false,
+            bold: false,
+            mirror: false,
+            font_name: "Arial".to_string(),
+            justification: TextJustification::BottomLeft,
+            flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
+            unique_id: None,
+        };
+        let geom = encode_text_geometry(&text);
+        assert_eq!(
+            &geom[3..9],
+            &[0xFF; 6],
+            "from-scratch text must keep the 0xFF net/polygon/component bytes"
+        );
+    }
+
+    #[test]
+    fn track_indices_encode_into_header() {
+        // A track carrying a net/component association writes those indices into
+        // the common header @3-8 (round-trip fidelity for a board-context primitive).
+        let mut track = Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::TopLayer);
+        track.net_index = 7;
+        track.component_index = 3;
+        let mut data = Vec::new();
+        encode_track(&mut data, &track);
+        let block = &data[4..];
+        assert_eq!(&block[3..5], &7u16.to_le_bytes(), "net @3-4");
+        assert_eq!(&block[5..7], &0xFFFFu16.to_le_bytes(), "polygon stays none");
+        assert_eq!(&block[7..9], &3u16.to_le_bytes(), "component @7-8");
     }
 
     #[test]
@@ -2524,6 +2693,9 @@ mod tests {
             font_name: "Arial".to_string(),
             justification: TextJustification::MiddleCenter,
             flags: PcbFlags::empty(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             unique_id: None,
         };
         let mut fp = Footprint::new("WS");

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -227,6 +227,9 @@ impl McpServer {
                                                 "relief_air_gap": { "type": "number", "description": "Thermal-relief air-gap width in mm. Default: 0.254 (10 mil)" },
                                                 "power_plane_relief_expansion": { "type": "number", "description": "Power-plane relief expansion in mm. Default: 0.508 (20 mil)" },
                                                 "power_plane_clearance": { "type": "number", "description": "Power-plane (anti-pad) clearance to the plane in mm. Default: 0.508 (20 mil)" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
@@ -247,6 +250,9 @@ impl McpServer {
                                                 "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Top Courtyard, Mechanical 1, etc." },
                                                 "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
                                                 "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
@@ -283,6 +289,8 @@ impl McpServer {
                                                 "power_plane_clearance": { "type": "number", "description": "Power-plane (anti-pad) clearance in mm. Default: 0.508 (20 mil)" },
                                                 "paste_mask_expansion": { "type": "number", "description": "Paste-mask expansion in mm. Default: 0" },
                                                 "net_index": { "type": "integer", "description": "Net index into the board net list (0-65534; 65535 = no net). Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "hole_positive_tolerance": { "type": "number", "description": "Positive drill tolerance in mm (optional; omit to leave unset)" },
                                                 "hole_negative_tolerance": { "type": "number", "description": "Negative drill tolerance in mm (optional; omit to leave unset)" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
@@ -305,6 +313,9 @@ impl McpServer {
                                                 "rotation": { "type": "number", "description": "Rotation in degrees. Default: 0" },
                                                 "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
                                                 "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
@@ -326,6 +337,9 @@ impl McpServer {
                                                 "layer": { "type": "string", "description": "Layer name: Top Overlay, Top Assembly, Mechanical 1, etc." },
                                                 "solder_mask_expansion": { "type": "number", "description": "Solder mask expansion override in mm (optional; omit to use the rule default)" },
                                                 "keepout_restrictions": { "type": "integer", "description": "Keepout restriction bitmask (optional; defaults to 0)" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
@@ -352,6 +366,8 @@ impl McpServer {
                                                 "kind": { "type": ["string", "integer"], "description": "Region kind (optional). \"copper\" (default) for a copper pour/fill, \"cutout\" for a board/polygon cutout, or a raw Altium KIND integer. Default: copper" },
                                                 "name": { "type": "string", "description": "Region name (the NAME parameter, optional). Default: empty" },
                                                 "net_index": { "type": "integer", "description": "Net index into the board net list (optional). 65535 = no net. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "cavity_height": { "type": "number", "description": "Cavity height in mm for embedded components (optional). Default: 0" },
                                                 "holes": {
                                                     "type": "array",
@@ -394,6 +410,9 @@ impl McpServer {
                                                 "mirror": { "type": "boolean", "description": "Mirror the text (bottom-side silkscreen). Default: false" },
                                                 "justification": { "type": "string", "enum": ["bottom_left", "bottom_center", "bottom_right", "middle_left", "middle_center", "middle_right", "top_left", "top_center", "top_right"], "description": "Text anchor / justification within its frame. Default: bottom_left" },
                                                 "stroke_width": { "type": "number", "description": "Stroke line width in mm (optional; defaults to Altium's ~4 mil)" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom). Default: none" }
                                             },
@@ -448,6 +467,9 @@ impl McpServer {
                                                 "model_id": { "type": "string", "description": "Model GUID referencing an embedded model (Altium MODELID). Default: \"\" (none)" },
                                                 "model_name": { "type": "string", "description": "Model filename or external path (Altium MODEL.NAME). Default: \"\" (none)" },
                                                 "embedded": { "type": "boolean", "description": "Whether the model is embedded in the library (Altium MODEL.EMBED). Default: false" },
+                                                "net_index": { "type": "integer", "description": "Net index into the board net list (common header, 0-65534; 65535 = no net). Normally omitted for library footprints; preserved on a read-modify-write. Default: 65535" },
+                                                "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
+                                                "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "additional_parameters": { "type": "array", "description": "Unmodelled body parameter keys captured verbatim on read (e.g. TEXTURE, MODEL.2D.X, IDENTIFIER, MODEL.MODELTYPE, MODEL.MODELSOURCE, the extrusion range). Each entry is a [key, value] string pair. Round-tripped so a read-modify-write does not drop keys the tool does not model. Normally omitted; supply only the pairs read_pcblib returned.", "items": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 } }
                                             },

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -81,6 +81,35 @@ fn json_keepout(json: &Value) -> Option<u8> {
         .and_then(|v| u8::try_from(v).ok())
 }
 
+/// Reads the optional common-header net index (u16) of a `PcbLib` primitive,
+/// defaulting to `0xFFFF` ("no net") — the from-scratch value the writer's
+/// header fill emits. Mirrors how `read_pcblib` serialises the `net_index` field.
+fn json_net_index(json: &Value) -> u16 {
+    json.get("net_index")
+        .and_then(Value::as_u64)
+        .and_then(|v| u16::try_from(v).ok())
+        .unwrap_or(0xFFFF)
+}
+
+/// Reads the optional common-header polygon index (u16) of a `PcbLib` primitive,
+/// defaulting to `0xFFFF` (none) — the from-scratch value.
+fn json_polygon_index(json: &Value) -> u16 {
+    json.get("polygon_index")
+        .and_then(Value::as_u64)
+        .and_then(|v| u16::try_from(v).ok())
+        .unwrap_or(0xFFFF)
+}
+
+/// Reads the optional common-header component index (i32) of a `PcbLib`
+/// primitive, defaulting to `-1` (free primitive; stored as the `0xFFFF`
+/// sentinel) — the from-scratch value.
+fn json_component_index(json: &Value) -> i32 {
+    json.get("component_index")
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+        .unwrap_or(-1)
+}
+
 /// Reads the optional `unique_id` (identity GUID) of any primitive.
 ///
 /// `read_pcblib` / `read_schlib` surface each primitive's 8-char Altium unique
@@ -319,6 +348,9 @@ impl McpServer {
             per_layer_shapes: None,
             per_layer_corner_radii: None,
             per_layer_offsets: None,
+            net_index: json_net_index(json),
+            polygon_index: json_polygon_index(json),
+            component_index: json_component_index(json),
             flags: json_flags(json),
             unique_id: json_unique_id(json),
         })
@@ -364,6 +396,9 @@ impl McpServer {
         // Optional EE tail (mirrors the modelled optionals; absent keys keep the
         // `Track::new` defaults so a from-scratch track is byte-identical).
         track.flags = json_flags(json);
+        track.net_index = json_net_index(json);
+        track.polygon_index = json_polygon_index(json);
+        track.component_index = json_component_index(json);
         track.solder_mask_expansion = json_f64(json, "solder_mask_expansion");
         track.keepout_restrictions = json_keepout(json);
         track.unique_id = json_unique_id(json);
@@ -419,6 +454,9 @@ impl McpServer {
             width,
             layer,
             flags: json_flags(json),
+            net_index: json_net_index(json),
+            polygon_index: json_polygon_index(json),
+            component_index: json_component_index(json),
             unique_id: json_unique_id(json),
             // Optional EE tail (mirrors the modelled optionals; absent keys keep
             // the default `None` so a from-scratch arc is byte-identical).
@@ -472,11 +510,9 @@ impl McpServer {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        let net_index = json
-            .get("net_index")
-            .and_then(Value::as_u64)
-            .and_then(|n| u16::try_from(n).ok())
-            .unwrap_or(0xFFFF);
+        let net_index = json_net_index(json);
+        let polygon_index = json_polygon_index(json);
+        let component_index = json_component_index(json);
         let cavity_height = json
             .get("cavity_height")
             .and_then(Value::as_f64)
@@ -523,6 +559,8 @@ impl McpServer {
             kind,
             name,
             net_index,
+            polygon_index,
+            component_index,
             cavity_height,
             unique_id,
             additional_parameters,
@@ -613,6 +651,9 @@ impl McpServer {
             font_name,
             justification,
             flags: json_flags(json),
+            net_index: json_net_index(json),
+            polygon_index: json_polygon_index(json),
+            component_index: json_component_index(json),
             unique_id: json_unique_id(json),
         })
     }
@@ -742,6 +783,10 @@ impl McpServer {
         {
             via.net_index = v;
         }
+        // Polygon @5 / component @7 connectivity indices. Absent keys keep the
+        // from-scratch defaults (none / free primitive), byte-identical.
+        via.polygon_index = json_polygon_index(json);
+        via.component_index = json_component_index(json);
 
         // Drill tolerances (SubRecord-1 @291/@295). Absent keys keep the
         // from-scratch defaults (tolerances unset), so an unspecified via
@@ -802,6 +847,9 @@ impl McpServer {
         }
         // Optional flags + mask/keepout tail (mirrors the modelled optionals).
         fill.flags = json_flags(json);
+        fill.net_index = json_net_index(json);
+        fill.polygon_index = json_polygon_index(json);
+        fill.component_index = json_component_index(json);
         fill.solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
         fill.keepout_restrictions = json_keepout(json);
         fill.unique_id = json_unique_id(json);

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -623,6 +623,8 @@ impl McpServer {
                             "kind",
                             "name",
                             "net_index",
+                            "polygon_index",
+                            "component_index",
                             "cavity_height",
                             "holes",
                             "unique_id",
@@ -642,6 +644,7 @@ impl McpServer {
                         text_json,
                         &[
                             "bold",
+                            "component_index",
                             "flags",
                             "font_name",
                             "height",
@@ -650,6 +653,8 @@ impl McpServer {
                             "kind",
                             "layer",
                             "mirror",
+                            "net_index",
+                            "polygon_index",
                             "rotation",
                             "stroke_font",
                             "stroke_width",
@@ -737,6 +742,10 @@ impl McpServer {
                             body_color_3d: 8_421_504,
                             body_opacity_3d: 1.0,
                             model_2d_rotation: 0.0,
+                            // External reference: no board association (free primitive).
+                            net_index: 0xFFFF,
+                            polygon_index: 0xFFFF,
+                            component_index: -1,
                             additional_parameters: Vec::new(),
                         });
                     }
@@ -847,6 +856,24 @@ impl McpServer {
                             .get("model_2d_rotation")
                             .and_then(Value::as_f64)
                             .unwrap_or(0.0),
+                        // Common-header connectivity indices. Absent keys default to
+                        // "none" (net/polygon 0xFFFF, component -1), byte-identical to
+                        // a from-scratch body; a modify-write preserves a read value.
+                        net_index: body_json
+                            .get("net_index")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u16::try_from(v).ok())
+                            .unwrap_or(0xFFFF),
+                        polygon_index: body_json
+                            .get("polygon_index")
+                            .and_then(Value::as_u64)
+                            .and_then(|v| u16::try_from(v).ok())
+                            .unwrap_or(0xFFFF),
+                        component_index: body_json
+                            .get("component_index")
+                            .and_then(Value::as_i64)
+                            .and_then(|v| i32::try_from(v).ok())
+                            .unwrap_or(-1),
                         // Round-trip unmodelled body keys (TEXTURE*, MODEL.2D.X/Y,
                         // etc.) captured on read. Absent -> empty -> the writer
                         // appends nothing (byte-identical to a from-scratch body).
@@ -890,6 +917,9 @@ impl McpServer {
                     // byte-identical (and oracle-safe).
                     justification: TextJustification::BottomLeft,
                     flags: PcbFlags::empty(),
+                    net_index: 0xFFFF,
+                    polygon_index: 0xFFFF,
+                    component_index: -1,
                     unique_id: None,
                 });
             }
@@ -928,6 +958,10 @@ impl McpServer {
                     body_color_3d: 8_421_504,
                     body_opacity_3d: 1.0,
                     model_2d_rotation: 0.0,
+                    // Synthesised body: no board association (free primitive).
+                    net_index: 0xFFFF,
+                    polygon_index: 0xFFFF,
+                    component_index: -1,
                     additional_parameters: Vec::new(),
                 });
                 true
@@ -2208,6 +2242,9 @@ mod tests {
             body_color_3d: 8_421_504,
             body_opacity_3d: 1.0,
             model_2d_rotation: 0.0,
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
             additional_parameters: Vec::new(),
         };
 

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -161,6 +161,9 @@ fn pcblib_file_roundtrip_all_primitives() {
         font_name: "Arial".to_string(),
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         unique_id: None,
     };
     fp.add_text(text);

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1747,6 +1747,91 @@ def test_write_pcblib_unique_id_roundtrip(client, runner, lib_path):
         )
 
 
+def test_write_pcblib_common_indices_roundtrip(client, runner, lib_path):
+    print("\n=== Test: write_pcblib net/polygon/component index round trip ===")
+    # Coverage PR-R4: the common-header connectivity indices (net_index @3,
+    # polygon_index @5, component_index @7) must be authorable via write_pcblib
+    # and round-trip through read_pcblib for every primitive that carries them.
+    # These are marginal for netless library footprints but complete round-trip
+    # fidelity for a board-context primitive read into a library.
+    footprint = {
+        "name": "INDICES_RT",
+        "pads": [
+            {
+                "designator": "1",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 0.6,
+                "height": 0.5,
+                "layer": "Top Layer",
+                "net_index": 11,
+                "polygon_index": 3,
+                "component_index": 5,
+            }
+        ],
+        "tracks": [
+            {
+                "x1": -1.0,
+                "y1": 0.0,
+                "x2": 1.0,
+                "y2": 0.0,
+                "width": 0.25,
+                "layer": "Top Layer",
+                "net_index": 11,
+                "component_index": 5,
+            }
+        ],
+        "text": [
+            {
+                "x": 0.0,
+                "y": 1.5,
+                "text": "NET",
+                "height": 1.0,
+                "layer": "Top Overlay",
+                "net_index": 22,
+                "component_index": 5,
+            }
+        ],
+    }
+    write = client.call_tool(
+        "write_pcblib",
+        {"filepath": lib_path, "footprints": [footprint], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_pcblib (indices) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_pcblib", {"filepath": lib_path})
+    runner.check(not read.get("_isError"), "read_pcblib succeeded", actual=read)
+    footprints = {fp.get("name"): fp for fp in read.get("footprints", [])}
+    fp = footprints.get("INDICES_RT", {})
+    runner.check(bool(fp), "INDICES_RT footprint present", actual=list(footprints))
+
+    pads = fp.get("pads", [])
+    pad = next((p for p in pads if p.get("designator") == "1"), None)
+    runner.check(pad is not None, "pad 1 survived", actual=[p.get("designator") for p in pads])
+    if pad is not None:
+        runner.check(pad.get("net_index") == 11, "pad net_index", actual=pad.get("net_index"), expected=11)
+        runner.check(pad.get("polygon_index") == 3, "pad polygon_index", actual=pad.get("polygon_index"), expected=3)
+        runner.check(pad.get("component_index") == 5, "pad component_index", actual=pad.get("component_index"), expected=5)
+
+    tracks = fp.get("tracks", [])
+    runner.check(len(tracks) == 1, "1 track survived", actual=len(tracks))
+    if tracks:
+        t = tracks[0]
+        runner.check(t.get("net_index") == 11, "track net_index", actual=t.get("net_index"), expected=11)
+        runner.check(t.get("component_index") == 5, "track component_index", actual=t.get("component_index"), expected=5)
+        # An unset polygon_index round-trips as the 65535 "none" default.
+        runner.check(t.get("polygon_index") == 65535, "track polygon_index default", actual=t.get("polygon_index"), expected=65535)
+
+    texts = fp.get("text", [])
+    ref = next((t for t in texts if t.get("text") == "NET"), None)
+    runner.check(ref is not None, "NET text survived", actual=[t.get("text") for t in texts])
+    if ref is not None:
+        runner.check(ref.get("net_index") == 22, "text net_index", actual=ref.get("net_index"), expected=22)
+        runner.check(ref.get("component_index") == 5, "text component_index", actual=ref.get("component_index"), expected=5)
+
+
 def test_write_schlib_unique_id_roundtrip(client, runner, schlib_path):
     print("\n=== Test: write_schlib unique_id round trip ===")
     # Coverage PR-R1: a SchLib shape's identity GUID (unique_id) written via the
@@ -1853,6 +1938,7 @@ def main():
         test_write_pcblib_additional_parameters_roundtrip(client, runner, lib_path)
         test_write_pcblib_text_font_style(client, runner, lib_path)
         test_write_pcblib_unique_id_roundtrip(client, runner, lib_path)
+        test_write_pcblib_common_indices_roundtrip(client, runner, lib_path)
         test_write_schlib_shapes(client, runner, schlib_path)
         test_write_schlib_fields(client, runner, schlib_path)
         test_write_schlib_display_flags(client, runner, schlib_path)

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -556,6 +556,9 @@ fn test_text_special_strings() {
         font_name: "Arial".to_string(),
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         unique_id: None,
     };
     fp.add_text(text1);
@@ -577,6 +580,9 @@ fn test_text_special_strings() {
         font_name: "Arial".to_string(),
         justification: TextJustification::default(),
         flags: PcbFlags::default(),
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         unique_id: None,
     };
     fp.add_text(text2);
@@ -843,6 +849,9 @@ fn test_component_body_roundtrip() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);
@@ -899,6 +908,9 @@ fn test_component_body_with_rotation() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);
@@ -2710,6 +2722,9 @@ fn test_component_body_external_model_reference() {
         body_color_3d: 8_421_504,
         body_opacity_3d: 1.0,
         model_2d_rotation: 0.0,
+        net_index: 0xFFFF,
+        polygon_index: 0xFFFF,
+        component_index: -1,
         additional_parameters: Vec::new(),
     };
     fp.component_bodies.push(body);


### PR DESCRIPTION
**Coverage roadmap PR-R4** (round-trip tier) — common-header net/polygon/component indices.

The common-header `NetIndex` @3-4 / `PolygonIndex` @5-6 / `ComponentIndex` @7-8 were skipped on read and hard-coded `0xFF` on write for most primitives — so a read-modify-write of a board-context primitive lost its net/component association. (Marginal for netless library footprints; completes round-trip fidelity.)

## Change
- Added `net_index` / `polygon_index` / `component_index` to **Pad, Track, Arc, Fill, Text, ComponentBody**. Via (had `net_index`, PR-7) gained polygon/component; Region (had all 3, PR-9) was refactored onto the shared helpers.
- Shared `read_common_indices` / `write_common_indices` helpers — one implementation, eight primitives; the old inline Via/Region overlays removed.

## Byte-identity
Defaults are all "none" (`0xFFFF`/`-1`), which encode to the exact `0xFF` header bytes the writer emits today → a from-scratch primitive is **byte-identical**. Pinned by dedicated writer tests; **oracle 0 regressions**.

## Tool
Read DTO serde-automatic; each `parse_*` + the `component_bodies` handler read the 3 keys; schemas extended; text/region `check_keys!` allow-lists extended (pad/track/arc/via/fill are permissive).

## Test
Round-trip (Track/Text with net/comp/poly) + byte-identity (from-scratch @3-8 = `0xFF`) + Python `test_write_pcblib_common_indices_roundtrip`.

Gate: fmt / clippy / `cargo doc -Dwarnings` / cargo test (365) / **integration 289/289** / **oracle 0 regressions**.

_With this, only R3 (SchLib Pin aux OLE streams) remains in the round-trip tier._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
