### PR TITLE
fix(deps): bump js-yaml to 5.2.3 for GHSA DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -430,9 +430,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-            "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+            "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Description

Clears Dependabot alert #9 (high, development scope): js-yaml `>= 5.0.0, <= 5.2.1` has exponential parsing time on flow collections, enabling denial of service. First patched version is 5.2.2; this bumps the lockfile to 5.2.3.

js-yaml is a transitive dependency of markdownlint-cli2 (dev tooling only), so real-world exposure was limited to the CI markdown-lint step — but there is no reason to keep the vulnerable pin.

Lockfile-only change (`npm update js-yaml --package-lock-only`); package.json is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)