### PR TITLE
docs(architecture): reflect the completed schlib module symmetry

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,11 +49,13 @@ src/
 │   │   ├── flags.rs             # On-disk flag-word bits
 │   │   ├── units.rs             # mm ↔ Altium internal units
 │   │   └── assets/              # Captured Library/Data stack + FileVersionInfo
-│   └── schlib/
-│       ├── mod.rs               # SchLib + Symbol types, CRUD, I/O orchestration
-│       ├── reader.rs            # Record parsing (text records + binary pin)
+│   └── schlib/                  # (mirrors pcblib/ — same module shape)
+│       ├── mod.rs               # SchLib + Symbol types, CRUD
+│       ├── read_io.rs           # OLE stream orchestration (read)
+│       ├── write_io.rs          # OLE stream orchestration (write)
+│       ├── reader/              # Record parsing (dispatch + per-record parsers)
 │       ├── writer.rs            # Record encoding (omit-when-default)
-│       ├── primitives.rs        # Pin, Rectangle, Line, Arc, Ellipse, etc.
+│       ├── primitives/          # Pin, shapes, text, footprint models
 │       ├── coord.rs             # Fractional (_Frac) coordinate codec
 │       └── pin_aux.rs           # PinFrac / PinSymbolLineWidth aux streams
 │


### PR DESCRIPTION
## Description

With the unification series merged (U1 #244, U2 #245, U3 #246), `schlib/` now mirrors `pcblib/` file-for-file. Update the Component Overview tree accordingly: `mod.rs` = types + CRUD, `read_io.rs`/`write_io.rs`, `reader/`, `primitives/`, and mark the module as the mirror of `pcblib/`.

Doc-only, one hunk.

## Type of Change

- [x] Documentation update

## Testing

- [x] markdownlint — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)