### PR TITLE
test: cover Layer/PinSymbol/pad-mode enums and text constructors

### DIFF
--- a/src/altium/pcblib/primitives/layer.rs
+++ b/src/altium/pcblib/primitives/layer.rs
@@ -595,3 +595,160 @@ impl Layer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Layer;
+
+    /// Every `Layer` variant, mirroring the `as_str`/`parse` match arms.
+    const ALL: &[Layer] = &[
+        Layer::TopLayer,
+        Layer::MidLayer1,
+        Layer::MidLayer2,
+        Layer::MidLayer3,
+        Layer::MidLayer4,
+        Layer::MidLayer5,
+        Layer::MidLayer6,
+        Layer::MidLayer7,
+        Layer::MidLayer8,
+        Layer::MidLayer9,
+        Layer::MidLayer10,
+        Layer::MidLayer11,
+        Layer::MidLayer12,
+        Layer::MidLayer13,
+        Layer::MidLayer14,
+        Layer::MidLayer15,
+        Layer::MidLayer16,
+        Layer::MidLayer17,
+        Layer::MidLayer18,
+        Layer::MidLayer19,
+        Layer::MidLayer20,
+        Layer::MidLayer21,
+        Layer::MidLayer22,
+        Layer::MidLayer23,
+        Layer::MidLayer24,
+        Layer::MidLayer25,
+        Layer::MidLayer26,
+        Layer::MidLayer27,
+        Layer::MidLayer28,
+        Layer::MidLayer29,
+        Layer::MidLayer30,
+        Layer::BottomLayer,
+        Layer::MultiLayer,
+        Layer::TopOverlay,
+        Layer::BottomOverlay,
+        Layer::TopSolder,
+        Layer::BottomSolder,
+        Layer::InternalPlane1,
+        Layer::InternalPlane2,
+        Layer::InternalPlane3,
+        Layer::InternalPlane4,
+        Layer::InternalPlane5,
+        Layer::InternalPlane6,
+        Layer::InternalPlane7,
+        Layer::InternalPlane8,
+        Layer::InternalPlane9,
+        Layer::InternalPlane10,
+        Layer::InternalPlane11,
+        Layer::InternalPlane12,
+        Layer::InternalPlane13,
+        Layer::InternalPlane14,
+        Layer::InternalPlane15,
+        Layer::InternalPlane16,
+        Layer::DrillGuide,
+        Layer::DrillDrawing,
+        Layer::TopPaste,
+        Layer::BottomPaste,
+        Layer::TopAssembly,
+        Layer::BottomAssembly,
+        Layer::TopCourtyard,
+        Layer::BottomCourtyard,
+        Layer::Top3DBody,
+        Layer::Bottom3DBody,
+        Layer::Mechanical1,
+        Layer::Mechanical2,
+        Layer::Mechanical3,
+        Layer::Mechanical4,
+        Layer::Mechanical5,
+        Layer::Mechanical6,
+        Layer::Mechanical7,
+        Layer::Mechanical8,
+        Layer::Mechanical9,
+        Layer::Mechanical10,
+        Layer::Mechanical11,
+        Layer::Mechanical12,
+        Layer::Mechanical13,
+        Layer::Mechanical14,
+        Layer::Mechanical15,
+        Layer::Mechanical16,
+        Layer::Mechanical17,
+        Layer::Mechanical18,
+        Layer::Mechanical19,
+        Layer::Mechanical20,
+        Layer::Mechanical21,
+        Layer::Mechanical22,
+        Layer::Mechanical23,
+        Layer::Mechanical24,
+        Layer::Mechanical25,
+        Layer::Mechanical26,
+        Layer::Mechanical27,
+        Layer::Mechanical28,
+        Layer::Mechanical29,
+        Layer::Mechanical30,
+        Layer::Mechanical31,
+        Layer::Mechanical32,
+        Layer::ConnectLayer,
+        Layer::BackgroundLayer,
+        Layer::DRCErrorLayer,
+        Layer::HighlightLayer,
+        Layer::GridColor1,
+        Layer::GridColor10,
+        Layer::PadHoleLayer,
+        Layer::ViaHoleLayer,
+        Layer::TopPadMaster,
+        Layer::BottomPadMaster,
+        Layer::DRCDetailLayer,
+        Layer::KeepOut,
+    ];
+
+    #[test]
+    fn every_variant_round_trips_through_as_str_and_parse() {
+        for layer in ALL {
+            let name = layer.as_str();
+            assert_eq!(
+                Layer::parse(name),
+                Some(*layer),
+                "'{name}' did not round-trip"
+            );
+            // Names are never empty and carry no leading/trailing whitespace.
+            assert!(!name.is_empty());
+            assert_eq!(name.trim(), name);
+        }
+    }
+
+    #[test]
+    fn all_layer_names_are_unique() {
+        let mut names: Vec<&str> = ALL.iter().map(Layer::as_str).collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count, "duplicate layer name string");
+    }
+
+    #[test]
+    fn parse_rejects_unknown_names() {
+        assert_eq!(Layer::parse(""), None);
+        assert_eq!(Layer::parse("Not A Real Layer"), None);
+        // Layer::parse is exact — space-less aliases are not accepted here.
+        assert_eq!(Layer::parse("TopLayer"), None);
+        assert_eq!(Layer::parse("top layer"), None);
+    }
+
+    #[test]
+    fn default_is_a_known_layer() {
+        // The derived Default must be one of the enumerated variants.
+        let d = Layer::default();
+        assert!(ALL.contains(&d));
+        assert_eq!(Layer::parse(d.as_str()), Some(d));
+    }
+}

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -815,3 +815,39 @@ impl Via {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{MaskExpansionMode, PowerPlaneConnectStyle};
+
+    #[test]
+    fn mask_expansion_mode_round_trips_and_defaults() {
+        for (id, mode) in [
+            (0, MaskExpansionMode::None),
+            (1, MaskExpansionMode::FromRule),
+            (2, MaskExpansionMode::Manual),
+        ] {
+            assert_eq!(MaskExpansionMode::from_id(id), mode);
+            assert_eq!(mode.to_id(), id);
+        }
+        // Unknown bytes fall back to the design-rule default.
+        assert_eq!(MaskExpansionMode::from_id(99), MaskExpansionMode::FromRule);
+    }
+
+    #[test]
+    fn power_plane_connect_style_round_trips_and_defaults() {
+        for (id, style) in [
+            (0, PowerPlaneConnectStyle::Relief),
+            (1, PowerPlaneConnectStyle::Direct),
+            (2, PowerPlaneConnectStyle::NoConnect),
+        ] {
+            assert_eq!(PowerPlaneConnectStyle::from_id(id), style);
+            assert_eq!(style.to_id(), id);
+        }
+        // Unknown bytes fall back to thermal relief (Altium's default).
+        assert_eq!(
+            PowerPlaneConnectStyle::from_id(99),
+            PowerPlaneConnectStyle::Relief
+        );
+    }
+}

