### PR TITLE
test: cover pcblib text/fill helpers and batch_update operations

### DIFF
--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -318,3 +318,39 @@ impl Fill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Fill, Layer, StrokeFont, TextKind};
+
+    #[test]
+    fn fill_from_center_computes_symmetric_corners() {
+        let f = Fill::from_center(1.0, 2.0, 4.0, 2.0, Layer::TopLayer);
+        assert!((f.x1 - -1.0).abs() < 1e-9);
+        assert!((f.y1 - 1.0).abs() < 1e-9);
+        assert!((f.x2 - 3.0).abs() < 1e-9);
+        assert!((f.y2 - 3.0).abs() < 1e-9);
+        assert_eq!(f.layer, Layer::TopLayer);
+        assert!((f.rotation - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn text_kind_serde_round_trips_every_variant() {
+        for k in [TextKind::Stroke, TextKind::TrueType, TextKind::BarCode] {
+            let s = serde_json::to_string(&k).unwrap();
+            assert_eq!(serde_json::from_str::<TextKind>(&s).unwrap(), k);
+        }
+    }
+
+    #[test]
+    fn stroke_font_serde_round_trips_every_variant() {
+        for font in [
+            StrokeFont::Default,
+            StrokeFont::SansSerif,
+            StrokeFont::Serif,
+        ] {
+            let s = serde_json::to_string(&font).unwrap();
+            assert_eq!(serde_json::from_str::<StrokeFont>(&s).unwrap(), font);
+        }
+    }
+}

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -878,4 +878,121 @@ mod tests {
             );
         }
     }
+
+    // ==================== operation success paths ====================
+
+    #[test]
+    fn batch_update_track_width_changes_matching_tracks() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Tracks.PcbLib");
+        create_tracked_pcblib(&path);
+
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "update_track_width",
+            "parameters": { "from_width": 0.2, "to_width": 0.25 },
+        }));
+        assert!(!r.is_error, "{}", get_result_text(&r));
+        let p = parse_result_json(&r);
+        assert_eq!(p["operation"], "update_track_width");
+        assert_eq!(p["dry_run"], false);
+
+        // The 0.2 mm tracks were widened; the 0.3 mm Mechanical1 track is untouched.
+        let lib = PcbLib::open(&path).unwrap();
+        let widened = lib
+            .iter()
+            .flat_map(|fp| fp.tracks.iter())
+            .filter(|t| (t.width - 0.25).abs() < 1e-4)
+            .count();
+        assert_eq!(widened, 3);
+    }
+
+    #[test]
+    fn batch_update_track_width_dry_run_leaves_file_untouched() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("TracksDry.PcbLib");
+        create_tracked_pcblib(&path);
+
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "update_track_width",
+            "parameters": { "from_width": 0.2, "to_width": 0.25 },
+            "dry_run": true,
+        }));
+        assert!(!r.is_error, "{}", get_result_text(&r));
+        assert_eq!(parse_result_json(&r)["dry_run"], true);
+
+        // Nothing was written: the 0.2 mm tracks survive unchanged.
+        let lib = PcbLib::open(&path).unwrap();
+        let unchanged = lib
+            .iter()
+            .flat_map(|fp| fp.tracks.iter())
+            .filter(|t| (t.width - 0.2).abs() < 1e-4)
+            .count();
+        assert_eq!(unchanged, 3);
+    }
+
+    #[test]
+    fn batch_rename_layer_moves_primitives() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Rename.PcbLib");
+        create_tracked_pcblib(&path);
+
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "rename_layer",
+            "parameters": { "from_layer": "Top Overlay", "to_layer": "Bottom Overlay" },
+        }));
+        assert!(!r.is_error, "{}", get_result_text(&r));
+        assert_eq!(parse_result_json(&r)["operation"], "rename_layer");
+
+        let lib = PcbLib::open(&path).unwrap();
+        let on_top = lib
+            .iter()
+            .flat_map(|fp| fp.tracks.iter())
+            .filter(|t| t.layer == Layer::TopOverlay)
+            .count();
+        assert_eq!(on_top, 0, "all Top Overlay tracks were moved");
+    }
+
+    #[test]
+    fn batch_rename_layer_rejects_invalid_layer() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("BadLayer.PcbLib");
+        create_tracked_pcblib(&path);
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "rename_layer",
+            "parameters": { "from_layer": "Nonexistent Layer", "to_layer": "Bottom Overlay" },
+        }));
+        assert!(r.is_error);
+        assert!(get_result_text(&r).contains("Invalid from_layer"));
+    }
+
+    #[test]
+    fn batch_update_schlib_parameters_adds_parameter() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Params.SchLib");
+        create_test_schlib(&path);
+
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "update_parameters",
+            "parameters": { "param_name": "Tolerance", "param_value": "1%", "add_if_missing": true },
+        }));
+        assert!(!r.is_error, "{}", get_result_text(&r));
+        assert_eq!(parse_result_json(&r)["operation"], "update_parameters");
+
+        let lib = SchLib::open(&path).unwrap();
+        let has_param = lib
+            .iter()
+            .flat_map(|s| s.parameters.iter())
+            .any(|p| p.name == "Tolerance" && p.value == "1%");
+        assert!(has_param, "the parameter was added to at least one symbol");
+    }
 }


### PR DESCRIPTION
## What

Seventh coverage installment. Covers the pcblib `Fill`/text enums and the `batch_update` operation success paths. Tests only; no production change.

## Coverage delta (local `cargo llvm-cov --workspace`)

| File | Before | After |
|---|---|---|
| `pcblib/primitives/text.rs` | 51.0% | **91.9%** |
| `mcp/tools/batch.rs` | 94.3% | **95.2%** |
| **Overall (lines)** | ~93.0% | **93.6%** |

## What's now covered

- **pcblib text.rs** — `Fill::from_center` (symmetric corner computation) and `TextKind` / `StrokeFont` serde round-trips over every variant (the file previously had no tests).
- **batch.rs** — the operation success paths the existing arg-validation tests skipped: `update_track_width` (matching-track selection + a dry-run that leaves the file untouched), `rename_layer` (moving primitives between layers + invalid-layer rejection), and `update_parameters` through the handler dispatch.

## Verification

- `cargo test` — all pass (**715** lib tests; every other target green)
- `cargo clippy --all-targets --all-features` — clean under the pedantic/nursery `-D warnings` gate
- `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)