### PR TITLE
docs(format): rewrite PcbLib/SchLib format references to the verified byte layouts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -43,15 +43,6 @@ Durable task list for the post-reverse-engineering fix campaign and the on-site 
 
 Outstanding SchLib field fidelity all needs an Altium-authored golden to settle — see §B.
 
-### A4. Doc rewrites (high correctness value, doc-only)
-
-- [ ] `docs/PCBLIB_FORMAT.md`: rewrite **Via** (single 321-byte block), **Text** (252-byte),
-      **Region** (single block + `holeCount`), **Fill** tail, **Track/Arc** extended tails,
-      **ComponentBody** (one block; drop the invented SNAPCOUNT / Block 1-2).
-- [ ] `docs/SCHLIB_FORMAT.md`: complete every per-record field table (omit-when-default, DXP units,
-      `*_Frac`, BGR colours); binary-pin `Description` + `FormalType` + `SwapIdGroup` /
-      `PartAndSequence` / `DefaultValue`.
-
 ### A5. Byte-order cosmetics (lowest value — last)
 
 - [ ] ⚪ Canonical field order (`IsNotAccesible` first, etc.) + `F3` angle formatting (`360.000`) +

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -1,8 +1,12 @@
 # PcbLib Binary Format
 
-This document describes the binary format of Altium Designer `.PcbLib` (PCB footprint library) files.
+This document describes the binary format of Altium Designer `.PcbLib` (PCB footprint library) files
+as implemented by this crate. Every offset below is verified against the byte-level
+reverse-engineering campaign (goldens + the pyaltiumlib oracle) and the current reader/writer in
+`src/altium/pcblib/`; where a field exists on disk but is not surfaced by our model it is explicitly
+marked *unmodelled* rather than omitted.
 
