### PR TITLE
test: cover protocol, components, query_update, diff and step handlers

### DIFF
--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -550,4 +550,90 @@ mod tests {
         assert_eq!(format!("{}", RequestId::Number(42)), "42");
         assert_eq!(format!("{}", RequestId::String("abc".to_string())), "abc");
     }
+
+    #[test]
+    fn outgoing_progress_notification_shape() {
+        let n = OutgoingNotification::progress("tok", 3, Some(10), Some("halfway"));
+        assert_eq!(n.method, "notifications/progress");
+        let p = n.params.unwrap();
+        assert_eq!(p["progressToken"], "tok");
+        assert_eq!(p["progress"], 3);
+        assert_eq!(p["total"], 10);
+        assert_eq!(p["message"], "halfway");
+
+        // Absent total/message serialise as JSON null.
+        let bare = OutgoingNotification::progress("t", 1, None, None);
+        let p = bare.params.unwrap();
+        assert_eq!(p["total"], Value::Null);
+        assert_eq!(p["message"], Value::Null);
+    }
+
+    #[test]
+    fn error_code_numbers_and_default_messages() {
+        for (code, num, msg) in [
+            (ErrorCode::ParseError, -32700, "Parse error"),
+            (ErrorCode::InvalidRequest, -32600, "Invalid Request"),
+            (ErrorCode::MethodNotFound, -32601, "Method not found"),
+            (ErrorCode::InvalidParams, -32602, "Invalid params"),
+            (ErrorCode::InternalError, -32603, "Internal error"),
+            (ErrorCode::ServerError(-32050), -32050, "Server error"),
+        ] {
+            assert_eq!(code.code(), num);
+            assert_eq!(code.default_message(), msg);
+        }
+    }
+
+    #[test]
+    fn error_data_from_code_message_and_data() {
+        let plain = JsonRpcErrorData::from_code(ErrorCode::InternalError);
+        assert_eq!(plain.code, -32603);
+        assert_eq!(plain.message, "Internal error");
+        assert!(plain.data.is_none());
+
+        let rich = JsonRpcErrorData::with_message(ErrorCode::InvalidParams, "bad arg")
+            .with_data(serde_json::json!({ "field": "x" }));
+        assert_eq!(rich.code, -32602);
+        assert_eq!(rich.message, "bad arg");
+        assert_eq!(rich.data.unwrap()["field"], "x");
+    }
+
+    #[test]
+    fn error_response_constructors_set_code_and_id() {
+        let parse = JsonRpcError::parse_error();
+        assert_eq!(parse.error.code, -32700);
+        assert!(parse.id.is_none());
+
+        let invalid = JsonRpcError::invalid_request(Some(RequestId::Number(1)));
+        assert_eq!(invalid.error.code, -32600);
+        assert_eq!(invalid.id, Some(RequestId::Number(1)));
+
+        let mnf = JsonRpcError::method_not_found(RequestId::Number(2), "tools/nope");
+        assert_eq!(mnf.error.code, -32601);
+        assert!(mnf.error.message.contains("tools/nope"));
+
+        let ip = JsonRpcError::invalid_params(RequestId::Number(3), "missing filepath");
+        assert_eq!(ip.error.code, -32602);
+        assert_eq!(ip.error.message, "missing filepath");
+
+        let ie = JsonRpcError::internal_error(RequestId::String("s7".to_string()), "boom");
+        assert_eq!(ie.error.code, -32603);
+        assert_eq!(ie.error.message, "boom");
+        assert_eq!(ie.id, Some(RequestId::String("s7".to_string())));
+    }
+
+    #[test]
+    fn incoming_message_accessors_for_request_and_notification() {
+        let req =
+            parse_message(r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"a":1}}"#)
+                .unwrap();
+        assert_eq!(req.method(), "tools/call");
+        assert_eq!(req.params().unwrap()["a"], 1);
+        assert_eq!(req.id(), Some(&RequestId::Number(7)));
+
+        let notif =
+            parse_message(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#).unwrap();
+        assert_eq!(notif.method(), "notifications/initialized");
+        assert!(notif.params().is_none());
+        assert!(notif.id().is_none());
+    }
 }

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -1938,4 +1938,304 @@ mod tests {
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("empty"));
     }
