### PR TITLE
fix(step): make extract_by_footprint's output_path a directory regardless of match count

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -427,7 +427,7 @@ Extract embedded STEP 3D models from an Altium .PcbLib file. Models are stored c
 | `mode` | enum | no | Extraction mode: 'auto' (default) extracts single model or lists if multiple; 'list' always lists models; 'extract_all' extracts all models to output_dir; 'extract_by_footprint' extracts models used by specified footprint (one of: auto, list, extract_all, extract_by_footprint) |
 | `model` | string | no | Model name (e.g., 'RESC1005X04L.step') or GUID to extract (for 'auto' mode) |
 | `offset` | integer | no | Number of models to skip when listing (for 'list' mode) |
-| `output_path` | string | no | For single extraction: file path for .step file. For extract_all: directory path for all models. |
+| `output_path` | string | no | Meaning depends only on the mode, never on how many models match: for 'auto' it is the FILE path for the extracted .step; for 'extract_all' and 'extract_by_footprint' it is a DIRECTORY that receives one file per model (created if absent). Omit to get the model inline as base64 ('auto' single model, or 'extract_by_footprint' with a single match). |
 
 ## `diff_libraries`
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1228,6 +1228,83 @@ mod tests {
     }
 
     // =========================================================================
+    // extract_step_model Tool Tests
+    // =========================================================================
+
+    /// Creates a test `PcbLib` with one footprint referencing one embedded
+    /// STEP model.
+    fn create_test_pcblib_with_model(path: &std::path::Path) {
+        use crate::altium::pcblib::{ComponentBody, EmbeddedModel};
+
+        const MODEL_ID: &str = "{11111111-2222-3333-4444-555555555555}";
+
+        let mut lib = PcbLib::new();
+        let mut fp = Footprint::new("FP_3D");
+        fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+        fp.add_component_body(ComponentBody::new(MODEL_ID, "part.step"));
+        lib.add(fp);
+        lib.add_model(EmbeddedModel::new(
+            MODEL_ID,
+            "part.step",
+            b"ISO-10303-21; test".to_vec(),
+        ));
+        lib.save(path).expect("save pcblib with model");
+    }
+
+    #[test]
+    fn extract_by_footprint_output_path_is_a_directory_even_for_one_match() {
+        // Regression (bug sweep 2026-07, deferred item): with exactly one
+        // matching model `output_path` used to be treated as a FILE path, but
+        // as a DIRECTORY for two or more — the same argument changed meaning
+        // based on data the caller does not control. It is now always a
+        // directory for extract_by_footprint.
+        let temp = test_temp_dir();
+        let lib_path = temp.path().join("with_model.PcbLib");
+        create_test_pcblib_with_model(&lib_path);
+
+        let out_dir = temp.path().join("models_out");
+        let server = create_test_server(temp.path());
+        let args = json!({
+            "filepath": lib_path.to_string_lossy(),
+            "mode": "extract_by_footprint",
+            "footprint_name": "FP_3D",
+            "output_path": out_dir.to_string_lossy(),
+        });
+
+        let result = server.call_extract_step_model(&args);
+        assert!(!result.is_error, "expected success: {:?}", result.content);
+
+        let extracted = out_dir.join("part.step");
+        assert!(
+            extracted.exists(),
+            "single-match extract_by_footprint must treat output_path as a directory"
+        );
+        assert_eq!(
+            std::fs::read(&extracted).expect("read extracted model"),
+            b"ISO-10303-21; test"
+        );
+    }
+
+    #[test]
+    fn extract_by_footprint_without_output_returns_base64_for_single_match() {
+        let temp = test_temp_dir();
+        let lib_path = temp.path().join("with_model.PcbLib");
+        create_test_pcblib_with_model(&lib_path);
+
+        let server = create_test_server(temp.path());
+        let args = json!({
+            "filepath": lib_path.to_string_lossy(),
+            "mode": "extract_by_footprint",
+            "footprint_name": "FP_3D",
+        });
+
+        let result = server.call_extract_step_model(&args);
+        assert!(!result.is_error, "expected success: {:?}", result.content);
+        let parsed: Value = serde_json::from_str(get_result_text(&result)).expect("valid JSON");
+        assert_eq!(parsed["encoding"], "base64");
+    }
+
+    // =========================================================================
     // list_components Tool Tests
     // =========================================================================
 

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -1120,7 +1120,7 @@ impl McpServer {
                         },
                         "output_path": {
                             "type": "string",
-                            "description": "For single extraction: file path for .step file. For extract_all: directory path for all models."
+                            "description": "Meaning depends only on the mode, never on how many models match: for 'auto' it is the FILE path for the extracted .step; for 'extract_all' and 'extract_by_footprint' it is a DIRECTORY that receives one file per model (created if absent). Omit to get the model inline as base64 ('auto' single model, or 'extract_by_footprint' with a single match)."
                         },
                         "model": {
                             "type": "string",

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -376,36 +376,43 @@ impl McpServer {
             return ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Extract or return the models
-        if matching_models.len() == 1 {
-            // Single model - use standard extraction
-            Self::extract_model_output(filepath, output_path, matching_models[0])
-        } else if let Some(out_dir) = output_path {
-            // Multiple models - extract to directory
-            self.extract_all_step_models(filepath, Some(out_dir), &matching_models)
-        } else {
-            // Multiple models, no output - return info
-            let model_info: Vec<Value> = matching_models
-                .iter()
-                .map(|m| {
-                    json!({
-                        "id": m.id,
-                        "name": m.name,
-                        "size_bytes": m.data.len(),
-                    })
-                })
-                .collect();
+        // Extract or return the models. `output_path` is ALWAYS a directory in
+        // this mode — previously it meant a file path for exactly one match
+        // and a directory for several, so the same call wrote to different
+        // places depending on how many models the footprint happened to
+        // reference. The footprint decides the match count, not the caller,
+        // so the meaning of the argument must not depend on it.
+        output_path.map_or_else(
+            || {
+                if matching_models.len() == 1 {
+                    // Single model, no output path - return it inline as base64
+                    Self::extract_model_output(filepath, None, matching_models[0])
+                } else {
+                    // Multiple models, no output - return info
+                    let model_info: Vec<Value> = matching_models
+                        .iter()
+                        .map(|m| {
+                            json!({
+                                "id": m.id,
+                                "name": m.name,
+                                "size_bytes": m.data.len(),
+                            })
+                        })
+                        .collect();
 
-            let result = json!({
-                "status": "list",
-                "filepath": filepath,
-                "footprint": footprint_name,
-                "message": "Multiple models found for footprint. Specify 'output_path' to extract all.",
-                "model_count": matching_models.len(),
-                "models": model_info,
-            });
-            ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
-        }
+                    let result = json!({
+                        "status": "list",
+                        "filepath": filepath,
+                        "footprint": footprint_name,
+                        "message": "Multiple models found for footprint. Specify 'output_path' to extract all.",
+                        "model_count": matching_models.len(),
+                        "models": model_info,
+                    });
+                    ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
+                }
+            },
+            |out_dir| self.extract_all_step_models(filepath, Some(out_dir), &matching_models),
+        )
     }
 
     /// Helper to output extracted model data (to file or base64).


### PR DESCRIPTION
## Description

Fixes the last **deferred behaviour-redesign item from the 2026-07-05 adversarial bug sweep**: `extract_step_model` with `mode=extract_by_footprint` treated `output_path` as a **file** path when exactly one model matched, but as a **directory** when two or more did. The match count is decided by the footprint's model references — data the caller does not control — so the same call could write to different places depending on library content: a caller passing a directory with one match failed the write, and a caller passing a file path with two matches got a directory named like a file.

`output_path` is now **always a directory** for `extract_by_footprint` (matching `extract_all`), whatever the match count. The no-`output_path` behaviour is unchanged (single match → inline base64; several → info list). The tool schema now spells out the per-mode meaning (`auto` = file, `extract_all`/`extract_by_footprint` = directory); `docs/TOOLS.md` regenerated via the drift guard.

Also **re-verified** the sweep's companion claim that `list_step_models` mis-computes `has_more` at `limit=0`: the current formula (`offset + returned_count < total_count`) is correct for `limit=0` at any offset — no change needed, claim retired.

### Behaviour change note

A caller relying on the old single-match file semantics now gets `<output_path>/<model_name>` instead of `<output_path>` — that data-dependent semantics is precisely the bug (the result JSON reports the exact paths written, so callers can follow them).

## Related Issue

Deferred item from the adversarial bug sweep (PRs #225–#228, #238 fixed the rest).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Standards Checklist

- [x] Primitive types (Pad, Track, Arc, etc.) maintain backwards compatibility
- [x] Altium file format compatibility is maintained (no reader/writer changes)
- [x] No breaking changes to existing MCP tool interfaces (schema shape unchanged; documented semantics clarified)

## Testing

- [x] 2 new regression tests: single-match extraction lands **inside** the directory; single-match base64 path unchanged
- [x] `cargo test` — 381 lib + all suites green
- [x] Integration — 336/336
- [x] Readability oracle — 13 passed, 0 regressions

## Code Quality

- [x] fmt / clippy `-D warnings` / `cargo doc -Dwarnings` clean
- [x] Documentation updated (`docs/TOOLS.md` regenerated)
- [x] CHANGELOG.md — not applicable (pre-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)