### PR TITLE
fix(mcp): scope write_schlib geometry echo to the symbols written

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2226,6 +2226,49 @@ mod tests {
         assert!(lib.get("NEW_SYM").is_some());
     }
 
+    #[test]
+    fn write_schlib_geometry_echo_covers_only_written_symbols() {
+        // The geometry echo exists so the caller can verify the pins it just wrote.
+        // It previously walked the whole library, so an `append: true` sequence
+        // re-echoed every pre-existing symbol and the response grew quadratically
+        // with the number of appends. Assert it is scoped to this call's symbols.
+        let temp = test_temp_dir();
+        let lib_path = temp.path().join("geom_scope.SchLib");
+        create_test_schlib(&lib_path); // seeds RESISTOR + CAPACITOR
+
+        let server = create_test_server(temp.path());
+        let args = json!({
+            "filepath": lib_path.to_string_lossy(),
+            "symbols": [{
+                "name": "APPENDED",
+                "designator": "X?",
+                "pins": [{"designator": "1", "name": "A", "x": -30, "y": 0,
+                          "length": 10, "orientation": "left"}]
+            }],
+            "append": true
+        });
+
+        let result = server.call_write_schlib(&args);
+        assert!(
+            !result.is_error,
+            "append must succeed, got: {}",
+            get_result_text(&result)
+        );
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(get_result_text(&result)).expect("response is JSON");
+        let geometry = parsed["geometry"].as_array().expect("geometry array");
+        let names: Vec<&str> = geometry.iter().filter_map(|g| g["name"].as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["APPENDED"],
+            "geometry must cover only the symbols written by this call"
+        );
+        // The library itself still grew — only the echo is scoped.
+        assert_eq!(parsed["symbol_count"].as_u64(), Some(3));
+    }
+
     // =========================================================================
     // delete_component Tool Tests
     // =========================================================================

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1169,6 +1169,12 @@ impl McpServer {
             }
         }
 
+        // Names of the symbols written by *this* call. Recorded as they are added
+        // (rather than reused from `new_names`) so a symbol that omitted "name" and
+        // fell back to the default is still represented. Used to scope the geometry
+        // echo below to what the caller actually wrote.
+        let mut written_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+
         for sym_json in symbols_json {
             check_keys!(
                 sym_json,
@@ -1809,6 +1815,7 @@ impl McpServer {
                 return ToolCallResult::error(e);
             }
 
+            written_names.insert(symbol.name.clone());
             library.add(symbol);
         }
 
@@ -1830,7 +1837,20 @@ impl McpServer {
                 // Echo computed pin geometry (body-attach end, connection tip,
                 // orientation, bounding box) so the caller can verify pin placement
                 // and catch flipped/misaligned pins without opening Altium.
-                result["geometry"] = Value::Array(library.iter().map(symbol_geometry).collect());
+                //
+                // Scoped to the symbols written by this call. Echoing the whole
+                // library made an `append: true` sequence grow the response
+                // quadratically — a 27-symbol library built over 11 appends echoed
+                // 196 symbol-geometry blocks instead of 26, large enough to stop the
+                // response being usable — and pre-existing symbols tell the caller
+                // nothing about the write it just performed.
+                result["geometry"] = Value::Array(
+                    library
+                        .iter()
+                        .filter(|s| written_names.contains(&s.name))
+                        .map(symbol_geometry)
+                        .collect(),
+                );
 
                 // Run post-write validation
                 if let Some(validation) = Self::post_write_validation_schlib(filepath) {


### PR DESCRIPTION
## Description

`write_schlib`'s `geometry` echo built its array from `library.iter()` — the **whole** library — rather than the symbols the call actually wrote. With `append: true` that makes the response grow quadratically with the number of appends.

Hit this while batch-building a 27-symbol library over 11 append calls (library counts 4 → 9 → 11 → … → 27):

- symbol-geometry blocks echoed: **196**
- blocks actually needed: **26**

With 105-pin symbols in the set, the later responses were large enough to stop being usable. Beyond size, echoing pre-existing symbols defeats the echo's stated purpose — the comment above it says it exists "so the caller can verify pin placement", i.e. verify *this* write.

## Fix

Record the names added during the write loop and filter the echo to that set.

Names are collected in the loop rather than reused from the existing `new_names` vector, because `new_names` is built with `filter_map` on the `"name"` field — a symbol that omits `name` is written under the default but would be missing from the echo.

`symbol_names` still reports the full library: that is intended (it describes the resulting library) and is cheap.

`write_pcblib` is **unaffected** — its `bodies` echo is built inside the footprint loop and was already scoped to the footprints written.

## Where it came from

Introduced in #170, which added the geometry echo. Reported and fixed against current `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] New regression test `write_schlib_geometry_echo_covers_only_written_symbols`. Verified it fails on the pre-fix code:
  ```
  left:  ["RESISTOR", "CAPACITOR", "APPENDED"]
  right: ["APPENDED"]
  ```
- [x] `cargo test` — 716 lib + all integration suites pass (incl. `mcp_e2e` 36/36)
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `ORACLE_REQUIRE_DEPS=1 python tests/integration/test_altium_readability.py` → 13 passed, 0 regressions

## Notes

Output-shape change only for callers that were reading geometry entries for symbols they did not write in that call — which was not the documented behaviour. No schema or input change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)