### PR TITLE
test: cover success paths of compare/maintenance/library_ops handlers

### DIFF
--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -1526,9 +1526,20 @@ impl McpServer {
 mod tests {
     use super::*;
     use crate::altium::pcblib::{
-        Fill, Layer, Pad, PcbFlags, Region, RegionKind, Text, TextJustification, TextKind, Via,
+        Arc, Fill, Layer, Pad, PcbFlags, Region, RegionKind, Text, TextJustification, TextKind,
+        Track, Via,
     };
     use crate::altium::schlib::{Parameter, Rectangle};
+
+    /// True when a `modified` diff entry carries a change for `property`.
+    fn has_change(diffs: &[Value], property: &str) -> bool {
+        diffs.iter().any(|d| {
+            d["status"] == "modified"
+                && d["changes"]
+                    .as_array()
+                    .is_some_and(|cs| cs.iter().any(|c| c["property"] == property))
+        })
+    }
 
     /// Builds a minimal stroke text at the given position.
     fn make_text(content: &str, x: f64, y: f64) -> Text {
@@ -1800,6 +1811,205 @@ mod tests {
         assert!(compare_serialized(&shapes_a, &shapes_b).is_empty());
     }
 
+    // ---- track detail (compare_tracks) ----
+
+    #[test]
+    fn track_width_and_layer_changes_reported() {
+        let a = Track::new(0.0, 0.0, 5.0, 0.0, 0.25, Layer::TopOverlay);
+        let mut wider = a.clone();
+        wider.width = 0.5;
+        assert!(has_change(
+            &McpServer::compare_tracks(std::slice::from_ref(&a), &[wider], 0.001),
+            "width"
+        ));
+
+        let mut moved_layer = a.clone();
+        moved_layer.layer = Layer::BottomOverlay;
+        assert!(has_change(
+            &McpServer::compare_tracks(&[a], &[moved_layer], 0.001),
+            "layer"
+        ));
+    }
+
+    #[test]
+    fn track_reverse_endpoints_still_match_as_modified() {
+        // Same segment described end-for-end, only the width differs.
+        let a = Track::new(0.0, 0.0, 5.0, 0.0, 0.25, Layer::TopOverlay);
+        let b = Track::new(5.0, 0.0, 0.0, 0.0, 0.5, Layer::TopOverlay);
+        let diffs = McpServer::compare_tracks(&[a], &[b], 0.001);
+        assert_eq!(diffs.len(), 1);
+        assert!(has_change(&diffs, "width"));
+    }
+
+    #[test]
+    fn track_one_sided_reported_per_side() {
+        let a = Track::new(0.0, 0.0, 5.0, 0.0, 0.25, Layer::TopOverlay);
+        let only_a = McpServer::compare_tracks(std::slice::from_ref(&a), &[], 0.001);
+        assert_eq!(only_a.len(), 1);
+        assert_eq!(only_a[0]["status"], "only_in_a");
+        let only_b = McpServer::compare_tracks(&[], &[a], 0.001);
+        assert_eq!(only_b[0]["status"], "only_in_b");
+    }
+
+    // ---- arc detail (compare_pcb_arcs) ----
+
+    #[test]
+    fn arc_property_changes_reported() {
+        let a = Arc::circle(0.0, 0.0, 1.0, 0.15, Layer::TopOverlay);
+
+        let mut start = a.clone();
+        start.start_angle = 90.0;
+        assert!(has_change(
+            &McpServer::compare_pcb_arcs(std::slice::from_ref(&a), &[start], 0.001),
+            "start_angle"
+        ));
+
+        let mut end = a.clone();
+        end.end_angle = 180.0;
+        assert!(has_change(
+            &McpServer::compare_pcb_arcs(std::slice::from_ref(&a), &[end], 0.001),
+            "end_angle"
+        ));
+
+        let mut wide = a.clone();
+        wide.width = 0.3;
+        assert!(has_change(
+            &McpServer::compare_pcb_arcs(std::slice::from_ref(&a), &[wide], 0.001),
+            "width"
+        ));
+
+        let mut layer = a.clone();
+        layer.layer = Layer::BottomOverlay;
+        assert!(has_change(
+            &McpServer::compare_pcb_arcs(&[a], &[layer], 0.001),
+            "layer"
+        ));
+    }
+
+    #[test]
+    fn arc_one_sided_reported_per_side() {
+        let a = Arc::circle(0.0, 0.0, 1.0, 0.15, Layer::TopOverlay);
+        let only_a = McpServer::compare_pcb_arcs(std::slice::from_ref(&a), &[], 0.001);
+        assert_eq!(only_a[0]["status"], "only_in_a");
+        let only_b = McpServer::compare_pcb_arcs(&[], &[a], 0.001);
+        assert_eq!(only_b[0]["status"], "only_in_b");
+    }
+
+    // ---- fill rotation + one-sided (compare_fills) ----
+
+    #[test]
+    fn fill_rotation_change_reported() {
+        let a = Fill::new(-0.5, -0.5, 0.5, 0.5, Layer::TopOverlay);
+        let mut rotated = a.clone();
+        rotated.rotation = 90.0;
+        assert!(has_change(
+            &McpServer::compare_fills(&[a], &[rotated], 0.001),
+            "rotation"
+        ));
+    }
+
+    #[test]
+    fn fill_one_sided_reported_per_side() {
+        let a = Fill::new(-0.5, -0.5, 0.5, 0.5, Layer::TopOverlay);
+        let b = Fill::new(5.0, 5.0, 6.0, 6.0, Layer::TopOverlay);
+        let diffs = McpServer::compare_fills(&[a], &[b], 0.001);
+        assert_eq!(diffs.len(), 2);
+        assert_eq!(diffs[0]["status"], "only_in_a");
+        assert_eq!(diffs[1]["status"], "only_in_b");
+    }
+
+    // ---- text detail (compare_pcb_text) ----
+
+    #[test]
+    fn text_property_changes_reported() {
+        let a = make_text("REF", 0.0, 0.0);
+
+        let mut rotated = make_text("REF", 0.0, 0.0);
+        rotated.rotation = 90.0;
+        assert!(has_change(
+            &McpServer::compare_pcb_text(std::slice::from_ref(&a), &[rotated], 0.001),
+            "rotation"
+        ));
+
+        let mut layer = make_text("REF", 0.0, 0.0);
+        layer.layer = Layer::BottomOverlay;
+        assert!(has_change(
+            &McpServer::compare_pcb_text(std::slice::from_ref(&a), &[layer], 0.001),
+            "layer"
+        ));
+
+        let mut kind = make_text("REF", 0.0, 0.0);
+        kind.kind = TextKind::TrueType;
+        assert!(has_change(
+            &McpServer::compare_pcb_text(std::slice::from_ref(&a), &[kind], 0.001),
+            "kind"
+        ));
+
+        let mut mirror = make_text("REF", 0.0, 0.0);
+        mirror.mirror = true;
+        assert!(has_change(
+            &McpServer::compare_pcb_text(&[a], &[mirror], 0.001),
+            "mirror"
+        ));
+    }
+
+    #[test]
+    fn text_differing_content_reported_per_side() {
+        let a = make_text("AAA", 0.0, 0.0);
+        let b = make_text("BBB", 5.0, 0.0);
+        let diffs = McpServer::compare_pcb_text(&[a], &[b], 0.001);
+        assert_eq!(diffs.len(), 2);
+        assert_eq!(diffs[0]["status"], "only_in_a");
+        assert_eq!(diffs[1]["status"], "only_in_b");
+    }
+
+    // ---- pin detail (compare_pins) ----
+
+    mod pin_detail {
+        use super::*;
+        use crate::altium::schlib::{Pin, PinElectricalType, PinOrientation};
+
+        #[test]
+        fn pin_property_changes_reported() {
+            let a = Pin::new("1", "1", -20, 0, 10, PinOrientation::Left);
+
+            let mut moved = a.clone();
+            moved.x = -10;
+            assert!(has_change(
+                &McpServer::compare_pins(std::slice::from_ref(&a), &[moved]),
+                "position"
+            ));
+
+            let mut longer = a.clone();
+            longer.length = 20;
+            assert!(has_change(
+                &McpServer::compare_pins(std::slice::from_ref(&a), &[longer]),
+                "length"
+            ));
+
+            let mut renamed = a.clone();
+            renamed.name = "PIN1".to_string();
+            assert!(has_change(
+                &McpServer::compare_pins(std::slice::from_ref(&a), &[renamed]),
+                "name"
+            ));
+
+            let mut etype = a.clone();
+            etype.electrical_type = PinElectricalType::Input;
+            assert!(has_change(
+                &McpServer::compare_pins(std::slice::from_ref(&a), &[etype]),
+                "electrical_type"
+            ));
+
+            let mut oriented = a.clone();
+            oriented.orientation = PinOrientation::Right;
+            assert!(has_change(
+                &McpServer::compare_pins(&[a], &[oriented]),
+                "orientation"
+            ));
+        }
+    }
+
     // ==================== call_compare_components dispatcher ====================
 
     mod dispatcher {
@@ -1987,6 +2197,89 @@ mod tests {
             assert!(differences.iter().any(|d| d["field"] == "description"));
             assert!(differences.iter().any(|d| d["field"] == "pins"));
             assert!(differences.iter().any(|d| d["field"] == "rectangle_count"));
+        }
+
+        #[test]
+        fn compare_symbols_reports_scalar_footprint_and_parameter_diffs() {
+            use crate::altium::schlib::{FootprintModel, Parameter};
+
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib_a = SchLib::new();
+            let mut sym_a = Symbol::new("SYM");
+            sym_a.designator = "R?".to_string();
+            sym_a.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+            sym_a.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right));
+            sym_a.add_parameter(Parameter::new("Value", "1k"));
+            lib_a.add(sym_a);
+            let path_a = dir.path().join("ScalarA.SchLib");
+            lib_a.save(&path_a).unwrap();
+
+            let mut lib_b = SchLib::new();
+            let mut sym_b = Symbol::new("SYM");
+            sym_b.designator = "U?".to_string(); // designator diff
+            sym_b.part_count = 2; // part_count diff (default is 1)
+            sym_b.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+            sym_b.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right));
+            sym_b.add_pin(Pin::new("3", "3", 20, 20, 10, PinOrientation::Right)); // pin_count diff
+            sym_b.add_parameter(Parameter::new("Value", "2k")); // parameter value diff
+            sym_b.add_footprint(FootprintModel::new("0603")); // footprint_count + names diff
+            lib_b.add(sym_b);
+            let path_b = dir.path().join("ScalarB.SchLib");
+            lib_b.save(&path_b).unwrap();
+
+            let result = server.call_compare_components(&json!({
+                "filepath_a": path_a.to_string_lossy(),
+                "component_a": "SYM",
+                "filepath_b": path_b.to_string_lossy(),
+                "component_b": "SYM",
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(parsed["identical"], false);
+            let fields: Vec<&str> = parsed["differences"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|d| d["field"].as_str().unwrap_or(""))
+                .collect();
+            for expected in [
+                "designator",
+                "part_count",
+                "pin_count",
+                "footprint_count",
+                "footprints",
+                "parameters",
+            ] {
+                assert!(
+                    fields.contains(&expected),
+                    "missing field {expected}: {fields:?}"
+                );
+            }
+
+            // The footprints entry names each side's unique footprint.
+            let fp_diff = parsed["differences"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|d| d["field"] == "footprints")
+                .unwrap();
+            assert!(fp_diff["only_in_b"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v == "0603"));
+
+            // The parameter diff reports the changed value.
+            let param_diff = parsed["differences"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|d| d["field"] == "parameters")
+                .unwrap();
+            let changes = &param_diff["differences"][0]["changes"];
+            assert_eq!(changes[0]["property"], "value");
         }
     }
 }

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1776,4 +1776,178 @@ mod tests {
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("missing required field 'x'"));
     }
