### PR TITLE
feat(mcp): support vias in update_primitive

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1096,5 +1096,5 @@ Update specific properties of a primitive (track, arc, region, or text) in a Pcb
 | `dry_run` | boolean | no | If true, show what would change without saving (default: false) |
 | `filepath` | string | yes | Path to the .PcbLib file |
 | `index` | integer | yes | Zero-based index of the primitive within its type array |
-| `primitive_type` | enum | yes | Type of primitive to update (one of: track, arc, region, text, fill) |
+| `primitive_type` | enum | yes | Type of primitive to update. Addressed by `index` into that primitive list. Pads are not here — they have a designator, so use update_pad. (one of: track, arc, region, text, fill, via) |
 | `updates` | object | yes | Properties to update (only specified properties are changed). Valid properties depend on primitive_type. |

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -2044,8 +2044,8 @@ impl McpServer {
                         },
                         "primitive_type": {
                             "type": "string",
-                            "enum": ["track", "arc", "region", "text", "fill"],
-                            "description": "Type of primitive to update"
+                            "enum": ["track", "arc", "region", "text", "fill", "via"],
+                            "description": "Type of primitive to update. Addressed by `index` into that primitive list. Pads are not here — they have a designator, so use update_pad."
                         },
                         "index": {
                             "type": "integer",

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -963,9 +963,64 @@ impl McpServer {
                 }
                 // Note: Updating region vertices would require array-based updates, which is more complex
             }
+            "via" => {
+                if index >= footprint.vias.len() {
+                    return ToolCallResult::error(format!(
+                        "Via index {} out of range (0..{})",
+                        index,
+                        footprint.vias.len()
+                    ));
+                }
+                let via = &mut footprint.vias[index];
+
+                // Vias carry no designator, so they are addressed positionally
+                // like tracks and arcs rather than by name like pads.
+                if let Some(x) = updates.get("x").and_then(Value::as_f64) {
+                    changes.push(json!({"property": "x", "old": via.x, "new": x}));
+                    via.x = x;
+                }
+                if let Some(y) = updates.get("y").and_then(Value::as_f64) {
+                    changes.push(json!({"property": "y", "old": via.y, "new": y}));
+                    via.y = y;
+                }
+                if let Some(diameter) = updates.get("diameter").and_then(Value::as_f64) {
+                    changes.push(
+                        json!({"property": "diameter", "old": via.diameter, "new": diameter}),
+                    );
+                    via.diameter = diameter;
+                }
+                if let Some(hole_size) = updates.get("hole_size").and_then(Value::as_f64) {
+                    changes.push(
+                        json!({"property": "hole_size", "old": via.hole_size, "new": hole_size}),
+                    );
+                    via.hole_size = hole_size;
+                }
+                for (key, is_from) in [("from_layer", true), ("to_layer", false)] {
+                    if let Some(layer_str) = updates.get(key).and_then(Value::as_str) {
+                        let Some(layer) = parse_layer(layer_str) else {
+                            return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
+                        };
+                        let old = if is_from {
+                            via.from_layer
+                        } else {
+                            via.to_layer
+                        };
+                        changes.push(json!({
+                            "property": key,
+                            "old": format!("{old:?}"),
+                            "new": layer_str
+                        }));
+                        if is_from {
+                            via.from_layer = layer;
+                        } else {
+                            via.to_layer = layer;
+                        }
+                    }
+                }
+            }
             _ => {
                 return ToolCallResult::error(format!(
-                    "Invalid primitive_type '{primitive_type}'. Valid: track, arc, region, text, fill"
+                    "Invalid primitive_type '{primitive_type}'. Valid: track, arc, region, text, fill, via"
                 ));
             }
         }
