### PR TITLE
feat(schlib): round-trip Pin OwnerPartDisplayMode + PinFrac/PinSymbolLineWidth streams (PR-R3)

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -47,6 +47,7 @@
 //! | 45 | Model | Footprint model reference |
 
 pub(crate) mod coord;
+pub(crate) mod pin_aux;
 pub mod primitives;
 pub mod reader;
 pub mod writer;
@@ -164,6 +165,21 @@ impl SchLib {
                 .unwrap_or_default();
 
             reader::parse_data_stream(&mut symbol, &data);
+
+            // Apply the optional per-component pin auxiliary streams. They sit
+            // alongside `Data` in the same storage and are keyed by pin ordinal,
+            // so they must be applied AFTER the pins are parsed. Absent streams
+            // (the common case, incl. the whole golden) leave the pins untouched.
+            if let Some(frac) =
+                crate::altium::read_stream_opt(&mut cfb, format!("{comp_name}/PinFrac"))
+            {
+                pin_aux::apply_pin_frac(&mut symbol.pins, &frac);
+            }
+            if let Some(widths) =
+                crate::altium::read_stream_opt(&mut cfb, format!("{comp_name}/PinSymbolLineWidth"))
+            {
+                pin_aux::apply_pin_symbol_line_widths(&mut symbol.pins, &widths);
+            }
 
             // Use the symbol's actual name (from LibReference) as the key
             // This handles long names that were truncated in the OLE storage path
@@ -298,6 +314,21 @@ impl SchLib {
             crate::altium::create_storage(&mut cfb, &format!("/{ole_name}"))?;
             let data = writer::encode_data_stream(symbol)?;
             crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/Data"), &data)?;
+
+            // Optional per-component pin auxiliary streams, written into the same
+            // storage. Each is emitted ONLY when at least one pin carries a
+            // non-default value; an all-default symbol (the common case, incl.
+            // the golden) writes neither, keeping its storage byte-identical.
+            if let Some(frac) = pin_aux::encode_pin_frac(&symbol.pins)? {
+                crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/PinFrac"), &frac)?;
+            }
+            if let Some(widths) = pin_aux::encode_pin_symbol_line_widths(&symbol.pins)? {
+                crate::altium::write_stream(
+                    &mut cfb,
+                    &format!("/{ole_name}/PinSymbolLineWidth"),
+                    &widths,
+                )?;
+            }
         }
 
         // Root Storage stream (Altium's icon storage). Always present; for a

--- a/src/altium/schlib/pin_aux.rs
+++ b/src/altium/schlib/pin_aux.rs
@@ -1,0 +1,402 @@
+//! Per-component pin auxiliary OLE streams (`PinFrac`, `PinSymbolLineWidth`).
+//!
+//! Alongside a symbol's `Data` stream, Altium may store two optional sibling
+//! streams that carry data the binary pin record cannot hold:
+//!
+//! - **`PinFrac`** — the fractional part of each off-grid pin's `X` / `Y` /
+//!   `length`. The binary pin record stores only the integer DXP part (`i16`),
+//!   so a pin sitting between grid points keeps its sub-unit remainder here.
+//! - **`PinSymbolLineWidth`** — a `SYMBOL_LINEWIDTH=N` parameter per pin whose
+//!   symbol line width is non-default.
+//!
+//! Both share Altium's *compressed-storage* framing (the same layout used for
+//! embedded icon images):
+//!
+//! ```text
+//! [u32 LE header_len][header_len header bytes]         # C-string param block
+//! then, per non-default pin:
+//!   [u32 LE size]        # low 24 bits = block size, high byte = 0x01 flag
+//!   0xD0                 # storage-entry tag
+//!   [u8 name_len][name]  # Pascal string: the pin ordinal as ASCII decimal
+//!   [u32 LE comp_len][comp_len bytes]   # zlib-compressed payload
+//! ```
+//!
+//! The compressed payload differs per stream:
+//! - `PinFrac`: 12 bytes = three little-endian `i32` (`frac_x`, `frac_y`,
+//!   `frac_length`).
+//! - `PinSymbolLineWidth`: a Unicode parameter block
+//!   (`[u32 LE inner_len][UTF-16LE "|SYMBOL_LINEWIDTH=N"]`).
+//!
+//! # Byte-identity note
+//!
+//! A symbol whose pins are all on-grid with default line width emits **neither**
+//! stream (the entry maps are empty), so its storage is byte-identical to
+//! Altium's — this is the load-bearing invariant the golden library exercises.
+//! For a NON-default pin there is no golden fixture, so the compressed bytes we
+//! emit are only verified by a self round-trip (we control both compress and
+//! decompress); zlib's DEFLATE output is implementation-specific, so the exact
+//! bytes may differ from Altium's writer even though the framing matches. Any
+//! genuinely Altium-authored stream still *reads* correctly (zlib inflate is
+//! standardised), so round-tripping a real off-grid pin is lossless.
+
+use super::primitives::{Pin, PinFrac};
+use crate::altium::bytes::{read_i32_le, read_u32_le};
+use crate::altium::framing::write_cstring_param_block;
+
+/// The storage-entry tag byte Altium writes before each compressed entry.
+const ENTRY_TAG: u8 = 0xD0;
+
+/// Flag byte OR-ed into the high byte of each entry's 24-bit size word.
+const ENTRY_SIZE_FLAG: u32 = 0x0100_0000;
+
+/// Upper bound on a single decompressed entry, guarding against a hostile or
+/// corrupt stream. Both payload kinds are tiny (12 bytes / a short param block),
+/// so 64 KiB is generous.
+const MAX_ENTRY_DECOMPRESSED: usize = 64 * 1024;
+
+/// Compresses `payload` with a zlib (RFC 1950) wrapper, matching the reader's
+/// inflate. Uses `flate2`'s default compression, exactly like the `PcbLib`
+/// model-data compressor (`compress_model_data`).
+fn zlib_compress(payload: &[u8]) -> crate::altium::error::AltiumResult<Vec<u8>> {
+    use crate::altium::error::AltiumError;
+    use flate2::{write::ZlibEncoder, Compression};
+    use std::io::Write as _;
+
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(payload)
+        .map_err(|e| AltiumError::compression_error("Failed to compress pin aux entry", Some(e)))?;
+    encoder.finish().map_err(|e| {
+        AltiumError::compression_error("Failed to finish pin aux compression", Some(e))
+    })
+}
+
+/// Decompresses a zlib entry, rejecting output larger than
+/// [`MAX_ENTRY_DECOMPRESSED`]. Returns `None` on any error (a corrupt entry is
+/// skipped rather than failing the whole read).
+fn zlib_decompress(data: &[u8]) -> Option<Vec<u8>> {
+    use flate2::read::ZlibDecoder;
+    use std::io::Read as _;
+
+    let limit = MAX_ENTRY_DECOMPRESSED.saturating_add(1) as u64;
+    let mut decoder = ZlibDecoder::new(data).take(limit);
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out).ok()?;
+    if out.len() > MAX_ENTRY_DECOMPRESSED {
+        return None;
+    }
+    Some(out)
+}
+
+/// Appends one compressed-storage entry (`0xD0` tag + Pascal-string key +
+/// zlib-compressed payload) for pin ordinal `index`.
+fn write_entry(
+    out: &mut Vec<u8>,
+    index: usize,
+    payload: &[u8],
+) -> crate::altium::error::AltiumResult<()> {
+    use crate::altium::error::AltiumError;
+
+    let compressed = zlib_compress(payload)?;
+    let name = index.to_string();
+    let name_bytes = name.as_bytes();
+
+    // block_size = tag(1) + name_len(1) + name(N) + comp_len(4) + compressed(N)
+    let block_size = 1 + 1 + name_bytes.len() + 4 + compressed.len();
+    if block_size > 0x00FF_FFFF {
+        return Err(AltiumError::InvalidParameter {
+            name: "pin_aux".to_string(),
+            message: format!("pin aux entry {index} is too large ({block_size} bytes)"),
+        });
+    }
+
+    #[allow(clippy::cast_possible_truncation)] // bounded above
+    let size_word = (block_size as u32) | ENTRY_SIZE_FLAG;
+    out.extend_from_slice(&size_word.to_le_bytes());
+    out.push(ENTRY_TAG);
+    #[allow(clippy::cast_possible_truncation)] // a pin ordinal never needs >255 ASCII digits
+    out.push(name_bytes.len() as u8);
+    out.extend_from_slice(name_bytes);
+    #[allow(clippy::cast_possible_truncation)] // bounded by block_size guard above
+    out.extend_from_slice(&(compressed.len() as u32).to_le_bytes());
+    out.extend_from_slice(&compressed);
+    Ok(())
+}
+
+/// Walks the compressed-storage entries after the header block, invoking
+/// `on_entry(pin_index, decompressed_payload)` for each well-formed entry.
+///
+/// Mirrors `AltiumSharp`'s parse loop: read the header length prefix and skip it,
+/// then read `[u32 size][0xD0][pascal key][u32 comp_len][comp]` entries until
+/// the stream is exhausted or a malformed entry is hit (which stops the walk,
+/// matching `AltiumSharp`'s `break`).
+fn for_each_entry<F: FnMut(usize, &[u8])>(raw: &[u8], mut on_entry: F) {
+    // Header block: [u32 LE len][len bytes]. Skip it.
+    let Some(header_len) = read_u32_le(raw, 0) else {
+        return;
+    };
+    let mut offset = 4 + header_len as usize;
+
+    while offset + 4 <= raw.len() {
+        let Some(size_word) = read_u32_le(raw, offset) else {
+            break;
+        };
+        let block_size = (size_word & 0x00FF_FFFF) as usize;
+        if block_size == 0 {
+            break;
+        }
+        let block_start = offset + 4;
+        let block_end = block_start + block_size;
+        if block_end > raw.len() {
+            break;
+        }
+        let block = &raw[block_start..block_end];
+
+        // 0xD0 tag
+        if block.first().copied() != Some(ENTRY_TAG) {
+            break;
+        }
+        // Pascal string: pin ordinal as ASCII decimal.
+        let (key, after_key) = crate::altium::framing::read_pascal_string(block, 1);
+        // Compressed data: [u32 LE comp_len][comp bytes].
+        if let (Some(comp_len), Ok(idx)) = (read_u32_le(block, after_key), key.parse::<usize>()) {
+            let comp_start = after_key + 4;
+            let comp_end = comp_start + comp_len as usize;
+            if comp_end <= block.len() {
+                if let Some(payload) = zlib_decompress(&block[comp_start..comp_end]) {
+                    on_entry(idx, &payload);
+                }
+            }
+        }
+
+        offset = block_end;
+    }
+}
+
+/// Writes the shared header block (`|HEADER=<name>|Weight=<count>`), matching
+/// Altium's mixed-case keys, then returns the buffer ready for entries.
+fn start_stream(header_name: &str, count: usize) -> Vec<u8> {
+    let text = format!("|HEADER={header_name}|Weight={count}");
+    let mut out = Vec::new();
+    write_cstring_param_block(&mut out, &crate::altium::encode_windows1252(&text));
+    out
+}
+
+/// Encodes the `PinFrac` stream for `pins`, or `None` when every pin is on-grid
+/// (no fractional parts) — in which case Altium writes no stream and the
+/// storage stays byte-identical to the golden.
+///
+/// # Errors
+///
+/// Returns an error if an entry's compressed payload exceeds the 24-bit block
+/// size (never in practice — each payload is 12 bytes).
+pub(super) fn encode_pin_frac(pins: &[Pin]) -> crate::altium::error::AltiumResult<Option<Vec<u8>>> {
+    let entries: Vec<(usize, PinFrac)> = pins
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| match p.frac {
+            Some(f) if !f.is_zero() => Some((i, f)),
+            _ => None,
+        })
+        .collect();
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut out = start_stream("PinFrac", entries.len());
+    for (index, frac) in entries {
+        let mut payload = Vec::with_capacity(12);
+        payload.extend_from_slice(&frac.x.to_le_bytes());
+        payload.extend_from_slice(&frac.y.to_le_bytes());
+        payload.extend_from_slice(&frac.length.to_le_bytes());
+        write_entry(&mut out, index, &payload)?;
+    }
+    Ok(Some(out))
+}
+
+/// Encodes the `PinSymbolLineWidth` stream for `pins`, or `None` when every pin
+/// has the default (zero) width — matching Altium's omit-when-default.
+///
+/// # Errors
+///
+/// Returns an error if an entry's compressed payload exceeds the 24-bit block
+/// size (never in practice — each payload is a short param block).
+pub(super) fn encode_pin_symbol_line_widths(
+    pins: &[Pin],
+) -> crate::altium::error::AltiumResult<Option<Vec<u8>>> {
+    let entries: Vec<(usize, i32)> = pins
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.symbol_line_width != 0)
+        .map(|(i, p)| (i, p.symbol_line_width))
+        .collect();
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut out = start_stream("PinSymbolLineWidth", entries.len());
+    for (index, width) in entries {
+        let payload = encode_unicode_param_block(&format!("|SYMBOL_LINEWIDTH={width}"));
+        write_entry(&mut out, index, &payload)?;
+    }
+    Ok(Some(out))
+}
+
+/// Encodes a Unicode (UTF-16LE) parameter block: `[u32 LE byte_len][utf16le]`.
+/// The length counts the UTF-16 byte count (not including its own 4 bytes),
+/// matching `AltiumSharp`'s `WriteUnicodeParameterBlock` / `ReadUnicodeParameterBlock`.
+fn encode_unicode_param_block(text: &str) -> Vec<u8> {
+    let utf16: Vec<u8> = text.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    let mut out = Vec::with_capacity(4 + utf16.len());
+    #[allow(clippy::cast_possible_truncation)] // a SYMBOL_LINEWIDTH param block is tiny
+    out.extend_from_slice(&(utf16.len() as u32).to_le_bytes());
+    out.extend_from_slice(&utf16);
+    out
+}
+
+/// Applies a parsed `PinFrac` stream onto `pins`, keyed by pin ordinal.
+pub(super) fn apply_pin_frac(pins: &mut [Pin], raw: &[u8]) {
+    for_each_entry(raw, |idx, payload| {
+        if payload.len() < 12 {
+            return;
+        }
+        let (Some(x), Some(y), Some(length)) = (
+            read_i32_le(payload, 0),
+            read_i32_le(payload, 4),
+            read_i32_le(payload, 8),
+        ) else {
+            return;
+        };
+        if let Some(pin) = pins.get_mut(idx) {
+            let frac = PinFrac { x, y, length };
+            pin.frac = if frac.is_zero() { None } else { Some(frac) };
+        }
+    });
+}
+
+/// Applies a parsed `PinSymbolLineWidth` stream onto `pins`, keyed by pin ordinal.
+pub(super) fn apply_pin_symbol_line_widths(pins: &mut [Pin], raw: &[u8]) {
+    for_each_entry(raw, |idx, payload| {
+        let Some(text) = decode_unicode_param_block(payload) else {
+            return;
+        };
+        let params = crate::altium::parse_pipe_params(&text);
+        if let Some(width) = params
+            .get("symbol_linewidth")
+            .and_then(|s| s.trim().parse::<i32>().ok())
+        {
+            if let Some(pin) = pins.get_mut(idx) {
+                pin.symbol_line_width = width;
+            }
+        }
+    });
+}
+
+/// Decodes a Unicode parameter block written by [`encode_unicode_param_block`].
+/// Returns `None` if the length prefix or the UTF-16 payload is malformed.
+fn decode_unicode_param_block(payload: &[u8]) -> Option<String> {
+    let inner_len = read_u32_le(payload, 0)? as usize;
+    let start = 4usize;
+    let end = start.checked_add(inner_len)?;
+    if end > payload.len() || inner_len % 2 != 0 {
+        return None;
+    }
+    let units: Vec<u16> = payload[start..end]
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::altium::schlib::primitives::PinOrientation;
+
+    fn pin() -> Pin {
+        Pin::new("A", "1", 0, 0, 10, PinOrientation::Right)
+    }
+
+    #[test]
+    fn all_default_pins_emit_no_streams() {
+        // The load-bearing byte-identity invariant: on-grid, default-width pins
+        // produce no aux streams at all (matching the golden library).
+        let pins = vec![pin(), pin()];
+        assert!(encode_pin_frac(&pins).unwrap().is_none());
+        assert!(encode_pin_symbol_line_widths(&pins).unwrap().is_none());
+    }
+
+    #[test]
+    fn pin_frac_self_round_trips() {
+        let mut pins = vec![pin(), pin(), pin()];
+        pins[1].frac = Some(PinFrac {
+            x: 50_000,
+            y: -25_000,
+            length: 12_345,
+        });
+        let stream = encode_pin_frac(&pins)
+            .unwrap()
+            .expect("a fractional pin must emit a PinFrac stream");
+
+        let mut read_back = vec![pin(), pin(), pin()];
+        apply_pin_frac(&mut read_back, &stream);
+        assert_eq!(read_back[0].frac, None, "on-grid pin 0 stays None");
+        assert_eq!(
+            read_back[1].frac,
+            Some(PinFrac {
+                x: 50_000,
+                y: -25_000,
+                length: 12_345,
+            }),
+            "fractional pin 1 survives the round-trip keyed by ordinal"
+        );
+        assert_eq!(read_back[2].frac, None, "on-grid pin 2 stays None");
+    }
+
+    #[test]
+    fn pin_symbol_line_width_self_round_trips() {
+        let mut pins = vec![pin(), pin()];
+        pins[0].symbol_line_width = 3;
+        let stream = encode_pin_symbol_line_widths(&pins)
+            .unwrap()
+            .expect("a non-default width must emit a PinSymbolLineWidth stream");
+
+        let mut read_back = vec![pin(), pin()];
+        apply_pin_symbol_line_widths(&mut read_back, &stream);
+        assert_eq!(
+            read_back[0].symbol_line_width, 3,
+            "width survives round-trip"
+        );
+        assert_eq!(read_back[1].symbol_line_width, 0, "default pin stays 0");
+    }
+
+    #[test]
+    fn header_uses_altium_mixed_case_keys() {
+        let stream = start_stream("PinFrac", 2);
+        let text = String::from_utf8_lossy(&stream);
+        assert!(
+            text.contains("|HEADER=PinFrac"),
+            "HEADER key present: {text}"
+        );
+        assert!(text.contains("|Weight=2"), "mixed-case Weight key: {text}");
+    }
+
+    #[test]
+    fn unicode_param_block_round_trips() {
+        let block = encode_unicode_param_block("|SYMBOL_LINEWIDTH=5");
+        assert_eq!(
+            decode_unicode_param_block(&block).as_deref(),
+            Some("|SYMBOL_LINEWIDTH=5")
+        );
+    }
+
+    #[test]
+    fn corrupt_stream_is_ignored_not_panicked() {
+        // A truncated / garbage stream must not panic; unknown entries are skipped.
+        let mut pins = vec![pin()];
+        apply_pin_frac(&mut pins, &[0x00, 0x00]); // too short for even a header
+        apply_pin_symbol_line_widths(&mut pins, &[0xFF; 8]);
+        assert_eq!(pins[0].frac, None);
+        assert_eq!(pins[0].symbol_line_width, 0);
+    }
+}

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -87,6 +87,13 @@ pub struct Pin {
     #[serde(default = "default_owner_part")]
     pub owner_part_id: i32,
 
+    /// Owner part display mode (alternate-view index). Stored in the binary pin
+    /// record's own byte at offset 7 — distinct from the `OwnerPartDisplayMode`
+    /// that `PR-14` put on the `SchLib` *shapes* (a text-record parameter). Altium
+    /// emits `0` for a normal pin; preserved on round-trip.
+    #[serde(default)]
+    pub owner_part_display_mode: i32,
+
     /// Pin colour (BGR format).
     #[serde(default)]
     pub colour: u32,
@@ -132,6 +139,50 @@ pub struct Pin {
     /// Pin default value (empty for a from-scratch pin).
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub default_value: String,
+
+    /// Symbol line width index. Lives in the per-component `PinSymbolLineWidth`
+    /// auxiliary OLE stream (a `SYMBOL_LINEWIDTH=N` parameter, one entry per
+    /// non-default pin), NOT in the binary pin record. `0` is the default and
+    /// causes no stream entry to be written, so a from-scratch pin is
+    /// byte-identical to Altium's output.
+    #[serde(default, skip_serializing_if = "is_zero_i32")]
+    pub symbol_line_width: i32,
+
+    /// Fractional companion of `x` / `y` / `length`, in 1/100000-DXP units,
+    /// preserved from the per-component `PinFrac` auxiliary OLE stream. The
+    /// binary pin record stores only the integer DXP part (i16); a pin sitting
+    /// off the integer grid carries its sub-unit remainder here so it
+    /// round-trips. `None` for an on-grid pin (the common case, incl. the whole
+    /// golden), which writes no `PinFrac` entry → byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frac: Option<PinFrac>,
+}
+
+/// Fractional companion coordinates for a [`Pin`].
+///
+/// Mirrors the three little-endian `i32` values in a `PinFrac` auxiliary-stream
+/// entry (`frac_x`, `frac_y`, `frac_length`). Each is a sub-DXP-unit remainder
+/// in 1/100000 units, matching Altium's `raw = num * 100000 + frac` convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PinFrac {
+    /// Fractional part of the pin's X coordinate (1/100000 DXP units).
+    #[serde(default)]
+    pub x: i32,
+    /// Fractional part of the pin's Y coordinate (1/100000 DXP units).
+    #[serde(default)]
+    pub y: i32,
+    /// Fractional part of the pin's length (1/100000 DXP units).
+    #[serde(default)]
+    pub length: i32,
+}
+
+impl PinFrac {
+    /// Returns `true` when every fractional part is zero (an on-grid pin that
+    /// needs no `PinFrac` stream entry).
+    #[must_use]
+    pub const fn is_zero(self) -> bool {
+        self.x == 0 && self.y == 0 && self.length == 0
+    }
 }
 
 const fn default_true() -> bool {
@@ -174,6 +225,7 @@ impl Pin {
             show_designator: true,
             description: String::new(),
             owner_part_id: 1,
+            owner_part_display_mode: 0,
             colour: 0,
             graphically_locked: false,
             is_not_accessible: false,
@@ -185,6 +237,8 @@ impl Pin {
             swap_id_group: String::new(),
             part_and_sequence: "|&|".to_string(),
             default_value: String::new(),
+            symbol_line_width: 0,
+            frac: None,
         }
     }
 }