+
+    // ==================== validate / export / import success paths ====================
+
+    mod more_coverage {
+        use super::*;
+        use crate::altium::pcblib::Pad;
+        use crate::altium::schlib::Rectangle;
+
+        #[test]
+        fn validate_pcblib_reports_pad_errors() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("BAD");
+            fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+            let mut dup = Pad::smd("1", 0.5, 0.0, 0.6, 0.5); // duplicate designator
+            dup.width = 0.0; // invalid dimensions
+            fp.add_pad(dup);
+            fp.add_pad(Pad::smd("", 0.0, 0.5, 0.6, 0.5)); // empty designator
+            lib.add(fp);
+            let path = dir.path().join("PcbErrors.PcbLib");
+            lib.save(&path).unwrap();
+
+            let parsed = parse_result_json(
+                &server.call_validate_library(&json!({ "filepath": path.to_string_lossy() })),
+            );
+            assert_eq!(parsed["status"], "invalid");
+            let issues = parsed["issues"].as_array().unwrap();
+            assert!(issues
+                .iter()
+                .any(|i| i["issue"] == "Duplicate pad designator: '1'"));
+            assert!(issues
+                .iter()
+                .any(|i| i["issue"] == "Pad has empty designator"));
+            assert!(issues.iter().any(|i| i["issue"]
+                .as_str()
+                .unwrap_or("")
+                .contains("invalid dimensions")));
+            assert!(parsed["error_count"].as_u64().unwrap() >= 3);
+        }
+
+        #[test]
+        fn validate_pcblib_empty_library_is_warning() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Empty.PcbLib");
+            PcbLib::new().save(&path).unwrap();
+
+            let parsed = parse_result_json(
+                &server.call_validate_library(&json!({ "filepath": path.to_string_lossy() })),
+            );
+            assert_eq!(parsed["status"], "warnings");
+            assert_eq!(
+                parsed["issues"][0]["issue"],
+                "Library is empty (no footprints)"
+            );
+        }
+
+        #[test]
+        fn validate_schlib_reports_pin_length_and_inverted_rect() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = SchLib::new();
+            let mut sym = Symbol::new("W");
+            sym.add_pin(Pin::new("A", "1", -20, 0, 0, PinOrientation::Left)); // length 0
+            sym.add_rectangle(Rectangle::new(10, 5, -10, -5)); // inverted corners
+            lib.add(sym);
+            let path = dir.path().join("SchWarn.SchLib");
+            lib.save(&path).unwrap();
+
+            let parsed = parse_result_json(
+                &server.call_validate_library(&json!({ "filepath": path.to_string_lossy() })),
+            );
+            assert_eq!(parsed["status"], "warnings");
+            let issues = parsed["issues"].as_array().unwrap();
+            assert!(issues.iter().any(|i| i["issue"]
+                .as_str()
+                .unwrap_or("")
+                .contains("zero or negative length")));
+            assert!(issues.iter().any(|i| i["issue"]
+                .as_str()
+                .unwrap_or("")
+                .contains("inverted corners")));
+        }
+
+        #[test]
+        fn export_pcblib_json_non_compact_keeps_detail() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Exp.PcbLib");
+            create_test_pcblib(&path);
+
+            let parsed = parse_result_json(&server.call_export_library(&json!({
+                "filepath": path.to_string_lossy(),
+                "format": "json",
+                "compact": false,
+            })));
+            assert_eq!(parsed["status"], "success");
+            assert_eq!(parsed["footprints"].as_array().unwrap().len(), 2);
+        }
+
+        #[test]
+        fn import_schlib_rejects_incomplete_rectangle() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let out = dir.path().join("ImpRect.SchLib");
+            let result = server.call_import_library(&json!({
+                "output_path": out.to_string_lossy(),
+                "json_data": {
+                    "file_type": "SchLib",
+                    "symbols": [{
+                        "name": "S",
+                        "pins": [{ "designator": "1", "name": "A", "x": -20, "y": 0, "length": 10 }],
+                        "rectangles": [{ "x1": 0, "y1": 0, "x2": 10 }],
+                    }],
+                },
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("rectangle 0 missing required field 'y2'"));
+        }
+
+        #[test]
+        fn import_schlib_creates_new_library() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let out = dir.path().join("NewSch.SchLib");
+            let result = server.call_import_library(&json!({
+                "output_path": out.to_string_lossy(),
+                "json_data": {
+                    "file_type": "SchLib",
+                    "symbols": [{
+                        "name": "LED",
+                        "designator": "D?",
+                        "pins": [
+                            { "designator": "1", "name": "A", "x": -20, "y": 0, "length": 10 },
+                            { "designator": "2", "name": "K", "x": 20, "y": 0, "length": 10 },
+                        ],
+                    }],
+                },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(parsed["imported_count"], 1);
+            assert_eq!(parsed["total_count"], 1);
+            assert_eq!(parsed["append"], false);
+            assert!(parsed.get("validation").is_some());
+            assert!(SchLib::open(&out).unwrap().get("LED").is_some());
+        }
+
+        #[test]
+        fn delete_component_surfaces_post_write_validation() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = PcbLib::new();
+            lib.add(Footprint::new("GOOD")); // deleted below
+            let mut bad = Footprint::new("BAD");
+            bad.add_pad(Pad::smd("1", 0.0, 0.0, 0.6, 0.5));
+            bad.add_pad(Pad::smd("1", 0.5, 0.0, 0.6, 0.5)); // duplicate designator remains
+            lib.add(bad);
+            let path = dir.path().join("PostVal.PcbLib");
+            lib.save(&path).unwrap();
+
+            let parsed = parse_result_json(&server.call_delete_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_names": ["GOOD"],
+            })));
+            assert_eq!(parsed["status"], "success");
+            assert_eq!(parsed["validation"]["status"], "invalid");
+            assert!(parsed["validation"]["error_count"].as_u64().unwrap() >= 1);
+        }
+    }
 }

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -1685,4 +1685,298 @@ mod tests {
             "Missing required parameter: index"
         );
     }
