### PR TITLE
chore(release): prepare the changelog and defer the tag to the maintainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-*This changelog will be populated once the first official release is published.*
+## [Unreleased]
+
+Everything below ships in the first tagged release (the version heading and date are
+stamped when the tag is cut). An MCP server that gives AI assistants file I/O and
+primitive-placement tools for Altium Designer `.PcbLib` (footprint) and `.SchLib`
+(symbol) libraries.
+
+### Added
+
+- **34 MCP tools** covering read/write, inspect/visualise (ASCII previews, style
+  extraction), compare/diff, edit-in-place (component/pad/primitive updates, batch
+  operations), component management (copy/rename/merge/reorder, cross-library),
+  library operations (validate/repair, JSON/CSV export + import, `.LibPkg` project
+  generation, embedded STEP extraction) and automatic timestamped backups with
+  restore. See `docs/TOOLS.md` for the full generated reference.
+- **PcbLib**: all eight footprint primitives (Pad, Via, Track, Arc, Region, Text,
+  Fill, ComponentBody) modelled byte-identically to Altium's own output, including
+  pad stacks and slot holes, thermal-relief/power-plane connection, solder/paste
+  mask control, TrueType/barcode/inverted text, region kinds, embedded STEP models
+  and 3D body handling.
+- **SchLib**: every record type that occurs in a real symbol library — pins (with
+  swap groups, symbol decorations and auxiliary streams), all graphic shapes
+  (rectangles, rounded rectangles, lines, polylines, polygons, arcs, elliptical
+  arcs, ellipses, pies, Béziers), images (including embedded image bytes in the
+  `/Storage` stream), text frames, labels, text, parameters and footprint links —
+  with fractional (off-grid) coordinate support and multi-part/display-mode symbols.
+- **Safety**: path confinement to configured `allowed_paths`, path-sanitised error
+  messages, automatic pre-mutation backups (5 retained), dry-run previews, token-
+  bucket rate limiting on mutating tools and an optional append-only audit log.
+- **Verification**: a strict independent Altium-readability oracle (pyaltiumlib) in
+  CI, Altium-authored golden fixtures with exact assertions, byte-identity tests
+  against captured Altium templates, and no-panic property tests over hostile input.

--- a/TODO.md
+++ b/TODO.md
@@ -86,16 +86,13 @@ Outstanding SchLib field fidelity all needs an Altium-authored golden to settle 
 
 ## D. Release & distribution (no release exists yet)
 
-- [ ] Cut the **first tagged release** so non-Rust users get a prebuilt binary (flagged in #68).
+- [ ] Cut the **first tagged release** so non-Rust users get a prebuilt binary — everything is
+      release-ready (`CHANGELOG` carries the content under `[Unreleased]`; `release.yml` validates
+      the tag against `Cargo.toml`), but **the tag is deferred until the maintainer triggers it
+      personally**. Tag-day steps: stamp the changelog heading/date, `git tag v0.1.0`, push, watch
+      the Release workflow, verify artefacts.
 - [ ] Consider a `.dxt` Claude Desktop extension for one-click install (pattern from
       coffeenmusic/altium-mcp).
-
-## E. Issues
-
-- [ ] **#68** — core fixes shipped and generated libraries now verified to open in real Altium 24.
-      Close once the reporter confirms (or declare verified on the strength of the on-site PASS).
-- [ ] **#113** — via block (#114), round-trip fidelity, and extruded ComponentBody (#133) largely
-      cover this; review the remaining items and close.
 
 ## F. Docs / AI workflow
 


### PR DESCRIPTION
## Description

Release preparation **without tagging** (the tag is deferred indefinitely until the maintainer triggers it personally — recorded in TODO §D with the tag-day steps):

- `CHANGELOG.md`: first-release content drafted under `[Unreleased]` (Keep-a-Changelog style; the `[0.1.0]` heading + date get stamped on tag day). This resolves the audit-flagged tension between the placeholder note and the contributor checklists that ask for changelog updates.
- `TODO.md`: §E removed (issues #68 and #113 reviewed and closed with evidence-mapped comments); §D annotated as maintainer-triggered.

## Type of Change

- [x] Documentation update / release chore

## Testing

- [x] markdownlint — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)