--- a/src/altium/schlib/reader.rs
+++ b/src/altium/schlib/reader.rs
@@ -297,7 +297,11 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
     let owner_part_id = read_i16(data, offset)?;
     offset += 2;
 
-    // owner_part_display_mode (1 byte)
+    // owner_part_display_mode (1 byte): the pin's own alternate-view index,
+    // stored in the binary record (AltiumSharp reads it here). Preserved so a
+    // pin authored on a non-default display mode round-trips; the golden pins
+    // carry 0, so a from-scratch pin stays byte-identical.
+    let owner_part_display_mode = i32::from(data.get(offset).copied().unwrap_or(0));
     offset += 1;
 
     // symbol flags (4 bytes: inner_edge, outer_edge, inside, outside)
@@ -377,6 +381,7 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
         show_designator,
         description,
         owner_part_id: owner_part_id.into(),
+        owner_part_display_mode,
         colour,
         graphically_locked,
         is_not_accessible,
@@ -388,6 +393,10 @@ fn parse_binary_pin(data: &[u8]) -> Option<Pin> {
         swap_id_group,
         part_and_sequence,
         default_value,
+        // Aux-stream fields, filled by apply_pin_frac / apply_pin_symbol_line_widths
+        // after the whole Data stream is parsed (they are keyed by pin ordinal).
+        symbol_line_width: 0,
+        frac: None,
     })
 }
 
