### PR TITLE
test: raise unit coverage of MCP layer and shared helpers

### DIFF
--- a/src/altium/serde_round.rs
+++ b/src/altium/serde_round.rs
@@ -89,3 +89,109 @@ pub mod vec_f64 {
         Option::<Vec<f64>>::deserialize(deserializer)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+
+    // Test structs wiring each helper into serde via the same attributes the
+    // real primitives use, so the tests exercise the actual serialise path.
+    #[derive(Serialize)]
+    struct Bare {
+        #[serde(serialize_with = "super::serialize")]
+        v: f64,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Opt {
+        #[serde(with = "super::option")]
+        v: Option<f64>,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct VecTup {
+        #[serde(with = "super::vec_tuple")]
+        v: Option<Vec<(f64, f64)>>,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct VecF {
+        #[serde(with = "super::vec_f64")]
+        v: Option<Vec<f64>>,
+    }
+
+    #[test]
+    fn round_reduces_to_six_decimal_places() {
+        assert!((super::round(1.234_567_89) - 1.234_568).abs() < 1e-12);
+        assert!((super::round(9.999_999_9) - 10.0).abs() < 1e-12);
+        // A value already within 6 dp is unchanged.
+        assert!((super::round(-2.5) + 2.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bare_serialiser_rounds() {
+        let j = serde_json::to_value(Bare { v: 1.234_567_89 }).unwrap();
+        assert_eq!(j["v"], json!(1.234_568));
+    }
+
+    #[test]
+    fn option_serialises_some_rounded_and_none_null() {
+        let some = serde_json::to_value(Opt {
+            v: Some(0.123_456_789),
+        })
+        .unwrap();
+        assert_eq!(some["v"], json!(0.123_457));
+        let none = serde_json::to_value(Opt { v: None }).unwrap();
+        assert_eq!(none["v"], Value::Null);
+    }
+
+    #[test]
+    fn option_round_trips_both_variants() {
+        for v in [Some(1.5_f64), None] {
+            let s = serde_json::to_string(&Opt { v }).unwrap();
+            let back: Opt = serde_json::from_str(&s).unwrap();
+            assert_eq!(back.v, v);
+        }
+    }
+
+    #[test]
+    fn vec_tuple_serialises_each_component_rounded_and_none_null() {
+        let some = serde_json::to_value(VecTup {
+            v: Some(vec![(1.111_111_9, 2.222_222_1)]),
+        })
+        .unwrap();
+        assert_eq!(some["v"], json!([[1.111_112, 2.222_222]]));
+        let none = serde_json::to_value(VecTup { v: None }).unwrap();
+        assert_eq!(none["v"], Value::Null);
+    }
+
+    #[test]
+    fn vec_tuple_round_trips() {
+        let orig = VecTup {
+            v: Some(vec![(1.0, 2.0), (3.0, 4.0)]),
+        };
+        let back: VecTup = serde_json::from_str(&serde_json::to_string(&orig).unwrap()).unwrap();
+        assert_eq!(back, orig);
+    }
+
+    #[test]
+    fn vec_f64_serialises_rounded_and_none_null() {
+        let some = serde_json::to_value(VecF {
+            v: Some(vec![9.999_999_9, 0.000_000_4]),
+        })
+        .unwrap();
+        assert_eq!(some["v"], json!([10.0, 0.0]));
+        let none = serde_json::to_value(VecF { v: None }).unwrap();
+        assert_eq!(none["v"], Value::Null);
+    }
+
+    #[test]
+    fn vec_f64_round_trips() {
+        let orig = VecF {
+            v: Some(vec![1.0, 2.0, 3.0]),
+        };
+        let back: VecF = serde_json::from_str(&serde_json::to_string(&orig).unwrap()).unwrap();
+        assert_eq!(back, orig);
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -93,4 +93,61 @@ mod tests {
         assert!(path.is_some());
         assert!(path.unwrap().to_string_lossy().contains("config.json"));
     }
+
+    #[test]
+    fn load_config_missing_file_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.json");
+        let err = load_config(Some(&missing)).unwrap_err();
+        assert!(matches!(err, ConfigError::NotFound { .. }));
+    }
+
+    #[test]
+    fn load_config_directory_is_read_error() {
+        // A directory exists() but cannot be read as a string — exercises the
+        // ReadError branch distinct from NotFound.
+        let dir = tempfile::tempdir().unwrap();
+        let err = load_config(Some(dir.path())).unwrap_err();
+        assert!(matches!(err, ConfigError::ReadError { .. }));
+    }
+
+    #[test]
+    fn load_config_malformed_json_is_parse_error() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "{ this is not json ").unwrap();
+        let err = load_config(Some(file.path())).unwrap_err();
+        assert!(matches!(err, ConfigError::ParseError { .. }));
+    }
+
+    #[test]
+    fn load_config_invalid_log_level_is_validation_error() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"logging":{"level":"chatty"}}"#).unwrap();
+        let err = load_config(Some(file.path())).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationError { .. }));
+        assert!(err.to_string().to_lowercase().contains("log level"));
+    }
+
+    #[test]
+    fn load_config_valid_file_parses_and_validates() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"{"allowed_paths":["/tmp/libs"],"logging":{"level":"warn"}}"#,
+        )
+        .unwrap();
+        let config = load_config(Some(file.path())).expect("valid config loads");
+        assert_eq!(config.allowed_paths.len(), 1);
+        assert_eq!(config.logging.level, "warn");
+    }
+
+    #[test]
+    fn shipped_example_config_loads() {
+        // Drift guard: the documented example must always parse and validate
+        // against the current schema.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("config")
+            .join("example-config.json");
+        load_config(Some(&path)).expect("shipped example-config.json must load");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,4 +175,32 @@ mod tests {
         use clap::CommandFactory;
         Args::command().debug_assert();
     }
+
+    #[test]
+    fn quiet_forces_error_regardless_of_verbose_or_config() {
+        assert_eq!(get_log_level(0, true, "trace"), Level::ERROR);
+        assert_eq!(get_log_level(3, true, "info"), Level::ERROR);
+    }
+
+    #[test]
+    fn verbose_flags_map_to_levels() {
+        assert_eq!(get_log_level(1, false, "warn"), Level::INFO);
+        assert_eq!(get_log_level(2, false, "warn"), Level::DEBUG);
+        assert_eq!(get_log_level(3, false, "warn"), Level::TRACE);
+        // Beyond -vvv still saturates at TRACE.
+        assert_eq!(get_log_level(9, false, "warn"), Level::TRACE);
+    }
+
+    #[test]
+    fn config_level_used_when_no_verbose_flags() {
+        assert_eq!(get_log_level(0, false, "trace"), Level::TRACE);
+        assert_eq!(get_log_level(0, false, "debug"), Level::DEBUG);
+        assert_eq!(get_log_level(0, false, "info"), Level::INFO);
+        assert_eq!(get_log_level(0, false, "warn"), Level::WARN);
+        assert_eq!(get_log_level(0, false, "error"), Level::ERROR);
+        // Case-insensitive.
+        assert_eq!(get_log_level(0, false, "INFO"), Level::INFO);
+        // Unknown config level falls back to WARN.
+        assert_eq!(get_log_level(0, false, "chatty"), Level::WARN);
+    }
 }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -2618,4 +2618,121 @@ mod tests {
             assert_eq!(parsed["status"], "error");
         }
     }
