### PR TITLE
feat(schlib): let write_schlib author Bezier and EllipticalArc primitives

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -138,10 +138,6 @@ we handle: 1,2,4,5,6,7,8,10,11,12,13,14,34,41,45 — note the holes):
       AltiumSharp `ParseStorageImageData`) are not yet read. Add the Storage-stream extraction.
 - [ ] 🟠 **TextFrame** (`SchTextFrameDto`) — a bordered multi-line text box (distinct from
       Label/Text: has a frame rect, word-wrap, alignment). Not modelled. Add primitive + sample + test.
-- [ ] 🟠 **Bezier + EllipticalArc authoring** — both families are read and RMW-preserved
-      (update_component carries them through), but `write_schlib` cannot author them: no schema
-      entry, no `parse_schlib_*`, and the symbol allow-list rejects the keys. Add schema + parser +
-      allow-list + tests per the tool-completeness recipe.
 - [ ] ⚪ **Verify in-scope:** `ParameterSet`, `Hyperlink`, `Note`, `CompileMask` — confirm whether
       any can appear inside a `.SchLib` symbol (vs `.SchDoc` only) before implementing.
 - **OUT OF SCOPE (SchDoc-only, cannot appear in a symbol library — do NOT implement):** Bus,

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -200,7 +200,7 @@ Write footprints to an Altium .PcbLib file. Each footprint is defined by its pri
 
 ## `write_schlib`
 