@@ -1049,6 +1058,7 @@ mod tests {
         pin.swap_id_group = "GRP".to_string();
         pin.part_and_sequence = "A|&|B".to_string();
         pin.default_value = "5V".to_string();
+        pin.owner_part_display_mode = 3;
 
         let mut data = Vec::new();
         write_binary_pin(&mut data, &pin).unwrap();
@@ -1061,6 +1071,28 @@ mod tests {
         assert_eq!(parsed.swap_id_group, "GRP");
         assert_eq!(parsed.part_and_sequence, "A|&|B");
         assert_eq!(parsed.default_value, "5V");
+        assert_eq!(
+            parsed.owner_part_display_mode, 3,
+            "OwnerPartDisplayMode byte (offset 7) must round-trip"
+        );
+    }
+
+    #[test]
+    fn pin_owner_part_display_mode_default_byte_is_zero() {
+        // Byte-identity: a from-scratch pin must leave the OwnerPartDisplayMode
+        // byte at 0x00 (the value every golden pin carries). The record layout is
+        // [len:3][flag:1] frame, then payload: i32 rectype(2), u8 unknown,
+        // i16 owner_part_id, then this byte at payload offset 7 => data offset 11.
+        use crate::altium::schlib::primitives::Pin;
+        use crate::altium::schlib::writer::write_binary_pin;
+        let pin = Pin::new("VCC", "1", 0, 0, 100, PinOrientation::Right);
+        let mut data = Vec::new();
+        write_binary_pin(&mut data, &pin).unwrap();
+        assert_eq!(
+            data[4 + 7],
+            0x00,
+            "default pin OwnerPartDisplayMode byte must be 0x00 (byte-identical to Altium)"
+        );
     }
 
     #[test]

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -176,8 +176,10 @@ pub(crate) fn write_binary_pin(
     let owner_part = pin.owner_part_id as i16;
     record.extend_from_slice(&owner_part.to_le_bytes());
 
-    // Owner part display mode (1 byte)
-    record.push(0x00);
+    // Owner part display mode (1 byte). Round-tripped from the pin; a from-scratch
+    // pin defaults to 0, matching Altium's output byte-for-byte.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    record.push(pin.owner_part_display_mode as u8);
 
     // Symbol flags (4 bytes: inner_edge, outer_edge, inside, outside)
     record.push(pin.symbol_inner_edge.to_id());

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -561,7 +561,10 @@ impl McpServer {
                                                 "symbol_inner_edge": { "type": "string", "description": "Decoration on the INNER edge (nearest the body), e.g. 'dot' (inversion bubble), 'clock'. Default: none" },
                                                 "symbol_outer_edge": { "type": "string", "description": "Decoration on the OUTER edge (furthest from the body), e.g. 'dot', 'clock'. Default: none" },
                                                 "symbol_inside": { "type": "string", "description": "Decoration drawn inside the pin line, e.g. 'postponed_output', 'open_collector'. Default: none" },
-                                                "symbol_outside": { "type": "string", "description": "Decoration drawn outside the pin line, e.g. 'right_left_signal_flow', 'analog_signal_in'. Default: none" }
+                                                "symbol_outside": { "type": "string", "description": "Decoration drawn outside the pin line, e.g. 'right_left_signal_flow', 'analog_signal_in'. Default: none" },
+                                                "owner_part_display_mode": { "type": "integer", "description": "Pin's alternate-view (display-mode) index in the binary pin record. Default: 0" },
+                                                "symbol_line_width": { "type": "integer", "description": "Pin symbol line-width index. Non-zero writes a PinSymbolLineWidth auxiliary stream; 0 (default) writes none." },
+                                                "frac": { "type": "object", "description": "Fractional pin coordinates for off-grid pins, in 1/100000 schematic-unit steps. Non-zero writes a PinFrac auxiliary stream; omit for on-grid pins.", "properties": { "x": { "type": "integer" }, "y": { "type": "integer" }, "length": { "type": "integer" } } }
                                             },
                                             "required": ["designator", "name", "x", "y", "length", "orientation"]
                                         }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -983,6 +983,20 @@ impl McpServer {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
+        // Pin binary-record display mode (own byte, distinct from the shape flag).
+        let owner_part_display_mode = json_i32(json, "owner_part_display_mode").unwrap_or(0);
+        // Symbol line width; 0 (default) writes no PinSymbolLineWidth aux stream.
+        let symbol_line_width = json_i32(json, "symbol_line_width").unwrap_or(0);
+        // Fractional pin coordinates ({x,y,length} in 1/100000 DXP units); an
+        // all-zero or absent object writes no PinFrac aux stream.
+        let frac = json.get("frac").and_then(|f| {
+            let pf = crate::altium::schlib::PinFrac {
+                x: json_i32(f, "x").unwrap_or(0),
+                y: json_i32(f, "y").unwrap_or(0),
+                length: json_i32(f, "length").unwrap_or(0),
+            };
+            (!pf.is_zero()).then_some(pf)
+        });
 
         Some(Pin {
             name: name.to_string(),
@@ -997,6 +1011,7 @@ impl McpServer {
             show_designator,
             description,
             owner_part_id,
+            owner_part_display_mode,
             colour,
             graphically_locked,
             symbol_inner_edge,
@@ -1008,6 +1023,8 @@ impl McpServer {
             swap_id_group,
             part_and_sequence,
             default_value,
+            symbol_line_width,
+            frac,
         })
     }
 
@@ -1893,6 +1910,9 @@ mod tests {
             "swap_id_group": "grpA",
             "part_and_sequence": "|1&2|",
             "default_value": "0",
+            "owner_part_display_mode": 2,
+            "symbol_line_width": 3,
+            "frac": { "x": 50000, "y": -25000, "length": 0 },
         }))
         .expect("pin should parse");
         assert_eq!(pin.description, "clock input");
@@ -1901,6 +1921,16 @@ mod tests {
         assert_eq!(pin.swap_id_group, "grpA");
         assert_eq!(pin.part_and_sequence, "|1&2|");
         assert_eq!(pin.default_value, "0");
+        assert_eq!(pin.owner_part_display_mode, 2);
+        assert_eq!(pin.symbol_line_width, 3);
+        assert_eq!(
+            pin.frac,
+            Some(crate::altium::schlib::PinFrac {
+                x: 50000,
+                y: -25000,
+                length: 0
+            })
+        );
     }
 
     #[test]
@@ -1918,6 +1948,10 @@ mod tests {
         assert_eq!(pin.swap_id_group, "");
         assert_eq!(pin.part_and_sequence, "|&|");
         assert_eq!(pin.default_value, "");
+        // PR-R3 aux fields default so no aux stream is written for a plain pin.
+        assert_eq!(pin.owner_part_display_mode, 0);
+        assert_eq!(pin.symbol_line_width, 0);
+        assert_eq!(pin.frac, None);
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1304,7 +1304,10 @@ impl McpServer {
                             "graphically_locked",
                             "swap_id_group",
                             "part_and_sequence",
-                            "default_value"
+                            "default_value",
+                            "owner_part_display_mode",
+                            "symbol_line_width",
+                            "frac"
                         ]
                     );
                     if let Some(pin) = Self::parse_schlib_pin(pin_json) {

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -477,6 +477,161 @@ fn schlib_preserves_unique_id_and_pin_accessibility() {
     );
 }
 
+/// Returns the set of OLE stream paths (lower-cased) in a written library file,
+/// used to assert whether the optional pin auxiliary streams were emitted.
+fn ole_stream_paths(path: &std::path::Path) -> Vec<String> {
+    let file = File::open(path).expect("open written SchLib");
+    let cfb = cfb::CompoundFile::open(file).expect("parse OLE");
+    cfb.walk()
+        .filter(cfb::Entry::is_stream)
+        .map(|e| e.path().to_string_lossy().to_lowercase())
+        .collect()
+}
+
+#[test]
+fn schlib_pin_owner_part_display_mode_roundtrips() {
+    // PR-R3 Part 1: the pin binary record's own OwnerPartDisplayMode byte (offset
+    // 7) is preserved. A from-scratch pin defaults to 0 (byte-identical to
+    // Altium); a non-default value survives write -> read.
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_pin_odm.SchLib");
+
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("MODE");
+    let mut pin = Pin::new("1", "1", -20, 0, 10, PinOrientation::Left);
+    pin.owner_part_display_mode = 2;
+    sym.add_pin(pin);
+    sym.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right)); // default 0
+    lib.add(sym);
+    lib.save(&file_path).expect("write SchLib");
+
+    let read_lib = SchLib::open(&file_path).expect("read SchLib");
+    let read_sym = read_lib.get("MODE").expect("symbol not found");
+    assert_eq!(
+        read_sym.pins[0].owner_part_display_mode, 2,
+        "non-default pin OwnerPartDisplayMode must survive round-trip"
+    );
+    assert_eq!(
+        read_sym.pins[1].owner_part_display_mode, 0,
+        "default pin OwnerPartDisplayMode stays 0"
+    );
+}
+
+#[test]
+fn schlib_pin_symbol_line_width_roundtrips_and_omits_when_default() {
+    // PR-R3 Part 2: a non-default SymbolLineWidth survives a full library
+    // write -> read via the per-component PinSymbolLineWidth stream, keyed by
+    // pin ordinal. There is no golden for this stream, so this self round-trip
+    // (we control both compress and decompress) is the verification.
+    let temp_dir = test_temp_dir();
+
+    // Non-default: pin[1] carries width 5.
+    let path_nondefault = temp_dir.path().join("test_pin_slw.SchLib");
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("SLW");
+    sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left)); // default 0
+    let mut pin = Pin::new("2", "2", 20, 0, 10, PinOrientation::Right);
+    pin.symbol_line_width = 5;
+    sym.add_pin(pin);
+    lib.add(sym);
+    lib.save(&path_nondefault).expect("write SchLib");
+
+    let streams = ole_stream_paths(&path_nondefault);
+    assert!(
+        streams.iter().any(|s| s.ends_with("pinsymbollinewidth")),
+        "a non-default symbol line width must emit a PinSymbolLineWidth stream; streams: {streams:?}"
+    );
+
+    let read_lib = SchLib::open(&path_nondefault).expect("read SchLib");
+    let read_sym = read_lib.get("SLW").expect("symbol not found");
+    assert_eq!(
+        read_sym.pins[0].symbol_line_width, 0,
+        "default pin[0] line width stays 0"
+    );
+    assert_eq!(
+        read_sym.pins[1].symbol_line_width, 5,
+        "non-default pin[1] line width survives round-trip, keyed by ordinal"
+    );
+
+    // Default: all pins width 0 -> no stream (byte-identity anchor).
+    let path_default = temp_dir.path().join("test_pin_slw_default.SchLib");
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("PLAIN");
+    sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+    sym.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right));
+    lib.add(sym);
+    lib.save(&path_default).expect("write SchLib");
+    let streams = ole_stream_paths(&path_default);
+    assert!(
+        !streams.iter().any(|s| s.ends_with("pinsymbollinewidth")),
+        "all-default pins must write NO PinSymbolLineWidth stream; streams: {streams:?}"
+    );
+}
+
+#[test]
+fn schlib_pin_frac_roundtrips_and_omits_when_default() {
+    // PR-R3 Part 3: a fractional (off-grid) pin survives a full library
+    // write -> read via the per-component PinFrac stream, keyed by pin ordinal.
+    // No golden exists for this stream, so this self round-trip is the check.
+    use altium_designer_mcp::altium::schlib::PinFrac;
+    let temp_dir = test_temp_dir();
+
+    // Off-grid: pin[0] carries a fractional remainder.
+    let path_frac = temp_dir.path().join("test_pin_frac.SchLib");
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("FRAC");
+    let mut pin = Pin::new("1", "1", -20, 0, 10, PinOrientation::Left);
+    pin.frac = Some(PinFrac {
+        x: 50_000,
+        y: -25_000,
+        length: 12_345,
+    });
+    sym.add_pin(pin);
+    sym.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right)); // on-grid
+    lib.add(sym);
+    lib.save(&path_frac).expect("write SchLib");
+
+    let streams = ole_stream_paths(&path_frac);
+    assert!(
+        streams.iter().any(|s| s.ends_with("pinfrac")),
+        "a fractional pin must emit a PinFrac stream; streams: {streams:?}"
+    );
+
+    let read_lib = SchLib::open(&path_frac).expect("read SchLib");
+    let read_sym = read_lib.get("FRAC").expect("symbol not found");
+    assert_eq!(
+        read_sym.pins[0].frac,
+        Some(PinFrac {
+            x: 50_000,
+            y: -25_000,
+            length: 12_345,
+        }),
+        "off-grid pin[0] fractional coords survive round-trip, keyed by ordinal"
+    );
+    assert_eq!(
+        read_sym.pins[1].frac, None,
+        "on-grid pin[1] carries no PinFrac remainder"
+    );
+    // The integer part of the coordinates is untouched by the PinFrac layer.
+    assert_eq!(
+        read_sym.pins[0].x, -20,
+        "integer X preserved alongside frac"
+    );
+
+    // Default: all pins on-grid -> no stream (byte-identity anchor).
+    let path_default = temp_dir.path().join("test_pin_frac_default.SchLib");
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("GRID");
+    sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+    lib.add(sym);
+    lib.save(&path_default).expect("write SchLib");
+    let streams = ole_stream_paths(&path_default);
+    assert!(
+        !streams.iter().any(|s| s.ends_with("pinfrac")),
+        "all-on-grid pins must write NO PinFrac stream; streams: {streams:?}"
+    );
+}
+
 #[test]
 fn schlib_file_roundtrip_multiple_symbols() {
     let temp_dir = test_temp_dir();

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1894,6 +1894,95 @@ def test_write_schlib_unique_id_roundtrip(client, runner, schlib_path):
         )
 
 