@@ -996,6 +1051,20 @@ impl McpServer {
             }
             "text" => {
                 (footprint.text[index].height <= 0.0).then_some("text height must be positive")
+            }
+            "via" => {
+                // Mirrors parse_via's create-path checks: the hole must fit inside
+                // the annular ring, both positive.
+                let v = &footprint.vias[index];
+                if v.diameter <= 0.0 {
+                    Some("via diameter must be positive")
+                } else if v.hole_size <= 0.0 {
+                    Some("via hole_size must be positive")
+                } else if v.hole_size >= v.diameter {
+                    Some("via hole_size must be smaller than diameter")
+                } else {
+                    None
+                }
             }
             _ => None,
         };
@@ -1641,7 +1710,7 @@ mod tests {
     mod primitive_arms {
         use super::*;
         use crate::altium::pcblib::{
-            Arc, Fill, PcbFlags, Region, Text, TextJustification, TextKind,
+            Arc, Fill, PcbFlags, Region, Text, TextJustification, TextKind, Via,
         };
 
         /// A footprint carrying one of every 2D primitive at index 0, so each
@@ -1654,6 +1723,7 @@ mod tests {
             fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.15, Layer::TopOverlay));
             fp.add_fill(Fill::new(-0.5, -0.5, 0.5, 0.5, Layer::TopPaste));
             fp.add_region(Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopLayer));
+            fp.add_via(Via::new(0.6, 0.6, 0.6, 0.3));
             fp.add_text(Text {
                 x: 0.0,
                 y: 1.0,
@@ -1725,6 +1795,102 @@ mod tests {
             let arc = &lib.get("RICH").unwrap().arcs[0];
             assert!((arc.radius - 1.5).abs() < 1e-4);
             assert_eq!(arc.layer, Layer::BottomOverlay);
+        }
+
+        #[test]
+        fn update_primitive_via_arm_persists() {
+            // Vias were the only footprint primitive with no update path: pads have
+            // update_pad (addressed by designator), everything else is reachable
+            // through update_primitive by index, but vias were reachable by neither,
+            // so moving one meant rewriting the whole footprint.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Via.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "via",
+                "index": 0,
+                "updates": {
+                    "x": -0.55, "y": 0.55,
+                    "diameter": 0.8, "hole_size": 0.4,
+                    "from_layer": "Top Layer", "to_layer": "Bottom Layer",
+                },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(parsed["primitive_type"], "via");
+            let props = change_props(&parsed);
+            for want in ["x", "y", "diameter", "hole_size", "from_layer", "to_layer"] {
+                assert!(props.contains(&want.to_string()), "missing change {want}");
+            }
+
+            let lib = PcbLib::open(&path).unwrap();
+            let via = &lib.get("RICH").unwrap().vias[0];
+            assert!((via.x - -0.55).abs() < 1e-4, "x {}", via.x);
+            assert!((via.y - 0.55).abs() < 1e-4, "y {}", via.y);
+            assert!((via.diameter - 0.8).abs() < 1e-4, "dia {}", via.diameter);
+            assert!((via.hole_size - 0.4).abs() < 1e-4, "hole {}", via.hole_size);
+            assert_eq!(via.from_layer, Layer::TopLayer);
+            assert_eq!(via.to_layer, Layer::BottomLayer);
+        }
+
+        #[test]
+        fn update_primitive_via_rejects_degenerate_geometry() {
+            // Same invariants parse_via enforces on the create path: the hole must
+            // fit inside the annular ring, both positive. update_primitive bypasses
+            // parse_via, so the check has to be repeated here.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("ViaBad.PcbLib");
+
+            for (updates, needle) in [
+                (json!({"hole_size": 0.9}), "smaller than diameter"),
+                (json!({"diameter": 0.0}), "diameter must be positive"),
+                (json!({"hole_size": 0.0}), "hole_size must be positive"),
+            ] {
+                create_rich_pcblib(&path);
+                let result = server.call_update_primitive(&json!({
+                    "filepath": path.to_string_lossy(),
+                    "component_name": "RICH",
+                    "primitive_type": "via",
+                    "index": 0,
+                    "updates": updates,
+                }));
+                assert!(result.is_error, "{updates:?} must be rejected");
+                let txt = get_result_text(&result);
+                assert!(txt.contains(needle), "expected {needle:?} in: {txt}");
+
+                // Rejected before save: the file keeps its original geometry.
+                let lib = PcbLib::open(&path).unwrap();
+                let via = &lib.get("RICH").unwrap().vias[0];
+                assert!((via.diameter - 0.6).abs() < 1e-4, "unchanged diameter");
+                assert!((via.hole_size - 0.3).abs() < 1e-4, "unchanged hole");
+            }
+        }
+
+        #[test]
+        fn update_primitive_via_index_out_of_range() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("ViaRange.PcbLib");
+            create_rich_pcblib(&path);
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RICH",
+                "primitive_type": "via",
+                "index": 7,
+                "updates": { "x": 0.0 },
+            }));
+            assert!(result.is_error);
+            assert!(
+                get_result_text(&result).contains("Via index 7 out of range"),
+                "{}",
+                get_result_text(&result)
+            );
         }
 
         #[test]