+
+    // ==================== dry-run, cross-library and merge deep paths ====================
+
+    mod deep_coverage {
+        use super::*;
+
+        #[test]
+        fn copy_component_schlib_dry_run() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("CopyDry.SchLib");
+            create_test_schlib(&path);
+            let r = server.call_copy_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "source_name": "RESISTOR",
+                "target_name": "RESISTOR_COPY",
+                "dry_run": true,
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "dry_run");
+            assert_eq!(p["file_type"], "SchLib");
+            assert!(SchLib::open(&path).unwrap().get("RESISTOR_COPY").is_none());
+        }
+
+        #[test]
+        fn rename_component_pcblib_dry_run() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("RenameDry.PcbLib");
+            create_test_pcblib(&path);
+            let r = server.call_rename_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "old_name": "CHIP_0402",
+                "new_name": "CHIP_0402_R",
+                "dry_run": true,
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "dry_run");
+            assert_eq!(p["file_type"], "PcbLib");
+            let lib = PcbLib::open(&path).unwrap();
+            assert!(lib.get("CHIP_0402").is_some());
+            assert!(lib.get("CHIP_0402_R").is_none());
+        }
+
+        /// Builds a `PcbLib` whose footprint references an embedded model id that
+        /// is NOT present in the library (a dangling reference).
+        fn lib_with_missing_model(path: &std::path::Path, model_id: &str) {
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("QFN_MISSING");
+            fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.3, 0.8));
+            fp.add_component_body(ComponentBody::new(model_id, "missing.step"));
+            lib.add(fp);
+            lib.save(path).unwrap();
+        }
+
+        #[test]
+        fn cross_library_copy_pcblib_missing_model_ignored() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let source = dir.path().join("Missing.PcbLib");
+            lib_with_missing_model(&source, "{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}");
+            let target = dir.path().join("MissingTarget.PcbLib");
+
+            let r = server.call_copy_component_cross_library(&json!({
+                "source_filepath": source.to_string_lossy(),
+                "target_filepath": target.to_string_lossy(),
+                "component_name": "QFN_MISSING",
+                "ignore_missing_models": true,
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "success");
+            assert_eq!(p["embedded_models_copied"], 0);
+            let warnings = p["warnings"].as_array().unwrap();
+            assert!(warnings
+                .iter()
+                .any(|w| w.as_str().unwrap_or("").contains("component body")));
+            let out = PcbLib::open(&target).unwrap();
+            assert_eq!(out.get("QFN_MISSING").unwrap().component_bodies.len(), 0);
+        }
+
+        #[test]
+        fn cross_library_copy_pcblib_missing_model_errors() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let source = dir.path().join("MissingErr.PcbLib");
+            lib_with_missing_model(&source, "{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}");
+            let r = server.call_copy_component_cross_library(&json!({
+                "source_filepath": source.to_string_lossy(),
+                "target_filepath": dir.path().join("Err.PcbLib").to_string_lossy(),
+                "component_name": "QFN_MISSING",
+            }));
+            assert!(r.is_error);
+            assert!(get_result_text(&r).contains("missing embedded model"));
+        }
+
+        #[test]
+        fn cross_library_copy_pcblib_preserve_external_paths() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let model_id = "{11111111-2222-3333-4444-555555555555}";
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("QFN16");
+            fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.3, 0.8));
+            fp.add_component_body(ComponentBody::new(model_id, "QFN16.step"));
+            lib.add(fp);
+            lib.add_model(EmbeddedModel::new(
+                model_id,
+                "QFN16.step",
+                b"ISO-10303-21; test".to_vec(),
+            ));
+            let source = dir.path().join("Preserve.PcbLib");
+            lib.save(&source).unwrap();
+            let target = dir.path().join("PreserveTarget.PcbLib");
+
+            let r = server.call_copy_component_cross_library(&json!({
+                "source_filepath": source.to_string_lossy(),
+                "target_filepath": target.to_string_lossy(),
+                "component_name": "QFN16",
+                "preserve_external_paths": true,
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["preserve_external_paths"], true);
+            assert_eq!(p["embedded_models_copied"], 1);
+            assert!(p["warnings"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|w| w.as_str().unwrap_or("").contains("preserved")));
+        }
+
+        #[test]
+        fn cross_library_copy_pcblib_into_existing_target() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let source = dir.path().join("XSrc.PcbLib");
+            create_test_pcblib(&source);
+            let target = dir.path().join("XDst.PcbLib");
+            create_test_pcblib(&target); // pre-existing target
+            let r = server.call_copy_component_cross_library(&json!({
+                "source_filepath": source.to_string_lossy(),
+                "target_filepath": target.to_string_lossy(),
+                "component_name": "CHIP_0402",
+                "new_name": "CHIP_0402_IMPORTED",
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            assert_eq!(parse_result_json(&r)["target_component_count"], 3);
+        }
+
+        #[test]
+        fn cross_library_copy_schlib_into_existing_target() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let source = dir.path().join("SXSrc.SchLib");
+            create_test_schlib(&source);
+            let target = dir.path().join("SXDst.SchLib");
+            create_test_schlib(&target);
+            let r = server.call_copy_component_cross_library(&json!({
+                "source_filepath": source.to_string_lossy(),
+                "target_filepath": target.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "new_name": "RESISTOR_IMPORTED",
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["file_type"], "SchLib");
+            assert_eq!(p["target_component_count"], 3);
+        }
+
+        #[test]
+        fn merge_libraries_rejects_mixed_types() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let pcb = dir.path().join("Mix.PcbLib");
+            create_test_pcblib(&pcb);
+            let sch = dir.path().join("Mix.SchLib");
+            create_test_schlib(&sch);
+
+            let r = server.call_merge_libraries(&json!({
+                "source_filepaths": [pcb.to_string_lossy(), sch.to_string_lossy()],
+                "target_filepath": dir.path().join("Out.PcbLib").to_string_lossy(),
+            }));
+            assert!(r.is_error);
+            assert!(get_result_text(&r).contains("same type"));
+
+            let r = server.call_merge_libraries(&json!({
+                "source_filepaths": [pcb.to_string_lossy()],
+                "target_filepath": dir.path().join("Out.SchLib").to_string_lossy(),
+            }));
+            assert!(r.is_error);
+            assert!(get_result_text(&r).contains("Target library type"));
+        }
+
+        #[test]
+        fn merge_libraries_pcblib_rename_into_existing_target() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let target = dir.path().join("ExMerge.PcbLib");
+            create_test_pcblib(&target);
+            let a = dir.path().join("SA.PcbLib");
+            create_test_pcblib(&a);
+            let b = dir.path().join("SB.PcbLib");
+            create_test_pcblib(&b);
+            let r = server.call_merge_libraries(&json!({
+                "source_filepaths": [a.to_string_lossy(), b.to_string_lossy()],
+                "target_filepath": target.to_string_lossy(),
+                "on_duplicate": "rename",
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["renamed_count"], 4);
+            assert_eq!(p["final_count"], 6);
+            let lib = PcbLib::open(&target).unwrap();
+            assert!(lib.get("CHIP_0402_1").is_some());
+            assert!(lib.get("CHIP_0402_2").is_some()); // proves the counter loop ran
+        }
+
+        #[test]
+        fn merge_libraries_schlib_rename_into_existing_target() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let target = dir.path().join("SEx.SchLib");
+            create_test_schlib(&target);
+            let a = dir.path().join("SSA.SchLib");
+            create_test_schlib(&a);
+            let b = dir.path().join("SSB.SchLib");
+            create_test_schlib(&b);
+            let r = server.call_merge_libraries(&json!({
+                "source_filepaths": [a.to_string_lossy(), b.to_string_lossy()],
+                "target_filepath": target.to_string_lossy(),
+                "on_duplicate": "rename",
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["file_type"], "SchLib");
+            assert_eq!(p["renamed_count"], 4);
+            assert_eq!(p["final_count"], 6);
+            assert!(SchLib::open(&target).unwrap().get("RESISTOR_2").is_some());
+        }
+
+        #[test]
+        fn merge_libraries_schlib_skip_and_dry_run() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let a = dir.path().join("SkA.SchLib");
+            create_test_schlib(&a);
+            let b = dir.path().join("SkB.SchLib");
+            create_test_schlib(&b);
+            let target = dir.path().join("Sk.SchLib");
+            let r = server.call_merge_libraries(&json!({
+                "source_filepaths": [a.to_string_lossy(), b.to_string_lossy()],
+                "target_filepath": target.to_string_lossy(),
+                "on_duplicate": "skip",
+                "dry_run": true,
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "dry_run");
+            assert_eq!(p["merged_count"], 2);
+            assert_eq!(p["skipped_count"], 2);
+            assert!(!target.exists());
+        }
+
+        #[test]
+        fn reorder_components_pcblib_error_branches() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let txt = dir.path().join("thing.txt");
+            let r = server.call_reorder_components(&json!({
+                "filepath": txt.to_string_lossy(),
+                "component_order": ["A"],
+            }));
+            assert!(r.is_error);
+            assert!(get_result_text(&r).contains("Unknown file type"));
+
+            let ghost = dir.path().join("Ghost.PcbLib");
+            let r = server.call_reorder_components(&json!({
+                "filepath": ghost.to_string_lossy(),
+                "component_order": ["A"],
+            }));
+            assert!(r.is_error);
+            assert_eq!(parse_result_json(&r)["status"], "error");
+        }
+
+        #[test]
+        fn reorder_components_schlib_open_error() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let ghost = dir.path().join("Ghost.SchLib");
+            let r = server.call_reorder_components(&json!({
+                "filepath": ghost.to_string_lossy(),
+                "component_order": ["RESISTOR"],
+            }));
+            assert!(r.is_error);
+            assert_eq!(parse_result_json(&r)["status"], "error");
+        }
+    }
 }

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -570,4 +570,239 @@ mod tests {
             .iter()
             .any(|c| c.as_str().unwrap() == "rectangle_count: 1 -> 0"));
     }
+
+    // ==================== per-family count-change detail ====================
+
+    mod field_diffs {
+        use super::*;
+        use crate::altium::pcblib::PcbFlags;
+        use crate::altium::pcblib::{
+            ComponentBody, Layer, Region, Text, TextJustification, TextKind, Track,
+        };
+        use crate::altium::schlib::{FootprintModel, Line, Polyline, Rectangle, ShapeDisplayFlags};
+
+        fn pcb_text() -> Text {
+            Text {
+                x: 0.0,
+                y: 0.6,
+                text: "R".to_string(),
+                height: 0.3,
+                layer: Layer::TopOverlay,
+                rotation: 0.0,
+                kind: TextKind::Stroke,
+                stroke_font: None,
+                stroke_width: None,
+                italic: false,
+                bold: false,
+                mirror: false,
+                is_comment: false,
+                is_designator: false,
+                font_name: "Arial".to_string(),
+                justification: TextJustification::BottomLeft,
+                is_inverted: false,
+                inverted_border: None,
+                use_inverted_rectangle: false,
+                inverted_rect_width: None,
+                inverted_rect_height: None,
+                inverted_rect_text_offset: None,
+                flags: PcbFlags::empty(),
+                net_index: 0xFFFF,
+                polygon_index: 0xFFFF,
+                component_index: -1,
+                unique_id: None,
+            }
+        }
+
+        fn sch_arc() -> crate::altium::schlib::Arc {
+            crate::altium::schlib::Arc {
+                x: 0.0,
+                y: 0.0,
+                radius: 6.0,
+                is_not_accessible: true,
+                start_angle: 0.0,
+                end_angle: 180.0,
+                line_width: 1,
+                color: 0,
+                fill_color: 0,
+                owner_part_id: 1,
+                display_flags: ShapeDisplayFlags::default(),
+                unique_id: None,
+            }
+        }
+
+        fn sch_poly() -> Polyline {
+            Polyline {
+                points: vec![(0.0, 0.0), (5.0, 5.0)],
+                line_width: 1,
+                color: 0,
+                line_style: 0,
+                start_line_shape: 0,
+                end_line_shape: 0,
+                line_shape_size: 0,
+                transparent: false,
+                is_not_accessible: true,
+                owner_part_id: 1,
+                display_flags: ShapeDisplayFlags::default(),
+                unique_id: None,
+            }
+        }
+
+        /// Change strings for the modified component named `name`.
+        fn changes_for(parsed: &serde_json::Value, name: &str) -> Vec<String> {
+            parsed["modified"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|m| m["name"] == name)
+                .expect("modified entry present")["changes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|c| c.as_str().unwrap_or("").to_string())
+                .collect()
+        }
+
+        #[test]
+        fn diff_pcblibs_reports_all_family_count_changes() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path_a = dir.path().join("A.PcbLib");
+            create_test_pcblib(&path_a);
+
+            // B: CHIP_0402 same pads/description but one of each new family;
+            // CHIP_0603 rebuilt identically so it stays unchanged.
+            let mut lib_b = PcbLib::new();
+            let mut fp = Footprint::new("CHIP_0402");
+            fp.description = "0402 chip resistor".to_string();
+            fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+            fp.add_pad(Pad::smd("2", 0.5, 0.0, 0.6, 0.5));
+            fp.add_track(Track::new(-0.5, 0.5, 0.5, 0.5, 0.15, Layer::TopOverlay));
+            fp.add_arc(crate::altium::pcblib::Arc::circle(
+                0.0,
+                0.0,
+                0.5,
+                0.1,
+                Layer::TopOverlay,
+            ));
+            fp.add_region(Region::rectangle(-0.5, -0.5, 0.5, 0.5, Layer::TopOverlay));
+            fp.add_text(pcb_text());
+            fp.add_component_body(ComponentBody::new(
+                "{AAAA0000-0000-0000-0000-000000000000}",
+                "m.step",
+            ));
+            lib_b.add(fp);
+            let mut fp2 = Footprint::new("CHIP_0603");
+            fp2.description = "0603 chip resistor".to_string();
+            fp2.add_pad(Pad::smd("1", -0.8, 0.0, 0.8, 0.8));
+            fp2.add_pad(Pad::smd("2", 0.8, 0.0, 0.8, 0.8));
+            lib_b.add(fp2);
+            let path_b = dir.path().join("B.PcbLib");
+            lib_b.save(&path_b).unwrap();
+
+            let r = server.call_diff_libraries(&json!({
+                "filepath_a": path_a.to_string_lossy(),
+                "filepath_b": path_b.to_string_lossy(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["summary"]["modified_count"], 1);
+            assert_eq!(p["summary"]["unchanged_count"], 1);
+            let changes = changes_for(&p, "CHIP_0402");
+            for expected in [
+                "track_count: 0 -> 1",
+                "arc_count: 0 -> 1",
+                "region_count: 0 -> 1",
+                "text_count: 0 -> 1",
+                "component_body_count: 0 -> 1",
+            ] {
+                assert!(
+                    changes.iter().any(|c| c == expected),
+                    "missing {expected}: {changes:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn diff_pcblibs_lib_b_unreadable_is_error() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path_a = dir.path().join("Good.PcbLib");
+            create_test_pcblib(&path_a);
+            let r = server.call_diff_libraries(&json!({
+                "filepath_a": path_a.to_string_lossy(),
+                "filepath_b": dir.path().join("Missing.PcbLib").to_string_lossy(),
+            }));
+            assert!(r.is_error);
+            assert_eq!(parse_result_json(&r)["status"], "error");
+        }
+
+        #[test]
+        fn diff_schlibs_open_errors_on_either_side() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let good = dir.path().join("Good.SchLib");
+            create_test_schlib(&good);
+            let missing = dir.path().join("Missing.SchLib");
+
+            let a_bad = server.call_diff_libraries(&json!({
+                "filepath_a": missing.to_string_lossy(),
+                "filepath_b": good.to_string_lossy(),
+            }));
+            assert!(a_bad.is_error);
+            let b_bad = server.call_diff_libraries(&json!({
+                "filepath_a": good.to_string_lossy(),
+                "filepath_b": missing.to_string_lossy(),
+            }));
+            assert!(b_bad.is_error);
+        }
+
+        #[test]
+        fn diff_schlibs_reports_all_family_count_changes() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path_a = dir.path().join("A.SchLib");
+            create_test_schlib(&path_a);
+
+            let mut lib_b = SchLib::new();
+            let mut sym = Symbol::new("RESISTOR");
+            sym.description = "Precision resistor".to_string(); // description change
+            sym.designator = "R?".to_string();
+            sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+            sym.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right));
+            sym.add_rectangle(Rectangle::new(-10, -5, 10, 5));
+            sym.add_line(Line::new(-10, 0, 10, 0));
+            sym.add_polyline(sch_poly());
+            sym.add_arc(sch_arc());
+            sym.add_footprint(FootprintModel::new("0402"));
+            lib_b.add(sym);
+            // CAPACITOR identical to fixture -> unchanged.
+            let mut cap = Symbol::new("CAPACITOR");
+            cap.description = "Generic capacitor".to_string();
+            cap.designator = "C?".to_string();
+            cap.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+            cap.add_pin(Pin::new("2", "2", 20, 0, 10, PinOrientation::Right));
+            lib_b.add(cap);
+            let path_b = dir.path().join("B.SchLib");
+            lib_b.save(&path_b).unwrap();
+
+            let r = server.call_diff_libraries(&json!({
+                "filepath_a": path_a.to_string_lossy(),
+                "filepath_b": path_b.to_string_lossy(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let changes = changes_for(&parse_result_json(&r), "RESISTOR");
+            assert!(changes.iter().any(|c| c.starts_with("description:")));
+            for expected in [
+                "line_count: 0 -> 1",
+                "polyline_count: 0 -> 1",
+                "arc_count: 0 -> 1",
+                "footprint_count: 0 -> 1",
+            ] {
+                assert!(
+                    changes.iter().any(|c| c == expected),
+                    "missing {expected}: {changes:?}"
+                );
+            }
+        }
+    }
 }

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -1559,4 +1559,194 @@ mod tests {
         }));
         assert!(result.is_error);
     }
+
+    // ==================== update_component: full-family parse + preview ====================
+
+    mod update_families {
+        use super::*;
+        use serde_json::Value;
+
+        /// A footprint payload carrying one of every 2D primitive family.
+        fn rich_footprint() -> Value {
+            json!({
+                "description": "rich",
+                "pads": [
+                    { "designator": "1", "x": -0.5, "y": 0.0, "width": 0.6, "height": 0.5 },
+                    { "designator": "2", "x": 0.5, "y": 0.0, "width": 0.6, "height": 0.5 }
+                ],
+                "tracks": [{ "x1": -1.0, "y1": -0.6, "x2": 1.0, "y2": -0.6, "width": 0.15, "layer": "Top Overlay" }],
+                "arcs": [{ "x": 0.0, "y": 0.0, "radius": 0.5, "start_angle": 0.0, "end_angle": 90.0, "width": 0.1, "layer": "Top Overlay" }],
+                "regions": [{ "layer": "Top Layer", "kind": "copper",
+                    "vertices": [ {"x": -0.5,"y": -0.5}, {"x": 0.5,"y": -0.5}, {"x": 0.0,"y": 0.5} ] }],
+                "vias": [{ "x": 0.0, "y": 0.0, "diameter": 0.6, "hole_size": 0.3 }],
+                "fills": [{ "x1": -0.3, "y1": -0.3, "x2": 0.3, "y2": 0.3, "layer": "Top Layer" }],
+                "component_bodies": [{ "model_name": "CHIP", "overall_height": 0.5, "standoff_height": 0.0,
+                    "outline": [ {"x": -0.5,"y": -0.25}, {"x": 0.5,"y": -0.25}, {"x": 0.5,"y": 0.25}, {"x": -0.5,"y": 0.25} ] }],
+                "text": [{ "x": 0.0, "y": 0.7, "text": "R1", "height": 0.3, "layer": "Top Overlay" }]
+            })
+        }
+
+        /// A symbol payload carrying one of every schematic primitive family.
+        fn rich_symbol() -> Value {
+            json!({
+                "designator": "R?",
+                "pins": [
+                    { "designator": "1", "name": "1", "x": -20, "y": 0, "length": 10, "orientation": "left" },
+                    { "designator": "2", "name": "2", "x": 20, "y": 0, "length": 10, "orientation": "right" }
+                ],
+                "polylines": [{ "points": [ {"x": -10,"y": 0}, {"x": 0,"y": 5}, {"x": 10,"y": 0} ] }],
+                "arcs": [{ "x": 0, "y": 0, "radius": 8, "start_angle": 0.0, "end_angle": 180.0 }],
+                "ellipses": [{ "x": 0, "y": 0, "radius_x": 6, "radius_y": 4 }],
+                "round_rects": [{ "x1": -10, "y1": -6, "x2": 10, "y2": 6, "corner_x_radius": 2, "corner_y_radius": 2 }],
+                "polygons": [{ "points": [ {"x": -5,"y": -5}, {"x": 5,"y": -5}, {"x": 0,"y": 5} ] }],
+                "labels": [{ "x": 0, "y": 12, "text": "R" }],
+                "text": [{ "x": 0, "y": -12, "text": "note" }],
+                "pies": [{ "x": 0, "y": 0, "radius": 5, "start_angle": 0.0, "end_angle": 90.0 }],
+                "images": [{ "x1": -8, "y1": -8, "x2": 8, "y2": 8, "file_name": "img.png" }],
+                "text_frames": [{ "x1": -12, "y1": -14, "x2": 12, "y2": -10, "text": "frame" }]
+            })
+        }
+
+        fn change_strings(parsed: &Value) -> Vec<String> {
+            parsed["changes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|c| c.as_str().unwrap_or("").to_string())
+                .collect()
+        }
+
+        #[test]
+        fn update_pcblib_parses_all_primitive_families() {
+            use crate::altium::PcbLib;
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("UpdRich.PcbLib");
+            create_test_pcblib(&path);
+
+            let r = server.call_update_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "CHIP_0402",
+                "footprint": rich_footprint(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "success");
+            assert_eq!(p["old_description"], "0402 chip resistor");
+
+            let lib = PcbLib::open(&path).unwrap();
+            let fp = lib.get("CHIP_0402").unwrap();
+            assert_eq!(fp.tracks.len(), 1);
+            assert_eq!(fp.arcs.len(), 1);
+            assert_eq!(fp.regions.len(), 1);
+            assert_eq!(fp.vias.len(), 1);
+            assert_eq!(fp.fills.len(), 1);
+            assert_eq!(fp.component_bodies.len(), 1);
+            assert_eq!(fp.text.len(), 1);
+        }
+
+        #[test]
+        fn update_pcblib_dry_run_previews_all_family_counts() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("UpdRichDry.PcbLib");
+            create_test_pcblib(&path);
+            let r = server.call_update_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "CHIP_0402",
+                "dry_run": true,
+                "footprint": rich_footprint(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "dry_run");
+            let changes = change_strings(&p);
+            for expected in [
+                "track_count: 0 -> 1",
+                "arc_count: 0 -> 1",
+                "region_count: 0 -> 1",
+                "text_count: 0 -> 1",
+                "via_count: 0 -> 1",
+                "fill_count: 0 -> 1",
+                "component_body_count: 0 -> 1",
+            ] {
+                assert!(
+                    changes.iter().any(|c| c == expected),
+                    "missing {expected}: {changes:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn update_schlib_parses_all_primitive_families() {
+            use crate::altium::SchLib;
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("UpdRich.SchLib");
+            create_test_schlib(&path);
+
+            let r = server.call_update_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "symbol": rich_symbol(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "success");
+            assert_eq!(p["old_description"], "Generic resistor");
+
+            let lib = SchLib::open(&path).unwrap();
+            let sym = lib.get("RESISTOR").unwrap();
+            assert_eq!(sym.polylines.len(), 1);
+            assert_eq!(sym.arcs.len(), 1);
+            assert_eq!(sym.ellipses.len(), 1);
+            assert_eq!(sym.round_rects.len(), 1);
+            assert_eq!(sym.polygons.len(), 1);
+            assert_eq!(sym.labels.len(), 1);
+            assert_eq!(sym.pies.len(), 1);
+        }
+
+        #[test]
+        fn update_schlib_dry_run_previews_designator_and_families() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("UpdRichDry.SchLib");
+            create_test_schlib(&path);
+            let r = server.call_update_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "dry_run": true,
+                "symbol": {
+                    "designator": "RN?",
+                    "part_count": 4,
+                    "pins": [{ "designator": "1", "name": "1", "x": -20, "y": 0, "length": 10 }],
+                    "lines": [{ "x1": -10, "y1": 0, "x2": 10, "y2": 0 }],
+                    "polylines": [{ "points": [ {"x":-5,"y":0}, {"x":5,"y":0} ] }],
+                    "arcs": [{ "x": 0, "y": 0, "radius": 5 }],
+                    "labels": [{ "x": 0, "y": 10, "text": "R" }],
+                    "parameters": [{ "name": "Tol", "value": "1%" }],
+                },
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "dry_run");
+            let changes = change_strings(&p);
+            for expected in [
+                "designator: 'R?' -> 'RN?'",
+                "part_count: 1 -> 4",
+                "pin_count: 2 -> 1",
+                "line_count: 0 -> 1",
+                "polyline_count: 0 -> 1",
+                "arc_count: 0 -> 1",
+                "rectangle_count: 1 -> 0",
+                "label_count: 0 -> 1",
+                "parameter_count: 0 -> 1",
+            ] {
+                assert!(
+                    changes.iter().any(|c| c == expected),
+                    "missing {expected}: {changes:?}"
+                );
+            }
+        }
+    }
 }

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -853,4 +853,203 @@ mod tests {
             "Missing required parameter: filepath"
         );
     }