+def test_write_schlib_pin_aux_data(client, runner, schlib_path):
+    print("\n=== Test: write_schlib pin auxiliary data round trip ===")
+    # Coverage PR-R3: the three pin auxiliary fields must be authorable via
+    # write_schlib and survive read_schlib.
+    #   - owner_part_display_mode: the pin binary record's own byte (Part 1).
+    #   - symbol_line_width: per-component PinSymbolLineWidth stream (Part 2).
+    #   - frac: per-component PinFrac stream, fractional off-grid coords (Part 3).
+    # A default pin (P0) sets none of them, proving the omit-when-default path
+    # (which writes no aux stream, keeping the golden byte-identical); the aux
+    # pin (PA) sets all three and must read them back keyed by pin ordinal.
+    symbol = {
+        "name": "PINAUX",
+        "pins": [
+            {
+                "designator": "0",
+                "name": "P0",
+                "x": -50,
+                "y": 0,
+                "length": 30,
+                "orientation": "left",
+            },
+            {
+                "designator": "1",
+                "name": "PA",
+                "x": -50,
+                "y": 20,
+                "length": 30,
+                "orientation": "left",
+                "owner_part_display_mode": 2,
+                "symbol_line_width": 3,
+                "frac": {"x": 50000, "y": -25000, "length": 12345},
+            },
+        ],
+    }
+
+    write = client.call_tool(
+        "write_schlib",
+        {"filepath": schlib_path, "symbols": [symbol], "append": False},
+    )
+    runner.check(
+        not write.get("_isError"), "write_schlib (pin aux) succeeded", actual=write
+    )
+
+    read = client.call_tool("read_schlib", {"filepath": schlib_path})
+    runner.check(not read.get("_isError"), "read_schlib succeeded", actual=read)
+
+    symbols = {s.get("name"): s for s in read.get("symbols", [])}
+    sym = symbols.get("PINAUX", {})
+    runner.check(bool(sym), "PINAUX symbol present", actual=list(symbols))
+
+    pins = {p.get("name"): p for p in sym.get("pins", [])}
+    p0 = pins.get("P0", {})
+    pa = pins.get("PA", {})
+
+    # Default pin: every aux field stays at its default (serde omits them).
+    runner.check(
+        p0.get("owner_part_display_mode", 0) == 0,
+        "default pin owner_part_display_mode",
+        actual=p0.get("owner_part_display_mode", 0),
+    )
+    runner.check(
+        p0.get("symbol_line_width", 0) == 0,
+        "default pin symbol_line_width",
+        actual=p0.get("symbol_line_width", 0),
+    )
+    runner.check(p0.get("frac") is None, "default pin has no frac", actual=p0.get("frac"))
+
+    # Aux pin: all three survive, keyed by pin ordinal.
+    runner.check(
+        pa.get("owner_part_display_mode") == 2,
+        "aux pin owner_part_display_mode",
+        actual=pa.get("owner_part_display_mode"),
+        expected=2,
+    )
+    runner.check(
+        pa.get("symbol_line_width") == 3,
+        "aux pin symbol_line_width",
+        actual=pa.get("symbol_line_width"),
+        expected=3,
+    )
+    frac = pa.get("frac") or {}
+    runner.check(
+        frac.get("x") == 50000 and frac.get("y") == -25000 and frac.get("length") == 12345,
+        "aux pin frac (x, y, length) round-trip",
+        actual=frac,
+        expected={"x": 50000, "y": -25000, "length": 12345},
+    )
+
+
 def main():
     binary = find_binary()
     print(f"Using binary: {binary}")
