### PR TITLE
fix(mcp): share one pad-shape vocabulary between write_pcblib and update_pad

### DIFF
--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -221,7 +221,7 @@ impl McpServer {
                                                 "shape": {
                                                     "type": "string",
                                                     "enum": ["rectangle", "rounded_rectangle", "round", "circle", "oval", "octagonal"],
-                                                    "description": "Pad shape: rectangle (pin 1), rounded_rectangle (SMD default), round/circle (equivalent, for through-hole), oval, octagonal"
+                                                    "description": "Pad shape. Omitting this field yields rounded_rectangle, which suits chip/QFN lands but is WRONG for BGA/CSP: circular NSMD BGA lands must set \"round\" explicitly. rectangle is conventional for pin 1; round/circle are equivalent and used for both BGA lands and through-hole pads; also oval, octagonal. Matching is case-insensitive and ignores '_'/'-'."
                                                 },
                                                 "layer": { "type": "string", "description": "Layer name: Top Layer, Bottom Layer, Multi-Layer (default for SMD)" },
                                                 "hole_size": { "type": "number", "description": "Hole diameter for through-hole pads (mm)" },
@@ -2010,7 +2010,7 @@ impl McpServer {
                                 "y": { "type": "number", "description": "New Y position in mm" },
                                 "width": { "type": "number", "description": "New width in mm" },
                                 "height": { "type": "number", "description": "New height in mm" },
-                                "shape": { "type": "string", "description": "New shape (Rectangle, Round, Oval, Octagonal, RoundedRectangle)" },
+                                "shape": { "type": "string", "enum": ["rectangle", "rounded_rectangle", "round", "circle", "oval", "octagonal"], "description": "New pad shape. Same vocabulary as write_pcblib: rectangle, rounded_rectangle, round/circle, oval, octagonal. Matching is case-insensitive and ignores '_'/'-'." },
                                 "rotation": { "type": "number", "description": "New rotation in degrees" },
                                 "hole_size": { "type": "number", "description": "New hole diameter for through-hole pads" }
                             }

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -529,7 +529,6 @@ impl McpServer {
     /// Updates specific properties of a pad in a `PcbLib` footprint.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn call_update_pad(&self, arguments: &Value) -> ToolCallResult {
-        use crate::altium::pcblib::primitives::PadShape;
         use crate::altium::PcbLib;
 
         let Some(filepath) = arguments.get("filepath").and_then(Value::as_str) else {
@@ -614,17 +613,11 @@ impl McpServer {
             pad.hole_size = Some(hole_size);
         }
         if let Some(shape_str) = updates.get("shape").and_then(Value::as_str) {
-            let new_shape = match shape_str.to_lowercase().as_str() {
-                "rectangle" | "rect" => PadShape::Rectangle,
-                "round" | "circular" => PadShape::Round,
-                "oval" | "oblong" => PadShape::Oval,
-                "octagonal" | "octagon" => PadShape::Octagonal,
-                "roundedrectangle" | "rounded" => PadShape::RoundedRectangle,
-                _ => {
-                    return ToolCallResult::error(format!(
-                    "Invalid shape '{shape_str}'. Valid: Rectangle, Round, Oval, Octagonal, RoundedRectangle"
-                ))
-                }
+            let Some(new_shape) = Self::parse_pad_shape(shape_str) else {
+                return ToolCallResult::error(format!(
+                    "Invalid shape '{shape_str}'. {}",
+                    crate::mcp::tools::parsing::PAD_SHAPE_HELP
+                ));
             };
             changes.push(
                 json!({"property": "shape", "old": format!("{:?}", pad.shape), "new": shape_str}),
@@ -1466,6 +1459,49 @@ mod tests {
         assert!((pad.x - -0.6).abs() < 1e-4);
         assert!((pad.width - 0.7).abs() < 1e-4);
         assert_eq!(format!("{:?}", pad.shape), "Round");
+    }
+
+    #[test]
+    fn update_pad_accepts_write_pcblib_shape_spellings() {
+        // Regression: update_pad had its own shape vocabulary, so the spellings
+        // write_pcblib documents and defaults to were rejected here — round-tripping
+        // a pad through the two tools failed on `rounded_rectangle` and `circle`.
+        for spelling in ["rounded_rectangle", "circle", "ROUND"] {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("PadShape.PcbLib");
+            create_test_pcblib(&path);
+
+            let result = server.call_update_pad(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "CHIP_0402",
+                "designator": "1",
+                "updates": { "shape": spelling },
+            }));
+            assert!(
+                !result.is_error,
+                "shape {spelling:?} must be accepted: {}",
+                get_result_text(&result)
+            );
+        }
+
+        // Still rejects genuine nonsense, with the shared guidance text.
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("PadBad.PcbLib");
+        create_test_pcblib(&path);
+        let bad = server.call_update_pad(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "designator": "1",
+            "updates": { "shape": "hexagon" },
+        }));
+        assert!(bad.is_error);
+        assert!(
+            get_result_text(&bad).contains("rounded_rectangle"),
+            "error should list the accepted spellings: {}",
+            get_result_text(&bad)
+        );
     }
 
     #[test]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -123,7 +123,34 @@ fn json_unique_id(json: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Accepted pad-shape spellings, quoted in every shape error so the two tools
+/// give identical guidance.
+pub const PAD_SHAPE_HELP: &str = "Valid shapes are: rectangle, round (or circle), \
+     oval, octagonal, rounded_rectangle. Matching is case-insensitive and ignores \
+     '_'/'-' separators.";
+
 impl McpServer {
+    /// Parses a pad shape name, shared by `write_pcblib` and `update_pad` so the
+    /// same spelling is accepted everywhere.
+    ///
+    /// The two tools previously carried separate `match` arms with different
+    /// vocabularies: `write_pcblib` took `rounded_rectangle`/`circle` but rejected
+    /// any capitalisation, while `update_pad` lower-cased its input yet only knew
+    /// `roundedrectangle`/`circular` — so the very spelling `write_pcblib`
+    /// documents and defaults to (`rounded_rectangle`) was rejected by
+    /// `update_pad`. This accepts the union, case-insensitively, ignoring `_`/`-`.
+    pub(crate) fn parse_pad_shape(s: &str) -> Option<crate::altium::pcblib::PadShape> {
+        use crate::altium::pcblib::PadShape;
+        match s.to_lowercase().replace(['_', '-'], "").as_str() {
+            "rectangle" | "rect" => Some(PadShape::Rectangle),
+            "round" | "circle" | "circular" => Some(PadShape::Round),
+            "oval" | "oblong" => Some(PadShape::Oval),
+            "octagonal" | "octagon" => Some(PadShape::Octagonal),
+            "roundedrectangle" | "rounded" => Some(PadShape::RoundedRectangle),
+            _ => None,
+        }
+    }
+
     // ==================== Primitive Parsing Helpers ====================
 
     pub(crate) fn check_unknown_fields(
@@ -146,7 +173,7 @@ impl McpServer {
     #[allow(clippy::too_many_lines)] // Pad has many fields requiring individual parsing
     pub(crate) fn parse_pad(json: &Value) -> Result<crate::altium::pcblib::Pad, String> {
         use crate::altium::pcblib::{
-            Layer, MaskExpansionMode, Pad, PadShape, PadStackMode, PowerPlaneConnectStyle,
+            Layer, MaskExpansionMode, Pad, PadStackMode, PowerPlaneConnectStyle,
         };
 
         let designator = json
@@ -188,23 +215,16 @@ impl McpServer {
             ));
         }
 
+        // Omitting `shape` yields RoundedRectangle. That suits chip/QFN lands but is
+        // wrong for BGA/CSP, whose circular NSMD lands need an explicit "round" —
+        // see the `shape` description in tool_definitions.rs.
         let shape_str = json
             .get("shape")
             .and_then(Value::as_str)
             .unwrap_or("rounded_rectangle");
-        let shape = match shape_str {
-            "rectangle" => PadShape::Rectangle,
-            "round" | "circle" => PadShape::Round,
-            "oval" => PadShape::Oval,
-            "octagonal" => PadShape::Octagonal,
-            "rounded_rectangle" => PadShape::RoundedRectangle,
-            _ => {
-                return Err(format!(
-                    "Pad '{designator}' has invalid shape '{shape_str}'. \
-                     Valid shapes are: rectangle, round, circle, oval, octagonal, rounded_rectangle"
-                ))
-            }
-        };
+        let shape = Self::parse_pad_shape(shape_str).ok_or_else(|| {
+            format!("Pad '{designator}' has invalid shape '{shape_str}'. {PAD_SHAPE_HELP}")
+        })?;
 
         // Parse hole_size first to determine default layer
         let hole_size = json.get("hole_size").and_then(Value::as_f64);
@@ -2683,5 +2703,59 @@ mod tests {
         }))
         .expect("rectangle should parse");
         assert_eq!(plain.unique_id, None);
+    }
+
+    #[test]
+    fn pad_shape_vocabulary_is_shared_and_lenient() {
+        use crate::altium::pcblib::PadShape;
+        // Both tools now resolve the same spellings. The pairs below span the two
+        // previously-divergent vocabularies: `rounded_rectangle`/`circle` came from
+        // write_pcblib, `roundedrectangle`/`circular`/`rect` from update_pad.
+        for (input, want) in [
+            ("rectangle", PadShape::Rectangle),
+            ("rect", PadShape::Rectangle),
+            ("round", PadShape::Round),
+            ("circle", PadShape::Round),
+            ("circular", PadShape::Round),
+            ("oval", PadShape::Oval),
+            ("oblong", PadShape::Oval),
+            ("octagonal", PadShape::Octagonal),
+            ("octagon", PadShape::Octagonal),
+            ("rounded_rectangle", PadShape::RoundedRectangle),
+            ("roundedrectangle", PadShape::RoundedRectangle),
+            ("rounded-rectangle", PadShape::RoundedRectangle),
+            ("rounded", PadShape::RoundedRectangle),
+            // case-insensitive: update_pad accepted these, write_pcblib did not
+            ("Round", PadShape::Round),
+            ("ROUNDED_RECTANGLE", PadShape::RoundedRectangle),
+        ] {
+            assert_eq!(
+                McpServer::parse_pad_shape(input),
+                Some(want),
+                "shape {input:?} must resolve"
+            );
+        }
+        assert_eq!(McpServer::parse_pad_shape("hexagon"), None);
+    }
+
+    #[test]
+    fn parse_pad_shape_defaults_to_rounded_rectangle() {
+        // Documents the default that BGA callers must override. A change here is a
+        // silent geometry change for every caller that omits `shape`, so it should
+        // be deliberate.
+        use crate::altium::pcblib::PadShape;
+        let pad = McpServer::parse_pad(&json!({
+            "designator": "A1", "x": 0.0, "y": 0.0, "width": 0.3, "height": 0.3
+        }))
+        .expect("pad without shape should parse");
+        assert_eq!(pad.shape, PadShape::RoundedRectangle);
+
+        // A BGA land opting in explicitly stays circular.
+        let bga = McpServer::parse_pad(&json!({
+            "designator": "A1", "x": 0.0, "y": 0.0, "width": 0.3, "height": 0.3,
+            "shape": "round"
+        }))
+        .expect("round pad should parse");
+        assert_eq!(bga.shape, PadShape::Round);
     }
 }


