### PR TITLE
docs(architecture): refresh the source tree to match the real module layout

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,33 +37,18 @@ See `docs/VISION.md` for the full architecture.
 
 ## Project Structure
 
-```
-src/
-├── lib.rs              # Library crate root
-├── main.rs             # CLI entry point
-├── error.rs            # Top-level error types
-├── config/             # Configuration
-│   ├── mod.rs
-│   └── settings.rs
-├── mcp/                # MCP server
-│   ├── mod.rs
-│   ├── server.rs       # Tool definitions & handlers
-│   ├── protocol.rs     # JSON-RPC types
-│   └── transport.rs    # Stdio transport
-└── altium/             # Altium file I/O
-    ├── mod.rs
-    ├── error.rs        # Altium-specific errors
-    ├── pcblib/         # .PcbLib read/write
-    │   ├── mod.rs
-    │   ├── primitives.rs
-    │   ├── reader.rs
-    │   └── writer.rs
-    └── schlib/         # .SchLib read/write
-        ├── mod.rs
-        ├── primitives.rs
-        ├── reader.rs
-        └── writer.rs
-```
+See `docs/ARCHITECTURE.md` § Component Overview for the maintained source tree —
+it is the single source of truth; do not duplicate it here.
+
+Key orientation points:
+
+- `src/altium/` — file-format layer: shared framing/encoding helpers at the root,
+  `pcblib/` (binary records over byte templates) and `schlib/` (text records,
+  omit-when-default) beneath.
+- `src/mcp/` — server layer: dispatch + security choke-points in `server.rs`, one
+  handler file per tool family in `tools/`, tool schemas in `tool_definitions.rs`
+  (the source of truth for the generated `docs/TOOLS.md`).
+- `src/security/` — rate limiting + audit log for mutating tools.
 
 ## MCP Tools
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,30 +20,51 @@ src/
 ├── lib.rs                       # Library crate root
 ├── main.rs                      # CLI entry point
 ├── error.rs                     # Top-level error types
+├── util.rs                      # Path redaction, CSV escaping, UniqueId generation
 │
 ├── config/                      # Configuration
 │   ├── mod.rs                   # Module exports
 │   └── settings.rs              # Config file parsing + defaults
 │
-├── altium/                      # Altium file I/O
+├── security/                    # Safety controls
 │   ├── mod.rs                   # Module exports
-│   ├── error.rs                 # Altium-specific errors
+│   ├── audit.rs                 # Append-only audit log for mutating tools
+│   └── rate_limit.rs            # Token-bucket rate limiter (mutating tools)
+│
+├── altium/                      # Altium file I/O
+│   ├── mod.rs                   # Shared helpers: Windows-1252, OLE names, atomic save
+│   ├── error.rs                 # Altium-specific errors (path-sanitised Display)
+│   ├── bytes.rs                 # Bounds-checked little-endian scalar readers
+│   ├── framing.rs               # Shared block / Pascal-string / C-string frames
+│   ├── text.rs                  # TextJustification (shared enum)
+│   ├── serde_round.rs           # 6-decimal f64 rounding on serialise
+│   ├── libpkg.rs                # .LibPkg project-file generator
 │   ├── pcblib/
-│   │   ├── mod.rs               # PcbLib module exports
-│   │   ├── primitives.rs        # Pad, Track, Arc, Region, Text, Fill, etc.
-│   │   ├── reader.rs            # Binary parsing
-│   │   └── writer.rs            # Binary encoding
+│   │   ├── mod.rs               # PcbLib + Footprint types, CRUD
+│   │   ├── read_io.rs           # OLE stream orchestration (read)
+│   │   ├── write_io.rs          # OLE stream orchestration (write)
+│   │   ├── reader/              # Binary parsing (dispatch, per-primitive, 3D models)
+│   │   ├── writer.rs            # Binary encoding (byte templates)
+│   │   ├── primitives/          # Pad, Via, Track, Arc, Region, Text, Fill, bodies
+│   │   ├── flags.rs             # On-disk flag-word bits
+│   │   ├── units.rs             # mm ↔ Altium internal units
+│   │   └── assets/              # Captured Library/Data stack + FileVersionInfo
 │   └── schlib/
-│       ├── mod.rs               # SchLib module exports
+│       ├── mod.rs               # SchLib + Symbol types, CRUD, I/O orchestration
+│       ├── reader.rs            # Record parsing (text records + binary pin)
+│       ├── writer.rs            # Record encoding (omit-when-default)
 │       ├── primitives.rs        # Pin, Rectangle, Line, Arc, Ellipse, etc.
-│       ├── reader.rs            # Binary parsing
-│       └── writer.rs            # Binary encoding
+│       ├── coord.rs             # Fractional (_Frac) coordinate codec
+│       └── pin_aux.rs           # PinFrac / PinSymbolLineWidth aux streams
 │
 └── mcp/                         # MCP server implementation
     ├── mod.rs                   # Module exports
-    ├── server.rs                # JSON-RPC server + tool handlers
+    ├── server.rs                # JSON-RPC dispatch, path validation, backups, audit
     ├── protocol.rs              # MCP protocol types
-    └── transport.rs             # stdio transport
+    ├── transport.rs             # stdio transport
+    ├── tool_definitions.rs      # Tool schemas (source of truth for docs/TOOLS.md)
+    ├── tool_docs.rs             # docs/TOOLS.md generator + drift guard (test-only)
+    └── tools/                   # One file per tool family (read_write, compare, …)
 ```
 
 ---


### PR DESCRIPTION
## Description

The **Component Overview** tree in `docs/ARCHITECTURE.md` predated the `mcp/tools/` split, `src/security/`, the pcblib `reader/` + `primitives/` directories, `read_io.rs`/`write_io.rs`, `libpkg.rs`, and the shared root helpers (`bytes`/`framing`/`text`/`serde_round`) — anyone navigating by it would look for files that no longer exist. This refreshes it to the real layout.

`.claude/CLAUDE.md` carried a second (equally stale) copy of the same tree; per the single-source-of-truth rule it now points at ARCHITECTURE.md and keeps only brief orientation notes.

Doc-only.

## Type of Change

- [x] Documentation update

## Testing

- [x] `markdownlint-cli2` — 0 errors on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)