-Write schematic symbols to an Altium .SchLib file. Each symbol is defined by its primitives: pins, rectangles, round_rects, lines, polylines, polygons, arcs, pies, images, ellipses, labels, and text. Coordinates must be in schematic units (10 units = 1 grid square, not mm).
+Write schematic symbols to an Altium .SchLib file. Each symbol is defined by its primitives: pins, rectangles, round_rects, lines, polylines, polygons, arcs, pies, images, beziers, ellipses, elliptical_arcs, labels, and text. Coordinates must be in schematic units (10 units = 1 grid square, not mm).
 
 **Example**
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1950,6 +1950,12 @@ mod tests {
                 "ellipses": [{"x": 0, "y": 0, "radius_x": 5, "radius_y": 3,
                     "line_width": 1, "line_color": 128, "fill_color": 11_599_871,
                     "filled": true, "owner_part_id": 1}],
+                "beziers": [{"x1": -10, "y1": 0, "x2": -5, "y2": 8, "x3": 5, "y3": 8,
+                    "x4": 10, "y4": 0, "line_width": 1, "color": 128,
+                    "is_not_accessible": true, "owner_part_id": 1}],
+                "elliptical_arcs": [{"x": 0, "y": 0, "radius": 10, "secondary_radius": 5,
+                    "start_angle": 0, "end_angle": 90, "line_width": 1, "color": 128,
+                    "fill_color": 0, "owner_part_id": 1}],
                 "labels": [{"x": 0, "y": 0, "text": "L", "font_id": 1, "color": 128,
                     "rotation": 0, "is_mirrored": false, "is_hidden": false,
                     "justification": "bottom_left", "owner_part_id": 1}],
@@ -1967,6 +1973,58 @@ mod tests {
             !result.is_error,
             "all schlib primitive fields must be accepted, got: {}",
             get_result_text(&result)
+        );
+    }
+
+    #[test]
+    fn write_schlib_authors_beziers_and_elliptical_arcs() {
+        // These two families used to be read/RMW-preserved only (write_schlib
+        // rejected the keys). Author one of each and read them back through
+        // the real writer + reader.
+        let temp = test_temp_dir();
+        let lib_path = temp.path().join("bez_earc.SchLib");
+        let server = create_test_server(temp.path());
+        let args = json!({
+            "filepath": lib_path.to_string_lossy(),
+            "symbols": [{
+                "name": "CURVES",
+                "beziers": [{"x1": -10, "y1": 0, "x2": -5, "y2": 8,
+                    "x3": 5, "y3": 8, "x4": 10, "y4": 0}],
+                "elliptical_arcs": [{"x": 0, "y": 0, "radius": 10,
+                    "secondary_radius": 5, "start_angle": 0, "end_angle": 90}]
+            }]
+        });
+        let result = server.call_write_schlib(&args);
+        assert!(
+            !result.is_error,
+            "write failed: {}",
+            get_result_text(&result)
+        );
+
+        let lib = SchLib::open(&lib_path).expect("reopen");
+        let sym = lib.get("CURVES").expect("symbol present");
+        assert_eq!(sym.beziers.len(), 1, "bezier authored");
+        let bez = &sym.beziers[0];
+        assert!(
+            (bez.x1 + 10.0).abs() < 1e-9
+                && (bez.y2 - 8.0).abs() < 1e-9
+                && (bez.x4 - 10.0).abs() < 1e-9,
+            "bezier control points round-trip, got ({}, {}) .. ({}, {})",
+            bez.x1,
+            bez.y1,
+            bez.x4,
+            bez.y4
+        );
+        assert_eq!(sym.elliptical_arcs.len(), 1, "elliptical arc authored");
+        let ell = &sym.elliptical_arcs[0];
+        assert!(
+            (ell.radius - 10.0).abs() < 1e-9
+                && (ell.secondary_radius - 5.0).abs() < 1e-9
+                && (ell.end_angle - 90.0).abs() < 1e-9,
+            "elliptical arc fields round-trip, got r={} r2={} end={}",
+            ell.radius,
+            ell.secondary_radius,
+            ell.end_angle
         );
     }
 

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -532,7 +532,7 @@ impl McpServer {
                 description: Some(
                     "Write schematic symbols to an Altium .SchLib file. Each symbol is defined by \
                      its primitives: pins, rectangles, round_rects, lines, polylines, polygons, \
-                     arcs, pies, images, ellipses, labels, and text. \
+                     arcs, pies, images, beziers, ellipses, elliptical_arcs, labels, and text. \
                      Coordinates must be in schematic units (10 units = 1 grid square, not mm)."
                         .to_string(),
                 ),
@@ -816,6 +816,50 @@ impl McpServer {
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2"]
+                                        }
+                                    },
+                                    "beziers": {
+                                        "type": "array",
+                                        "description": "Cubic Bezier curve definitions (four control points)",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x1": { "type": "number", "description": "First control point X" },
+                                                "y1": { "type": "number", "description": "First control point Y" },
+                                                "x2": { "type": "number", "description": "Second control point X" },
+                                                "y2": { "type": "number", "description": "Second control point Y" },
+                                                "x3": { "type": "number", "description": "Third control point X" },
+                                                "y3": { "type": "number", "description": "Third control point Y" },
+                                                "x4": { "type": "number", "description": "Fourth control point X" },
+                                                "y4": { "type": "number", "description": "Fourth control point Y" },
+                                                "line_width": { "type": "integer", "description": "Curve width. Default: 1" },
+                                                "color": { "type": "integer", "description": "Curve BGR colour. Default: 32896 (dark red)" },
+                                                "is_not_accessible": { "type": "boolean", "description": "Whether the curve is marked not-accessible (Altium tags every shape; default true)" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" },
+                                                "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" }
+                                            },
+                                            "required": ["x1", "y1", "x2", "y2", "x3", "y3", "x4", "y4"]
+                                        }
+                                    },
+                                    "elliptical_arcs": {
+                                        "type": "array",
+                                        "description": "Elliptical arc definitions (arc with independent X/Y radii)",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "x": { "type": "number", "description": "Centre X coordinate" },
+                                                "y": { "type": "number", "description": "Centre Y coordinate" },
+                                                "radius": { "type": "number", "description": "Primary (X) radius in schematic units" },
+                                                "secondary_radius": { "type": "number", "description": "Secondary (Y) radius in schematic units" },
+                                                "start_angle": { "type": "number", "description": "Start angle in degrees (0 = right, CCW). Default: 0" },
+                                                "end_angle": { "type": "number", "description": "End angle in degrees. Default: 360" },
+                                                "line_width": { "type": "integer", "description": "Arc width. Default: 1" },
+                                                "color": { "type": "integer", "description": "Arc BGR colour. Default: 32896 (dark red)" },
+                                                "fill_color": { "type": "integer", "description": "Fill BGR colour (AreaColor). Default: 0" },
+                                                "owner_part_id": { "type": "integer", "description": "Part number (1-based). Default: 1" },
+                                                "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" }
+                                            },
+                                            "required": ["x", "y", "radius", "secondary_radius"]
                                         }
                                     },
                                     "ellipses": {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -1692,6 +1692,93 @@ impl McpServer {
         })
     }
 
