### PR TITLE
fix: minor + cosmetic defects from the adversarial bug sweep

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -44,7 +44,8 @@ use std::hash::{BuildHasher, Hash, Hasher};
 /// Maximum length for OLE Compound File storage/stream names.
 ///
 /// OLE Compound Document format limits entry names to 31 UTF-16 code units.
-/// We enforce 31 bytes for ASCII compatibility.
+/// We enforce that 31-code-unit limit (see `utf16_len` / `truncate_utf16`); for
+/// ASCII names one code unit is one byte, so the effective limit is 31 chars.
 pub const MAX_OLE_NAME_LEN: usize = 31;
 
 /// Reserve 4 chars for "~XXX" suffix (allows 999 collisions).

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -26,9 +26,12 @@
 //! [name_block_len:4][str_len:1][name:str_len]  // Component name
 //! [record_type:1][blocks...]                   // First primitive
 //! [record_type:1][blocks...]                   // Second primitive
-//! ...
-//! [0x00]                                       // End marker
+//! ...                                          // exactly the primitive count from the component header
 //! ```
+//!
+//! There is NO trailing end marker: the writer must never emit a final `0x00`.
+//! Altium reads exactly the primitive count from the component header, and a
+//! stray `0x00` is mis-parsed as a zero-length record (see issue #68).
 //!
 //! Record types: Arc(1), Pad(2), Via(3), Track(4), Text(5), Fill(6), Region(11), ComponentBody(12)
 

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -9,9 +9,11 @@
 //! [name_block_len:4][str_len:1][name:str_len]  // Component name
 //! [record_type:1][blocks...]                   // First primitive
 //! [record_type:1][blocks...]                   // Second primitive
-//! ...
-//! [0x00]                                       // End marker
+//! ...                                          // exactly the primitive count from the component header
 //! ```
+//!
+//! There is NO trailing end marker — the writer deliberately omits any final
+//! `0x00` (a stray one is mis-read as a zero-length record; see issue #68).
 //!
 //! # Record Types
 //!

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -742,7 +742,7 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
 /// [y:4 i32]                     // Y position
 /// [height:4 i32]                // Text height
 /// ...                           // Additional fields (font, style)
-/// [rotation:8 f64]              // Rotation angle (at offset 37)
+/// [rotation:8 f64]              // Rotation angle (at offset 27)
 /// [font_name:varies]            // Font name in UTF-16 (null-terminated)
 /// [text_content:varies]         // Text content in UTF-16 or reference
 /// ```