-> **Note:** This documentation is based on reverse engineering from AltiumSharp, pyAltiumLib, and sample file analysis.
+> **Note:** Cross-referenced against AltiumSharp, pyAltiumLib and Altium-authored sample libraries.
 > See [References](#references) for links.
 
 ## File Structure
@@ -11,7 +15,7 @@ PcbLib files are OLE Compound Documents (CFB format, **OLE v3 with 512-byte sect
 
 ```text
 /
-├── FileHeader                          # Binary version string
+├── FileHeader                          # Binary version string (53 bytes)
 ├── Library/
 │   ├── Header                          # u32: record count (always 1)
 │   ├── Data                            # Params block + component count + names
@@ -24,7 +28,7 @@ PcbLib files are OLE Compound Documents (CFB format, **OLE v3 with 512-byte sect
 └── {ComponentName}/                    # One storage per footprint
     ├── Header                          # u32: exact primitive count
     ├── Parameters                      # Block-prefixed pipe-delimited params
-    ├── Data                            # Name block + primitives + end marker
+    ├── Data                            # Name block + primitives (NO end marker)
     ├── WideStrings                     # Block-prefixed ENCODEDTEXT params
     └── UniqueIdPrimitiveInformation/
         ├── Header                      # u32: record count
@@ -32,6 +36,11 @@ PcbLib files are OLE Compound Documents (CFB format, **OLE v3 with 512-byte sect
 ```
 
 > **Note:** OLE version MUST be V3 (512-byte sectors). Altium Designer rejects V4 (4096-byte) files.
+>
+> Real Altium libraries also carry `SectionKeys` (root, for >31-char names), `FileVersionInfo`,
+> `EmbeddedFonts`, `LayerKindMapping`, `PadViaLibrary`, `ComponentParamsTOC`, `Textures`,
+> `ModelsNoEmbed` and `PrimitiveGuids` streams/storages. These are **unmodelled**: the reader
+> ignores them and the writer does not emit them.
 
 ## Encoding Primitives (Building Blocks)
 
@@ -41,14 +50,15 @@ All Altium streams use these common encoding patterns:
 |---------|--------|
 | `WriteBlock(data)` | `[block_len:4 LE][data]` |
 | `WriteStringBlock(str)` | `[block_len:4][str_len:1][raw_string]` |
-| `WriteParameters(params)` | `WriteCString(pipe-params)` = `"\|KEY=VAL\|..." + \x00` |
-| `WriteBlock(WriteParameters)` | `[block_len:4]["\|KEY=VAL\|..." + \x00]` |
+| `WriteCStringParameterBlock(str)` | `[block_len:4]["\|KEY=VAL\|..." + \x00]` (length includes the null) |
+| Pascal short string | `[str_len:1][raw_string]` (max 255 bytes) |
 
 **Critical rules:**
 
-- Parameters ALWAYS start with a leading `|` pipe character
-- Parameters ALWAYS end with `\x00` null terminator
-- Block lengths INCLUDE the null terminator
+- Parameter strings start with a leading `|` pipe character (exceptions: the Region /
+  ComponentBody nested param blocks and the `Models/Data` records, which have **no** leading pipe)
+- Parameter blocks ALWAYS end with `\x00`, and the block length INCLUDES the null terminator
+- There is NO trailing pipe after the last `KEY=VALUE`
 - All strings use Windows-1252 encoding, NOT UTF-8
 
 ## `FileHeader` Stream
@@ -83,7 +93,8 @@ Contains library-level parameters and the component directory:
 [block_len:4][str_len:1][component_name]   // WriteStringBlock
 ```
 
-The parameter block uses the standard `WriteBlock(WriteParameters)` encoding.
+The parameter block uses the standard `WriteCStringParameterBlock` encoding. `VERSION=3.00`
+requires the `V9_MASTERSTACK` + `V9_STACK_LAYER` layer-stack entries in the same block.
 
 ## Per-Component Streams
 
@@ -98,10 +109,11 @@ This is the **exact** primitive count. NOT count + 1.
 ### `/{component}/Parameters`
 
 ```text
-[block_len:4]["|PATTERN=MyComponent|DESCRIPTION=My Desc|" + \x00]
+[block_len:4]["|PATTERN=MyComponent|DESCRIPTION=My Desc" + \x00]
 ```
 
-Standard `WriteBlock(WriteParameters)` encoding — block-prefixed, pipe-delimited, null-terminated.
+Standard `WriteCStringParameterBlock` encoding. Altium-authored libraries also carry `HEIGHT`,
+`ITEMGUID` and `REVISIONGUID` keys here.
 
 ### `/{component}/WideStrings`
 
@@ -109,13 +121,18 @@ Standard `WriteBlock(WriteParameters)` encoding — block-prefixed, pipe-delimit
 [block_len:4]["|ENCODEDTEXT0=72,101,108,108,111|..." + \x00]
 ```
 
-When empty (no text content): `[block_len:4]["|" + \x00]` (`block_len` = 2).
+One `|ENCODEDTEXT{n}=` entry per text primitive with real (non-special, non-empty) content, in
+primitive order — a leading pipe per entry, NO trailing pipe. The value is the comma-separated
+byte values of the text.
+
+When empty (no text content): `[block_len:4][\x00]` (`block_len` = 1 — just the null terminator,
+no pipe).
 
 ### `/{component}/UniqueIdPrimitiveInformation`
 
 **Header:** `[record_count:4 LE u32]`
 
-**Data:** Block-prefixed records, one per primitive:
+**Data:** Block-prefixed records, one per primitive **that carries a unique id**:
 
 ```text
 [block_len:4]["|PRIMITIVEINDEX=0|PRIMITIVEOBJECTID=Pad|UNIQUEID=ABCD1234" + \x00]
@@ -123,50 +140,53 @@ When empty (no text content): `[block_len:4]["|" + \x00]` (`block_len` = 2).
 
 | Field | Description |
 |-------|-------------|
-| `PRIMITIVEINDEX` | 0-based index within primitive type |
-| `PRIMITIVEOBJECTID` | Primitive type name (Pad, Via, Track, Arc, Region, Text, Fill, ComponentBody) |
+| `PRIMITIVEINDEX` | Single **global 0-based ordinal** over ALL primitives in Data-stream emit order |
+| `PRIMITIVEOBJECTID` | Primitive type name (Pad, Via, Track, Arc, Text, Region, Fill, ComponentBody) |
 | `UNIQUEID` | 8-character alphanumeric identifier |
 
-> **Note:** `PRIMITIVEINDEX` is 0-based (matching AltiumSharp convention). The reader auto-detects
-> 0-based vs 1-based indexing for backward compatibility with older Altium files.
-> Lookup is by (type, index) tuple.
+> **Note:** `PRIMITIVEINDEX` is NOT a per-type index. Every primitive consumes an ordinal in the
+> Data-stream order (Arcs, Pads, Vias, Tracks, Text, Regions, Fills, ComponentBodies) whether or
+> not it has a unique id, so e.g. the first pad behind two silkscreen arcs is `PRIMITIVEINDEX=2`.
+> On read the entry's `PRIMITIVEOBJECTID` must match the primitive found at that ordinal; a
+> mismatch (e.g. a foreign file with a different index base) is skipped rather than mis-attached.
 
 ## Data Stream Format
 
 Each component's Data stream contains the footprint primitives:
 
 ```text
-[name_block_len:4][str_len:1][name:str_len]  # Component name block
+[name_block_len:4][str_len:1][name:str_len]  # Component name block (WriteStringBlock)
 [record_type:1][blocks...]                   # First primitive
 [record_type:1][blocks...]                   # Second primitive
 ...
-[0x00]                                       # End marker
 ```
+
+There is **NO end-of-stream marker**. Altium reads exactly the primitive count declared in the
+component `Header` stream; a trailing `0x00` byte is mis-read as a record with object-id 0 and
+breaks the stream (issue #68). Never emit one.
 
 ### Record Types
 
 | ID | Type | Description |
 |----|------|-------------|
-| `0x01` | Arc | Arc or circle |
-| `0x02` | Pad | SMD or through-hole pad |
-| `0x03` | Via | Via (6 blocks, similar to pad) |
-| `0x04` | Track | Line segment |
-| `0x05` | Text | Text string |
-| `0x06` | Fill | Filled rectangle |
-| `0x0B` | Region | Filled polygon |
-| `0x0C` | ComponentBody | 3D body reference |
-
-> **Note:** Other record types may exist but have not been observed in sample files.
+| `0x01` | Arc | Arc or circle (single 60-byte block) |
+| `0x02` | Pad | SMD or through-hole pad (6 blocks) |
+| `0x03` | Via | Via (single 321-byte block) |
+| `0x04` | Track | Line segment (single 49-byte block) |
+| `0x05` | Text | Text string (2 blocks) |
+| `0x06` | Fill | Filled rectangle (single 50-byte block) |
+| `0x0B` | Region | Filled polygon (single variable-length block) |
+| `0x0C` | ComponentBody | 3D body (single variable-length block) |
 
 ### Block Format
 
-Most primitives use length-prefixed blocks:
+Every sub-block is length-prefixed:
 
 ```text
 [block_length:4 LE][block_data:block_length]
 ```
 
-**Block size limits:**
+**Block size limits (this crate):**
 
 | Block Type | Maximum Size |
 |------------|--------------|
@@ -174,18 +194,19 @@ Most primitives use length-prefixed blocks:
 | UniqueID record | 10,000 bytes |
 | String field | 255 bytes |
 
-**Minimum block sizes (for parsing):**
+**Block sizes (reader minimum / writer output):**
 
-| Primitive | Minimum Size | Notes |
-|-----------|--------------|-------|
-| Pad geometry | 52 bytes | Required for shape data |
-| Track | 33 bytes | Header + coordinates + width |
-| Arc | 45 bytes | Header + geometry + angles + width |
-| Text geometry | 25 bytes | Minimum to extract position; writer pads to 80 |
-| Via geometry | 31 bytes | Reader minimum; writer pads to 46 |
-| Fill | 37 bytes | Header + coordinates + rotation |
-| Region properties | 22 bytes | Before parameter string |
-| Per-layer data | 320 bytes | Minimum without offsets; 576 with offsets |
+| Primitive | Reader minimum | Writer output | Notes |
+|-----------|----------------|---------------|-------|
+| Pad geometry (Block 4) | 52 bytes | 202 bytes | Altium rejects pads with a shorter main block |
+| Pad size/shape (Block 5) | — | 0, 651 or 320/576 bytes | See [Pad](#pad-0x02) |
+| Track | 33 bytes | 49 bytes | Extended tail from offset 33 |
+| Arc | 45 bytes | 60 bytes | Extended tail from offset 45 |
+| Text geometry | 25 bytes | 252 bytes | Fixed `TEXT_SR1_TEMPLATE` layout |
+| Via | 31 bytes | 321 bytes | Fixed `VIA_SR1_TEMPLATE` layout |
+| Fill | 37 bytes | 50 bytes | Tail from offset 37 |
+| Region | 22 bytes + params | variable | Single block incl. vertices |
+| ComponentBody | — | variable | Single block incl. outline |
 
 ## Coordinate System
 
@@ -275,135 +296,22 @@ These mechanical layers are typically configured as component layer pairs:
 > The layer field is a plain `u8`. There is no `255 = Unknown` layer — any out-of-range id is
 > simply unrecognised (an unknown layer *name* maps to `0 = NoLayer`).
 
-## Primitive Formats
+### V7 Layer IDs
 
-### Pad (0x02)
+Several primitives carry a derived 32-bit "v7 saved layer id" alongside the layer byte
+(`v7_layer_id` in the writer, ported from AltiumSharp `V7LayerId`):
 
-Pads have 6 blocks:
-
-| Block | Content |
-|-------|---------|
-| 0 | Designator string (length-prefixed) |
-| 1 | Layer stack data (typically empty for simple pads) |
-| 2 | Marker string (`\|&\|0`) — internal reference marker |
-| 3 | Net/connectivity data (typically empty in libraries) |
-| 4 | Geometry data (main pad definition) |
-| 5 | Per-layer data (for complex pads with different shapes/sizes per layer) |
-
-**Geometry block structure:**
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1-12 | 12 | Flags and padding (see Common Header) |
-| 13-16 | 4 | X position (internal units, signed) |
-| 17-20 | 4 | Y position (internal units, signed) |
-| 21-24 | 4 | Width (top layer stack) |
-| 25-28 | 4 | Height (top layer stack) |
-| 29-32 | 4 | Width (middle layer stack) |
-| 33-36 | 4 | Height (middle layer stack) |
-| 37-40 | 4 | Width (bottom layer stack) |
-| 41-44 | 4 | Height (bottom layer stack) |
-| 45-48 | 4 | Hole size (0 for SMD pads) |
-| 49 | 1 | Shape (top) |
-| 50 | 1 | Shape (middle) |
-| 51 | 1 | Shape (bottom) |
-| 52-59 | 8 | Rotation (IEEE 754 double, degrees) |
-| 60 | 1 | Is plated (0 = no, 1 = yes) |
-| 61 | 1 | Hole shape (0 = Round, 1 = Square, 2 = Slot) |
-| 62 | 1 | Stack mode (see below) |
-| 63-85 | 23 | Reserved (zeros) |
-| 86-89 | 4 | Paste mask expansion (internal units, signed) |
-| 90-93 | 4 | Solder mask expansion (internal units, signed) |
-| 94-100 | 7 | Reserved |
-| 101 | 1 | Paste mask expansion manual (0 = auto, 1 = manual) |
-| 102 | 1 | Solder mask expansion manual (0 = auto, 1 = manual) |
-| 103-109 | 7 | Reserved |
-| 110-111 | 2 | Jumper ID (internal use) |
-
-**Parsing thresholds:**
-
-| Field | Threshold | Behaviour |
-|-------|-----------|-----------|
-| Hole size | < 0.001 mm | Treated as zero (SMD pad) |
-| Mask expansion | < 0.0001 mm | Filtered out (no manual expansion) |
-
-**Pad shapes:**
-
-| ID | Shape | Notes |
-|----|-------|-------|
-| 0 | RoundedRectangle | Default for unknown IDs |
-| 1 | Round / RoundedRectangle | Distinguished by corner_radius_percent (0 or 100 = Round, 1-99 = RoundedRectangle) |
-| 2 | Rectangular | Sharp corners |
-| 3 | Octagonal | 8-sided (often mapped to Oval) |
-
-> **Note:** Round and RoundedRectangle share shape ID 1. The distinction is made via the per-layer
-> corner_radius_percent field. RoundedRectangle pads require FullStack mode to preserve their shape.
->
-> **Implementation note:** When writing pads with `corner_radius_percent` set (1-99%) or shape
-> `RoundedRectangle`, the tool automatically upgrades from Simple to FullStack mode to preserve the
-> corner radius data.
-
-**Stack modes:**
-
-| ID | Mode | Description |
-|----|------|-------------|
-| 0 | Simple | All layers mirror top layer settings |
-| 1 | TopMiddleBottom | Independent top, middle (layers 1-30), bottom |
-| 2 | FullStack | Complete per-layer customisation (32 layers) |
-
-**Per-layer data (Block 6):**
-
-When stack mode is not Simple, Block 6 contains per-layer arrays:
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0-255 | 256 | 32 size entries (width/height pairs, 4+4 bytes each as i32) |
-| 256-287 | 32 | 32 shape IDs (1 byte each) |
-| 288-319 | 32 | 32 corner radius percentages (1 byte each, 0-100) |
-| 320-575 | 256 | 32 offset entries (x/y pairs, 4+4 bytes each as i32) — optional |
-
-**Layer index mapping:**
-
-| Index | Layer |
-|-------|-------|
-| 0 | Top Layer |
-| 1 | Bottom Layer |
-| 2-31 | Mid Layers 1-30 |
-
-Total size: 320 bytes minimum (without offsets), 576 bytes with offsets.
-
-> **Note:** Corner radius is stored as a percentage (0-100) of the smaller pad dimension, not as an absolute value.
-> Default corner radius for RoundedRectangle is 50% if not specified.
-
-### Track (0x04)
-
-Single block with geometry:
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1-12 | 12 | Flags and padding |
-| 13-16 | 4 | Start X |
-| 17-20 | 4 | Start Y |
-| 21-24 | 4 | End X |
-| 25-28 | 4 | End Y |
-| 29-32 | 4 | Width |
-
-### Arc (0x01)
-
-Single block with geometry:
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1-12 | 12 | Flags and padding |
-| 13-16 | 4 | Center X |
-| 17-20 | 4 | Center Y |
-| 21-24 | 4 | Radius |
-| 25-32 | 8 | Start angle (double, degrees) |
-| 33-40 | 8 | End angle (double, degrees) |
-| 41-44 | 4 | Width |
+| Layer byte | V7 id |
+|------------|-------|
+| 1-31 (signal top/mid) | `0x01000000 + id` |
+| 32 (bottom) | `0x0100FFFF` |
+| 39-54 (internal plane n) | `0x01010000 + n` |
+| 57-72 (mechanical n) | `0x01020000 + n` |
+| 33 / 34 (overlay) | `0x01030006` / `0x01030007` |
+| 35 / 36 (paste) | `0x01030008` / `0x01030009` |
+| 37 / 38 (solder) | `0x0103000A` / `0x0103000B` |
+| 55 / 56 / 73 | `0x0103000C` / `0x0103000D` / `0x0103000E` |
+| 74 (multi-layer) + fallback | `0x0103000F` |
 
 ## Common Header (13 bytes)
 
@@ -412,16 +320,18 @@ All primitives start with a common header:
 | Offset | Size | Field |
 |--------|------|-------|
 | 0 | 1 | Layer ID |
-| 1-2 | 2 | Flags word (uint16, see below) |
-| 3-4 | 2 | NetIndex (uint16; `0xFFFF` when unconnected) |
-| 5-6 | 2 | PolygonIndex (uint16; `0xFFFF`) |
-| 7-8 | 2 | ComponentIndex (uint16; `0xFFFF`) |
-| 9-12 | 4 | Reserved (uint32) |
+| 1-2 | 2 | Flags word (u16, see below) |
+| 3-4 | 2 | NetIndex (u16; `0xFFFF` when unconnected) |
+| 5-6 | 2 | PolygonIndex (u16; `0xFFFF` = none) |
+| 7-8 | 2 | ComponentIndex (u16; `0xFFFF` = free primitive, modelled as `-1`) |
+| 9-12 | 4 | Reserved (`0xFFFFFFFF`) |
 
-For a footprint-library primitive the index fields are unused (all `0xFF`), which is why bytes
-3–12 look like padding — but in a board file they carry the net / polygon / component links.
+For a footprint-library primitive the index fields are unused (all `0xFF`) — but in a board file
+they carry the net / polygon / component links. The reader and writer model all three indices; the
+from-scratch defaults (`net = 0xFFFF`, `polygon = 0xFFFF`, `component = -1`) reproduce the `0xFF`
+fill byte-identically.
 
-**Flags word (bytes 1–2, uint16) — on-wire bits** (`src/altium/pcblib/flags.rs`):
+**Flags word (bytes 1-2, u16) — on-wire bits** (`src/altium/pcblib/flags.rs`):
 
 | Bit | Flag | Meaning |
 |-----|------|---------|
@@ -431,84 +341,255 @@ For a footprint-library primitive the index fields are unused (all `0xFF`), whic
 | `0x0040` | TentingBottom | Solder-mask tented on bottom |
 | `0x0200` | Keepout | Keep-out primitive |
 
+A normal saved primitive therefore carries `0x000C` (Saved + Unlocked), not `0x0000`; a keepout
+primitive carries `0x020C`.
+
 > **Note:** These are the literal bits on disk. The crate also exposes an internal abstract
 > `PcbFlags` enum (`LOCKED` / `KEEPOUT` / `TENTING_TOP` / `TENTING_BOTTOM`, with its own distinct
 > values) for the public API; the reader/writer translate between the two. Do not confuse the
 > abstract enum's values with the on-wire bits above.
 
+## Primitive Formats
+
+### Pad (0x02)
+
+Pads have 6 blocks:
+
+| Block | Content |
+|-------|---------|
+| 0 | Designator string (`WriteStringBlock`) |
+| 1 | Reserved — a 1-byte block containing `0x00` |
+| 2 | Marker string `\|&\|0` (`WriteStringBlock`) |
+| 3 | Reserved — a 1-byte block containing `0x00` |
+| 4 | Main geometry block (202 bytes) |
+| 5 | Size/shape block (empty, 651 bytes, or the legacy 320/576-byte per-layer form) |
+
+**Block 4 — main geometry (202 bytes).** Offsets 0-60 are typed geometry; offsets 61-201 are the
+extended tail, written by overlaying the modelled fields onto a canonical byte template
+(`PAD_EXTENDED_TAIL_TEMPLATE`) captured from a standard Altium pad:
+
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header (layer, flags, net/poly/comp indices) | yes |
+| 13-16 | 4 | X position (i32, internal units) | yes |
+| 17-20 | 4 | Y position (i32) | yes |
+| 21-24 | 4 | Width, top layer (i32) | yes |
+| 25-28 | 4 | Height, top layer (i32) | yes |
+| 29-32 | 4 | Width, middle layers (i32) | yes (TopMiddleBottom mode) |
+| 33-36 | 4 | Height, middle layers (i32) | yes (TopMiddleBottom mode) |
+| 37-40 | 4 | Width, bottom layer (i32) | yes (TopMiddleBottom mode) |
+| 41-44 | 4 | Height, bottom layer (i32) | yes (TopMiddleBottom mode) |
+| 45-48 | 4 | Hole size (i32; 0 for SMD) | yes |
+| 49 | 1 | Shape, top | yes |
+| 50 | 1 | Shape, middle | yes (TopMiddleBottom mode) |
+| 51 | 1 | Shape, bottom | yes (TopMiddleBottom mode) |
+| 52-59 | 8 | Rotation (f64, degrees) | yes |
+| 60 | 1 | Is plated (0/1) | write-only (derived from hole presence) |
+| 61 | 1 | Reserved (`0x00`) — **NOT** the hole shape (that lives in Block 5 @262) | — |
+| 62 | 1 | Stack mode (0=Simple, 1=TopMiddleBottom, 2=FullStack) | yes |
+| 67 | 1 | Power-plane connection style (0=Relief, 1=Direct, 2=NoConnect) | yes |
+| 68-71 | 4 | Thermal-relief conductor (spoke) width (i32; default 0.254 mm) | yes |
+| 72-73 | 2 | Thermal-relief spoke count (i16; default 4) | yes |
+| 74-77 | 4 | Thermal-relief air gap (i32; default 0.254 mm) | yes |
+| 78-81 | 4 | Power-plane relief expansion (i32; default 0.508 mm) | yes |
+| 82-85 | 4 | Power-plane (anti-pad) clearance (i32; default 0.508 mm) | yes |
+| 86-89 | 4 | Paste mask expansion (i32) | yes |
+| 90-93 | 4 | Solder mask expansion (i32) | yes |
+| 101 | 1 | Paste mask expansion mode (0=None, 1=FromRule, 2=Manual) | yes |
+| 102 | 1 | Solder mask expansion mode (0=None, 1=FromRule, 2=Manual) | yes |
+| 110-111 | 2 | Jumper ID (i16) | unmodelled (template) |
+| 114-117 | 4 | V7 layer id (derived from the pad's layer) | yes (write) |
+| 121-124 | 4 | Solder-mask cache (mirrors @90) | unmodelled (template) |
+| 126-141 | 16 | Identity GUID A (fresh per pad on write) | write-only |
+| 142-157 | 16 | Identity GUID B (fresh per pad on write) | write-only |
+| 162-165 | 4 | Hole positive tolerance (i32; `0x7FFFFFFF` = unset) | yes |
+| 166-169 | 4 | Hole negative tolerance (i32; `0x7FFFFFFF` = unset) | yes |
+| 172 | 1 | Format marker (`0x1A` PcbLib / `0x12` PcbDoc) | template |
+| 185 | 1 | Reserved marker (`0x03` for a standard PcbLib pad) | yes (write) |
+
+All remaining bytes of the tail are reserved / cache / identity values replayed verbatim from the
+template so the record matches Altium's 202-byte layout exactly.
+
+**Parsing thresholds:**
+
+| Field | Threshold | Behaviour |
+|-------|-----------|-----------|
+| Hole size | ≤ 0.001 mm | Treated as zero (SMD pad) |
+| Mask expansion | ≤ 0.0001 mm | Read back as `None` (no manual expansion) |
+
+**Pad shapes (bytes @49-51 and in Block 5):**
+
+| ID | Shape | Notes |
+|----|-------|-------|
+| 1 | Round / Oval | An oval pad is a Round pad with width ≠ height |
+| 2 | Rectangular | Sharp corners |
+| 3 | Octagonal | 8-sided |
+| 9 | RoundedRectangle | Written directly as id 9; requires the 651-byte Block 5 for the corner radius |
+
+> **Note:** For backwards compatibility with older files the reader also promotes a shape-1 pad
+> whose Block 5 corner radius is 1-99% to RoundedRectangle.
+
+**Stack modes (@62):**
+
+| ID | Mode | Description |
+|----|------|-------------|
+| 0 | Simple | All layers mirror top layer settings; Block 5 empty |
+| 1 | TopMiddleBottom | Independent top / middle / bottom sizes+shapes, carried in the MAIN block (@29-44, @50-51); Block 5 empty |
+| 2 | FullStack | Complete per-layer customisation, carried in Block 5 |
+
+**Block 5 — size/shape block.** Three forms are written:
+
+1. **Empty block** (`block_len = 0`) — plain Simple / TopMiddleBottom pads.
+2. **Canonical 651-byte size/shape block** — a Simple pad with a non-round hole or an explicit
+   corner radius. Layout:
+
+   | Offset | Size | Field |
+   |--------|------|-------|
+   | 0-115 | 116 | 29 × i32 internal-layer X sizes |
+   | 116-231 | 116 | 29 × i32 internal-layer Y sizes |
+   | 232-260 | 29 | 29 × u8 internal-layer shape ids |
+   | 261 | 1 | Reserved |
+   | 262 | 1 | Hole type (0=Round, 1=Square, 2=Slot) |
+   | 263-266 | 4 | Hole slot length (i32) |
+   | 267-274 | 8 | Hole rotation (f64, degrees) |
+   | 275-402 | 128 | 32 × i32 per-layer X offsets from hole centre |
+   | 403-530 | 128 | 32 × i32 per-layer Y offsets from hole centre |
+   | 531 | 1 | Has-rounded-rect flag (u8 bool) |
+   | 532-563 | 32 | 32 × u8 per-layer shape ids |
+   | 564-595 | 32 | 32 × u8 per-layer corner radii (%) |
+   | 596-627 | 32 | Reserved (zeros) — full-stack tail starts here |
+   | 628-631 | 4 | Tail entry count (i32; we write 1) |
+   | 632-635 | 4 | Tail entry stride (i32 = 15) |
+   | 636-650 | 15 | One 15-byte entry: layer code (4=top signal), 3 flag bytes, shape id, size X (i32), size Y (i32), corner radius % (fixed 50), trailing 0 |
+
+   Altium NEVER emits a bare 596-byte block — every non-empty size/shape block in a golden
+   `.PcbLib` is 651 (one tail entry) or 696 (four) bytes; an under-length block makes Altium
+   reject the pad. Multi-entry tails (count > 1) are currently unmodelled.
+
+3. **Legacy per-layer block (320 or 576 bytes)** — written for FullStack pads and still accepted
+   on read:
+
+   | Offset | Size | Field |
+   |--------|------|-------|
+   | 0-255 | 256 | 32 size entries (width/height i32 pairs) |
+   | 256-287 | 32 | 32 shape IDs (1 byte each) |
+   | 288-319 | 32 | 32 corner radius percentages (0-100) |
+   | 320-575 | 256 | 32 offset entries (x/y i32 pairs) — optional |
+
+   Layer index mapping: 0 = Top, 1 = Bottom, 2-31 = Mid Layers 1-30.
+
+> **Note:** Corner radius is stored as a percentage (0-100) of the smaller pad dimension.
+> Default corner radius for RoundedRectangle is 50% if not specified.
+
+### Track (0x04)
+
+Single 49-byte block:
+
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header | yes |
+| 13-16 | 4 | Start X (i32) | yes |
+| 17-20 | 4 | Start Y (i32) | yes |
+| 21-24 | 4 | End X (i32) | yes |
+| 25-28 | 4 | End Y (i32) | yes |
+| 29-32 | 4 | Width (i32) | yes |
+| 33-34 | 2 | Sub-polygon index (i16; 0 in libraries) | write-only (0) |
+| 35-38 | 4 | Solder mask expansion (i32) | yes |
+| 39-40 | 2 | Paste mask expansion (i16 — 2 bytes, cf. the Arc's 1-byte field) | write-only (0) |
+| 41-44 | 4 | V7 layer id (u32, derived from layer) | yes (write) |
+| 45 | 1 | Keepout restrictions (u8) | yes |
+| 46-48 | 3 | Reserved (zeros) | — |
+
+Every Altium-authored track carries the extended tail (offsets 33-48); the reader accepts a
+33-byte legacy block and defaults the tail fields.
+
+### Arc (0x01)
+
+Single 60-byte block:
+
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header | yes |
+| 13-16 | 4 | Centre X (i32) | yes |
+| 17-20 | 4 | Centre Y (i32) | yes |
+| 21-24 | 4 | Radius (i32) | yes |
+| 25-32 | 8 | Start angle (f64, degrees) | yes |
+| 33-40 | 8 | End angle (f64, degrees) | yes |
+| 41-44 | 4 | Width (i32) | yes |
+| 45-46 | 2 | Sub-polygon index (i16; 0 in libraries) | write-only (0) |
+| 47-50 | 4 | Solder mask expansion (i32) | yes |
+| 51 | 1 | Paste mask expansion (u8 — 1 byte, cf. the Track's 2-byte field) | write-only (0) |
+| 52-55 | 4 | V7 layer id (u32, derived from layer) | yes (write) |
+| 56 | 1 | Keepout restrictions (u8) | yes |
+| 57-59 | 3 | Reserved (zeros) | — |
+
+The reader accepts a 45-byte legacy block and defaults the tail fields.
+
 ### Text (0x05)
 
 Text has 2 blocks:
 
-**Block 0 (Geometry):**
+- **Block 0**: the fixed **252-byte** geometry record (`TEXT_SR1_TEMPLATE`) — the writer overlays
+  the modelled fields onto a canonical template captured from a real Altium text primitive and
+  replays every reserved byte verbatim.
+- **Block 1**: the text content as a `WriteStringBlock` (`[u32 len][u8 str_len][Windows-1252 text]`).
 
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1 | 1 | Text kind (0=Stroke, 1=TrueType, 2=BarCode) |
-| 2-12 | 11 | Flags and padding (0xFF) |
-| 13-16 | 4 | X position (internal units) |
-| 17-20 | 4 | Y position |
-| 21-24 | 4 | Height |
-| 25-26 | 2 | Stroke font ID (see below) |
-| 27-34 | 8 | Rotation (double, degrees) |
-| 35-38 | 4 | Font size (same as height) |
-| 39-42 | 4 | Reserved (zeros) |
-| 43-60 | 18 | Font name (UTF-16LE, null-terminated, e.g., "Arial") |
-| 61-67 | 7 | Font style bytes |
-| 68-71 | 4 | Line spacing |
-| 72 | 1 | Justification (see below) |
-| 73 | 1 | Reserved |
-| 74-77 | 4 | Glyph width |
-| 78-114 | 37 | Reserved padding |
-| 115-116 | 2 | WideStringsIndex (u16, reference to WideStrings stream) |
-| 117+ | var | Additional padding |
+**Block 0 — 252-byte geometry record:**
 
-**Block size constraints:**
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header (layer, flags, net/poly/comp indices) | yes |
+| 13-16 | 4 | X position (i32) | yes |
+| 17-20 | 4 | Y position (i32) | yes |
+| 21-24 | 4 | Height (i32) | yes |
+| 25-26 | 2 | Stroke font id (u16; 1=Default, 2=Sans Serif, 3=Serif) | yes |
+| 27-34 | 8 | Rotation (f64, degrees) | yes |
+| 35 | 1 | Mirrored (u8 bool) | yes |
+| 36-39 | 4 | Stroke line width (i32; template default 4 mil) | yes |
+| 40 | 1 | IsComment flag (u8 bool) | unmodelled (offset verified; dropped on read, 0 on write) |
+| 41 | 1 | IsDesignator flag (u8 bool) | unmodelled (offset verified; dropped on read, 0 on write) |
+| 42 | 1 | Character set (u8) | unmodelled (template) |
+| 43 | 1 | Base font type (0=stroke, 1=TrueType) | derived from kind @160 |
+| 44 | 1 | Bold (u8 bool) | yes |
+| 45 | 1 | Italic (u8 bool) | yes |
+| 46-109 | 64 | Font name (UTF-16LE, null-terminated; default "Arial") | yes |
+| 110 | 1 | IsInverted (u8 bool) | yes |
+| 111-114 | 4 | Inverted border width (i32) | yes |
+| 115-118 | 4 | WideStrings index (i32; -1 = none) | partially (reader consults the low u16 @115) |
+| 119-122 | 4 | Union index (i32) | unmodelled (template) |
+| 123 | 1 | UseInvertedRectangle (u8 bool) | yes |
+| 124-127 | 4 | Inverted rect width (i32) | yes |
+| 128-131 | 4 | Inverted rect height (i32) | yes |
+| 132 | 1 | Text-box justification (u8, see below) | yes |
+| 133-136 | 4 | Inverted rect text offset (i32) | yes |
+| 137-159 | 23 | Barcode geometry / kind / render fields | unmodelled (BarCode deferred; template) |
+| 160 | 1 | **Text kind (authoritative)**: 0=Stroke, 1=TrueType, 2=BarCode | yes |
+| 161-224 | 64 | Barcode font name (UTF-16LE) | unmodelled (template) |
+| 225 | 1 | Barcode show-text flag | unmodelled (template) |
+| 226-229 | 4 | V7 layer id (u32, derived from layer) | yes (write) |
+| 230-251 | 22 | Frame / snapping / snap-point fields | unmodelled (template) |
 
-| Constraint | Value | Notes |
-|------------|-------|-------|
-| Minimum for reading | 25 bytes | Minimum to extract basic geometry |
-| Writer padding | 80 bytes | Total block padded to at least 80 bytes |
+**Text-box justification (@132)** — Altium encodes this column-major, 1-based (0 = manual):
 
-> **Note:** WideStrings index at offset 115 references the WideStrings stream.
-> Justification offset (67-72) may vary based on font name length.
->
-> Font style bytes at offset 61-67 are typically: `0x56, 0x40, 0x01, 0x00, 0x00, 0x00, 0x00`.
+| ID | Position | ID | Position | ID | Position |
+|----|----------|----|----------|----|----------|
+| 1 | Top Left | 4 | Top Centre | 7 | Top Right |
+| 2 | Middle Left | 5 | Middle Centre | 8 | Middle Right |
+| 3 | Bottom Left | 6 | Bottom Centre | 9 | Bottom Right |
 
-**Text kinds:**
+The from-scratch default `BottomLeft` encodes to `0x03` (the template byte); ids 0 and 3 both
+decode to BottomLeft.
+
+**Text kinds (@160):**
 
 | ID | Kind | Description |
 |----|------|-------------|
 | 0 | Stroke | Vector-based outline text |
-| 1 | TrueType | Font-based rendering |
-| 2 | BarCode | Barcode representation |
+| 1 | TrueType | Font-based rendering (base font type @43 = 1) |
+| 2 | BarCode | Barcode representation (deferred — not modelled) |
 
-**Stroke font IDs:**
-
-| ID | Font |
-|----|------|
-| 0 | Default |
-| 1 | Sans Serif |
-| 3 | Serif |
-
-**Text justification:**
-
-| ID | Position |
-|----|----------|
-| 0 | Bottom Left |
-| 1 | Bottom Center |
-| 2 | Bottom Right |
-| 3 | Middle Left |
-| 4 | Middle Center |
-| 5 | Middle Right |
-| 6 | Top Left |
-| 7 | Top Center |
-| 8 | Top Right |
-
-**Block 1 (Content):**
-
-Length-prefixed string with text content, or index reference to `WideStrings` stream via `WideStringsIndex`.
+**Block 1 (Content):** a length-prefixed string with the text content, a special string, or a
+numeric WideStrings index reference.
 
 **Special text values (inline):**
 
@@ -517,117 +598,139 @@ Length-prefixed string with text content, or index reference to `WideStrings` st
 | `.Designator` | Pad/component designator |
 | `.Comment` | Component comment |
 
-**WideStrings stream format:**
-
-```text
-|ENCODEDTEXT0=84,69,83,84|ENCODEDTEXT1=...|
-```
-
-Where `84,69,83,84` are ASCII codes (e.g., "TEST" = 84,69,83,84).
-
-> **Note:** Inline `.Designator` and `.Comment` text is detected. Full WideStrings stream parsing is documented above.
->
-> WideStrings indices: Index 0 is reserved for `.Designator`, index 1 for `.Comment`. Actual text content starts at index 2.
+> **Note:** When Block 1 is empty the reader falls back to scanning the geometry block for the
+> special strings and to the WideStrings index at offset 115.
 
 ### Fill (0x06)
 
-Filled rectangle, single block (50 bytes total):
+Filled rectangle, single 50-byte block:
 
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1-12 | 12 | Flags and padding |
-| 13-16 | 4 | X1 (first corner) |
-| 17-20 | 4 | Y1 |
-| 21-24 | 4 | X2 (second corner) |
-| 25-28 | 4 | Y2 |
-| 29-36 | 8 | Rotation (double, degrees) |
-| 37-49 | 13 | Reserved (zeros) |
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header | yes |
+| 13-16 | 4 | X1 (first corner, i32) | yes |
+| 17-20 | 4 | Y1 (i32) | yes |
+| 21-24 | 4 | X2 (second corner, i32) | yes |
+| 25-28 | 4 | Y2 (i32) | yes |
+| 29-36 | 8 | Rotation (f64, degrees) | yes |
+| 37-40 | 4 | Solder mask expansion (i32) | yes |
+| 41 | 1 | Paste mask expansion (u8) | write-only (0) |
+| 42-45 | 4 | V7 layer id (u32, derived from layer) | yes (write) |
+| 46 | 1 | Keepout restrictions (u8) | yes |
+| 47-49 | 3 | Reserved (zeros) | — |
 
 ### Region (0x0B)
 
-Filled polygon with 2 blocks:
-
-**Block 0 (Properties + Vertices):**
+Filled polygon — a **single** size-prefixed block. (Earlier revisions of this crate wrote a
+spurious empty second block, which Altium read as an invalid record type, silently dropping every
+primitive after the region.)
 
 | Offset | Size | Field |
 |--------|------|-------|
-| 0 | 1 | Layer ID |
-| 1-12 | 12 | Flags and padding |
-| 13-17 | 5 | Reserved |
-| 18-21 | 4 | Parameter string length |
-| 22+ | var | Parameter string (ASCII key=value, pipe-delimited) |
-| 22+len | 4 | Vertex count |
-| 26+len | 16×N | Vertices (N pairs of doubles) |
+| 0-12 | 13 | Common header (layer, flags, net/poly/comp indices) |
+| 13 | 1 | Reserved (`0x00`) |
+| 14-15 | 2 | Hole contour count (u16) |
+| 16-17 | 2 | Reserved (`0x00 0x00`) |
+| 18-21 | 4 | Parameter string length (u32, INCLUDES the null terminator) |
+| 22.. | var | Parameter string (Windows-1252 C-string, **no leading pipe**) |
+| +0 | 4 | Outline vertex count (u32) |
+| +4 | 16×N | Outline vertices: N × (f64 X, f64 Y) in internal units |
+| ... | var | Hole contours: hole_count × `[u32 count][count × (f64 X, f64 Y)]` |
 
-**Parameter string format:**
+**Parameter string** — canonical key order (no leading pipe, `|`-separated):
 
 ```text
-V7_LAYER={layer}|NAME= |KIND=0|...
+V7_LAYER={token}|NAME={name}|KIND={kind}|SUBPOLYINDEX={spi}|UNIONINDEX={uix}|ARCRESOLUTION={mil}|ISSHAPEBASED={bool}|CAVITYHEIGHT={mil}
 ```
 
-| Key | Description |
-|-----|-------------|
-| `V7_LAYER` | Layer name (e.g., "TOPLAYER") |
-| `NAME` | Region name (usually empty) |
-| `KIND` | Region kind (0 = standard) |
+| Key | Description | Default |
+|-----|-------------|---------|
+| `V7_LAYER` | Canonical layer token — `MECHANICAL{n}` for mechanical layers, else the display name upper-cased with spaces stripped (e.g. `TOPLAYER`) | matches layer byte |
+| `NAME` | Region name | empty |
+| `KIND` | Region kind (0 = copper/standard, 1 = cutout, ...) | 0 |
+| `SUBPOLYINDEX` | Sub-polygon index | -1 |
+| `UNIONINDEX` | Union index | 0 |
+| `ARCRESOLUTION` | Arc resolution, mil-suffixed (`0mil`, `0.5mil`) | 0mil |
+| `ISSHAPEBASED` | `TRUE` / `FALSE` | FALSE |
+| `CAVITYHEIGHT` | Cavity height, mil-suffixed | 0mil |
+| `NET` | Numeric net index (read-side override of the header index) | absent |
 
-> **Note:** Layer names are formatted by removing spaces and converting to uppercase (e.g., "Top Layer" → "TOPLAYER").
+Board-region keys the model does not consume (`LAYER`, `KEEPOUT`, `ISBOARDCUTOUT`, ...) are
+captured verbatim on read and re-emitted after the canonical set, so a read-modify-write does not
+drop them.
 
-**Block 1:** Outline data for display (usually empty in simple regions).
+> **Warning:** Altium resolves a Region's layer from the `V7_LAYER` token, NOT the header layer
+> byte. Mechanical layers MUST use their `MECHANICAL{n}` token (e.g. Top Courtyard →
+> `MECHANICAL4`); the space-stripped display name is not a valid token and makes Altium silently
+> drop the region onto Top Layer.
 
-**Vertex format:**
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0-7 | 8 | X coordinate (IEEE 754 double, internal units) |
-| 8-15 | 8 | Y coordinate (IEEE 754 double, internal units) |
-
-> **Note:** Vertices are stored as doubles but rounded to integers before conversion:
-> `mm = round(internal_double) / 10000.0 * 0.0254`
+**Vertex format:** each vertex is two IEEE 754 doubles (X then Y) in internal units. Values are
+whole internal units in real files; the reader rounds to integers before converting to mm.
 
 ### ComponentBody (0x0C)
 
-3D model reference with 3 blocks:
+3D body — a **single** size-prefixed block (verified against AltiumSharp and the `BODY_3D` /
+`BODY_3D_STEP` golden libraries). The outline lives inside the block; there are NO separate
+snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 
-**Block 0 (Properties):**
+| Offset | Size | Field |
+|--------|------|-------|
+| 0 | 1 | Layer ID (e.g. 62 for Top 3D Body) |
+| 1-2 | 2 | Record-type marker (`0x0C 0x00`) |
+| 3-12 | 10 | Net/polygon/component indices + reserved (`0xFF` fill for a free body) |
+| 13-17 | 5 | Zeros |
+| 18-21 | 4 | Parameter string length (u32, INCLUDES the null) |
+| 22.. | var | Parameter string (Windows-1252 C-string, **no leading pipe**, starts `V7_LAYER=`) |
+| +0 | 4 | Outline vertex count (u32) |
+| +4 | 16×N | Outline vertices: N × (f64 X, f64 Y) in internal units |
 
-Binary header followed by pipe-delimited key=value parameters. Parameters start with `V7_LAYER=`.
+> **Warning:** Outline coordinates MUST be whole internal units. Altium silently drops a body
+> whose outline has fractional internal coordinates.
+
+**Parameter keys** (writer canonical order; values from the typed model):
 
 | Key | Description | Example |
 |-----|-------------|---------|
-| `V7_LAYER` | Layer name | "MECHANICAL6" |
-| `MODELID` | Model GUID | "{GUID}" |
-| `MODEL.NAME` | Model filename | "RESC1005X04L.step" |
-| `MODEL.EMBED` | Embedded flag | "TRUE" or "FALSE" |
-| `MODEL.CHECKSUM` | Model integrity hash | Integer value |
-| `MODEL.2D.X` | 2D placement X | Coordinate |
-| `MODEL.2D.Y` | 2D placement Y | Coordinate |
-| `MODEL.2D.ROTATION` | 2D rotation | Degrees |
-| `MODEL.3D.ROTX` | X rotation (degrees) | "0.000" |
-| `MODEL.3D.ROTY` | Y rotation (degrees) | "0.000" |
-| `MODEL.3D.ROTZ` | Z rotation (degrees) | "0.000" |
-| `MODEL.3D.DZ` | Z offset | "15.748mil" |
-| `MODEL.SNAPCOUNT` | Snap point count | Integer |
-| `STANDOFFHEIGHT` | Standoff height | "0mil" |
-| `OVERALLHEIGHT` | Overall height | "0.4mm" |
-| `ARCRESOLUTION` | Arc resolution | "0.5mil" |
-| `ISSHAPEBASED` | Shape-based flag | "FALSE" |
-| `CAVITYHEIGHT` | Cavity height | "0mil" |
-| `BODYPROJECTION` | Body projection | "0" |
-| `BODYCOLOR3D` | 3D body colour | "8421504" |
-| `BODYOPACITY3D` | 3D body opacity | "1.000" |
-| `MODEL.MODELTYPE` | Model type | "1" |
-| `MODEL.MODELSOURCE` | Model source | "Undefined" |
+| `V7_LAYER` | Canonical layer token (must match the header layer byte) | `MECHANICAL6` |
+| `NAME` | Body name | ` ` (single space) |
+| `KIND` | Body kind | `0` |
+| `SUBPOLYINDEX` | Sub-polygon index | `-1` |
+| `UNIONINDEX` | Union index | `0` |
+| `ARCRESOLUTION` | Arc resolution (emitted TWICE — repeated after `BODYPROJECTION`, matching Altium) | `0.5mil` |
+| `ISSHAPEBASED` | Shape-based flag | `FALSE` |
+| `CAVITYHEIGHT` | Cavity height | `0mil` |
+| `STANDOFFHEIGHT` | Standoff height (mil-suffixed, trimmed) | `0mil` |
+| `OVERALLHEIGHT` | Overall height | `15.748mil` |
+| `BODYPROJECTION` | Body projection | `0` |
+| `BODYCOLOR3D` | 3D body colour | `8421504` |
+| `BODYOPACITY3D` | 3D body opacity | `1.000` |
+| `IDENTIFIER` | Identifier (comma-separated codepoint list — deferred, emitted empty) | `` |
+| `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields (fixed defaults) | |
+| `MODELID` | Model GUID (synthesised for extruded bodies when absent) | `{GUID}` |
+| `MODEL.CHECKSUM` | Model integrity checksum (round-tripped verbatim, see below) | `0` |
+| `MODEL.EMBED` | `TRUE` / `FALSE` | |
+| `MODEL.NAME` | Model filename | `RESC1005X04L.step` |
+| `MODEL.2D.X`, `MODEL.2D.Y` | 2D placement (fixed `0mil`) | |
+| `MODEL.2D.ROTATION` | 2D rotation (degrees, 3 decimals) | `0.000` |
+| `MODEL.3D.ROTX/Y/Z` | 3D rotations (degrees, 3 decimals) | `0.000` |
+| `MODEL.3D.DZ` | Z offset (mil-suffixed) | `15.748mil` |
+| `MODEL.MODELTYPE` | `0` = extruded, `1` = model-backed (STEP) | |
+| `MODEL.EXTRUDED.MINZ` / `MAXZ` | Extrusion Z range (extruded bodies ONLY) | `0mil` / `15.748mil` |
+| `MODEL.MODELSOURCE` | Model source (model-backed bodies ONLY) | `Undefined` |
 
-> **Note:** Height values can be in "mil" or "mm" units. The tool parses both formats:
-> `15.748mil` → 0.4mm, `0.4mm` → 0.4mm. Mil values are converted using factor 0.0254 (1 mil = 0.0254 mm).
+**Extruded vs model-backed:** a body with no model file (empty `MODEL.NAME`, not embedded) is a
+generic *extruded* body — `MODEL.MODELTYPE=0` plus `MODEL.EXTRUDED.MINZ/MAXZ` (the Z range Altium
+extrudes the outline between; without it the body has no volume and is discarded). A model-backed
+body uses `MODEL.MODELTYPE=1` plus `MODEL.MODELSOURCE=Undefined` instead. `ISSHAPEBASED` stays
+`FALSE` in both cases.
 
-**Block 1:** Model snap points data (usually empty).
+Unmodelled keys captured on read are re-emitted verbatim after the canonical set (with canonical
+duplicates dropped) so read-modify-write round-trips.
 
-**Block 2:** Reserved (usually empty).
+> **Note:** Height values can be in "mil" or "mm" units on read. The tool parses both formats;
+> mil values are converted using 1 mil = 0.0254 mm.
 
-**V7_LAYER mapping:**
+**V7_LAYER mapping** (any `MECHANICAL1`-`MECHANICAL32` token is valid; the common pairs):
 
 | V7_LAYER | Layer |
 |----------|-------|
@@ -638,46 +741,47 @@ Binary header followed by pipe-delimited key=value parameters. Parameters start 
 | MECHANICAL6 | Top 3D Body |
 | MECHANICAL7 | Bottom 3D Body |
 
+The body's authoritative layer on read is the header layer byte at offset 0; `V7_LAYER` is the
+fallback only when the byte is absent.
+
 ### Via (0x03)
 
-Vias have 6 blocks, similar to Pads:
+Altium writes a via as **ONE** block: a fixed **321-byte** record (`VIA_SR1_TEMPLATE`) whose first
+13 bytes are the common header. (A 6-block pad-style layout is wrong and was misread by Altium —
+issue #113.) The writer overlays the modelled fields onto the canonical template; undecoded
+constant regions are replayed verbatim.
 
-| Block | Content |
-|-------|---------|
-| 0 | Designator/name block (typically empty) |
-| 1 | Layer stack data |
-| 2 | Marker string (`\|&\|0`) |
-| 3 | Net/connectivity data |
-| 4 | Geometry data |
-| 5 | Per-layer diameters (when stack mode ≠ Simple) |
+| Offset | Size | Field | Modelled |
+|--------|------|-------|----------|
+| 0-12 | 13 | Common header (layer byte = 74 Multi-Layer; flags; net/poly/comp indices) | yes |
+| 13-16 | 4 | X position (i32) | yes |
+| 17-20 | 4 | Y position (i32) | yes |
+| 21-24 | 4 | Diameter (i32) | yes |
+| 25-28 | 4 | Hole size (i32) | yes |
+| 29 | 1 | From (start) layer ID | yes |
+| 30 | 1 | To (end) layer ID | yes |
+| 31 | 1 | Power-plane connection style (0=Relief, 1=Direct, 2=NoConnect) | yes |
+| 32-35 | 4 | Thermal relief air gap (i32; default 0.254 mm) | yes |
+| 36 | 1 | Thermal relief conductor count (u8; default 4) | yes |
+| 38-41 | 4 | Thermal relief conductor width (i32; default 0.254 mm) | yes |
+| 42-45 | 4 | Power-plane relief expansion (i32; default 0.508 mm) | yes |
+| 46-49 | 4 | Power-plane clearance (i32; default 0.508 mm) | yes |
+| 50-53 | 4 | Paste mask expansion (i32) | yes |
+| 54-57 | 4 | Solder mask expansion, front (i32) | yes |
+| 61-64 | 4 | Cache-valid word | unmodelled (template) |
+| 66 | 1 | Solder mask expansion mode (0=None, 1=FromRule, 2=Manual) | yes |
+| 74 | 1 | Diameter stack mode (0=Simple, 1=TopMiddleBottom, 2=FullStack) | yes |
+| 75-202 | 128 | Per-layer diameters (32 × i32; a Simple via repeats its diameter) | yes |
+| 242-245 | 4 | Solder mask expansion, back/bottom face (i32; mirrors the front when unset) | yes |
+| 258 | 1 | Solder-mask-from-hole-edge flag | unmodelled (template) |
+| 259-274 | 16 | Identity GUID A (fresh per via on write) | write-only |
+| 275-290 | 16 | Identity GUID B (fresh per via on write) | write-only |
+| 291-294 | 4 | Hole positive tolerance (i32; `0x7FFFFFFF` = unset) | yes |
+| 295-298 | 4 | Hole negative tolerance (i32; `0x7FFFFFFF` = unset) | yes |
+| 312 | 1 | Drill layer-pair type (0=Through, 1/2/3 = blind/buried) | unmodelled (template) |
+| 320 | 1 | Trailing constant (`0x01`) | template |
 
-**Geometry block structure:**
-
-| Offset | Size | Field |
-|--------|------|-------|
-| 0 | 1 | Layer ID (typically Multi-Layer) |
-| 1-12 | 12 | Flags and padding |
-| 13-16 | 4 | X position |
-| 17-20 | 4 | Y position |
-| 21-24 | 4 | Diameter |
-| 25-28 | 4 | Hole size |
-| 29 | 1 | From layer ID |
-| 30 | 1 | To layer ID |
-| 31-34 | 4 | Thermal relief air gap width (default: 10 mils = 2540 units) |
-| 35 | 1 | Thermal relief conductors count (default: 4) |
-| 36-39 | 4 | Thermal relief conductors width (default: 10 mils = 2540 units) |
-| 40-43 | 4 | Solder mask expansion |
-| 44 | 1 | Solder mask expansion manual flag |
-| 45 | 1 | Diameter stack mode |
-| 46+ | var | Per-layer diameters (32 × 4 bytes when FullStack) |
-
-**Diameter stack mode:** Same as Pad stack modes (Simple, TopMiddleBottom, FullStack).
-
-Via geometry block minimum size: 46 bytes.
-
-**Per-layer diameters (Block 6):**
-
-When diameter stack mode is not Simple, Block 6 contains 32 diameter values (4 bytes each as i32), using the same layer index mapping as Pads.
+The reader accepts any block ≥ 31 bytes and defaults every absent field.
 
 ### 3D Model Storage
 
@@ -692,23 +796,18 @@ Altium embeds 3D models in the library file:
 └── ...
 ```
 
-**Header stream format:**
+**Header stream format:** a single 4-byte little-endian unsigned integer containing the number of
+embedded models.
 
-A single 4-byte little-endian unsigned integer containing the number of embedded models.
-
-**Data stream format:**
-
-A sequence of block-prefixed records using standard `WriteBlock(WriteParameters)` encoding:
+**Data stream format:** a sequence of C-string parameter blocks — **NO leading pipe** (the record
+starts at `EMBED=`, matching AltiumSharp's `string.Join` and every `BODY_3D` golden):
 
 ```text
-[block_len:4 LE]["|EMBED=TRUE|MODELSOURCE=Undefined|ID={GUID}|..." + \x00]
-[block_len:4 LE]["|EMBED=TRUE|..." + \x00]
+[block_len:4 LE]["EMBED=TRUE|MODELSOURCE=Undefined|ID={GUID}|ROTX=0.000|ROTY=0.000|ROTZ=0.000|DZ=0|CHECKSUM=0|NAME=model.step" + \x00]
 ...
 ```
 
-Block length includes the null terminator. Parameters start with a leading `|`.
-
-Each record contains pipe-delimited key=value pairs:
+Block length includes the null terminator.
 
 | Field | Description |
 |-------|-------------|
@@ -717,12 +816,18 @@ Each record contains pipe-delimited key=value pairs:
 | `ID` | GUID matching `MODELID` in ComponentBody |
 | `ROTX`, `ROTY`, `ROTZ` | Rotation values (degrees) |
 | `DZ` | Z offset |
-| `CHECKSUM` | Model checksum |
-| `NAME` | Model filename (e.g., `model.step`) |
+| `CHECKSUM` | Model checksum (see below) |
+| `NAME` | Model filename (e.g. `model.step`) |
 
-The record's position (0, 1, 2, ...) corresponds to the model stream index.
+The record's position (0, 1, 2, ...) corresponds to the numbered model stream index. The
+numbered streams (`/Library/Models/0`, ...) are the raw model bytes with a standard **zlib**
+wrapper (RFC 1950: `78 9C` header + Adler-32; matches flate2 `ZlibEncoder` / .NET `ZLibStream`).
 
-> **Note:** STEP models are stored with zlib compression. Models are referenced by GUID in `ComponentBody` records.
+**Checksum algorithm** (`PcbModel.ComputeChecksum` in AltiumSharp): a position-weighted byte sum
+over the **uncompressed** model bytes — weight 1 for byte 0, weight `i` for byte `i` — modulo
+2^32, stored as a signed i32. `CHECKSUM=0` is explicitly tolerated by Altium, and this crate
+writes 0 rather than recomputing (the value is round-tripped verbatim on read-modify-write; a
+recomputed body checksum that disagreed with the Models/Data record would be worse than 0/0).
 
 ## Primitive Writing Order
 
@@ -736,22 +841,21 @@ When writing footprint data, primitives are encoded in this specific order:
 6. Regions (0x0B)
 7. Fills (0x06)
 8. ComponentBodies (0x0C)
-9. End marker (0x00)
+
+There is **no** end marker after the last primitive (issue #68).
 
 ## Notes
 
 - **OLE version**: MUST be V3 (512-byte sectors); Altium rejects V4
-- **WideStrings stream**: Per-component, block-prefixed; inline `.Designator` and `.Comment` are detected
+- **No end markers**: neither the Data stream nor any primitive carries a trailing `0x00`
+- **WideStrings stream**: per-component, block-prefixed; inline `.Designator` and `.Comment` are detected
 - **3D model embedding**: zlib-compressed STEP files, referenced by GUID
-- **Pad hole shapes**: Round (0), Square (1), Slot (2)
-- **Net information**: Used in board files, not library files
-- **Component variants**: Not applicable to library files
-- **Unique IDs**: All primitives support 8-character alphanumeric unique IDs for tracking (0-based index)
-- **Default layer mapping**: Unknown layer IDs default to Multi-Layer (74)
-- **Default hole shape**: Unknown hole shape IDs default to Round (0)
-- **Default stack mode**: Unknown stack mode IDs default to Simple (0)
-- **Default justification**: Unknown justification IDs default to MiddleCenter (4)
-- **Internal OLE entries filtered**: FileHeader, Library, Models, Textures, ModelsNoEmbed, PadViaLibrary, LayerKindMapping, ComponentParamsTOC, FileVersionInfo, PrimitiveGuids
+- **Pad hole shapes**: Round (0), Square (1), Slot (2) — stored at offset 262 of the 651-byte size/shape block, NOT in the main geometry block
+- **Net information**: modelled via the common-header indices; used in board files, not library files
+- **Unique IDs**: 8-character alphanumeric, keyed by a single global 0-based `PRIMITIVEINDEX` over all primitives in Data order
+- **Default layer mapping**: unknown layer IDs default to Multi-Layer (74)
+- **Default stack mode**: unknown stack mode IDs default to Simple (0)
+- **Internal OLE entries filtered on read**: FileHeader, Library, Models, Textures, ModelsNoEmbed, PadViaLibrary, LayerKindMapping, ComponentParamsTOC, FileVersionInfo, PrimitiveGuids
 
 ## References
 

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -1,84 +1,104 @@
 # SchLib Binary Format
 
-This document describes the binary format of Altium Designer `.SchLib` (Schematic symbol library) files.
+This document describes the binary format of Altium Designer `.SchLib` (Schematic symbol library)
+files as implemented by this crate. Every field below is verified against the byte-level
+reverse-engineering campaign, the regenerated golden fixtures (`scripts/samples/symbols.SchLib`,
+authored by real Altium 24) and the current reader/writer in `src/altium/schlib/`.
 
-> **Note:** This documentation is based on reverse engineering from AltiumSharp, pyAltiumLib, and sample file analysis.
+> **Note:** Cross-referenced against AltiumSharp, pyAltiumLib and Altium-authored sample libraries.
 > See [References](#references) for links.
 
 ## File Structure
 
-SchLib files are OLE Compound Documents (CFB format) containing:
+SchLib files are OLE Compound Documents (CFB format, OLE v3) containing:
 
 ```text
 /
-├── FileHeader          # Library metadata
-├── Storage             # Section key mappings (maps LibRef names to storage names)
-└── {ComponentName}/    # One storage per symbol
-    └── Data            # Symbol primitives stream
+├── FileHeader              # Library metadata (C-string param block)
+├── Storage                 # Embedded image bytes (compressed-storage stream)
+└── {ComponentName}/        # One storage per symbol
+    ├── Data                # Symbol records stream
+    ├── PinFrac             # OPTIONAL: fractional pin coordinates (compressed storage)
+    └── PinSymbolLineWidth  # OPTIONAL: per-pin symbol line widths (compressed storage)
 ```
+
+The two pin auxiliary streams are emitted only when at least one pin needs them (see
+[Pin auxiliary streams](#pin-auxiliary-streams)); a symbol with on-grid, default-width pins has
+only its `Data` stream, byte-identical to Altium's own output.
+
+## Cross-Cutting Conventions
+
+These rules apply to every text record and are referenced throughout the per-record tables
+instead of being repeated:
+
+- **Omit-when-default:** zero-valued numeric keys and false booleans are OMITTED from the record
+  (Altium's `AddNonZero` / `AddBool` helpers). A missing key means its default — numeric `0`,
+  boolean false. Boolean keys are written as `=T` only; `=F` is never written.
+- **`IsNotAccesible`:** Altium's own single-'s' misspelling of "IsNotAccessible". Emitted as
+  `IsNotAccesible=T` when set, omitted when false.
+- **Colours are BGR:** 32-bit `0x00BBGGRR` (e.g. `128` = dark red, `8388608` = dark blue,
+  `11599871` = light yellow, `16711680` = blue). An absent colour key reads back as 0 (black).
+- **DXP units:** coordinates are integer DXP units where **10 units = 1 grid square** (1 DXP unit
+  = 10 mil = 100,000 raw internal units). Sub-unit precision uses the `_Frac` companion keys (see
+  [Fractional coordinates](#fractional-coordinates)).
+- **Signed `_Frac`:** the fractional companion is signed, truncation is toward zero, and a zero
+  integer part is omitted when the fraction is non-zero — golden-verified 2026-07-11 (details
+  below).
+- **`IndexInSheet`:** one shared sequential 0-based counter over all content records (see
+  [IndexInSheet](#indexinsheet)).
+- **`%UTF8%` keys:** a text value that Windows-1252 cannot represent (Cyrillic, CJK, Greek `Ω`,
+  ...) is stored under a `%UTF8%<Key>` key (e.g. `%UTF8%Text`) holding the raw UTF-8 bytes,
+  INSTEAD of the lossy plain `<Key>` — only one of the two is ever written. Applies to `Text` on
+  Label, Text, Parameter, Designator and TextFrame records.
+- **`UniqueID`:** 8-character alphanumeric per-record id, emitted as the LAST key.
+- **Encoding:** records are Windows-1252, with a leading `|`, no trailing `|`, and a trailing
+  `0x00` (the record length includes the null).
 
 ## FileHeader Stream
 
-The FileHeader contains library-level metadata as pipe-delimited key=value pairs:
+A single C-string parameter block:
 
 ```text
-[length:4 LE][text...]
+[block_len:4 LE]["|HEADER=...|Weight=47|..." + 0x00]    # length INCLUDES the null terminator
 ```
 
-Key fields:
+Keys as written by this crate (matching the golden library; note the mixed-case key spellings —
+the reader is case-insensitive):
 
-| Key | Description | Notes |
-|-----|-------------|-------|
-| `HEADER` | File type identifier | "Schematic Library Editor Binary File Version 5.0" |
-| `WEIGHT` | File weight/version | Typically 47 |
-| `MINORVERSION` | Minor version number | Typically 9 |
-| `UNIQUEID` | Library unique ID | 8-char alphanumeric |
-| `CompCount` | Number of components | |
-| `LibRef{N}` | Component name | 0-indexed |
-| `CompDescr{N}` | Component description | |
-| `PartCount{N}` | Number of parts | Stored as count+1 in file |
-| `FontIdCount` | Number of custom fonts | Default: 1 |
-| `FontName{N}` | Font name | Default: "Times New Roman" |
-| `Size{N}` | Font size | Default: 10 |
-| `UseMBCS` | Multibyte character set | "T" or "F" |
-| `IsBOC` | Binary OLE Container flag | "T" or "F" |
-| `SheetStyle` | Sheet style number | |
-| `BorderOn` | Border enabled | "T" or "F" |
-| `SnapGridOn` | Snap grid enabled | "T" or "F" |
-| `SnapGridSize` | Snap grid size | Default: 10 |
-| `VisibleGridOn` | Visible grid enabled | "T" or "F" |
-| `VisibleGridSize` | Visible grid size | Default: 10 |
-| `CustomX`, `CustomY` | Custom sheet dimensions | |
-| `UseCustomSheet` | Use custom sheet | "T" or "F" |
-| `AreaColor` | Background colour (BGR) | |
+| Key | Value | Notes |
+|-----|-------|-------|
+| `HEADER` | `Protel for Windows - Schematic Library Editor Binary File Version 5.0` | File type identifier |
+| `Weight` | 47 | File weight |
+| `MinorVersion` | 9 | Minor version number |
+| `UniqueID` | 8-char alphanumeric | Library unique ID |
+| `FontIdCount` | 1 | Number of fonts in the font table |
+| `Size1` | 10 | Font 1 size |
+| `FontName1` | Times New Roman | Font 1 name |
+| `UseMBCS` | T | Multibyte character set |
+| `IsBOC` | T | Binary OLE container flag |
+| `SheetStyle` | 9 | Sheet style number |
+| `BorderOn` | T | Border enabled |
+| `SheetNumberSpaceSize` | 12 | |
+| `AreaColor` | 16317695 | Background colour (BGR) |
+| `SnapGridOn` / `SnapGridSize` | T / 10 | |
+| `VisibleGridOn` / `VisibleGridSize` | T / 10 | |
+| `CustomX`, `CustomY` | 18000 | Custom sheet dimensions |
+| `UseCustomSheet` | T | |
+| `ReferenceZonesOn` | T | |
+| `Display_Unit` | 0 | |
+| `CompCount` | N | Number of components |
+| `LibRef{i}` | name | Component name (0-indexed; OLE-safe storage name) |
+| `CompDescr{i}` | text | Component description |
+| `PartCount{i}` | N+1 | Stored as **count + 1** |
 
-**Typical hardcoded values:**
-
-| Key | Value |
-|-----|-------|
-| `WEIGHT` | 47 |
-| `MINORVERSION` | 9 |
-| `FontIdCount` | 1 |
-| `Size1` | 10 |
-| `FontName1` | Times New Roman |
-| `UseMBCS` | T |
-| `IsBOC` | T |
-| `SheetStyle` | 9 |
-| `BorderOn` | T |
-| `SheetNumberSpaceSize` | 12 |
-| `SnapGridSize` | 10 |
-| `VisibleGridSize` | 10 |
-| `CustomX`, `CustomY` | 18000 |
-| `UseCustomSheet` | T |
-| `ReferenceZonesOn` | T |
-| `Display_Unit` | 0 |
-
-> **Note:** `PartCount` is stored as actual_count + 1 in the file. When reading, subtract 1 to get the true part count.
-> A minimum part count of 1 is enforced even if the file contains 0.
+> **Note:** every `PartCount` in the format (here and in RECORD=1) is stored as
+> `actual_count + 1`. Read as `max(0, stored - 1)` — do NOT floor at 1: a single-part symbol
+> stores `PartCount=1`, which must decode to internal 0 and re-emit as 1 (flooring corrupted the
+> round-trip to `PartCount=2`).
 
 ## Data Stream Format
 
-Each component's Data stream contains the symbol primitives:
+Each component's Data stream contains the symbol records:
 
 ```text
 [length:3 LE][flags:1][data:length]
@@ -89,7 +109,8 @@ Each component's Data stream contains the symbol primitives:
 The 4-byte header is a single 32-bit little-endian size word: the low 24 bits are the payload
 length and the high byte is a flag (`0x00` = text record, `0x01` = binary pin). For payloads under
 16 MiB (always, in practice) this is byte-identical to a `[u16 length LE][u16 BE type]` reading,
-which is why earlier notes described it that way.
+which is why earlier notes described it that way. For text records the length INCLUDES the
+trailing `0x00`.
 
 There is **no end-of-stream marker** — records simply run until the stream is exhausted. A trailing
 `0x0000` would be mis-read as a zero-length record (this was part of issue #68; the writer must not
@@ -99,10 +120,8 @@ emit one).
 
 | Flag | Format | Description |
 |------|--------|-------------|
-| `0x00` | Text | Pipe-delimited key=value pairs (most primitives) |
+| `0x00` | Text | Pipe-delimited key=value pairs (most records) |
 | `0x01` | Binary | Binary pin record (more compact than text) |
-
-> **Note:** Most primitives use text format (type 0). Binary format (type 1) is used for pins to reduce file size.
 
 ## Text Records (Type 0)
 
@@ -114,83 +133,91 @@ Text records contain pipe-delimited key=value pairs:
 
 ### Record IDs (RECORD= field)
 
+Every record type this crate models:
+
 | ID | Type | Description |
 |----|------|-------------|
 | 1 | Component | Symbol header (name, description, part count) |
-| 2 | Pin | Pin (text format, rarely used — binary preferred) |
+| 2 | Pin | Pin in text form (rare — skipped on read; binary pins are used instead) |
 | 3 | Text | Text annotation (general-purpose text) |
 | 4 | Label | Text label |
-| 5 | Bezier | Bezier curve |
+| 5 | Bezier | Cubic Bezier curve (4 control points) |
 | 6 | Polyline | Multiple connected line segments |
 | 7 | Polygon | Filled polygon |
 | 8 | Ellipse | Ellipse or circle |
+| 9 | Pie | Filled circular sector |
 | 10 | RoundRectangle | Rounded rectangle |
 | 11 | EllipticalArc | Elliptical arc |
 | 12 | Arc | Circular arc |
 | 13 | Line | Single line segment |
 | 14 | Rectangle | Rectangle shape |
-| 34 | Designator | Component designator (R?, U?, etc.) |
+| 28 | TextFrame | Bordered multi-line text box |
+| 30 | Image | Embedded/linked picture (bytes in `/Storage`) |
+| 34 | Designator | Component designator (R?, U?, etc.) — a parameter record variant |
 | 41 | Parameter | Component parameter (Value, Part Number, etc.) |
 | 44 | ImplementationList | Container for a component's implementations |
 | 45 | Implementation | One implementation (footprint model link) |
 | 46 | MapDefinerList | Container for the implementation's map definers |
-| 47 | MapDefiner | Pin-to-pad mapping |
+| 47 | MapDefiner | Pin-to-pad mapping (structure known; skipped on read) |
 | 48 | ImplementationParameters | Per-implementation parameters |
+
+Records 44/46/47/48 carry structural links only; this crate writes 44, 46 and 48 (46/48 as empty
+`OwnerIndex`-bearing children of each RECORD=45) and skips all four on read. Record IDs that only
+occur in schematic *documents* (Wire, Port, PowerObject, Note, ...) never occur in a `.SchLib` and
+are out of scope.
 
 ## Binary Pin Records (Type 1)
 
-Binary pin records have a variable-length structure with three length-prefixed strings.
-
-### Fixed Header (12 bytes)
+Binary pin records have a variable-length structure: a fixed header, then Pascal short strings
+(`[u8 len][bytes]`, Windows-1252) interleaved with fixed fields. Field order is strict. With `N` =
+description length, the layout is:
 
 | Offset | Size | Field | Notes |
 |--------|------|-------|-------|
 | 0-3 | 4 | Record type | Always 2 for pin (i32, LE) |
-| 4 | 1 | Reserved | Unknown purpose |
+| 4 | 1 | Reserved | Always `0x00` |
 | 5-6 | 2 | OwnerPartId | Signed i16, LE (-1 = all parts) |
-| 7 | 1 | OwnerPartDisplayMode | Display mode (typically 0) |
-| 8-11 | 4 | Symbol flags | 4 bytes: InnerEdge, OuterEdge, Inside, Outside |
+| 7 | 1 | OwnerPartDisplayMode | Alternate-view index (0 in practice) |
+| 8 | 1 | Symbol: InnerEdge | See [Pin Symbols](#pin-symbols) |
+| 9 | 1 | Symbol: OuterEdge | |
+| 10 | 1 | Symbol: Inside | |
+| 11 | 1 | Symbol: Outside | |
+| 12 | 1+N | Description | Pascal short string — NO interior reserved byte |
+| 13+N | 1 | **FormalType** | `0x01` for a normal pin; AFTER Description, BEFORE Electrical |
+| 14+N | 1 | Electrical type | See [Electrical Types](#electrical-types) |
+| 15+N | 1 | Flags | See [Pin Flags](#pin-flags) |
+| 16+N | 2 | Length | DXP units, signed i16 LE (integer part; fraction in `PinFrac`) |
+| 18+N | 2 | Location.X | Signed i16, LE (integer part) |
+| 20+N | 2 | Location.Y | Signed i16, LE (integer part) |
+| 22+N | 4 | Colour | BGR, u32 LE |
+| 26+N | 1+M | Name | Pascal short string |
+| after | 1+K | Designator | Pascal short string |
+| after | 1+P | SwapIdGroup | Pascal short string (empty by default) |
+| after | 1+Q | PartAndSequence | Pascal short string; default `\|&\|` (= `{SwapIdPart}\|&\|{SwapIdSequence}` with both empty) |
+| after | 1+R | DefaultValue | Pascal short string (e.g. `3.3V`); LAST field |
 
-> **Note:** See [Pin Symbols](#pin-symbols) for the full format specification.
+A truncated legacy record is read tolerantly: any absent trailing Pascal string reads as `""` and
+is reproduced exactly on write (an empty `PartAndSequence` is NOT coerced back to `|&|`).
 
-### Description Block
+### Pin Flags
 
-| Offset | Size | Field |
-|--------|------|-------|
-| 12 | 1 | Description length (N) |
-| 13 | 1 | Reserved |
-| 14+ | N | Description string (ASCII) |
+Flags byte at `15+N`:
 
-### Pin Properties (after description)
-
-| Offset | Size | Field | Notes |
-|--------|------|-------|-------|
-| +0 | 1 | Electrical_Type | See [Electrical Types](#electrical-types) |
-| +1 | 1 | Flags | See [Pin Flags](#pin-flags-byte-at-1) |
-| +2-3 | 2 | Length | Schematic units, signed i16, LE |
-| +4-5 | 2 | Location.X | Signed i16, LE |
-| +6-7 | 2 | Location.Y | Signed i16, LE |
-| +8-11 | 4 | Colour | BGR format |
-
-### Name Block (after properties)
-
-| Offset | Size | Field |
-|--------|------|-------|
-| +0 | 1 | Name length (N) |
-| +1+ | N | Name string (ASCII) |
-
-### Designator Block (after name)
-
-| Offset | Size | Field |
-|--------|------|-------|
-| +0 | 1 | Designator length (N) |
-| +1+ | N | Designator string (ASCII) |
+| Bit | Flag | Description |
+|-----|------|-------------|
+| 0x01 | Rotated | Pin rotated 90° |
+| 0x02 | Flipped | Pin flipped |
+| 0x04 | Hidden | Pin hidden from view |
+| 0x08 | DisplayNameVisible | Show pin name |
+| 0x10 | DesignatorVisible | Show pin designator |
+| 0x20 | IsNotAccessible | Not selectable |
+| 0x40 | GraphicallyLocked | Pin is graphically locked |
+| 0x80 | Reserved | — |
 
 ### Pin Symbols
 
-Pin symbol decorations appear at four positions on the pin to indicate electrical characteristics.
-
-The four symbol positions (InnerEdge, OuterEdge, Inside, Outside) can each have one of these decorations:
+Pin symbol decorations appear at four positions on the pin (bytes 8-11) to indicate electrical
+characteristics:
 
 | ID | Symbol | Description |
 |----|--------|-------------|
@@ -217,26 +244,11 @@ The four symbol positions (InnerEdge, OuterEdge, Inside, Outside) can each have 
 | 20 | LeftRightSignalFlow | Left-to-right signal flow arrow |
 | 21 | BidirectionalSignalFlow | Bidirectional signal flow |
 
-### Pin Flags (byte at +1)
-
-| Bit | Flag | Description | Implemented |
-|-----|------|-------------|-------------|
-| 0x01 | Rotated | Pin rotated 90° | ✓ |
-| 0x02 | Flipped | Pin flipped | ✓ |
-| 0x04 | Hidden | Pin hidden from view | ✓ |
-| 0x08 | DisplayNameVisible | Show pin name | ✓ |
-| 0x10 | DesignatorVisible | Show pin designator | ✓ |
-| 0x20 | Reserved | Reserved | — |
-| 0x40 | GraphicallyLocked | Pin is graphically locked | ✓ |
-| 0x80 | Reserved | Reserved | — |
-
 ### Pin Constraints
 
 | Field | Limit |
 |-------|-------|
-| Name | 255 bytes max |
-| Designator | 255 bytes max |
-| Description | 255 bytes max |
+| Name / Designator / Description / SwapIdGroup / PartAndSequence / DefaultValue | 255 **encoded** (Windows-1252) bytes max |
 | Location.X, Location.Y | i16 range (±32767) |
 | Length | i16 range (±32767) |
 
@@ -245,13 +257,15 @@ The four symbol positions (InnerEdge, OuterEdge, Inside, Outside) can each have 
 | Field | Default |
 |-------|---------|
 | `electrical_type` | Passive (ID 4) |
-| `show_name` | true |
-| `show_designator` | true |
+| `formal_type` | 1 |
+| `show_name` / `show_designator` | true |
 | `colour` | Black (0x000000) |
+| `part_and_sequence` | `\|&\|` |
+| `swap_id_group` / `default_value` | empty |
 
 ### Pin Orientation
 
-Derived from Rotated and Flipped flags:
+Derived from the Rotated and Flipped flags:
 
 | Rotated | Flipped | Orientation |
 |---------|---------|-------------|
@@ -273,6 +287,52 @@ Derived from Rotated and Flipped flags:
 | 6 | OpenEmitter |
 | 7 | Power |
 
+### Pin auxiliary streams
+
+Two optional per-component OLE streams carry data the binary pin record cannot hold. Both use the
+[compressed-storage framing](#compressed-storage-framing) with each entry keyed by the **pin
+ordinal** as an ASCII-decimal Pascal string:
+
+- **`PinFrac`** — the fractional part of each off-grid pin's X / Y / length. Payload: 12 bytes =
+  three little-endian `i32` (`frac_x`, `frac_y`, `frac_length`), each scaled by 100,000 like the
+  text-record `_Frac` keys.
+- **`PinSymbolLineWidth`** — a per-pin symbol line width. Payload: a Unicode parameter block
+  `[u32 LE byte_len][UTF-16LE "|SYMBOL_LINEWIDTH=N"]`.
+
+A symbol whose pins are all on-grid with default line width emits **neither** stream.
+
+## Compressed-Storage Framing
+
+Three stream families share one byte layout: `PinFrac`, `PinSymbolLineWidth` and the root
+`/Storage` stream:
+
+```text
+[u32 LE header_len][header_len header bytes]         # C-string param block
+then, per entry:
+  [u32 LE size]        # low 24 bits = block size, high byte = 0x01 flag
+  0xD0                 # storage-entry tag
+  [u8 name_len][name]  # Pascal-string entry key (Windows-1252)
+  [u32 LE comp_len][comp_len bytes]   # zlib-compressed payload
+```
+
+The header param block is `|HEADER=<name>` plus `|Weight=<count>` (Altium's mixed-case key) when
+at least one entry follows.
+
+### `/Storage` (embedded images)
+
+The root `/Storage` stream carries the raw bytes of every embedded image (`RECORD=30` with
+`EmbedImage=T`), one compressed entry per image:
+
+- **Header:** `|HEADER=Icon storage|Weight=<count>`. An **empty** library carries the bare
+  `|HEADER=Icon storage` block with NO `Weight` key.
+- **Entry names:** real AD24 names each entry with the image's **full file path** (the record's
+  `FileName` value); AltiumSharp's own writer uses the zero-based index instead. This crate
+  follows real AD24 on write.
+- **Matching:** entry names are ignored on read — payloads are matched to `EmbedImage=T` images
+  **in order across all symbols** (global stream order), exactly like AltiumSharp's
+  `ParseStorageImageData`.
+- **Payload:** the raw image file bytes (BMP/PNG/JPG), zlib-compressed (RFC 1950).
+
 ## Coordinate System
 
 - Schematic units: **10 units = 1 grid square**
@@ -290,11 +350,11 @@ value = <key> + <key>_Frac / 100000
 ```
 
 This applies to every coordinate key — `Location.X`/`Y`, `Corner.X`/`Y`,
-`Radius`, `SecondaryRadius`, `CornerXRadius`/`CornerYRadius`, and the polyline /
-polygon vertices `X{n}`/`Y{n}`. The `_Frac` field is **signed**: AD24 truncates
-the integer part **toward zero** and lets the fraction carry the coordinate's
-sign (range `-99999..=99999`, never opposite in sign to the integer part). The
-FRACSHAPES golden fixture stores `-5.45` as `Location.X=-5` with
+`Radius`, `SecondaryRadius`, `CornerXRadius`/`CornerYRadius`, `TextMargin` and
+the polyline / polygon vertices `X{n}`/`Y{n}`. The `_Frac` field is **signed**:
+AD24 truncates the integer part **toward zero** and lets the fraction carry the
+coordinate's sign (range `-99999..=99999`, never opposite in sign to the integer
+part). The FRACSHAPES golden fixture stores `-5.45` as `Location.X=-5` with
 `Location.X_Frac=-45000` (`-5 + -45000/100000 = -5.45`). When the integer part
 is zero but the fraction is not, AD24 **omits the integer key entirely** (the
 golden arc centred at `0.05` carries only `Location.X_Frac=5000`, no
@@ -312,8 +372,8 @@ fractional part rounds up to a whole unit it **carries** into the integer part
 > dropping the fractional part of every AD24-written negative off-grid
 > coordinate.)
 
-Binary pin records (Type 1) store integer coordinates only and do not use
-`_Frac`.
+Binary pin records (Type 1) store integer coordinates only; their fractional
+parts live in the separate `PinFrac` stream.
 
 ## Colour Format
 
@@ -327,136 +387,124 @@ Common colours:
 
 | Value | Colour | Usage |
 |-------|-------|-------|
-| `0x000080` | Dark Red | Lines, outlines |
-| `0x800000` | Dark Blue | Text, parameters |
-| `0xB0FFFF` | Light Yellow | Fill colour |
-| `0xFF0000` | Blue | Component body |
-| `0x000000` | Black | Pins |
+| `0x000080` (128) | Dark Red | Component outline |
+| `0x800000` (8388608) | Dark Blue | Text, parameters |
+| `0xB0FFFF` (11599871) | Light Yellow | Fill colour |
+| `0xFF0000` (16711680) | Blue | Component body |
+| `0x000000` (0) | Black | Pins; the read-back default for any absent colour key |
+
+## IndexInSheet
+
+All content records — every graphic shape, user Label/Parameter record **and** every binary pin —
+share ONE sequential 0-based `IndexInSheet` counter in stream order (golden-confirmed against both
+the regenerated fixture and real Altium-authored libraries):
+
+- The token is **omitted at slot 0** and sits immediately after `IsNotAccesible` (before
+  `OwnerPartId`), matching the golden token order `|RECORD=12|IsNotAccesible=T|IndexInSheet=1|…`.
+- **Binary pins store no token** (the binary record has no such field) but still consume a
+  counter slot: a real Altium symbol with parameters 0-2, two pins, then a rectangle stores
+  `IndexInSheet=5` on the rectangle (slots 3 and 4 are the pins).
+- The component header (RECORD=1) and the trailing system Designator (RECORD=34) / Comment
+  (RECORD=41) records carry `IndexInSheet=-1`; RECORD=44/46/48 carry no token and RECORD=45
+  carries `-1`.
+- The value is purely positional, so this crate derives it on write rather than storing it.
 
 ## Common Text Record Fields
 
-Most text records include these standard fields:
+Most text records include these standard fields (see
+[Cross-Cutting Conventions](#cross-cutting-conventions) for the omission rules):
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `RECORD` | int | Record type ID |
+| `RECORD` | int | Record type ID (first key) |
+| `IsNotAccesible` | bool | Not selectable; single-'s' spelling; emit only when `T` |
+| `IndexInSheet` | int | Shared content counter (0 omitted; -1 on header/system records) |
 | `OwnerPartId` | int | Part ownership (-1 = all parts, 1+ = specific part) |
-| `OwnerPartDisplayMode` | int | Display mode (typically 0) |
-| `IndexInSheet` | int | Sequential content-record ordinal (0 omitted; -1 on header/system records) |
-| `UniqueID` | string | 8-char alphanumeric identifier |
-| `IsNotAccesible` | bool | Access flag ("T" or "F") |
+| `OwnerPartDisplayMode` | int | Alternate display mode; omitted when 0 |
+| `GraphicallyLocked` / `Disabled` / `Dimmed` | bool | Universal display/lock flags; emit only when `T` |
+| `UniqueID` | string | 8-char alphanumeric identifier, last key |
 
-> **Note:** `UniqueID` is present on all shape records for tracking across edits.
+The four universal display/lock flags (`GraphicallyLocked`, `Disabled`, `Dimmed`,
+`OwnerPartDisplayMode`) are modelled on **all** shape records.
 
 ## Component Header (RECORD=1)
 
-The component header contains symbol-level metadata:
+The first record of each component's Data stream. Keys as written (in order):
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `LibReference` | string | Component name |
 | `ComponentDescription` | string | Description |
-| `PartCount` | int | Number of parts (stored as count+1) |
+| `PartCount` | int | **Stored as count + 1** (see FileHeader note) |
 | `DisplayModeCount` | int | Number of display modes (typically 1) |
-| `IndexInSheet` | int | Sheet index (-1) |
-| `CurrentPartId` | int | Currently displayed part (1) |
-| `SourceLibraryName` | string | Source library ("*") |
-| `TargetFileName` | string | Target file ("*") |
-| `AllPinCount` | int | Total number of pins (calculated from symbol) |
-| `AreaColor` | int | Fill colour (BGR, default: 11599871 = light yellow) |
-| `Color` | int | Border colour (BGR, default: 128 = dark red) |
-| `PartIDLocked` | bool | Lock part ID ("T" or "F") |
+| `IndexInSheet` | int | -1 for the component root |
+| `OwnerPartId` | int | -1 for the component root |
+| `CurrentPartId` | int | Currently displayed part (default 1) |
+| `LibraryPath` | string | `*` sentinel |
+| `SourceLibraryName` | string | `*` sentinel |
+| `SheetPartFileName` | string | `*` sentinel |
+| `TargetFileName` | string | `*` sentinel |
+| `AllPinCount` | int | Total number of pins (calculated from the symbol) |
+| `AreaColor` | int | Fill colour (BGR, 11599871 = light yellow) |
+| `Color` | int | Border colour (BGR, 128 = dark red) |
+| `PartIDLocked` | bool | `T`/`F` |
 
-**Typical hardcoded values:**
+> **Note:** Altium-authored headers also carry a component `UniqueID` and may carry
+> `DesignItemId` / `ComponentKind`; these are currently unmodelled (dropped on read).
 
-| Property | Value |
-|----------|-------|
-| `DisplayModeCount` | 1 |
-| `IndexInSheet` | -1 |
-| `CurrentPartId` | 1 |
-| `SourceLibraryName` | * |
-| `TargetFileName` | * |
-| `AreaColor` | 11599871 (light yellow) |
-| `Color` | 128 (dark red) |
-| `PartIDLocked` | F |
+## Primitive Records
 
-## Text Record Examples
+All shape records carry the [common fields](#common-text-record-fields) in addition to the tables
+below; every coordinate accepts a `_Frac` companion.
 
-### Component Header (RECORD=1)
+### Text (RECORD=3) and Label (RECORD=4)
 
-```text
-|RECORD=1|LibReference=SMD Chip Resistor|ComponentDescription=generic SMD chip resistor|PartCount=2|DisplayModeCount=1|...
-```
-
-### Rectangle (RECORD=14)
-
-```text
-|RECORD=14|Location.X=-10|Location.Y=-4|Corner.X=10|Corner.Y=4|LineWidth=1|Color=16711680|AreaColor=11599871|...
-```
-
-### Parameter (RECORD=41)
-
-```text
-|RECORD=41|Location.X=-22|Location.Y=-34|Color=8388608|FontID=1|IsHidden=T|Text=*|Name=Value|...
-```
-
-### Footprint Model (RECORD=45)
-
-```text
-|RECORD=45|OwnerIndex=0|Description=Generic Chip Resistor, 0805|ModelName=GENERIC_CHIP_RES_0805_IPC_MEDIUM_DENSITY|ModelType=PCBLIB|...
-```
-
-## Primitive Details
-
-### Rectangle (RECORD=14)
+Two distinct record types sharing one field set. This crate reads/writes RECORD=3 as a
+general-purpose text annotation and RECORD=4 as a label.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `Location.X` | int | First corner X |
-| `Location.Y` | int | First corner Y |
-| `Corner.X` | int | Second corner X |
-| `Corner.Y` | int | Second corner Y |
-| `LineWidth` | int | Border line width |
-| `Color` | int | Border colour (BGR) |
-| `AreaColor` | int | Fill colour (BGR) |
-| `IsSolid` | bool | Whether the rectangle is **filled** (emitted only when `T`; absent ⇒ unfilled) |
-| `Transparent` | bool | Whether transparent |
+| `Location.X` / `Location.Y` | coord | Anchor position |
+| `Text` / `%UTF8%Text` | string | Content |
+| `FontId` | int | Font-table reference (default 1) |
+| `Color` | int | Text colour (BGR; absent = 0) |
+| `Orientation` | int | 0-3 = 0°/90°/180°/270° |
+| `Justification` | int | Text alignment (see below) |
+| `IsMirrored` | bool | Emit only when `T` |
+| `IsHidden` | bool | Emit only when `T` |
 
-> **Note:** Altium omits `IsSolid` when the shape is unfilled and writes `IsSolid=T` only when
-> filled (it is never written as `F`). `Color` / `AreaColor` are likewise omitted when 0, and an
-> absent colour reads back as 0 (black).
+**Orientation values:** `orientation = (rotation_degrees / 90) % 4`.
+
+**Justification values:**
+
+| ID | Position | ID | Position | ID | Position |
+|----|----------|----|----------|----|----------|
+| 0 | Bottom Left | 3 | Middle Left | 6 | Top Left |
+| 1 | Bottom Centre | 4 | Middle Centre | 7 | Top Centre |
+| 2 | Bottom Right | 5 | Middle Right | 8 | Top Right |
+
+### Bezier (RECORD=5)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `LocationCount` | int | Control point count (always 4; not validated on read) |
+| `X{n}` / `Y{n}` | coord | Control points, 1-indexed (`X1`..`Y4`) |
+| `LineWidth` | int | Line width index |
+| `Color` | int | Line colour (BGR; omit at 0) |
+| `IsNotAccesible` | bool | Emit only when `T` |
 
 ### Polyline (RECORD=6)
 
-| Property | Type | Description | Implemented |
-|----------|------|-------------|-------------|
-| `LocationCount` | int | Number of vertices | ✓ |
-| `X{N}`, `Y{N}` | int | Vertex coordinates (1-indexed) | ✓ |
-| `LineWidth` | int | Line thickness | ✓ |
-| `Color` | int | Line colour (BGR) | ✓ |
-| `LineStyle` | int | 0=Solid, 1=Dashed, 2=Dotted | ✓ |
-| `StartLineShape` | int | Start endpoint shape | ✓ |
-| `EndLineShape` | int | End endpoint shape | ✓ |
-| `LineShapeSize` | int | Size of endpoint shapes | ✓ |
->
-> Polylines require a minimum of 2 vertices.
-
-### Polygon (RECORD=7)
-
 | Property | Type | Description |
 |----------|------|-------------|
-| `LocationCount` | int | Number of vertices |
-| `X{N}`, `Y{N}` | int | Vertex coordinates (1-indexed) |
-| `LineWidth` | int | Border line width |
-| `Color` | int | Border colour (BGR) |
-| `AreaColor` | int | Fill colour (BGR) |
-| `IsSolid` | bool | Whether the polygon is **filled** (emitted only when `T`; absent ⇒ unfilled) |
-
-> **Note:** `IsSolid` is the **fill** flag, not a border style. Altium omits it when unfilled
-> (the default) and writes `IsSolid=T` only when filled. Zero-valued `Color` / `AreaColor` and
-> zero vertex coordinates are likewise omitted; an absent colour reads back as 0.
->
-> Polygons require a minimum of 3 vertices.
+| `LineWidth` | int | Line width index (always written) |
+| `Color` | int | Line colour (BGR; omit at 0) |
+| `LineStyle` | int | 0=Solid, 1=Dashed, 2=Dotted |
+| `StartLineShape` / `EndLineShape` | int | Endpoint shapes (see below) |
+| `LineShapeSize` | int | Size of endpoint shapes |
+| `LocationCount` | int | Vertex count (minimum 2) |
+| `X{n}` / `Y{n}` | coord | Vertices, 1-indexed |
+| `Transparent` | bool | Emit only when `T` |
 
 **Line shapes:**
 
@@ -470,279 +518,279 @@ The component header contains symbol-level metadata:
 | 5 | Circle |
 | 6 | Square |
 
-### Text (RECORD=3)
-
-Text annotations are general-purpose text objects used for notes and annotations on schematic symbols.
+### Polygon (RECORD=7)
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `Location.X` | int | Position X |
-| `Location.Y` | int | Position Y |
-| `Text` | string | Text content |
-| `FontId` | int | Font reference (default: 1) |
-| `Color` | int | Text colour (BGR) |
-| `Orientation` | int | Text orientation (0-3) |
-| `Justification` | int | Text alignment (see Label for values) |
-| `IsMirrored` | bool | Mirror horizontally |
-| `IsHidden` | bool | Hidden from view |
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `LineWidth` | int | Border width index |
+| `Color` | int | Border colour (BGR; omit at 0) |
+| `AreaColor` | int | Fill colour (BGR; omit at 0) |
+| `LineStyle` | int | 0=Solid, 1=Dashed, 2=Dotted; omit at 0 |
+| `IsSolid` | bool | Whether **filled**; emit only when `T` (absent = unfilled) |
+| `LocationCount` | int | Vertex count (minimum 3) |
+| `X{n}` / `Y{n}` | coord | Vertices, 1-indexed |
+| `Transparent` | bool | Emit only when `T` |
 
-> **Note:** Text (RECORD=3) and Label (RECORD=4) have similar properties but are distinct record types.
-> Text is typically used for annotations, while Label is used for pin labels.
-
-### Label (RECORD=4)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.X` | int | Position X |
-| `Location.Y` | int | Position Y |
-| `Text` | string | Label text |
-| `FontId` | int | Font reference (default: 1) |
-| `Color` | int | Text colour (BGR) |
-| `Orientation` | int | Text orientation (0-3) |
-| `Justification` | int | Text alignment (see below) |
-| `IsMirrored` | bool | Mirror horizontally |
-| `IsHidden` | bool | Hidden from view |
-
-**Orientation values:**
-
-| Value | Rotation |
-|-------|----------|
-| 0 | 0° (horizontal) |
-| 1 | 90° |
-| 2 | 180° |
-| 3 | 270° |
-
-Formula: `orientation = (rotation_degrees / 90) % 4`
-
-**Justification values:**
-
-| ID | Position |
-|----|----------|
-| 0 | Bottom Left |
-| 1 | Bottom Centre |
-| 2 | Bottom Right |
-| 3 | Middle Left |
-| 4 | Middle Centre |
-| 5 | Middle Right |
-| 6 | Top Left |
-| 7 | Top Centre |
-| 8 | Top Right |
-
-### Parameter (RECORD=41)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.X` | int | Position X |
-| `Location.Y` | int | Position Y |
-| `Name` | string | Parameter name |
-| `Text` | string | Parameter value |
-| `FontId` | int | Font reference |
-| `Color` | int | Text colour (BGR) |
-| `ShowName` | bool | Display name with value |
-| `IsHidden` | bool | Hidden from view |
-| `ReadOnlyState` | int | Read-only flag |
-| `ParamType` | int | 0=String, 1=Boolean, 2=Integer, 3=Float |
-
-### Designator (RECORD=34)
-
-The designator record identifies the component (e.g., R?, U?, C?).
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.Y` | int | Position Y (typically -6) |
-| `Text` | string | Designator text |
-| `FontId` | int | Font reference |
-| `Color` | int | Text colour (BGR) |
-| `Name` | string | Always "Designator" |
-| `ReadOnlyState` | int | Read-only flag |
-
-**Typical hardcoded values:**
-
-| Property | Value |
-|----------|-------|
-| `Location.Y` | -6 |
-| `Color` | 8388608 (dark blue) |
-| `FontID` | 1 |
-| `Name` | Designator |
-| `ReadOnlyState` | 1 |
-| `IndexInSheet` | -1 |
-| `OwnerPartId` | -1 |
-
-### Implementation (RECORD=45)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Description` | string | Model description |
-| `ModelName` | string | Model identifier |
-| `ModelType` | string | Type (PCBLIB, SIM, etc.) |
-| `IsCurrent` | bool | Active implementation |
-| `DataFileCount` | int | Number of data files |
-| `ModelDataFileKind{N}` | string | Data file references |
-
-### EllipticalArc (RECORD=11)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.X` | int | Centre X |
-| `Location.Y` | int | Centre Y |
-| `Radius` | int | Primary radius (integer part) |
-| `Radius_Frac` | int | Primary radius fractional part (× 100,000) |
-| `SecondaryRadius` | int | Secondary radius (integer part) |
-| `SecondaryRadius_Frac` | int | Secondary radius fractional part (× 100,000) |
-| `StartAngle` | float | Start angle (degrees) |
-| `EndAngle` | float | End angle (degrees) |
-| `LineWidth` | int | Line width |
-| `Color` | int | Line colour (BGR) |
-
-> **Note:** Fractional radius values are stored multiplied by 100,000 for precision without floating point
-> (see [Fractional coordinates](#fractional-coordinates) for the signed toward-zero convention).
-> A value rounding up to a whole unit carries into the integer part rather than being clamped.
->
-> `Location.Y` may be omitted if the value is 0.
->
-> Default values: `StartAngle=0.0`, `EndAngle=360.0` (full ellipse).
-
-### Arc (RECORD=12)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.X` | int | Centre X |
-| `Location.Y` | int | Centre Y |
-| `Radius` | int | Arc radius |
-| `StartAngle` | float | Start angle (degrees, default: 0.0) |
-| `EndAngle` | float | End angle (degrees, default: 360.0) |
-| `LineWidth` | int | Line width |
-| `Color` | int | Line colour (BGR) |
-
-> **Note:** Default angles create a full circle when not specified.
-
-### Line (RECORD=13)
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `Location.X` | int | Start X |
-| `Location.Y` | int | Start Y |
-| `Corner.X` | int | End X |
-| `Corner.Y` | int | End Y |
-| `LineWidth` | int | Line width |
-| `Color` | int | Line colour (BGR) |
+> **Note:** `IsSolid` is the **fill** flag, not a border style.
 
 ### Ellipse (RECORD=8)
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `Location.X` | int | Centre X |
-| `Location.Y` | int | Centre Y |
-| `Radius` | int | X radius |
-| `SecondaryRadius` | int | Y radius |
-| `LineWidth` | int | Border line width |
-| `Color` | int | Border colour (BGR) |
-| `AreaColor` | int | Fill colour (BGR) |
-| `IsSolid` | bool | Whether filled |
+| `Location.X` / `Location.Y` | coord | Centre |
+| `Radius` | coord | X radius |
+| `SecondaryRadius` | coord | Y radius; defaults to `Radius` when absent (circle) |
+| `LineWidth` | int | Border width index |
+| `Color` / `AreaColor` | int | Border / fill colour (BGR; omit at 0) |
+| `IsSolid` | bool | Filled; emit only when `T` |
+| `Transparent` | bool | Emit only when `T` |
 
-> **Note:** If `SecondaryRadius` is missing, it defaults to the value of `Radius` (circle).
+### Pie (RECORD=9)
+
+A filled circular sector.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `Location.X` / `Location.Y` | coord | Centre |
+| `Radius` | coord | Radius |
+| `StartAngle` / `EndAngle` | float | Degrees (defaults 0.0 / 360.0) |
+| `LineWidth` | int | Border width index |
+| `Color` / `AreaColor` | int | Border / fill colour (BGR; omit at 0) |
+| `IsSolid` | bool | Filled; emit only when `T` |
+| `Transparent` | bool | Emit only when `T` |
 
 ### RoundRectangle (RECORD=10)
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `Location.X` | int | First corner X |
-| `Location.Y` | int | First corner Y |
-| `Corner.X` | int | Second corner X |
-| `Corner.Y` | int | Second corner Y |
-| `CornerXRadius` | int | Corner X radius |
-| `CornerYRadius` | int | Corner Y radius |
-| `LineWidth` | int | Border line width |
-| `Color` | int | Border colour (BGR) |
-| `AreaColor` | int | Fill colour (BGR) |
-| `IsSolid` | bool | Whether filled |
+| `Location.X` / `Location.Y` | coord | First corner |
+| `Corner.X` / `Corner.Y` | coord | Second corner |
+| `CornerXRadius` / `CornerYRadius` | coord | Corner radii |
+| `LineWidth` | int | Border width index |
+| `Color` / `AreaColor` | int | Border / fill colour (BGR; omit at 0) |
+| `LineStyle` | int | 0=Solid, 1=Dashed, 2=Dotted; omit at 0 |
+| `IsSolid` | bool | Filled; emit only when `T` |
+| `Transparent` | bool | Emit only when `T` |
 
-### Bezier (RECORD=5)
+### EllipticalArc (RECORD=11)
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `LocationCount` | int | Number of control points (always 4) |
-| `X{N}`, `Y{N}` | int | Control point coordinates (1-indexed) |
+| `Location.X` / `Location.Y` | coord | Centre |
+| `Radius` (+ `Radius_Frac`) | coord | Primary radius |
+| `SecondaryRadius` (+ `_Frac`) | coord | Secondary radius; defaults to `Radius` when absent |
+| `StartAngle` / `EndAngle` | float | Degrees (defaults 0.0 / 360.0 = full ellipse) |
 | `LineWidth` | int | Line width |
-| `Color` | int | Line colour (BGR) |
+| `Color` / `AreaColor` | int | Line / fill colour (BGR; omit at 0) |
 
-> **Note:** Bezier curves always have exactly 4 control points. The `LocationCount` value is not validated during parsing.
+> **Note:** a fractional radius rounding up to a whole unit carries into the integer part rather
+> than being clamped (see [Fractional coordinates](#fractional-coordinates)).
+
+### Arc (RECORD=12)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `Location.X` / `Location.Y` | coord | Centre |
+| `Radius` | coord | Arc radius |
+| `StartAngle` / `EndAngle` | float | Degrees (defaults 0.0 / 360.0 = full circle) |
+| `LineWidth` | int | Line width |
+| `Color` / `AreaColor` | int | Line / fill colour (BGR; omit at 0) |
+
+> **Note:** Altium formats angles with three decimals (`45.000`); this crate currently emits the
+> shortest float form. The reader accepts either (byte-order cosmetics tracked in TODO §A5).
+
+### Line (RECORD=13)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `Location.X` / `Location.Y` | coord | Start point |
+| `Corner.X` / `Corner.Y` | coord | End point |
+| `LineWidth` | int | Line width index |
+| `Color` | int | Line colour (BGR; omit at 0) |
+| `LineStyle` | int | 0=Solid, 1=Dashed, 2=Dotted; omit at 0 |
+
+### Rectangle (RECORD=14)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Always `T` on write |
+| `Location.X` / `Location.Y` | coord | First corner |
+| `Corner.X` / `Corner.Y` | coord | Second corner |
+| `LineWidth` | int | Border line width index |
+| `Color` / `AreaColor` | int | Border / fill colour (BGR; omit at 0) |
+| `LineStyleExt` | int | Border style — rectangles store the line style in `LineStyleExt`, NOT `LineStyle`; omit at 0 |
+| `IsSolid` | bool | Filled; emit only when `T` |
+| `Transparent` | bool | `T`/`F` (this crate always writes it) |
+
+### TextFrame (RECORD=28)
+
+A bordered multi-line text box. All keys below are omit-when-default (note the defaults of 0 for
+`LineWidth` and `FontID`, unlike other shapes).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `Location.X` / `Location.Y` | coord | First corner |
+| `Corner.X` / `Corner.Y` | coord | Second corner |
+| `LineWidth` | int | Border width; omit at 0 |
+| `LineStyle` | int | Border style; omit at 0 |
+| `Color` / `AreaColor` / `TextColor` | int | Border / fill / text colours (BGR; omit at 0) |
+| `FontID` | int | Font reference; omit at 0 |
+| `IsSolid` / `ShowBorder` | bool | Emit only when `T` |
+| `Alignment` | int | Text alignment; omit at 0 |
+| `WordWrap` / `ClipToRect` / `Transparent` | bool | Emit only when `T` |
+| `Text` / `%UTF8%Text` | string | Multi-line content (always written) |
+| `Orientation` | int | 0-3; omit at 0 |
+| `TextMargin` (+ `_Frac`) | coord | Margin — a coordinate whose zero integer part Altium omits entirely (a default frame carries only `TextMargin_Frac=5`) |
+
+### Image (RECORD=30)
+
+The picture metadata; embedded bytes live in [`/Storage`](#storage-embedded-images).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IsNotAccesible` | bool | Emit only when `T` |
+| `Location.X` / `Location.Y` | coord | Bounding-box corner 1 |
+| `Corner.X` / `Corner.Y` | coord | Bounding-box corner 2 |
+| `LineWidth` | int | Border width index |
+| `Color` | int | Border colour (BGR; omit at 0) |
+| `LineStyle` | int | Border style; omit at 0 |
+| `AreaColor` | int | Fill colour (BGR; omit at 0) |
+| `IsSolid` / `Transparent` / `ShowBorder` | bool | Emit only when `T` |
+| `KeepAspect` | bool | Preserve aspect ratio; emit only when `T` |
+| `EmbedImage` | bool | `T` = bytes embedded in `/Storage` (matched in global stream order) |
+| `FileName` | string | Image file path (also used as the `/Storage` entry name); omit when empty |
+
+### Designator (RECORD=34)
+
+A parameter-record variant selected by `Name=Designator`. As written by this crate:
+
+| Property | Value |
+|----------|-------|
+| `IndexInSheet` / `OwnerPartId` | -1 / -1 (system record) |
+| `Location.Y` | -6 (hardcoded; `Location.X` omitted) |
+| `Color` | 8388608 (dark blue) |
+| `FontID` | 1 |
+| `Text` / `%UTF8%Text` | Designator text (e.g. `R?`) |
+| `Name` | `Designator` |
+| `ReadOnlyState` | 1 |
+| `UniqueID` | 8-char id |
+
+### Parameter (RECORD=41)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `IndexInSheet` | int | Shared content counter, directly after `RECORD` (parameters carry no `IsNotAccesible` token) |
+| `OwnerPartId` | int | Part ownership |
+| `Location.X` / `Location.Y` | coord | Position (integer keys always written; `_Frac` companions appended after `FontID`) |
+| `Color` | int | Text colour (BGR; always written, default 8388608) |
+| `FontID` | int | Font reference (always written) |
+| `IsHidden` | bool | Emit only when `T` |
+| `ReadOnlyState` | int | Omit at 0 |
+| `ParamType` | int | 0=String, 1=Boolean, 2=Integer, 3=Float; omit at 0 |
+| `Orientation` | int | 0-3; omit at 0 |
+| `ShowName` / `HideName` / `IsConfigurable` | bool | Emit only when `T` |
+| `Text` / `%UTF8%Text` | string | Parameter value; omit when empty |
+| `Description` | string | Omit when empty |
+| `Name` | string | Parameter name (always written) |
+
+### Implementation chain (RECORD=44/45/46/47/48)
+
+- **RECORD=44 (ImplementationList)** — always written, exactly `|RECORD=44`, even when the symbol
+  has no footprint models.
+- **RECORD=45 (Implementation)** — one per footprint model, owned by the RECORD=44 via
+  `OwnerIndex` = the 44's 0-based stream-index:
+
+  | Property | Type | Description |
+  |----------|------|-------------|
+  | `OwnerIndex` | int | Stream-index of the owning RECORD=44 |
+  | `IndexInSheet` | int | -1 |
+  | `Description` | string | Model description |
+  | `ModelName` | string | Footprint name |
+  | `ModelType` | string | `PCBLIB` (also `SIM` / `SI` in the wild) |
+  | `DatafileCount` | int | Number of datafile links (this crate writes 1) |
+  | `ModelDatafile0` | string | Optional `.PcbLib` path — what lets Altium resolve the footprint directly |
+  | `ModelDatafileEntity0` | string | Footprint entity (resolution key) |
+  | `ModelDatafileKind0` | string | `PCBLib` |
+  | `IsCurrent` | bool | `T` on the default footprint |
+
+- **RECORD=46 (MapDefinerList)** and **RECORD=48 (ImplementationParameters)** — written as empty
+  children of each RECORD=45 (`|RECORD=46|OwnerIndex={45's index}` / `|RECORD=48|OwnerIndex=...`).
+- **RECORD=47 (MapDefiner)** — pin-to-pad mapping (`DESINTF`, `DESIMPCOUNT`, `DESIMP{i}`,
+  `ISTRIVIAL`); structure known from AltiumSharp but currently skipped on read and never written.
+
+> **Note:** `DatafileCount=1` plus the `ModelDatafileEntity0` link is what lets Altium *resolve*
+> the model to an actual footprint in a `PcbLib`; a name-only record with `DatafileCount=0` shows
+> in the list but reports "model not found". AltiumSharp indexes the datafile keys 1-based
+> (`MODELDATAFILEKIND1`); this crate writes 0-based, matching observed files — the index base is
+> still under golden verification (TODO §B).
 
 ## Default Values
 
-Common default values used when properties are not specified:
+Read-side defaults when properties are absent:
 
 | Property | Default | Notes |
 |----------|---------|-------|
-| `FontId` | 1 | Times New Roman, 10pt |
-| `StartAngle` | 0.0 | For Arc and EllipticalArc |
-| `EndAngle` | 360.0 | For Arc and EllipticalArc |
-| `OwnerPartId` | 1 | First part (shapes default to 1, not -1) |
-| `OwnerPartDisplayMode` | 0 | Default display mode |
+| `FontId` | 1 | Except TextFrame (0) |
+| `StartAngle` / `EndAngle` | 0.0 / 360.0 | Arc, EllipticalArc, Pie |
+| `OwnerPartId` | 1 | Shapes default to 1; -1 = all parts |
+| `OwnerPartDisplayMode` | 0 | |
 | `IndexInSheet` | positional | Shared 0-based content counter; slot 0 omitted; `-1` on header/system records |
-| `LineWidth` | 1 | All shapes |
-| `Color` (lines) | 0x000080 | Dark red (BGR) |
-| `Color` (text) | 0x800000 | Dark blue (BGR) |
-| `AreaColor` | 0xB0FFFF | Light yellow (BGR) |
-| `PartCount` | 1 | Minimum enforced |
+| `LineWidth` | 1 | Except TextFrame (0) |
+| `Color` / `AreaColor` | 0 (black) | Absent colour keys read as 0 — EXCEPT the Parameter record's `Color`, which defaults to 8388608 (dark blue) |
+| `SecondaryRadius` | = `Radius` | Ellipse, EllipticalArc |
+| `PartCount` | stored − 1 | No floor at 1 |
+| Booleans | false | Only `=T` is ever written |
 
 ## Symbol Writing Order
 
-When writing symbol data, records are encoded in this specific order:
+When writing symbol data, this crate encodes records in this specific order (the shared
+`IndexInSheet` counter runs across steps 2-15):
 
 1. Component header (RECORD=1)
 2. Parameters (RECORD=41)
-3. Pins (binary format, type 0x0001)
-4. Rectangles (RECORD=14)
+3. Rectangles (RECORD=14) — before the pins so a solid body does not paint over pin names
+4. Pins (binary records; each consumes an `IndexInSheet` slot)
 5. Lines (RECORD=13)
 6. Polylines (RECORD=6)
 7. Polygons (RECORD=7)
 8. Arcs (RECORD=12)
-9. Bezier curves (RECORD=5)
-10. Ellipses (RECORD=8)
-11. Rounded rectangles (RECORD=10)
-12. Elliptical arcs (RECORD=11)
-13. Labels (RECORD=4)
-14. Text annotations (RECORD=3)
-15. Designator (RECORD=34)
-16. Implementation list (RECORD=44)
-17. Footprint models (RECORD=45)
+9. Pies (RECORD=9)
+10. Images (RECORD=30)
+11. Text frames (RECORD=28)
+12. Bezier curves (RECORD=5)
+13. Ellipses (RECORD=8)
+14. Rounded rectangles (RECORD=10)
+15. Elliptical arcs (RECORD=11)
+16. Labels (RECORD=4)
+17. Text annotations (RECORD=3)
+18. Designator (RECORD=34, when non-empty)
+19. Implementation list (RECORD=44), then per footprint model: RECORD=45 + RECORD=46 + RECORD=48
 
 The stream ends with the last record's payload — there is **no** trailing end marker (see the Data
 Stream Format section and issue #68).
 
-> **Note:** All content records — every graphic shape, user Label/Parameter record **and** every
-> binary pin — share one sequential 0-based `IndexInSheet` counter in stream order. The token is
-> omitted at slot 0, and sits immediately after `IsNotAccesible` (before `OwnerPartId`). Binary
-> pin records store no `IndexInSheet` field but still consume a counter slot: a real
-> Altium-authored symbol with parameters 0–2, two pins, then a rectangle stores `IndexInSheet=5`
-> on the rectangle. The component header (RECORD=1) and the trailing system Designator
-> (RECORD=34) / Comment (RECORD=41) records carry `IndexInSheet=-1`; RECORD=44/46/48 carry no
-> token and RECORD=45 carries `-1`.
-
 ## Multi-Part Symbols
 
-Some symbols have multiple parts (e.g., quad op-amp):
+Some symbols have multiple parts (e.g. quad op-amp):
 
-- `PartCount` in component header indicates total parts
-- Each primitive has `OwnerPartId` field:
+- `PartCount` in the component header indicates total parts (stored as count + 1)
+- Each primitive has an `OwnerPartId` field:
     - `-1` = belongs to all parts
-    - `1+` = belongs to specific part
+    - `1+` = belongs to a specific part
 
 ## Notes
 
-- **ImplementationList (RECORD=44)**: Container for a component's implementations
-- **Implementation (RECORD=45)**: One implementation (footprint model link)
-- **MapDefinerList (RECORD=46)**: Container for the implementation's map definers
-- **MapDefiner (RECORD=47)**: Pin-to-pad mapping
-- **ImplementationParameters (RECORD=48)**: Per-implementation parameters
-- **Pin text format (RECORD=2)**: Rarely used, binary format preferred
-- **Pin symbol decorations**: Supported (22 symbol types)
-- **Pin colour**: Stored in binary format (BGR)
-- **Display modes**: Stored in `DisplayModeCount`, primitives have `OwnerPartDisplayMode`
-- **Font storage**: Fonts defined in FileHeader (`FontName{N}`, `Size{N}`)
-- **Unique IDs**: All shapes have 8-char alphanumeric `UniqueID` for tracking
-- **Polyline styles**: `LineStyle`, `StartLineShape`, `EndLineShape`, `LineShapeSize` supported
+- **Pin text format (RECORD=2)**: rare; skipped on read (binary pins are authoritative)
+- **Pin symbol decorations**: supported (22 symbol types at 4 positions)
+- **Display modes**: count in `DisplayModeCount`; primitives carry `OwnerPartDisplayMode`
+- **Font storage**: fonts defined in FileHeader (`FontName{N}`, `Size{N}`)
+- **Unique IDs**: all records carry an 8-char alphanumeric `UniqueID` (last key)
+- **Embedded images**: `RECORD=30` metadata + zlib payloads in `/Storage`, order-matched
 
 ## References
 


### PR DESCRIPTION
## Description

**TODO §A4** — the format references predated the RE campaign and contradicted the (golden/oracle-proven) code in eleven places, including a stale description of the very `0x00` end-marker bug behind #68. Every offset in the rewrite was verified against the current writer/reader code and cross-checked against the preserved RE specs; where sources disagreed, code won.

### PCBLIB_FORMAT.md
- **Via**: single 321-byte `VIA_SR1_TEMPLATE` with the full modelled-offset table (replaces the wrong '6 blocks like a pad').
- **Text**: the fixed 252-byte template table (incl. inverted-rect block, UTF-16 font name @46-109, justification @132, kind @160); `IsComment`@40/`IsDesignator`@41 documented as verified-but-unmodelled.
- **Pad**: corrected @61 (reserved — hole shape actually lives in Block 5 @262), the 202-byte extended tail, all three Block-5 forms.
- **Region / Fill / Track / Arc / ComponentBody**: single-block layouts, real tails, extruded-vs-STEP branching, Models zlib framing + the position-weighted checksum algorithm; invented `SNAPCOUNT`/'Blocks 1-2' deleted.

### SCHLIB_FORMAT.md
- New **Cross-Cutting Conventions** section (omit-when-default, signed toward-zero `_Frac`, the `IndexInSheet` counter rule incl. silent pin slots, `%UTF8%`, BGR, DXP units) referenced by per-record tables for **every** record we model (1–14, 28, 30 incl. `/Storage`, 34, 41, 44–48).
- Binary pin fully corrected: phantom 'reserved byte' removed, `FormalType` position, flag bit 0x20 = IsNotAccessible, the three trailing Pascal strings, aux streams.

Also corrected: `PRIMITIVEINDEX` global-ordinal semantics, empty-WideStrings framing, `Models/Data` no-leading-pipe, FileHeader key casing, symbol emit order, absent-colour defaults.

TODO §A4 removed (shipped; section was then empty).

## Type of Change

- [x] Documentation update

## Testing

- [x] markdownlint 0 errors on all three files; full `cargo test` green (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)