+    /// Parses a `SchLib` Bezier from JSON. Requires the four control points
+    /// (`x1`..`y4`); optionals default as [`crate::altium::schlib::Bezier::new`]
+    /// does when absent.
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn parse_schlib_bezier(json: &Value) -> Option<crate::altium::schlib::Bezier> {
+        use crate::altium::schlib::Bezier;
+
+        let x1 = json_f64(json, "x1")?;
+        let y1 = json_f64(json, "y1")?;
+        let x2 = json_f64(json, "x2")?;
+        let y2 = json_f64(json, "y2")?;
+        let x3 = json_f64(json, "x3")?;
+        let y3 = json_f64(json, "y3")?;
+        let x4 = json_f64(json, "x4")?;
+        let y4 = json_f64(json, "y4")?;
+        let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
+        let color = json
+            .get("color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0x00_00_80) as u32;
+        let is_not_accessible = json
+            .get("is_not_accessible")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
+
+        Some(Bezier {
+            x1,
+            y1,
+            x2,
+            y2,
+            x3,
+            y3,
+            x4,
+            y4,
+            line_width,
+            color,
+            is_not_accessible,
+            owner_part_id,
+            unique_id: json_unique_id(json),
+        })
+    }
+
+    /// Parses a `SchLib` elliptical arc from JSON. Requires centre and both
+    /// radii; optionals default as
+    /// [`crate::altium::schlib::EllipticalArc::new`] does when absent.
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn parse_schlib_elliptical_arc(
+        json: &Value,
+    ) -> Option<crate::altium::schlib::EllipticalArc> {
+        use crate::altium::schlib::EllipticalArc;
+
+        let x = json_f64(json, "x")?;
+        let y = json_f64(json, "y")?;
+        let radius = json_f64(json, "radius")?;
+        let secondary_radius = json_f64(json, "secondary_radius")?;
+        let start_angle = json
+            .get("start_angle")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+        let end_angle = json
+            .get("end_angle")
+            .and_then(Value::as_f64)
+            .unwrap_or(360.0);
+        let line_width = json.get("line_width").and_then(Value::as_u64).unwrap_or(1) as u8;
+        let color = json
+            .get("color")
+            .and_then(Value::as_u64)
+            .unwrap_or(0x00_00_80) as u32;
+        let fill_color = json.get("fill_color").and_then(Value::as_u64).unwrap_or(0) as u32;
+        let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
+
+        Some(EllipticalArc {
+            x,
+            y,
+            radius,
+            secondary_radius,
+            start_angle,
+            end_angle,
+            line_width,
+            color,
+            fill_color,
+            owner_part_id,
+            unique_id: json_unique_id(json),
+        })
+    }
+
     /// Parses a schematic ellipse from JSON.
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn parse_schlib_ellipse(json: &Value) -> Option<crate::altium::schlib::Ellipse> {

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -502,19 +502,19 @@ impl McpServer {
             }
         }
 
-        // Beziers and elliptical arcs cannot be authored via write_schlib yet,
-        // but get_component returns them in serde shape, so a read-modify-write
-        // must carry them through — deserialise them directly.
+        // Beziers and elliptical arcs (mirror the create path, which authors
+        // them through the same parse helpers — the JSON keys equal the serde
+        // field names, so a get_component echo parses identically).
         if let Some(beziers) = sym_json.get("beziers").and_then(Value::as_array) {
             for bezier_json in beziers {
-                if let Ok(bezier) = serde_json::from_value(bezier_json.clone()) {
+                if let Some(bezier) = Self::parse_schlib_bezier(bezier_json) {
                     symbol.beziers.push(bezier);
                 }
             }
         }
         if let Some(ell_arcs) = sym_json.get("elliptical_arcs").and_then(Value::as_array) {
             for ell_arc_json in ell_arcs {
-                if let Ok(ell_arc) = serde_json::from_value(ell_arc_json.clone()) {
+                if let Some(ell_arc) = Self::parse_schlib_elliptical_arc(ell_arc_json) {
                     symbol.elliptical_arcs.push(ell_arc);
                 }
             }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1129,7 +1129,9 @@ impl McpServer {
                     "arcs",
                     "pies",
                     "images",
+                    "beziers",
                     "ellipses",
+                    "elliptical_arcs",
                     "labels",
                     "text",
                     "parameters",
@@ -1462,6 +1464,56 @@ impl McpServer {
                     );
                     if let Some(image) = Self::parse_schlib_image(image_json) {
                         symbol.add_image(image);
+                    }
+                }
+            }
+
+            if let Some(beziers) = sym_json.get("beziers").and_then(Value::as_array) {
+                for bezier_json in beziers {
+                    check_keys!(
+                        bezier_json,
+                        &[
+                            "x1",
+                            "y1",
+                            "x2",
+                            "y2",
+                            "x3",
+                            "y3",
+                            "x4",
+                            "y4",
+                            "line_width",
+                            "color",
+                            "is_not_accessible",
+                            "owner_part_id",
+                            "unique_id"
+                        ]
+                    );
+                    if let Some(bezier) = Self::parse_schlib_bezier(bezier_json) {
+                        symbol.add_bezier(bezier);
+                    }
+                }
+            }
+
+            if let Some(ell_arcs) = sym_json.get("elliptical_arcs").and_then(Value::as_array) {
+                for ell_arc_json in ell_arcs {
+                    check_keys!(
+                        ell_arc_json,
+                        &[
+                            "x",
+                            "y",
+                            "radius",
+                            "secondary_radius",
+                            "start_angle",
+                            "end_angle",
+                            "line_width",
+                            "color",
+                            "fill_color",
+                            "owner_part_id",
+                            "unique_id"
+                        ]
+                    );
+                    if let Some(ell_arc) = Self::parse_schlib_elliptical_arc(ell_arc_json) {
+                        symbol.add_elliptical_arc(ell_arc);
                     }
                 }
             }


### PR DESCRIPTION
## Description

Closes the authoring gap logged by the family-completeness fix (#242): Beziers and elliptical arcs were readable and RMW-preserved but **could not be authored** via `write_schlib` (no schema, no parser, allow-list rejected the keys).

- New `parse_schlib_bezier` / `parse_schlib_elliptical_arc` in `parsing.rs`, defaults identical to the struct constructors.
- Create path wired: symbol-level + per-item `check_keys!` allow-lists and full schema entries (every field documented, matching the serde names so a `get_component` echo round-trips).
- `update_schlib_component` now uses the same shared helpers for these two families (was a serde fallback) — create and update parse identically, per the recurrence-proofing pattern.
- `write_schlib` description names every family; `docs/TOOLS.md` regenerated via the drift guard; TODO item removed.

Every SchLib primitive family the model carries is now authorable through the tool.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types maintain backwards compatibility
- [x] Altium file format compatibility is maintained (reader/writer untouched — they already supported both records)
- [x] No breaking changes to existing MCP tool interfaces (purely additive)

## Testing

- [x] All-fields allow-list guard extended with full bezier + elliptical_arc entries
- [x] New write→read round-trip test through the real tool handler and reader
- [x] `cargo test` — all suites green
- [x] Integration — 348/348
- [x] Readability oracle — 13 passed, 0 regressions
- [x] fmt / clippy `-D warnings` / `cargo doc -Dwarnings` / markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)