@@ -1012,12 +1012,13 @@ pub(super) fn extract_text_from_block(block: &[u8], wide_strings: Option<&WideSt
     // The WideStringsIndex is a u16 at offset 115 in the geometry block
     // Verified by reverse-engineering an Altium-authored library with Text primitives
     if let Some(ws) = wide_strings {
-        if block.len() > 117 {
-            if let Some(index) = read_u16(block, 115) {
-                if let Some(resolved) = ws.get(&(index as usize)) {
-                    tracing::trace!(index, resolved = %resolved, "Resolved WideStrings from offset 115");
-                    return resolved.clone();
-                }
+        // The u16 at offset 115 needs bytes 115..117, i.e. len >= 117; `read_u16`
+        // already bounds-checks, so no redundant length guard (the old `> 117`
+        // wrongly rejected a block of exactly 117 bytes).
+        if let Some(index) = read_u16(block, 115) {
+            if let Some(resolved) = ws.get(&(index as usize)) {
+                tracing::trace!(index, resolved = %resolved, "Resolved WideStrings from offset 115");
+                return resolved.clone();
             }
         }
     }

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -235,12 +235,15 @@ impl PcbLib {
 
     /// Writes the `/FileHeader` stream.
     ///
-    /// The `FileHeader` contains a binary-encoded version string:
+    /// The canonical PcbLib `FileHeader` is **53 bytes** with THREE fields
+    /// (matching AltiumSharp `PcbLibWriter.WriteFileHeader`); Altium rejects the
+    /// file if the version double or the `UniqueId` block are missing:
     /// ```text
-    /// [string_length:4 LE u32][string_length:1 u8]["PCB 6.0 Binary Library File"]
+    /// [len:4 LE u32][len:1 u8]["PCB 6.0 Binary Library File"]  // version string (4+1+27 = 32 bytes)
+    /// [5.01 : 8 f64]                                            // format version double
+    /// [len:4 LE u32][len:1 u8][8-char UniqueId]                // 4+1+8 = 13 bytes
     /// ```
-    ///
-    /// The 4-byte and 1-byte lengths are the same value (27).
+    /// The version string's 4-byte and 1-byte lengths are the same value (27).
     /// Component metadata is stored in `/Library/Data`, not here.
     #[allow(clippy::unused_self)]
     fn write_file_header<F: std::io::Read + std::io::Write + std::io::Seek>(

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -235,9 +235,9 @@ impl PcbLib {
 
     /// Writes the `/FileHeader` stream.
     ///
-    /// The canonical PcbLib `FileHeader` is **53 bytes** with THREE fields
-    /// (matching AltiumSharp `PcbLibWriter.WriteFileHeader`); Altium rejects the
-    /// file if the version double or the `UniqueId` block are missing:
+    /// The canonical `PcbLib` `FileHeader` is **53 bytes** with THREE fields
+    /// (matching `AltiumSharp`'s `PcbLibWriter.WriteFileHeader`); Altium rejects
+    /// the file if the version double or the `UniqueId` block are missing:
     /// ```text
     /// [len:4 LE u32][len:1 u8]["PCB 6.0 Binary Library File"]  // version string (4+1+27 = 32 bytes)
     /// [5.01 : 8 f64]                                            // format version double

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -409,7 +409,10 @@ fn encode_pad_per_layer_data(pad: &Pad) -> Vec<u8> {
                     default_radius
                 }
             });
-        block.push(radius);
+        // Corner radius is a 0-100 percentage; clamp on write to mirror the
+        // reader's `.min(100)`, so an out-of-range value round-trips symmetrically
+        // rather than emitting a byte the reader would then clamp.
+        block.push(radius.min(100));
     }
 
     // 32 offset entries (x, y for each layer) - 256 bytes (optional)
@@ -1125,9 +1128,9 @@ pub fn encode_text_geometry(text: &Text) -> Vec<u8> {
     // zero fill — byte-identical to the "Arial\0…" template for a from-scratch text.
     encode_font_name_field(&mut block[46..110], &text.font_name);
 
-    // Text-box justification (offset 132). The from-scratch default `MiddleCenter`
-    // encodes to 0x00 (the template byte); other anchors map onto the Altium
-    // column-major text-box encoding.
+    // Text-box justification (offset 132). The from-scratch default `BottomLeft`
+    // encodes to 0x03 (the template byte at offset 132); other anchors map onto
+    // Altium's column-major text-box encoding.
     block[132] = pcb_justification_to_id(text.justification);
 
     // Inverted (knockout) text-box descriptor. Defaults reproduce the template
@@ -1495,13 +1498,15 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         if body.is_shape_based { "TRUE" } else { "FALSE" }
     ));
     params.push("CAVITYHEIGHT=0mil".to_string());
+    // Use the canonical trimmed mil formatting (as the region encoder does) rather
+    // than raw {} float formatting, so body heights match Altium's own output shape.
     params.push(format!(
-        "STANDOFFHEIGHT={}mil",
-        mm_to_mil(body.standoff_height)
+        "STANDOFFHEIGHT={}",
+        format_mil_coord(body.standoff_height)
     ));
     params.push(format!(
-        "OVERALLHEIGHT={}mil",
-        mm_to_mil(body.overall_height)
+        "OVERALLHEIGHT={}",
+        format_mil_coord(body.overall_height)
     ));
     params.push(format!("BODYPROJECTION={}", body.body_projection));
     // Altium repeats ARCRESOLUTION after BODYPROJECTION (verbatim shape from the
@@ -1541,7 +1546,7 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     params.push(format!("MODEL.3D.ROTX={:.3}", body.rotation_x));
     params.push(format!("MODEL.3D.ROTY={:.3}", body.rotation_y));
     params.push(format!("MODEL.3D.ROTZ={:.3}", body.rotation_z));
-    params.push(format!("MODEL.3D.DZ={}mil", mm_to_mil(body.z_offset)));
+    params.push(format!("MODEL.3D.DZ={}", format_mil_coord(body.z_offset)));
     // MODELTYPE 0 = Extruded (no model file); 1 = generic/STEP model.
     let model_type = if extruded { "0" } else { "1" };
     params.push(format!("MODEL.MODELTYPE={model_type}"));
@@ -1550,12 +1555,12 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         // This is what Altium actually extrudes the outline between; without it
         // the body has no volume and is discarded on load.
         params.push(format!(
-            "MODEL.EXTRUDED.MINZ={}mil",
-            mm_to_mil(body.standoff_height)
+            "MODEL.EXTRUDED.MINZ={}",
+            format_mil_coord(body.standoff_height)
         ));
         params.push(format!(
-            "MODEL.EXTRUDED.MAXZ={}mil",
-            mm_to_mil(body.overall_height)
+            "MODEL.EXTRUDED.MAXZ={}",
+            format_mil_coord(body.overall_height)
         ));
     } else {
         params.push("MODEL.MODELSOURCE=Undefined".to_string());

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -14,16 +14,18 @@
 //! # Data Stream Format
 //!
 //! ```text
-//! [RecordLength:2 LE][RecordType:2 BE][data:RecordLength]
+//! [length:3 LE u24][flags:1 u8][data:length]
 //! ...
 //! ```
 //!
+//! The 4-byte header is Altium's single 32-bit little-endian size word: the low
+//! 24 bits are the payload length, the high byte is the record-type flag.
 //! There is NO end-of-stream marker — records run until the stream is exhausted.
 //! (A trailing `0x0000` would be mis-read as a zero-length record; see issue #68.)
 //!
-//! Record types:
-//! - `0x0000`: Text record (pipe-delimited key=value pairs)
-//! - `0x0001`: Binary pin record
+//! Record-type flag (the header's high byte):
+//! - `0x00`: Text record (pipe-delimited key=value pairs)
+//! - `0x01`: Binary pin record
 //!
 //! # Record IDs (RECORD= field in text records)
 //!

--- a/src/altium/schlib/primitives.rs
+++ b/src/altium/schlib/primitives.rs
@@ -1045,18 +1045,18 @@ impl EllipticalArc {
     pub fn new(
         x: impl Into<f64>,
         y: impl Into<f64>,
-        radius: f64,
-        secondary_radius: f64,
-        start_angle: f64,
-        end_angle: f64,
+        radius: impl Into<f64>,
+        secondary_radius: impl Into<f64>,
+        start_angle: impl Into<f64>,
+        end_angle: impl Into<f64>,
     ) -> Self {
         Self {
             x: x.into(),
             y: y.into(),
-            radius,
-            secondary_radius,
-            start_angle,
-            end_angle,
+            radius: radius.into(),
+            secondary_radius: secondary_radius.into(),
+            start_angle: start_angle.into(),
+            end_angle: end_angle.into(),
             line_width: 1,
             color: 0x00_00_80, // Dark red (BGR)
             fill_color: 0,
@@ -1070,8 +1070,8 @@ impl EllipticalArc {
     pub fn full_ellipse(
         x: impl Into<f64>,
         y: impl Into<f64>,
-        radius: f64,
-        secondary_radius: f64,
+        radius: impl Into<f64>,
+        secondary_radius: impl Into<f64>,
     ) -> Self {
         Self::new(x, y, radius, secondary_radius, 0.0, 360.0)
     }

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -6,14 +6,15 @@
 //! # Data Stream Format
 //!
 //! ```text
-//! [RecordLength:2 LE][RecordType:2 BE][data:RecordLength]
+//! [length:3 LE u24][flags:1 u8][data:length]
 //! ...
 //! ```
 //!
-//! The 4-byte record header is equivalent to Altium's single 32-bit
-//! little-endian size word whose high byte is a flag (0x00 text, 0x01 pin).
-//! Records run until the stream is exhausted — there is NO end-of-stream
-//! marker (a trailing 0x0000 would be mis-read as a zero-length record).
+//! The 4-byte record header is Altium's single 32-bit little-endian size word:
+//! the low 24 bits are the payload length and the high byte is a flag (0x00
+//! text record, 0x01 binary pin record). Records run until the stream is
+//! exhausted — there is NO end-of-stream marker (a trailing 0x0000 would be
+//! mis-read as a zero-length record).
 //!
 //! Record types:
 //! - `0x0000`: Text record (pipe-delimited key=value pairs)

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -217,6 +217,14 @@ impl McpServer {
                                                     "enum": ["none", "from_rule", "manual"],
                                                     "description": "Solder mask expansion mode. Default: from_rule"
                                                 },
+                                                "paste_mask_expansion": { "type": "number", "description": "Paste (stencil) mask expansion in mm (optional; omit to use the rule default)" },
+                                                "paste_mask_expansion_mode": {
+                                                    "type": "string",
+                                                    "enum": ["none", "from_rule", "manual"],
+                                                    "description": "Paste mask expansion mode. Default: from_rule"
+                                                },
+                                                "corner_radius_percent": { "type": "integer", "description": "Rounded-rectangle corner radius as a percentage of the shorter side (0-100). Default: 0" },
+                                                "rotation": { "type": "number", "description": "Pad rotation in degrees. Default: 0" },
                                                 "power_plane_connect_style": {
                                                     "type": "string",
                                                     "enum": ["relief", "direct", "no_connect"],
@@ -467,7 +475,7 @@ impl McpServer {
                                                 "union_index": { "type": "integer", "description": "Altium UNIONINDEX for grouped primitives. Default: 0" },
                                                 "is_shape_based": { "type": "boolean", "description": "Altium ISSHAPEBASED (shape-based vs. model-based body). Default: false" },
                                                 "body_projection": { "type": "integer", "description": "Altium BODYPROJECTION (board side). Default: 0" },
-                                                "body_color_3d": { "type": "integer", "description": "3D body colour as decimal RGB (Altium BODYCOLOR3D). Default: 8421504 (0xE0E0E0, grey)" },
+                                                "body_color_3d": { "type": "integer", "description": "3D body colour as decimal RGB (Altium BODYCOLOR3D). Default: 8421504 (0x808080, grey)" },
                                                 "body_opacity_3d": { "type": "number", "description": "3D body opacity, 0.0-1.0 (Altium BODYOPACITY3D). Default: 1.0" },
                                                 "model_2d_rotation": { "type": "number", "description": "2D placement rotation in degrees (Altium MODEL.2D.ROTATION). Default: 0" },
                                                 "model_id": { "type": "string", "description": "Model GUID referencing an embedded model (Altium MODELID). Default: \"\" (none)" },
@@ -549,8 +557,8 @@ impl McpServer {
                                             "properties": {
                                                 "designator": { "type": "string" },
                                                 "name": { "type": "string" },
-                                                "x": { "type": "number", "description": "Pin's body-attach (INNER) end, in schematic units (10 units = 1 grid square). This is the end that touches the symbol body, NOT the connection tip. The pin is drawn from (x,y) extending 'length' units in the 'orientation' direction; the connection tip is at the far end." },
-                                                "y": { "type": "number", "description": "Y of the pin's body-attach (inner) end, in schematic units. See 'x'." },
+                                                "x": { "type": "integer", "description": "Pin's body-attach (INNER) end, in whole schematic units (10 units = 1 grid square). This is the end that touches the symbol body, NOT the connection tip. The pin is drawn from (x,y) extending 'length' units in the 'orientation' direction; the connection tip is at the far end. Pins are integer-positioned; for an off-grid pin supply the sub-unit remainder via 'frac' (a fractional value here is truncated)." },
+                                                "y": { "type": "integer", "description": "Y of the pin's body-attach (inner) end, in whole schematic units. See 'x' (use 'frac' for off-grid)." },
                                                 "length": { "type": "number", "description": "Pin length in schematic units (10 = 1 grid). Drawn from (x,y) outward in the 'orientation' direction." },
                                                 "orientation": { "type": "string", "enum": ["left", "right", "up", "down"], "description": "Direction the pin POINTS, away from the body — NOT which side it sits on. A pin on the LEFT side uses 'left' (tip at x-length); a RIGHT-side pin uses 'right' (tip at x+length); 'up'/'down' for top/bottom pins. Put each pin's (x,y) on the matching body-rectangle edge so it attaches flush, e.g. left pin {x:-50,y:20,length:30,orientation:'left'} with rectangle x1=-50, and the matching right pin {x:50,y:20,length:30,orientation:'right'} with x2=50. For TOP/BOTTOM pins, (x,y) sits on the body's top/bottom edge and the pin points outward (away from the body centre): a top-side pin uses 'up' (tip at y+length, above the body), a bottom-side pin uses 'down' (tip at y-length, below) — e.g. a vertical 2-pin part with the body near y=0: top pin {x:0,y:10,length:30,orientation:'up'} (tip at y=40), bottom pin {x:0,y:-10,length:30,orientation:'down'} (tip at y=-40)." },
                                                 "electrical_type": { "type": "string", "enum": ["input", "output", "bidirectional", "passive", "power", "open_collector", "open_emitter", "hi_z", "tristate"], "description": "Pin electrical type. 'tristate' is accepted as an alias for 'hi_z'. Default: passive" },

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -404,7 +404,7 @@ impl McpServer {
                     if name == component_name {
                         String::new()
                     } else {
-                        " (note: name in library key unchanged)".to_string()
+                        format!(" and change its saved name to '{name}' (use rename_component if you also need the in-session lookup key updated)")
                     }
                 ),
             });
@@ -433,7 +433,7 @@ impl McpServer {
                 if name == component_name {
                     String::new()
                 } else {
-                    " (note: name in library key unchanged, use rename_component to change key)".to_string()
+                    format!(" and changed its saved name to '{name}' (use rename_component if you also need the in-session lookup key updated)")
                 }
             ),
         });

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -232,9 +232,10 @@ impl McpServer {
             }
         }
 
-        // Draw origin crosshair
+        // Draw origin crosshair only onto a blank cell, so it never hides a
+        // primitive (consistent with render_symbol_ascii).
         let (ox, oy) = to_canvas(0.0, 0.0);
-        if ox < canvas_width && oy < canvas_height {
+        if ox < canvas_width && oy < canvas_height && canvas[oy][ox] == ' ' {
             canvas[oy][ox] = '+';
         }
 
@@ -724,12 +725,14 @@ impl McpServer {
 
         // Build output string
         let mut output = String::new();
+        // Clamp the displayed part index to 1..=part_count so an out-of-range
+        // part_id can't render a nonsensical header like "part 5/2".
+        let part_count_i32 = i32::try_from(symbol.part_count).unwrap_or(i32::MAX).max(1);
+        let shown_part = part_id.clamp(1, part_count_i32);
         let _ = writeln!(
             output,
             "Symbol: {} (part {}/{})",
-            symbol.name,
-            if part_id == 0 { 1 } else { part_id },
-            symbol.part_count
+            symbol.name, shown_part, symbol.part_count
         );
         let _ = writeln!(
             output,

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -21,9 +21,14 @@ use serde::Serialize;
 pub enum AuditOutcome {
     /// The operation completed successfully.
     Success,
-    /// The operation returned an error result.
+    /// The operation returned an error result. NOTE: the dispatch chokepoint
+    /// currently records every failed mutating call (including a path-rejected or
+    /// rate-limited one) as `Error`, because at that point only `is_error` is
+    /// known, not the failure category.
     Error,
-    /// The operation was denied (e.g. rate limited or path rejected).
+    /// The operation was denied (e.g. rate limited or path rejected). Reserved:
+    /// distinguishing a denial from a plain `Error` needs the denial category
+    /// threaded from the reject sites, which the dispatch path does not yet do.
     Denied,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,11 +34,15 @@ pub fn redact_absolute_paths(message: &str) -> String {
     static WINDOWS: OnceLock<Regex> = OnceLock::new();
     static UNIX: OnceLock<Regex> = OnceLock::new();
 
-    // Group 1 is a leading boundary (start, whitespace, quote, paren, `=`) so a
-    // drive letter preceded by other letters — e.g. the `s:` in `https://` — is
-    // not mistaken for `C:\`.
-    let windows = WINDOWS
-        .get_or_init(|| Regex::new(r#"(^|[\s"'(=])((?:[A-Za-z]:[\\/]|\\\\)[^\s"'<>|]*)"#).unwrap());
+    // Group 1 is a leading boundary (start, whitespace, quote, paren, `=`, `:`) so a
+    // drive letter preceded by other letters — e.g. the `s:` in `https://` — is not
+    // mistaken for `C:\`, while a path glued straight after a colon (`detail:C:\…`)
+    // is still redacted. The false-positive guard holds: in `https://` the drive
+    // candidate `s:/` is preceded by `p` (a letter, not in the class), so it never
+    // matches.
+    let windows = WINDOWS.get_or_init(|| {
+        Regex::new(r#"(^|[\s"'(=:])((?:[A-Za-z]:[\\/]|\\\\)[^\s"'<>|]*)"#).unwrap()
+    });
     let unix = UNIX.get_or_init(|| Regex::new(r"(^|\s)(/[^\s/]+(?:/[^\s/]+)+)").unwrap());
 
     let redact = |caps: &regex::Captures| format!("{}{}", &caps[1], basename(&caps[2]));
@@ -137,6 +141,16 @@ mod tests {
         assert_eq!(
             redact_absolute_paths("at C:/Users/me/Lib.PcbLib here"),
             "at Lib.PcbLib here"
+        );
+        // A drive path glued straight after a colon (no space) must still redact.
+        assert_eq!(
+            redact_absolute_paths("detail:C:\\Users\\me\\secret\\Lib.PcbLib"),
+            "detail:Lib.PcbLib"
+        );
+        // The `https://` guard still holds — no drive-letter false positive.
+        assert_eq!(
+            redact_absolute_paths("see https://example.com/x"),
+            "see https://example.com/x"
         );
     }
 


### PR DESCRIPTION
A batch of small correctness / consistency / documentation fixes — each a confirmed finding from the multi-agent adversarial bug sweep (≥2/3 refuters). Grouped here because they're individually tiny; the higher-severity bugs shipped in #225–#227.

## Logic / behaviour
- **pad writer**: clamp `corner_radius_percent` to 100 on write, mirroring the reader's `.min(100)` (out-of-range values now round-trip symmetrically).
- **ComponentBody**: format `STANDOFFHEIGHT`/`OVERALLHEIGHT`/`MODEL.3D.DZ`/`MODEL.EXTRUDED.*` via the canonical trimmed `format_mil_coord` (as the region encoder does) instead of raw `{}` float formatting. **Oracle 0 regressions.**
- **render**: clamp the displayed symbol part index to `1..=part_count` (could print `part 5/2`); draw the footprint origin crosshair only onto a blank cell so it never hides a primitive (matches `render_symbol_ascii`).
- **util `redact_absolute_paths`**: add `:` to the leading-boundary class so a drive path glued straight after a colon (`detail:C:\…`) is still redacted; the `https://` guard still holds. Covering tests added.
- **text reader**: drop the off-by-one `block.len() > 117` guard (`read_u16` already bounds-checks; it wrongly rejected a 117-byte block).
- **update_component messages**: now state the saved name *is* changed on a rename, instead of the contradictory "name in library key unchanged".

## Schema
- **write_schlib pin x/y** declared `"number"` but parsed with `json_i32` (a fractional value silently truncated → the whole pin vanished). Declared `"integer"`, documenting that off-grid pins use `frac`.
- **write_pcblib pad schema**: added the `paste_mask_expansion(_mode)`, `corner_radius_percent` and `rotation` properties `parse_pad` already honours.

## API consistency
- **`EllipticalArc::new` / `full_ellipse`**: accept `impl Into<f64>` for radius/angle args like every sibling shape constructor.

## Docs / comments (were factually wrong)
- `parse_text` rotation offset 37 → 27; PcbLib + SchLib Data-stream docs no longer claim a trailing `0x00` end marker (issue #68); SchLib record-frame doc now `[u24 len LE][u8 flags]`; `write_file_header` doc now describes the 53-byte three-field header; PcbLib justification comment corrected to BottomLeft/0x03; `body_color_3d` hex `0xE0E0E0` → `0x808080`; `MAX_OLE_NAME_LEN` doc now "31 UTF-16 code units"; `AuditOutcome::Denied` documented as reserved.

## Deferred to a follow-up
Genuine behaviour redesigns (not cosmetic), each warranting its own PR + tests: `compare_*` duplicate-key collapse, `compare_footprints` region/text geometry depth, and the STEP extract `output_path` file-vs-directory / `has_more(limit=0)` semantics.

## Gates (all green)
- fmt · clippy `-D warnings` · `cargo doc -Dwarnings` · `tools_md_in_sync`
- `cargo test` — 375 lib + integration + doc, 0 failed
- `test_mcp_tools.py` — **314 passed, 0 failed**
- `test_altium_readability.py` — **13 passed, 0 regressions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)