### PR TITLE
fix(pcblib): cap pad-overlap issues in validate_library; tidy warning text

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -136,6 +136,13 @@ pub struct Footprint {
     pub model_3d: Option<Model3D>,
 }
 
+/// Most overlapping pad pairs a tool reports before collapsing to a summary.
+///
+/// Overlaps are quadratic in pad count, so a systematic error on a large BGA
+/// would otherwise bury the response in tens of thousands of entries. Shared by
+/// `write_pcblib` and `validate_library` so both truncate alike.
+pub const MAX_REPORTED_PAD_OVERLAPS: usize = 20;
+
 impl Footprint {
     /// Finds pairs of pads whose copper overlaps on a shared layer.
     ///

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -316,6 +316,7 @@ impl McpServer {
     /// Validates a `PcbLib` file.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn validate_pcblib(filepath: &str) -> ToolCallResult {
+        use crate::altium::pcblib::MAX_REPORTED_PAD_OVERLAPS;
         use crate::altium::PcbLib;
         use std::collections::HashSet;
 
@@ -453,7 +454,12 @@ impl McpServer {
             // together passes all of it. Warning rather than error - stacked
             // same-designator pads are legal and are already excluded by
             // overlapping_pad_pairs().
-            for (i, j, ox, oy) in fp.overlapping_pad_pairs() {
+            //
+            // Truncated like the write_pcblib warning: pairs are quadratic in
+            // pad count, so a library holding one systematically broken BGA
+            // would otherwise emit tens of thousands of issues here.
+            let overlaps = fp.overlapping_pad_pairs();
+            for &(i, j, ox, oy) in overlaps.iter().take(MAX_REPORTED_PAD_OVERLAPS) {
                 issues.push(json!({
                     "severity": "warning",
                     "component": name,
@@ -464,6 +470,16 @@ impl McpServer {
                         ox,
                         oy,
                         fp.pads[i].layer.as_str()
+                    )
+                }));
+            }
+            if overlaps.len() > MAX_REPORTED_PAD_OVERLAPS {
+                issues.push(json!({
+                    "severity": "warning",
+                    "component": name,
+                    "issue": format!(
+                        "{} overlapping pad pairs total; {MAX_REPORTED_PAD_OVERLAPS} shown",
+                        overlaps.len()
                     )
                 }));
             }
@@ -1837,6 +1853,50 @@ mod tests {
                 .unwrap_or("")
                 .contains("invalid dimensions")));
             assert!(parsed["error_count"].as_u64().unwrap() >= 3);
+        }
+
+        #[test]
+        fn validate_pcblib_caps_pad_overlap_issues() {
+            use crate::altium::pcblib::MAX_REPORTED_PAD_OVERLAPS;
+
+            // Overlapping pairs are quadratic in pad count, so a systematically
+            // broken part must not bury the response: 30 mutually overlapping
+            // pads are 435 pairs, which has to collapse to the cap plus one
+            // summary line carrying the true total.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("SHORTED");
+            for n in 0..30 {
+                fp.add_pad(Pad::smd(format!("{n}"), f64::from(n) * 0.01, 0.0, 1.0, 1.0));
+            }
+            lib.add(fp);
+            let path = dir.path().join("Shorted.PcbLib");
+            lib.save(&path).unwrap();
+
+            let parsed = parse_result_json(
+                &server.call_validate_library(&json!({ "filepath": path.to_string_lossy() })),
+            );
+            let overlap_issues: Vec<&str> = parsed["issues"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|i| i["issue"].as_str())
+                .filter(|s| s.contains("overlap"))
+                .collect();
+            assert_eq!(
+                overlap_issues.len(),
+                MAX_REPORTED_PAD_OVERLAPS + 1,
+                "expected {MAX_REPORTED_PAD_OVERLAPS} pairs plus a summary, got: {overlap_issues:?}"
+            );
+            assert!(
+                overlap_issues
+                    .last()
+                    .unwrap()
+                    .starts_with("435 overlapping pad pairs total"),
+                "summary must carry the true total: {overlap_issues:?}"
+            );
         }
 
         #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -208,8 +208,7 @@ fn silk_over_pad_warnings(fp: &crate::altium::pcblib::Footprint) -> Vec<Value> {
 /// Reporting is capped so a systematic error on a large BGA cannot bury the
 /// response; the cap message carries the true total.
 fn pad_copper_overlap_warnings(fp: &crate::altium::pcblib::Footprint) -> Vec<Value> {
-    /// Most pairs reported per footprint before collapsing to a summary.
-    const MAX_REPORTED: usize = 20;
+    use crate::altium::pcblib::MAX_REPORTED_PAD_OVERLAPS as MAX_REPORTED;
 
     let hits = fp.overlapping_pad_pairs();
     let mut warnings: Vec<Value> = hits
@@ -224,7 +223,7 @@ fn pad_copper_overlap_warnings(fp: &crate::altium::pcblib::Footprint) -> Vec<Val
                 "pads": [a.designator, b.designator],
                 "overlap_mm": [ox, oy],
                 "message": format!(
-                    "pads '{}' and '{}' overlap by {:.3} x {:.3} mm on {} —                      overlapping copper merges into one net",
+                    "pads '{}' and '{}' overlap by {:.3} x {:.3} mm on {} — overlapping copper merges into one net",
                     a.designator, b.designator, ox, oy, a.layer.as_str()
                 ),
             })


### PR DESCRIPTION
**Merge after #300** — this branch is #300 plus one commit, so its diff collapses to just that commit once #300 lands.

Two maintainer follow-ups found while reviewing #300:

### 1. `validate_library` had no cap (the real one)
`pad_copper_overlap_warnings` truncates at 20 pairs, but the `validate_library` path pushed one issue per pair unbounded. Overlapping pairs are **quadratic** in pad count, so sweeping a library containing one systematically broken BGA (say 1088 balls all shorted) could emit ~590k issues into a single JSON response — precisely the failure the write-path cap was introduced to prevent.

The limit now lives in the pcblib layer as `MAX_REPORTED_PAD_OVERLAPS`, so the two surfaces cannot drift apart again, and `validate_library` emits the same summary line carrying the true total. New test: 30 mutually overlapping pads (435 pairs) must collapse to 20 issues plus one summary reading `435 overlapping pad pairs total`.

### 2. Cosmetic: 22 stray spaces in a user-facing string
The `write_pcblib` warning read `on Top Layer —                      overlapping copper merges into one net`.

Credit for the feature itself is entirely @ande2407's (#300).

Verified locally: 724 lib tests + all integration suites pass, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)