### PR TITLE
ci: fail loudly on Codecov upload errors (badge frozen by an invalid token)

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -239,16 +239,15 @@ jobs:
                     target/
                 key: rust-coverage-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.toml') }}
 
+            # The token is mandatory despite the org's "upload tokens not
+            # required" setting: Codecov rejects tokenless uploads for a
+            # protected branch ("Token required because branch is protected").
             - name: Upload coverage to Codecov
               if: github.actor != 'dependabot[bot]'
               uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
               with:
                 files: lcov.info
-                # Don't fail CI on Codecov-side errors (e.g. the repository not
-                # yet being activated on codecov.io — a 404 on upload). Coverage
-                # is still computed and uploaded; flip to true once Codecov
-                # reporting is confirmed working.
-                fail_ci_if_error: false
+                fail_ci_if_error: true
                 verbose: true
               env:
                 CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -200,19 +200,14 @@ jobs:
             - name: Generate coverage summary
               run: cargo llvm-cov report --summary-only
 
-            # Skip the Codecov upload on Dependabot PRs: Dependabot runs with a
-            # read-only token, so secrets.CODECOV_TOKEN resolves to empty and the
-            # upload would fail. The coverage computation above still runs.
+            # The token is mandatory (see ci_main.yml). Dependabot cannot read
+            # secrets, so its PRs would fail the upload — skip them instead.
             - name: Upload coverage to Codecov
               if: github.actor != 'dependabot[bot]'
               uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
               with:
                 files: lcov.info
-                # Don't fail CI on Codecov-side errors (e.g. the repository not
-                # yet being activated on codecov.io — a 404 on upload). Coverage
-                # is still computed and uploaded; flip to true once Codecov
-                # reporting is confirmed working.
-                fail_ci_if_error: false
+                fail_ci_if_error: true
                 verbose: true
               env:
                 CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -46,9 +46,5 @@ ignore:
     - "docs/"
     # CLI entry point — uses clap, a Tokio runtime and std::process::ExitCode
     # which cannot be unit-tested without forking the process. Functionality
-    # is covered end-to-end by the Python integration tests in tests/integration/.
+    # is covered end-to-end by tests/mcp_e2e.rs, which spawns the real binary.
     - "src/main.rs"
-    # Stdio transport — async I/O wrapping tokio::io::stdin()/stdout(). Cannot
-    # be unit-tested without invasive refactoring to inject readers/writers.
-    # Behaviour is exercised end-to-end by the Python integration tests.
-    - "src/mcp/transport.rs"


### PR DESCRIPTION
## The bug

README badge shows **65.64%**; real coverage is **93.6%**. It's frozen at commit `672594a` (~30 Jun) because **every upload since then has failed**:

```
Upload queued for processing failed: {"message":"Repository not found"}   (HTTP 404)
```

`fail_ci_if_error: false` swallowed it — CI stayed green while Codecov received nothing for two weeks.

## Root cause: the token is dead

The repo **is** onboarded (19,468 tracked lines, data through 30 Jun). The **`CODECOV_TOKEN` secret** (set 2026-06-18) is no longer valid for it. Codecov resolves the repository **from the upload token**, so a dead token surfaces as `404 "Repository not found"` — which is what made this look like a missing repo.

**Proof** (from this PR's first CI run, which tried a tokenless upload):

```
HTTP 400: {"message":"Token required because branch is protected"}
```

Two things follow:
1. Codecov resolves the repo **fine from the slug** → the repo exists; only the *token* fails to resolve → the token is invalid.
2. **Tokenless is not an option here** — Codecov rejects it for a protected branch. The org's "upload tokens not required" setting does **not** override this. So a valid token is mandatory.

> Why does the sibling `git-proxy-mcp` work? It's under the personal `MatejGomboc` account with its own still-valid token — a different Codecov owner, unaffected by whatever invalidated this one.

## ⚠️ What you need to do (not fixable in code)

Regenerate the token — **Codecov → `embedded-society/altium-designer-mcp` → Configuration → General → upload token** — and update the repo secret `CODECOV_TOKEN`. That is the fix; no code change substitutes for it.

## What this PR does

Stops the failure from hiding:

- **`fail_ci_if_error: true`** — a broken upload now fails loudly instead of letting the badge silently rot. This is precisely what cost two weeks.
- **codecov.yml**: stop ignoring `src/mcp/transport.rs` (now ~95% covered via the `cfg(test)` capture sink from #263 — ignoring it understated the repo), and refresh the `src/main.rs` note; the Python integration tests it cited were ported to `tests/mcp_e2e.rs` in #262.
- Token env and Dependabot skip **kept** — the token is required, and Dependabot can't read secrets.

## Expect this PR to be RED until the token is regenerated

That is the point of the change. Sequence:

1. Regenerate the token + update the `CODECOV_TOKEN` secret.
2. Re-run this PR's CI → Code Coverage goes green (proving the token works).
3. Merge → next `main` run pushes ~93.6% → badge updates.

If you'd rather merge the codecov.yml cleanup first and fix the token later, say so and I'll split it — but then the upload stays silently broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)