+
+    // ==================== extract deep paths ====================
+
+    mod extract_deep {
+        use super::*;
+
+        /// A library whose footprint references a body model id with no matching
+        /// embedded model (dangling reference; `library.models()` stays empty).
+        fn lib_with_dangling_body(path: &std::path::Path, model_id: &str) {
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("QFN16");
+            fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.3, 0.8));
+            fp.add_component_body(ComponentBody::new(model_id, "ghost.step"));
+            lib.add(fp);
+            lib.save(path).unwrap();
+        }
+
+        #[test]
+        fn extract_corrupt_library_is_error() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Corrupt.PcbLib");
+            std::fs::write(&path, b"not a compound file").unwrap();
+            let r = server.call_extract_step_model(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+            assert_eq!(parse_result_json(&r)["status"], "error");
+        }
+
+        #[test]
+        fn extract_reports_component_body_and_external_references() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Refs.PcbLib");
+            lib_with_dangling_body(&path, "{DEAD0000-0000-0000-0000-000000000000}");
+
+            let r = server.call_extract_step_model(&json!({ "filepath": path.to_string_lossy() }));
+            assert!(r.is_error);
+            let p = parse_result_json(&r);
+            assert_eq!(p["error"], "No embedded 3D models found in this library.");
+            assert!(p["component_body_references"].is_array());
+            assert!(p["external_model_references"].is_array());
+            assert!(p["note"]
+                .as_str()
+                .unwrap_or("")
+                .contains("Component bodies reference"));
+        }
+
+        #[test]
+        fn extract_all_validate_path_push_error() {
+            let temp = test_temp_dir();
+            let server = create_test_server(temp.path());
+            let outside = test_temp_dir(); // not in the allow-list
+            let out = outside.path().join("out");
+            let out_s = out.to_string_lossy();
+
+            let m = EmbeddedModel::new(
+                "{ID000000-0000-0000-0000-000000000000}",
+                "m.step",
+                b"x".to_vec(),
+            );
+            let models = [&m];
+            let r = server.extract_all_step_models("lib.PcbLib", Some(out_s.as_ref()), &models);
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "partial");
+            assert_eq!(p["extracted_count"], 0);
+            assert_eq!(p["error_count"], 1);
+        }
+
+        #[test]
+        fn extract_all_fs_write_error_is_partial() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Models.PcbLib");
+            create_model_pcblib(&path); // modelA.step + modelB.step
+            let out_dir = dir.path().join("out");
+            // A directory sitting where modelA.step should be written -> write fails.
+            std::fs::create_dir_all(out_dir.join("modelA.step")).unwrap();
+
+            let r = server.call_extract_step_model(&json!({
+                "filepath": path.to_string_lossy(),
+                "mode": "extract_all",
+                "output_path": out_dir.to_string_lossy(),
+            }));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "partial");
+            assert!(p["error_count"].as_u64().unwrap() >= 1);
+        }
+
+        #[test]
+        fn extract_by_footprint_referenced_ids_not_found() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Mismatch.PcbLib");
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("QFN16");
+            fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.3, 0.8));
+            fp.add_component_body(ComponentBody::new(
+                "{NONEXIST-0000-0000-0000-000000000000}",
+                "ghost.step",
+            ));
+            lib.add(fp);
+            lib.add_model(EmbeddedModel::new(
+                "{REAL0000-0000-0000-0000-000000000000}",
+                "real.step",
+                b"data".to_vec(),
+            ));
+            lib.save(&path).unwrap();
+
+            let r = server.call_extract_step_model(&json!({
+                "filepath": path.to_string_lossy(),
+                "mode": "extract_by_footprint",
+                "footprint_name": "QFN16",
+            }));
+            assert!(r.is_error);
+            assert_eq!(
+                parse_result_json(&r)["error"],
+                "Referenced model IDs not found in embedded models"
+            );
+        }
+
+        #[test]
+        fn extract_by_footprint_multiple_models_lists() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Multi.PcbLib");
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("QFN16");
+            fp.add_pad(Pad::smd("1", -1.0, 0.0, 0.3, 0.8));
+            fp.add_component_body(ComponentBody::new(MODEL_A_ID, "modelA.step"));
+            fp.add_component_body(ComponentBody::new(MODEL_B_ID, "modelB.step"));
+            lib.add(fp);
+            lib.add_model(EmbeddedModel::new(
+                MODEL_A_ID,
+                "modelA.step",
+                MODEL_A_DATA.to_vec(),
+            ));
+            lib.add_model(EmbeddedModel::new(
+                MODEL_B_ID,
+                "modelB.step",
+                MODEL_B_DATA.to_vec(),
+            ));
+            lib.save(&path).unwrap();
+
+            let r = server.call_extract_step_model(&json!({
+                "filepath": path.to_string_lossy(),
+                "mode": "extract_by_footprint",
+                "footprint_name": "QFN16",
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "list");
+            assert_eq!(p["model_count"], 2);
+        }
+
+        #[test]
+        fn extract_by_footprint_with_output_extracts() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("ByFp.PcbLib");
+            create_model_pcblib(&path); // QFN16 -> modelA.step
+            let out_dir = dir.path().join("fp_export");
+
+            let r = server.call_extract_step_model(&json!({
+                "filepath": path.to_string_lossy(),
+                "mode": "extract_by_footprint",
+                "footprint_name": "QFN16",
+                "output_path": out_dir.to_string_lossy(),
+            }));
+            assert!(!r.is_error, "{}", get_result_text(&r));
+            assert_eq!(parse_result_json(&r)["status"], "success");
+            assert_eq!(
+                std::fs::read(out_dir.join("modelA.step")).unwrap(),
+                MODEL_A_DATA
+            );
+        }
+
+        #[test]
+        fn extract_model_output_write_error() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Single.PcbLib");
+            create_model_pcblib(&path);
+            let out_as_dir = dir.path().join("outdir");
+            std::fs::create_dir(&out_as_dir).unwrap(); // write target is a directory
+
+            let r = server.call_extract_step_model(&json!({
+                "filepath": path.to_string_lossy(),
+                "model": "modelA.step",
+                "output_path": out_as_dir.to_string_lossy(),
+            }));
+            assert!(r.is_error);
+            let p = parse_result_json(&r);
+            assert_eq!(p["status"], "error");
+            assert!(p["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("Failed to write file"));
+        }
+    }
 }


