### PR TITLE
fix(tools): round-trip Region arc_resolution/sub_poly_index/union_index/is_shape_based

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -369,6 +369,10 @@ impl McpServer {
                                                 "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
                                                 "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "cavity_height": { "type": "number", "description": "Cavity height in mm for embedded components (optional). Default: 0" },
+                                                "arc_resolution": { "type": "number", "description": "Altium ARCRESOLUTION (arc-to-line tolerance, optional). Normally omitted; preserved on a read-modify-write. Default: 0" },
+                                                "sub_poly_index": { "type": "integer", "description": "Altium SUBPOLYINDEX; -1 when not a polygon sub-shape. Preserved on a read-modify-write. Default: -1" },
+                                                "union_index": { "type": "integer", "description": "Altium UNIONINDEX for grouped primitives. Preserved on a read-modify-write. Default: 0" },
+                                                "is_shape_based": { "type": "boolean", "description": "Altium ISSHAPEBASED. Preserved on a read-modify-write. Default: false" },
                                                 "holes": {
                                                     "type": "array",
                                                     "description": "Interior hole/cutout contours (optional). Each hole is an array of {x,y} vertices subtracted from the outline.",

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -517,6 +517,19 @@ impl McpServer {
             .get("cavity_height")
             .and_then(Value::as_f64)
             .unwrap_or(0.0);
+        // These four are always serialised by read_pcblib (no skip_serializing_if),
+        // so a read-modify-write must accept AND preserve them, not reset to default.
+        // Their defaults mirror Region::default() so a from-scratch region is unchanged.
+        let arc_resolution = json
+            .get("arc_resolution")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let sub_poly_index = json_i32(json, "sub_poly_index").unwrap_or(-1);
+        let union_index = json_i32(json, "union_index").unwrap_or(0);
+        let is_shape_based = json
+            .get("is_shape_based")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
 
         // Optional interior hole contours: an array of vertex arrays (each >= 3 pts).
         let holes: Vec<Vec<Vertex>> = json
@@ -561,10 +574,13 @@ impl McpServer {
             net_index,
             polygon_index,
             component_index,
+            arc_resolution,
             cavity_height,
+            sub_poly_index,
+            union_index,
+            is_shape_based,
             unique_id,
             additional_parameters,
-            ..Region::default()
         })
     }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -625,7 +625,11 @@ impl McpServer {
                             "net_index",
                             "polygon_index",
                             "component_index",
+                            "arc_resolution",
                             "cavity_height",
+                            "sub_poly_index",
+                            "union_index",
+                            "is_shape_based",
                             "holes",
                             "unique_id",
                             "additional_parameters"

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -999,6 +999,12 @@ def test_write_pcblib_region_kind_net_name(client, runner, lib_path):
                 "name": "POUR_A",
                 "net_index": 7,
                 "cavity_height": 0.254,  # 10 mil in mm
+                # Bug sweep 2026-07: these four are always serialised by read_pcblib
+                # but were missing from the write allow-list (and unread by
+                # parse_region), so a read-modify-write of a region was rejected.
+                "sub_poly_index": 3,
+                "union_index": 2,
+                "is_shape_based": True,
             }
         ],
     }
@@ -1032,6 +1038,23 @@ def test_write_pcblib_region_kind_net_name(client, runner, lib_path):
             "region cavity_height",
             actual=rg.get("cavity_height"),
             expected=0.254,
+        )
+        runner.check(
+            rg.get("sub_poly_index") == 3,
+            "region sub_poly_index round-trips (was rejected by allow-list)",
+            actual=rg.get("sub_poly_index"),
+            expected=3,
+        )
+        runner.check(
+            rg.get("union_index") == 2,
+            "region union_index round-trips",
+            actual=rg.get("union_index"),
+            expected=2,
+        )
+        runner.check(
+            rg.get("is_shape_based") is True,
+            "region is_shape_based round-trips",
+            actual=rg.get("is_shape_based"),
         )
 
 


### PR DESCRIPTION
## Bug

`read_pcblib` always serialises four `Region` fields — `arc_resolution`, `sub_poly_index`, `union_index`, `is_shape_based` (none has `skip_serializing_if`) — but the `write_pcblib` region `check_keys!` allow-list omitted them. So feeding a read result straight back to `write_pcblib` was **rejected**:

```
Unknown field 'arc_resolution'. Allowed fields are: [...]
```

i.e. a plain read-modify-write of any footprint containing a region failed. And `parse_region` never read them (it filled them from `Region::default()` via `..`), so even once accepted they would silently reset on write.

## Fix

- Add the four keys to the region allow-list.
- Read them in `parse_region` — defaults mirror `Region::default()` (`arc_resolution=0`, `sub_poly_index=-1`, `union_index=0`, `is_shape_based=false`), so a from-scratch region is unchanged.
- Document them in the write schema.
- Extend the region round-trip integration test to set and assert them.

Found by the adversarial bug sweep (3/3 refuters confirmed). The pin twin of this bug (`is_not_accessible`/`formal_type`) is fixed in #225.

## Gates (all green)

- fmt · clippy `-D warnings` · `cargo doc -Dwarnings` · `tools_md_in_sync`
- `cargo test` — 375 lib + integration + doc, 0 failed
- `test_mcp_tools.py` — **317 passed, 0 failed**
- `test_altium_readability.py` — **13 passed, 0 regressions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)