--- a/src/altium/schlib/primitives/pins.rs
+++ b/src/altium/schlib/primitives/pins.rs
@@ -436,4 +436,30 @@ mod tests {
             assert_eq!(etype.to_id(), id);
         }
     }
+
+    #[test]
+    fn pin_electrical_type_unknown_id_defaults_to_passive() {
+        assert_eq!(PinElectricalType::from_id(99), PinElectricalType::Passive);
+    }
+
+    #[test]
+    fn pin_orientation_up_and_down_flags() {
+        assert_eq!(PinOrientation::Up.to_flags(), (true, false));
+        assert_eq!(PinOrientation::Down.to_flags(), (true, true));
+    }
+
+    #[test]
+    fn pin_symbol_round_trips_all_ids() {
+        for id in 0..=21 {
+            assert_eq!(
+                PinSymbol::from_id(id).to_id(),
+                id,
+                "id {id} did not round-trip"
+            );
+        }
+        // Out-of-range ids fall back to the undecorated symbol (id 0).
+        assert_eq!(PinSymbol::from_id(99), PinSymbol::None);
+        assert_eq!(PinSymbol::from_id(255), PinSymbol::None);
+        assert_eq!(PinSymbol::None.to_id(), 0);
+    }
 }

--- a/src/altium/schlib/primitives/text.rs
+++ b/src/altium/schlib/primitives/text.rs
@@ -352,3 +352,30 @@ impl Parameter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Parameter, TextFrame};
+
+    #[test]
+    fn text_frame_new_stores_geometry_text_and_defaults() {
+        let tf = TextFrame::new(-10, -5, 10, 5, "hello");
+        assert_eq!(tf.text, "hello");
+        assert!((tf.x1 - -10.0).abs() < 1e-9);
+        assert!((tf.y2 - 5.0).abs() < 1e-9);
+        // Documented defaults.
+        assert!(tf.show_border);
+        assert!(tf.word_wrap);
+        assert!(tf.clip_to_rect);
+        assert_eq!(tf.owner_part_id, 1);
+    }
+
+    #[test]
+    fn parameter_new_stores_name_value_and_defaults() {
+        let p = Parameter::new("Value", "10k");
+        assert_eq!(p.name, "Value");
+        assert_eq!(p.value, "10k");
+        assert!(!p.hidden);
+        assert_eq!(p.owner_part_id, 1);
+    }
+}


### PR DESCRIPTION
## What

Sixth coverage installment — the format-layer primitive enums that had little or no direct unit coverage. Tests only; no production change.

## Coverage delta (local `cargo llvm-cov --workspace`)

| File | Before | After |
|---|---|---|
| `pcblib/primitives/layer.rs` | 53.8% | **100%** |
| `schlib/primitives/pins.rs` | 76.9% | **100%** |
| `pcblib/primitives/pads.rs` | 89.5% | **91.6%** |
| `schlib/primitives/text.rs` | 71.9% | **89.7%** |
| **Overall (lines)** | ~92.5% | **93.5%** |

## What's now covered

- **layer.rs** — the standout: round-trips **every one of the 107 `Layer` variants** through `as_str → parse` (covering both giant inverse match arms), asserts all name strings are unique and whitespace-clean, checks exact-parse rejection of unknown and space-less names, and the derived `Default`.
- **pins.rs** — `PinSymbol::from_id`/`to_id` across all 22 ids plus the unknown-id fallback, `PinOrientation` Up/Down flags, and the `PinElectricalType` unknown-id default.
- **pads.rs** — `MaskExpansionMode` and `PowerPlaneConnectStyle` `from_id`/`to_id` round-trips and their unknown-byte defaults (the file previously had no tests).
- **text.rs** — `TextFrame::new` and `Parameter::new` field/default coverage.

## Verification

- `cargo test` — all pass (**707** lib tests, +11; every other target green)
- `cargo clippy --all-targets --all-features` — clean under the pedantic/nursery `-D warnings` gate
- `cargo fmt --all --check` — clean

## Coverage arc

Original **87.34%** → #263–#267 → this **93.5%** line coverage. The remaining gaps are format-layer read/write byte plumbing (`reader/parsers.rs`, `writer.rs`, `read_io.rs`) — already well-exercised by the round-trip integration tests — and the `main.rs` / `run_with_shutdown` entry points that need real stdin/signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)