### PR DESCRIPTION
## Description

Two related pad-shape problems, both found while building a 1088-ball FCBGA footprint.

### 1. The two tools disagree on shape names (interop bug)

`write_pcblib` and `update_pad` each had their own `match` over shape strings, with different vocabularies:

| Value | `write_pcblib` | `update_pad` |
|---|---|---|
| `rounded_rectangle` | ✅ (**and the default**) | ❌ rejected |
| `circle` | ✅ | ❌ rejected |
| `Round` (any capitalisation) | ❌ rejected | ✅ |
| `rect`, `circular`, `oblong`, `octagon`, `rounded` | ❌ rejected | ✅ |

So the spelling `write_pcblib` documents **and defaults to** was rejected by `update_pad` — write a pad, then try to update it with the same shape string, and it errors.

Fixed by extracting one `parse_pad_shape` helper used by both, accepting the union case-insensitively and ignoring `_`/`-`, plus a shared `PAD_SHAPE_HELP` so both tools give identical guidance on error. **Input is only widened.**

### 2. The `shape` docs actively mislead for BGA/CSP

The description read:

> `round/circle (equivalent, for through-hole)`

BGA NSMD lands are round **and** SMD. Since omitting `shape` yields `rounded_rectangle`, a caller trusting that text — or omitting the field to shrink a large payload — silently converts every circular BGA land into a rounded rectangle. On a 1088-ball part that is 1088 wrong pads with no error raised.