### PR DESCRIPTION
## What

Fourth coverage installment (follows #263–#265). Covers the JSON-RPC protocol helpers plus the remaining tool handlers' untested **success** branches. Tests only; no production change. Overall line coverage now **92.5%**.

## Coverage delta (local `cargo llvm-cov --workspace`)

| File | Before | After |
|---|---|---|
| `mcp/protocol.rs` | 73% | **97.4%** |
| `mcp/tools/components.rs` | 85.4% | **94.5%** |
| `mcp/tools/query_update.rs` | 86.9% | **95.5%** |
| `mcp/tools/diff.rs` | 83.8% | **99.8%** |
| `mcp/tools/step.rs` | 87.9% | **98.7%** |
| **Overall (lines)** | 91.12% | **92.49%** |
| **Overall (functions)** | 90.35% | **91.03%** |

## What's now covered

- **protocol.rs** — `OutgoingNotification::progress`, `ErrorCode::code`/`default_message` for every variant (incl. `ServerError`), `JsonRpcErrorData::with_data`, all the `JsonRpcError` constructors, and the `IncomingMessage` `method`/`params`/`id` accessors for both request and notification.
- **components.rs** — schlib copy dry-run, pcblib rename dry-run, cross-library copy with a missing embedded model (ignored + error variants), preserved external paths, copy into an existing target (both types), merge type-mismatch rejection, merge-rename into an existing target exercising the dedupe counter loop (both types), schlib merge skip+dry-run, and reorder error branches.
- **query_update.rs** — `update_component` parsing every primitive family for both PcbLib footprints and SchLib symbols, plus the dry-run preview change-strings (`track_count: 0 -> 1`, `designator: 'R?' -> 'RN?'`, …).
- **diff.rs** — per-family count-change detail for both library types (tracks/arcs/regions/text/component-bodies; lines/polylines/arcs/footprints/description) and open-errors on either side.
- **step.rs** — corrupt-library error, the component-body/external-reference note paths, `extract_all` validate-path + fs-write partial-failure branches, `extract_by_footprint` (referenced-ids-not-found / multi-model list / with-output extract), and `extract_model_output` write error.

## Approach

Four read-only analysis agents mapped the exact uncovered branches into compile-ready recipes. Protocol tests call the constructors/accessors directly; handler tests use the `test_support` fixtures and write→read round-trips, with small helper builders for the few primitives lacking constructors (pcblib `Text`, schlib `Arc`/`Polyline`). The one branch the JSON handler guards against up front (`extract_all`'s per-model `validate_path`) is exercised via a direct `pub(crate)` helper call.

## Verification

- `cargo test` — all pass (**683** lib tests, +34; every other target green)
- `cargo clippy --all-targets --all-features` — clean under the pedantic/nursery `-D warnings` gate
- `cargo fmt --all --check` — clean

## Coverage arc

Original **87.34%** → #263 **88.0%** → #264 **89.7%** → #265 **91.1%** → this **92.5%** line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)