@@ -1945,6 +2034,7 @@ def main():
         test_write_schlib_parameter_display_fields(client, runner, schlib_path)
         test_write_schlib_utf8_text(client, runner, schlib_path)
         test_write_schlib_unique_id_roundtrip(client, runner, schlib_path)
+        test_write_schlib_pin_aux_data(client, runner, schlib_path)
         test_read_pcblib_exposes_vias_fills(client, runner, sample_path)
         test_read_schlib_exposes_round_rects_polygons(client, runner, schlib_sample_path)
         test_unknown_tool(client, runner)

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -149,6 +149,23 @@ fn samples_schlib_pins_etype() {
         assert_eq!(pin.length, 20, "pin[{i}] ({designator}) length");
         assert_eq!(pin.x, 0, "pin[{i}] ({designator}) x");
         assert_eq!(pin.y, y, "pin[{i}] ({designator}) y");
+        // PR-R3 pin auxiliary data. The Altium-authored golden pins are on-grid
+        // with a default symbol line width and display mode, so all three read
+        // back at their defaults — the byte-identity anchor for the aux streams
+        // (a from-scratch default pin therefore writes no PinFrac /
+        // PinSymbolLineWidth stream, keeping the storage identical).
+        assert_eq!(
+            pin.owner_part_display_mode, 0,
+            "pin[{i}] ({designator}) OwnerPartDisplayMode reads the golden byte (0)"
+        );
+        assert_eq!(
+            pin.symbol_line_width, 0,
+            "pin[{i}] ({designator}) has default symbol line width"
+        );
+        assert_eq!(
+            pin.frac, None,
+            "pin[{i}] ({designator}) is on-grid (no PinFrac remainder)"
+        );
     }
 
     // One Altium-default parameter (a `Comment` = "*").

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -1399,6 +1399,9 @@ fn test_schlib_rename_component() {
         swap_id_group: String::new(),
         part_and_sequence: "|&|".to_string(),
         default_value: String::new(),
+        owner_part_display_mode: 0,
+        symbol_line_width: 0,
+        frac: None,
     });
     lib.add(sym);
     lib.save(&file_path).expect("Failed to write");