### PR DESCRIPTION
Follow-up flagged in #300.

## Why

Vias were the only footprint primitive with **no update path**:

| Primitive | Addressed by | Tool |
|---|---|---|
| Pad | `designator` | `update_pad` |
| Track, Arc, Region, Text, Fill | `index` | `update_primitive` |
| **Via** | — | **nothing** |

Moving a single via meant rewriting the entire footprint. I hit this fixing a TPA6130A2 land pattern: correcting one via position required re-sending 21 pads, 4 paste apertures, 13 tracks, a region, text and the 3D body — geometry that was already correct, re-transmitted for no reason.

## Why one arm, not an `update_via` tool

The pad/primitive split isn't arbitrary duplication — it keys on **addressing**. Pads are the only footprint primitive with a stable semantic identifier, so they get a designator-addressed tool. Vias carry no designator and are positional, exactly like tracks and arcs, so they belong in the index-addressed tool. A separate `update_via` would be a second door to the same room with nothing extra behind it.

**#295 is the cautionary case**: `write_pcblib` and `update_pad` each had an independently written pad-shape `match`, and they drifted until `rounded_rectangle` — the value one documented *and defaulted to* — was rejected by the other. Two surfaces mutating the same thing is how that happens. There's also an MCP-specific cost: every tool ships its schema on `tools/list`, so a redundant tool inflates what every agent reads on every connect.

## What

Supports `x`, `y`, `diameter`, `hole_size`, `from_layer`, `to_layer`.

Also repeats `parse_via`'s create-path invariants, because `update_primitive` bypasses `parse_via`: diameter and hole_size positive, hole smaller than diameter. Without that, an update could write a degenerate via the create path would have refused — the same reasoning behind the existing track-width and arc-radius re-checks.

The shared `create_rich_pcblib` fixture gains a via, so it again carries one of every primitive `update_primitive` can reach.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Standards Checklist

- [x] Primitive types unchanged
- [x] Altium file format compatibility maintained
- [x] No breaking changes — the `primitive_type` enum is widened, never narrowed

## Testing

- [x] `update_primitive_via_arm_persists` — updates all six fields, asserts each is reported in `changes` and persisted on reopen
- [x] `update_primitive_via_rejects_degenerate_geometry` — hole ≥ diameter, zero diameter, zero hole all rejected, **and the file is left untouched** in each case
- [x] `update_primitive_via_index_out_of_range` — bounds error names the primitive
- [x] `cargo test` — 723 lib + all integration suites (incl. `mcp_e2e` 36/36)
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `ORACLE_REQUIRE_DEPS=1 python tests/integration/test_altium_readability.py` → 13 passed, 0 regressions
- [x] `docs/TOOLS.md` regenerated; the in-sync guard from #203 flagged the stale schema before I did

🤖 Generated with [Claude Code](https://claude.com/claude-code)