### PR TITLE
docs(readme): list write_libpkg in the MCP tools overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ read and write the actual `.PcbLib` / `.SchLib` files.
 
 ## MCP Tools
 
-The server exposes **33 tools**, working on both `.PcbLib` (footprints) and
+The server exposes **34 tools**, working on both `.PcbLib` (footprints) and
 `.SchLib` (symbols). Every tool's full parameters and examples live in
 **[docs/TOOLS.md](docs/TOOLS.md)** — this is the categorised overview.
 
@@ -169,6 +169,7 @@ The server exposes **33 tools**, working on both `.PcbLib` (footprints) and
 | Tool | Purpose |
 |------|---------|
 | [`merge_libraries`](docs/TOOLS.md#merge_libraries) | Merge multiple libraries into one. |
+| [`write_libpkg`](docs/TOOLS.md#write_libpkg) | Write a `.LibPkg` project grouping libraries for IntLib compilation. |
 | [`export_library`](docs/TOOLS.md#export_library) | Export to JSON/CSV. |
 | [`import_library`](docs/TOOLS.md#import_library) | Import from JSON (inverse of export). |
 | [`validate_library`](docs/TOOLS.md#validate_library) | Validate for common issues. |


### PR DESCRIPTION
## Description

The README's § MCP Tools overview said **33 tools** and its category tables omitted `write_libpkg`, which `docs/TOOLS.md` (generated from the served tool definitions) has carried since the tool shipped. This adds the missing row under **Library operations** and corrects the count to **34**.

Doc-only drift fix — no code changes.

## Related Issue

None (drift noticed while auditing README against the generated `docs/TOOLS.md`).

## Type of Change

- [x] Documentation update

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained
- [x] No breaking changes to existing MCP tool interfaces

## Testing

- [x] `markdownlint-cli2 README.md` — 0 errors

## Code Quality

- [x] Documentation updated if needed
- [ ] CHANGELOG.md — not applicable (pre-release; changelog is populated at first release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)