@@ -1626,6 +1629,9 @@ fn test_schlib_copy_cross_library() {
         swap_id_group: String::new(),
         part_and_sequence: "|&|".to_string(),
         default_value: String::new(),
+        owner_part_display_mode: 0,
+        symbol_line_width: 0,
+        frac: None,
     });
     source_lib.add(sym);
     source_lib
@@ -1775,6 +1781,9 @@ fn test_schlib_json_roundtrip() {
         swap_id_group: String::new(),
         part_and_sequence: "|&|".to_string(),
         default_value: String::new(),
+        owner_part_display_mode: 0,
+        symbol_line_width: 0,
+        frac: None,
     });
     lib.add(sym);
     lib.save(&original_path).expect("Failed to write original");
@@ -2049,6 +2058,9 @@ fn test_schlib_merge_libraries() {
         swap_id_group: String::new(),
         part_and_sequence: "|&|".to_string(),
         default_value: String::new(),
+        owner_part_display_mode: 0,
+        symbol_line_width: 0,
+        frac: None,
     });
     lib2.add(sym2);
     lib2.save(&source2_path).expect("Failed to write source2");
@@ -2362,6 +2374,9 @@ fn test_schlib_get_component() {
         swap_id_group: String::new(),
         part_and_sequence: "|&|".to_string(),
         default_value: String::new(),
+        owner_part_display_mode: 0,
+        symbol_line_width: 0,
+        frac: None,
     });
     lib.add(sym1);
 