+
+    // ==================== update_primitive: arc/text/fill/region arms ====================
+
+    mod primitive_arms {
+        use super::*;
+        use crate::altium::pcblib::{
+            Arc, Fill, PcbFlags, Region, Text, TextJustification, TextKind,
+        };
+
+        /// A footprint carrying one of every 2D primitive at index 0, so each
+        /// `update_primitive` arm has a target.
+        fn create_rich_pcblib(path: &std::path::Path) {
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("RICH");
+            fp.add_pad(Pad::smd("1", 0.0, 0.0, 0.5, 0.5));
+            fp.add_track(Track::new(-1.0, -1.0, 1.0, -1.0, 0.2, Layer::TopOverlay));
+            fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.15, Layer::TopOverlay));
+            fp.add_fill(Fill::new(-0.5, -0.5, 0.5, 0.5, Layer::TopPaste));
+            fp.add_region(Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopLayer));
+            fp.add_text(Text {
+                x: 0.0,
+                y: 1.0,
+                text: "REF".to_string(),
+                height: 0.5,
+                layer: Layer::TopOverlay,
+                rotation: 0.0,
+                kind: TextKind::Stroke,
+                stroke_font: None,
+                stroke_width: None,
+                italic: false,
+                bold: false,
+                mirror: false,
+                is_comment: false,
+                is_designator: false,
+                font_name: "Arial".to_string(),
+                justification: TextJustification::BottomLeft,
+                is_inverted: false,
+                inverted_border: None,
+                use_inverted_rectangle: false,
+                inverted_rect_width: None,
+                inverted_rect_height: None,
+                inverted_rect_text_offset: None,
+                flags: PcbFlags::empty(),
+                net_index: 0xFFFF,
+                polygon_index: 0xFFFF,
+                component_index: -1,
+                unique_id: None,
+            });
+            lib.add(fp);
+            lib.save(path).expect("Failed to create rich PcbLib");
+        }
+
+        fn change_props(parsed: &serde_json::Value) -> Vec<String> {
+            parsed["changes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|c| c["property"].as_str().unwrap_or("").to_string())
+                .collect()
+        }
+
+        #[test]
+        fn update_primitive_arc_arm_persists() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Arc.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "arc",
+                "index": 0,
+                "updates": {
+                    "x": 0.25, "y": -0.25, "radius": 1.5,
+                    "start_angle": 10.0, "end_angle": 200.0, "width": 0.2,
+                    "layer": "Bottom Overlay",
+                },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(parsed["primitive_type"], "arc");
+            let props = change_props(&parsed);
+            assert!(props.contains(&"radius".to_string()));
+            assert!(props.contains(&"x".to_string()));
+
+            let lib = PcbLib::open(&path).unwrap();
+            let arc = &lib.get("RICH").unwrap().arcs[0];
+            assert!((arc.radius - 1.5).abs() < 1e-4);
+            assert_eq!(arc.layer, Layer::BottomOverlay);
+        }
+
+        #[test]
+        fn update_primitive_arc_zero_radius_rejected() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("ArcBad.PcbLib");
+            create_rich_pcblib(&path);
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "arc",
+                "index": 0,
+                "updates": { "radius": 0.0 },
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("radius must be positive"));
+        }
+
+        #[test]
+        fn update_primitive_text_arm_persists() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Text.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "text",
+                "index": 0,
+                "updates": { "x": 0.1, "y": 0.2, "height": 0.7, "rotation": 90.0, "text": "NEW", "layer": "Top Overlay" },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let props = change_props(&parse_result_json(&result));
+            assert!(props.contains(&"text".to_string()));
+            assert!(props.contains(&"height".to_string()));
+
+            let lib = PcbLib::open(&path).unwrap();
+            assert_eq!(lib.get("RICH").unwrap().text[0].text, "NEW");
+        }
+
+        #[test]
+        fn update_primitive_fill_arm_persists() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Fill.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "fill",
+                "index": 0,
+                "updates": { "x": -0.3, "y": -0.3, "x2": 0.4, "y2": 0.4, "rotation": 45.0, "layer": "Bottom Paste" },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let props = change_props(&parse_result_json(&result));
+            assert!(props.contains(&"rotation".to_string()));
+            assert!(props.contains(&"x1".to_string()));
+
+            let lib = PcbLib::open(&path).unwrap();
+            assert!((lib.get("RICH").unwrap().fills[0].rotation - 45.0).abs() < 1e-4);
+        }
+
+        #[test]
+        fn update_primitive_region_arm_persists() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Region.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "region",
+                "index": 0,
+                "updates": { "layer": "Bottom Layer" },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let props = change_props(&parse_result_json(&result));
+            assert_eq!(props, vec!["layer".to_string()]);
+
+            let lib = PcbLib::open(&path).unwrap();
+            assert_eq!(
+                lib.get("RICH").unwrap().regions[0].layer,
+                Layer::BottomLayer
+            );
+        }
+
+        #[test]
+        fn update_primitive_spaceless_layer_aliases_resolve() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Alias.PcbLib");
+            create_rich_pcblib(&path);
+            let filepath = path.to_string_lossy().to_string();
+
+            // Space-less names bypass Layer::parse and exercise the alias arms.
+            for (input, expected) in [
+                ("MidLayer5", Layer::MidLayer5),
+                ("InternalPlane2", Layer::InternalPlane2),
+                ("Mechanical10", Layer::Mechanical10),
+            ] {
+                let result = server.call_update_primitive(&json!({
+                    "filepath": filepath,
+                    "component_name": "RICH",
+                    "primitive_type": "track",
+                    "index": 0,
+                    "updates": { "layer": input },
+                }));
+                assert!(!result.is_error, "{}", get_result_text(&result));
+                let lib = PcbLib::open(&path).unwrap();
+                assert_eq!(
+                    lib.get("RICH").unwrap().tracks[0].layer,
+                    expected,
+                    "{input}"
+                );
+            }
+        }
+    }
+
+    // ==================== update_pad: remaining update keys ====================
+
+    #[test]
+    fn update_pad_y_height_rotation_hole_size_persist() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("PadKeys.PcbLib");
+        create_test_pcblib(&path);
+
+        let result = server.call_update_pad(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "designator": "1",
+            "updates": { "y": 0.3, "height": 0.7, "rotation": 90.0, "hole_size": 0.2 },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let changes = parse_result_json(&result);
+        let props: Vec<&str> = changes["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["property"].as_str().unwrap_or(""))
+            .collect();
+        for expected in ["y", "height", "rotation", "hole_size"] {
+            assert!(props.contains(&expected), "missing {expected}: {props:?}");
+        }
+
+        let lib = PcbLib::open(&path).unwrap();
+        let pad = lib
+            .get("CHIP_0402")
+            .unwrap()
+            .pads
+            .iter()
+            .find(|p| p.designator == "1")
+            .unwrap();
+        assert!((pad.height - 0.7).abs() < 1e-4);
+        assert_eq!(pad.hole_size, Some(0.2));
+    }
+
+    #[test]
+    fn update_pad_negative_hole_size_rejected() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("PadBad.PcbLib");
+        create_test_pcblib(&path);
+        let result = server.call_update_pad(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "designator": "1",
+            "updates": { "hole_size": -0.1 },
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("hole_size must be >= 0"));
+    }
+
+    // ==================== bulk_rename: SchLib real apply ====================
+
+    #[test]
+    fn bulk_rename_schlib_applies_and_persists() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("BulkApply.SchLib");
+        create_test_schlib(&path);
+
+        let result = server.call_bulk_rename(&json!({
+            "filepath": path.to_string_lossy(),
+            "pattern": "^RESISTOR$",
+            "replacement": "RES",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let parsed = parse_result_json(&result);
+        assert_eq!(parsed["status"], "success");
+        assert_eq!(parsed["file_type"], "SchLib");
+        assert_eq!(parsed["renamed_count"], 1);
+        assert_eq!(parsed["renames"][0]["from"], "RESISTOR");
+        assert_eq!(parsed["renames"][0]["to"], "RES");
+
+        let lib = SchLib::open(&path).unwrap();
+        assert!(lib.get("RES").is_some());
+        assert!(lib.get("RESISTOR").is_none());
+        assert!(lib.get("CAPACITOR").is_some());
+    }
 }


### PR DESCRIPTION
## What

Follow-up to #263. Adds scenario tests that drive the previously-untested **success** branches of the three largest MCP tool handlers — the deep diff/apply/validate/export/import logic, not just the early error returns. Tests only; no production change.

## Coverage delta (local `cargo llvm-cov --workspace`)

| File | Before (baseline) | After |
|---|---|---|
| `mcp/tools/compare.rs` | 73.6% | **90.6%** |
| `mcp/tools/maintenance.rs` | 73.5% | **88.3%** |
| `mcp/tools/library_ops.rs` | 74.3% | **80.8%** |
| **Overall (lines)** | 88.02% | **89.69%** |
| **Overall (functions)** | 88.60% | **89.31%** |

Combined with #263, overall line coverage has moved from the original **87.34% → 89.69%**.

## What's now covered

**compare.rs** — the per-primitive diff detail that only runs when components actually differ:
- `compare_tracks` (width/layer change, reverse-endpoint match, one-sided), `compare_pcb_arcs` (start/end angle, width, layer, one-sided), `compare_pins` (position/length/name/electrical_type/orientation), `compare_fills` (rotation, one-sided), `compare_pcb_text` (rotation/layer/kind/mirror, differing content per-side)
- symbol-level scalar/metadata diffs: `designator`, `part_count`, `pin_count`, `footprint_count`, the `footprints` name-set diff, and `parameters` value diffs

**maintenance.rs** — `call_update_primitive`'s arc/text/fill/region arms (only `track` was covered), the space-less layer-alias fallback (`MidLayer5`/`InternalPlane2`/`Mechanical10`, which bypass `Layer::parse`), `call_update_pad`'s y/height/rotation/hole_size branches + negative-hole rejection, and the SchLib `bulk_rename` real-apply-and-persist path (only dry-run/conflict were covered).

**library_ops.rs** — `validate_library` error/warning branches (duplicate & empty pad designators, invalid dimensions, empty library, SchLib pin length + inverted rectangle), non-compact JSON export, `import_library` incomplete-rectangle rejection and new-SchLib creation, and `delete_component`'s post-write validation surfacing on a deliberately pre-broken library.

## Approach

Used the repo's existing `test_support` fixtures and the `pub(crate)` comparison helpers (called directly with in-memory slices — no file I/O where possible), mirroring the patterns already in each file. Deliberately-broken libraries are built with the `altium` types and `lib.save()` (which skips create-path validation) so the on-disk validators have something to catch.

## Verification

- `cargo test` — **all pass** (630 lib tests, +27; every other target green)
- `cargo clippy --all-targets --all-features` — clean under the pedantic/nursery `-D warnings` gate
- `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)