+
+    // ==================== read/write handler error paths ====================
+
+    mod handler_error_paths {
+        use crate::mcp::tools::test_support::{
+            create_test_pcblib, create_test_server, get_result_text, test_temp_dir,
+        };
+        use serde_json::json;
+
+        #[test]
+        fn read_pcblib_missing_filepath() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let r = server.call_read_pcblib(&json!({}));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: filepath");
+        }
+
+        #[test]
+        fn read_pcblib_denied_path_outside_allowed() {
+            let allowed = test_temp_dir();
+            let outside = test_temp_dir();
+            let server = create_test_server(allowed.path());
+            // Create a real library so its parent canonicalises — the denial is
+            // about the path being outside the allow-list, not a missing file.
+            let path = outside.path().join("X.PcbLib");
+            create_test_pcblib(&path);
+            let r = server.call_read_pcblib(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+            assert!(
+                get_result_text(&r).contains("Access denied"),
+                "{}",
+                get_result_text(&r)
+            );
+        }
+
+        #[test]
+        fn read_pcblib_nonexistent_file_is_error() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Nope.PcbLib");
+            let r = server.call_read_pcblib(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+        }
+
+        #[test]
+        fn write_pcblib_missing_filepath_then_footprints() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let r = server.call_write_pcblib(&json!({}));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: filepath");
+
+            let path = dir.path().join("W.PcbLib");
+            let r = server.call_write_pcblib(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+            assert_eq!(
+                get_result_text(&r),
+                "Missing required parameter: footprints"
+            );
+        }
+
+        #[test]
+        fn write_pcblib_denied_path_outside_allowed() {
+            let allowed = test_temp_dir();
+            let outside = test_temp_dir();
+            let server = create_test_server(allowed.path());
+            let path = outside.path().join("W.PcbLib");
+            let r = server.call_write_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+                "footprints": [{ "name": "X", "pads": [] }],
+                "append": false,
+            }));
+            assert!(r.is_error);
+            assert!(
+                get_result_text(&r).contains("Access denied"),
+                "{}",
+                get_result_text(&r)
+            );
+        }
+
+        #[test]
+        fn read_schlib_missing_filepath() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let r = server.call_read_schlib(&json!({}));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: filepath");
+        }
+
+        #[test]
+        fn write_schlib_missing_filepath_then_symbols() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let r = server.call_write_schlib(&json!({}));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: filepath");
+
+            let path = dir.path().join("W.SchLib");
+            let r = server.call_write_schlib(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: symbols");
+        }
+
+        #[test]
+        fn list_components_missing_filepath_and_nonexistent() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let r = server.call_list_components(&json!({}));
+            assert!(r.is_error);
+            assert_eq!(get_result_text(&r), "Missing required parameter: filepath");
+
+            let path = dir.path().join("Nope.PcbLib");
+            let r = server.call_list_components(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+        }
+    }
 }

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -341,3 +341,154 @@ impl McpServer {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::altium::pcblib::{Arc, Footprint, Layer, Pad, PadShape, Region, Track};
+    use crate::altium::schlib::{Ellipse, Line, Pin, PinOrientation, Rectangle, RoundRect, Symbol};
+    use crate::mcp::server::McpServer;
+
+    // ---- validate_coordinate ------------------------------------------------
+
+    #[test]
+    fn validate_coordinate_accepts_finite_in_range() {
+        assert!(McpServer::validate_coordinate(1234.5, "x").is_ok());
+        assert!(McpServer::validate_coordinate(0.0, "x").is_ok());
+    }
+
+    #[test]
+    fn validate_coordinate_rejects_nan_and_infinite() {
+        assert!(McpServer::validate_coordinate(f64::NAN, "x")
+            .unwrap_err()
+            .contains("finite"));
+        assert!(McpServer::validate_coordinate(f64::INFINITY, "x")
+            .unwrap_err()
+            .contains("finite"));
+    }
+
+    #[test]
+    fn validate_coordinate_rejects_out_of_range() {
+        assert!(McpServer::validate_coordinate(6000.0, "x")
+            .unwrap_err()
+            .contains("exceeds"));
+    }
+
+    // ---- pad_has_uniform_per_layer_data ------------------------------------
+
+    #[test]
+    fn pad_uniform_when_no_per_layer_data() {
+        let pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        assert!(McpServer::pad_has_uniform_per_layer_data(&pad));
+    }
+
+    #[test]
+    fn pad_non_uniform_sizes_shapes_radii_offsets() {
+        let base = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+
+        let mut sizes = base.clone();
+        sizes.per_layer_sizes = Some(vec![(2.0, 1.0)]); // width differs from 1.0
+        assert!(!McpServer::pad_has_uniform_per_layer_data(&sizes));
+
+        let mut shapes = base.clone();
+        shapes.per_layer_shapes = Some(vec![PadShape::Round]); // differs from primary
+        assert!(!McpServer::pad_has_uniform_per_layer_data(&shapes));
+
+        let mut radii = base.clone();
+        radii.corner_radius_percent = Some(0);
+        radii.per_layer_corner_radii = Some(vec![50]); // differs from 0
+        assert!(!McpServer::pad_has_uniform_per_layer_data(&radii));
+
+        let mut offsets = base;
+        offsets.per_layer_offsets = Some(vec![(0.5, 0.0)]); // non-zero offset
+        assert!(!McpServer::pad_has_uniform_per_layer_data(&offsets));
+    }
+
+    // ---- validate_footprint_coordinates ------------------------------------
+
+    fn valid_footprint() -> Footprint {
+        let mut fp = Footprint::new("F");
+        let mut pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        pad.hole_size = Some(0.5); // exercise the Some(hole) branch
+        fp.add_pad(pad);
+        fp.add_track(Track::new(-1.0, 0.0, 1.0, 0.0, 0.15, Layer::TopOverlay));
+        fp.add_arc(Arc::circle(0.0, 2.0, 0.5, 0.1, Layer::TopOverlay));
+        fp.add_region(Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopCourtyard));
+        fp
+    }
+
+    #[test]
+    fn footprint_all_families_in_range_ok() {
+        assert!(McpServer::validate_footprint_coordinates(&valid_footprint()).is_ok());
+    }
+
+    #[test]
+    fn footprint_bad_pad_coordinate_reports_field() {
+        let mut fp = Footprint::new("F");
+        fp.add_pad(Pad::smd("1", 6000.0, 0.0, 1.0, 1.0));
+        let err = McpServer::validate_footprint_coordinates(&fp).unwrap_err();
+        assert!(err.contains("pad 0 x"), "{err}");
+    }
+
+    #[test]
+    fn footprint_bad_track_coordinate_reports_field() {
+        let mut fp = Footprint::new("F");
+        fp.add_track(Track::new(0.0, 0.0, 6000.0, 0.0, 0.15, Layer::TopOverlay));
+        let err = McpServer::validate_footprint_coordinates(&fp).unwrap_err();
+        assert!(err.contains("track 0 x2"), "{err}");
+    }
+
+    #[test]
+    fn footprint_bad_arc_radius_reports_field() {
+        let mut fp = Footprint::new("F");
+        fp.add_arc(Arc::circle(0.0, 0.0, 6000.0, 0.1, Layer::TopOverlay));
+        let err = McpServer::validate_footprint_coordinates(&fp).unwrap_err();
+        assert!(err.contains("arc 0 radius"), "{err}");
+    }
+
+    #[test]
+    fn footprint_bad_region_vertex_reports_field() {
+        let mut fp = Footprint::new("F");
+        fp.add_region(Region::rectangle(
+            -6000.0,
+            -1.0,
+            1.0,
+            1.0,
+            Layer::TopCourtyard,
+        ));
+        let err = McpServer::validate_footprint_coordinates(&fp).unwrap_err();
+        assert!(err.contains("region 0 vertex"), "{err}");
+    }
+
+    // ---- validate_symbol_coordinates ---------------------------------------
+
+    fn valid_symbol() -> Symbol {
+        let mut sym = Symbol::new("S");
+        sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+        sym.add_rectangle(Rectangle::new(-10, -5, 10, 5));
+        sym.add_line(Line::new(0, 0, 20, 0));
+        sym.add_ellipse(Ellipse::new(5, 5, 3, 2));
+        sym.add_round_rect(RoundRect::new(0, 0, 10, 8, 2, 2));
+        sym
+    }
+
+    #[test]
+    fn symbol_common_families_in_range_ok() {
+        assert!(McpServer::validate_symbol_coordinates(&valid_symbol()).is_ok());
+    }
+
+    #[test]
+    fn symbol_bad_pin_coordinate_reports_field() {
+        let mut sym = Symbol::new("S");
+        sym.add_pin(Pin::new("1", "1", 40000, 0, 10, PinOrientation::Left));
+        let err = McpServer::validate_symbol_coordinates(&sym).unwrap_err();
+        assert!(err.contains("pin 0 x"), "{err}");
+    }
+
+    #[test]
+    fn symbol_bad_rectangle_coordinate_reports_field() {
+        let mut sym = Symbol::new("S");
+        sym.add_rectangle(Rectangle::new(0, 0, 40000, 5));
+        let err = McpServer::validate_symbol_coordinates(&sym).unwrap_err();
+        assert!(err.contains("rectangle 0 x2"), "{err}");
+    }
+}

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -76,6 +76,12 @@ pub struct StdioTransport {
     reader: BufReader<tokio::io::Stdin>,
     /// Handle for stdout.
     writer: tokio::io::Stdout,
+    /// Under `cfg(test)`, redirects writes to an in-memory buffer instead of
+    /// the real stdout so the write path can be asserted without a live pipe
+    /// (and without the intermittent stdout-teardown hangs seen on Windows CI).
+    /// Compiled out of non-test builds entirely.
+    #[cfg(test)]
+    test_sink: Option<std::sync::Arc<std::sync::Mutex<Vec<u8>>>>,
 }
 
 impl StdioTransport {
@@ -85,7 +91,18 @@ impl StdioTransport {
         Self {
             reader: BufReader::new(tokio::io::stdin()),
             writer: tokio::io::stdout(),
+            #[cfg(test)]
+            test_sink: None,
         }
+    }
+
+    /// Redirects subsequent writes into an in-memory buffer and returns a handle
+    /// to it, so tests can assert on the exact framed bytes.
+    #[cfg(test)]
+    pub(crate) fn capture_output(&mut self) -> std::sync::Arc<std::sync::Mutex<Vec<u8>>> {
+        let sink = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        self.test_sink = Some(std::sync::Arc::clone(&sink));
+        sink
     }
 
     /// Reads the next message line from stdin.
@@ -148,6 +165,17 @@ impl StdioTransport {
     ///
     /// Returns an error if writing fails.
     async fn write_raw(&mut self, json: &str) -> io::Result<()> {
+        #[cfg(test)]
+        if let Some(sink) = &self.test_sink {
+            // Mirror write_message_line's framing (message + single '\n') without
+            // holding the lock across an await point.
+            let mut framed = json.as_bytes().to_vec();
+            framed.push(b'\n');
+            sink.lock()
+                .expect("test sink mutex poisoned")
+                .extend_from_slice(&framed);
+            return Ok(());
+        }
         write_message_line(&mut self.writer, json).await
     }
 
@@ -253,5 +281,88 @@ mod tests {
         let mut buf: Vec<u8> = Vec::new();
         write_message_line(&mut buf, r#"{"a":1}"#).await.unwrap();
         assert_eq!(buf, b"{\"a\":1}\n");
+    }
+
+    /// Decodes the single framed line captured in a test sink.
+    fn sink_json(sink: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>) -> serde_json::Value {
+        let bytes = sink.lock().unwrap().clone();
+        let s = String::from_utf8(bytes).expect("utf-8 output");
+        assert!(s.ends_with('\n'), "output must be newline-terminated");
+        assert_eq!(s.matches('\n').count(), 1, "exactly one framed message");
+        serde_json::from_str(s.trim_end()).expect("valid JSON line")
+    }
+
+    #[tokio::test]
+    async fn write_response_frames_success_envelope() {
+        let mut t = StdioTransport::new();
+        let sink = t.capture_output();
+        let resp = JsonRpcResponse::success(RequestId::Number(7), serde_json::json!({"ok": true}));
+        t.write_response(&resp).await.unwrap();
+
+        let v = sink_json(&sink);
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["id"], 7);
+        assert_eq!(v["result"]["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn write_error_frames_error_object() {
+        let mut t = StdioTransport::new();
+        let sink = t.capture_output();
+        let err = JsonRpcError::method_not_found(RequestId::Number(1), "nope/method");
+        t.write_error(&err).await.unwrap();
+
+        let v = sink_json(&sink);
+        assert_eq!(v["error"]["code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn write_notification_frames_method_and_params() {
+        let mut t = StdioTransport::new();
+        let sink = t.capture_output();
+        let note = OutgoingNotification::new(
+            "notifications/progress",
+            Some(serde_json::json!({"progress": 42})),
+        );
+        t.write_notification(&note).await.unwrap();
+
+        let v = sink_json(&sink);
+        assert_eq!(v["method"], "notifications/progress");
+        assert_eq!(v["params"]["progress"], 42);
+        // Notifications carry no id.
+        assert!(v.get("id").is_none());
+    }
+
+    #[tokio::test]
+    async fn write_json_frames_arbitrary_value() {
+        let mut t = StdioTransport::new();
+        let sink = t.capture_output();
+        t.write_json(&serde_json::json!({"custom": [1, 2, 3]}))
+            .await
+            .unwrap();
+
+        let v = sink_json(&sink);
+        assert_eq!(v["custom"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[tokio::test]
+    async fn multiple_writes_accumulate_in_order() {
+        let mut t = StdioTransport::new();
+        let sink = t.capture_output();
+        t.write_json(&serde_json::json!({"n": 1})).await.unwrap();
+        t.write_json(&serde_json::json!({"n": 2})).await.unwrap();
+
+        let bytes = sink.lock().unwrap().clone();
+        let s = String::from_utf8(bytes).unwrap();
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(lines[0]).unwrap()["n"],
+            1
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(lines[1]).unwrap()["n"],
+            2
+        );
     }
 }


### PR DESCRIPTION
## What

Adds colocated unit tests to the lowest-covered modules — the MCP layer and shared helpers — with no production behaviour change. Patterns are drawn from the sibling **git-proxy-mcp** project's test suite (generic-over-IO framing, a `cfg(test)` transport capture sink, tempfile-based config-load tests, a thin `main` with a pure log-level helper).

## Coverage delta (local `cargo llvm-cov --workspace`)

| Module | Before | After |
|---|---|---|
| `altium/serde_round.rs` | 20% | **100%** |
| `config/mod.rs` | 41% | **95%** |
| `mcp/transport.rs` | 72% | **96%** |
| `mcp/tools/validation.rs` | 75% | **93%** |
| `main.rs` | 4% | **40%** |
| `mcp/tools/read_write.rs` | 77% | **79%** |
| **Overall (lines)** | 87.34% | **88.02%** |
| **Overall (functions)** | 86.79% | **88.60%** |

## Details

- **serde_round.rs** — full coverage of the rounding serialisers (`bare` / `option` / `vec_tuple` / `vec_f64`, `Some`+`None`, round-trips, the 6-dp `round` itself).
- **config/mod.rs** — `load_config` across every branch: `NotFound`, `ReadError` (a directory path), `ParseError`, `ValidationError`, and `Ok`, plus a drift guard that loads the shipped `config/example-config.json`.
- **transport.rs** — a `#[cfg(test)]`-gated in-memory capture sink on `StdioTransport` (compiled out of release builds) so `write_response` / `write_error` / `write_notification` / `write_json` / `write_raw` assert on the exact framed bytes without a live stdout pipe. This is the one non-test edit.
- **validation.rs** — `validate_footprint_coordinates` and `validate_symbol_coordinates` happy paths plus per-family error reporting, and all `pad_has_uniform_per_layer_data` branches.
- **main.rs** — exhaustive `get_log_level` cases (quiet override, `-v/-vv/-vvv` saturation, each config level, case-insensitivity, unknown → warn).
- **read_write.rs** — read/write/list handler error paths (missing params, denied path outside the allow-list, nonexistent file).

## Verification

- `cargo test` — **all pass** (603 lib tests, +40; every other target green)
- `cargo clippy --all-targets --all-features` — clean under the pedantic/nursery `-D warnings` gate
- `cargo fmt --all --check` — clean

## Note

The big tool-handler files (`compare`, `maintenance`, `library_ops`) already have error-path tests; their remaining gaps are deep success-path logic (diff computation, repair actions, export/import formats) that needs scenario tests — a good follow-up if we want to push overall coverage higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)