### PR DESCRIPTION
## What

Round-trip tier **R3** — the last item in the round-trip fidelity tier. Preserves the three pin data channels a SchLib symbol carries that the reader was previously dropping:

| Channel | Where | Before | After |
|---|---|---|---|
| `OwnerPartDisplayMode` | binary pin record, offset 7 | skipped on read, hard-written `0x00` | read + preserved |
| `PinFrac` | per-component OLE stream (sibling of `Data`) | not read/written | off-grid fractional pin coords preserved |
| `PinSymbolLineWidth` | per-component OLE stream | not read/written | non-default symbol line widths preserved |

The two auxiliary streams share Altium's compressed-storage framing (header param block + per-pin zlib entries keyed by pin ordinal), mirrored from AltiumSharp's `SchLibReader`/`SchLibWriter`. New `src/altium/schlib/pin_aux.rs`.

## Byte-identity

All three are **omit-when-default**: a pin with default display mode / on-grid coords / default width contributes nothing, and a symbol whose pins are all default writes **neither** aux stream. So a from-scratch symbol (and the entire golden library) stays byte-identical to Altium's output — **oracle 0 regressions**.

## Candour on the non-default path

The two streams have **no golden fixture** for a populated case, and the payloads are **zlib-compressed** (DEFLATE output is implementation-specific, so our bytes may differ from Altium's writer even with identical framing). They are therefore verified by **self round-trip** (we control compress + decompress), which is sound because zlib *inflate* is standardised — a genuinely Altium-authored stream reads back losslessly. `OwnerPartDisplayMode` is golden-verifiable and has a byte-level assertion. This limitation is documented in the module header.

## Tool

The three fields (`owner_part_display_mode`, `symbol_line_width`, `frac`) are plumbed through the write tool — schema, strict `check_keys!` allow-list, and `parse_schlib_pin` — with the same omit-when-default semantics (an all-zero `frac` object writes no stream).

## Gates (all green)

- `cargo fmt --all --check` · `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- `cargo test` — lib + integration + doc-tests, 0 failed
- `python tests/integration/test_mcp_tools.py` — **298 passed, 0 failed**
- `ORACLE_REQUIRE_DEPS=1 python tests/integration/test_altium_readability.py` — **13 passed, 0 regressions**

*Stream layout mirrored from [issus/AltiumSharp](https://github.com/issus/AltiumSharp).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)