The description now states the omit-default explicitly and names BGA as a round-land case. `update_pad`'s `shape` gains the same `enum` and wording; it previously advertised CamelCase values (`Rectangle, Round, …`) that didn't match the documented vocabulary.

### What is deliberately *not* changed

The default stays `rounded_rectangle`. Changing it would silently alter geometry for every existing caller that omits `shape`. It is now pinned by a test so any future change has to be deliberate rather than incidental.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Standards Checklist

- [x] Primitive types maintain backwards compatibility — accepted input is widened, never narrowed
- [x] Altium file format compatibility maintained (no writer change)
- [x] No breaking changes to MCP tool interfaces

## Testing

- [x] `pad_shape_vocabulary_is_shared_and_lenient` — every spelling from both former vocabularies resolves, plus casing/separator variants; `hexagon` still fails
- [x] `parse_pad_shape_defaults_to_rounded_rectangle` — pins the default and the explicit `round` opt-in
- [x] `update_pad_accepts_write_pcblib_shape_spellings` — regression for the interop gap; also asserts the error message lists the accepted spellings
- [x] `cargo test` — 718 lib + all integration suites (incl. `mcp_e2e` 36/36)
- [x] `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `ORACLE_REQUIRE_DEPS=1 python tests/integration/test_altium_readability.py` → 13 passed, 0 regressions

## Notes

`docs/TOOLS.md` is unchanged — the generator renders top-level schema properties and both edited fields are nested (`pads[].shape`, `updates.shape`). The in-sync guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)