### PR TITLE
ci(release): dry-run mode, pre-flight gates and artefact verification

### DIFF
--- a/.github/release-assets/README.md
+++ b/.github/release-assets/README.md
@@ -1,0 +1,198 @@
+# altium-designer-mcp @VERSION@
+
+An MCP server that gives AI assistants file I/O and primitive-placement tools for Altium Designer
+`.PcbLib` (footprint) and `.SchLib` (symbol) libraries. The assistant works out the geometry; this
+server writes the files.
+
+You do **not** need Rust or a build toolchain — the binary in this archive is prebuilt. The full
+project, issue tracker and contribution guide live on GitHub:
+
+<https://github.com/embedded-society/altium-designer-mcp>
+
+## What's in this bundle
+
+| File | Purpose |
+|------|---------|
+| `altium-designer-mcp` (`.exe` on Windows) | The MCP server binary. |
+| `example-config.json` | Starting configuration — set `allowed_paths` to your library folders. |
+| `docs/CLAUDE_CODE_GUIDE.md` | Full Claude Code guide, including example workflows and prompts. |
+| `docs/ANTIGRAVITY_GUIDE.md` | Full Google Antigravity guide. |
+| `docs/AGENT_GUIDE.md` | Invariants an AI assistant must follow (units, pin geometry, sandbox). |
+| `docs/TOOLS.md` | Reference for every MCP tool. |
+| `CHANGELOG.md` | Release history. |
+| `LICENCE` | GNU General Public License v3.0. |
+
+The two setup guides were written for people building from source, so ignore their "clone and build"
+step — you already have the binary. Everything after it applies.
+
+---
+
+## Step 1 — Install the binary
+
+Unpack this archive and move the binary somewhere permanent. It is a single self-contained
+executable; there is nothing to install and no runtime to add.
+
+**Windows**
+
+```powershell
+New-Item -ItemType Directory -Force "$env:LOCALAPPDATA\Programs\altium-designer-mcp"
+Copy-Item altium-designer-mcp.exe "$env:LOCALAPPDATA\Programs\altium-designer-mcp\"
+```
+
+**Linux / macOS**
+
+```bash
+sudo install -m 755 altium-designer-mcp /usr/local/bin/altium-designer-mcp
+```
+
+On macOS the binary is not code-signed, so Gatekeeper blocks the first run: right-click it in Finder
+and choose **Open** once, or run `xattr -d com.apple.quarantine altium-designer-mcp`.
+
+Check it works:
+
+```bash
+altium-designer-mcp --version
+```
+
+## Step 2 — Create your configuration
+
+Copy `example-config.json` to the default location, or keep it anywhere and pass the path as an
+argument.
+
+- **Windows:** `%USERPROFILE%\.altium-designer-mcp\config.json`
+- **Linux / macOS:** `~/.altium-designer-mcp/config.json`
+
+Edit `allowed_paths` to list the folders holding your Altium libraries:
+
+```json
+{
+    "allowed_paths": [
+        "C:\\Users\\you\\Documents\\Altium\\Libraries"
+    ]
+}
+```
+
+The server refuses to read or write anything outside those folders. That confinement is its main
+safety property, so keep the list as narrow as the work allows — a single project's library folder
+rather than your whole home directory.
+
+## Step 3 — Connect your AI assistant
+
+Every client below speaks the same protocol; they differ only in where the configuration lives.
+Replace the paths with your own.
+
+### Claude Code
+
+```bash
+claude mcp add altium /usr/local/bin/altium-designer-mcp -- ~/.altium-designer-mcp/config.json
+```
+
+On Windows PowerShell:
+
+```powershell
+claude mcp add altium "$env:LOCALAPPDATA\Programs\altium-designer-mcp\altium-designer-mcp.exe" -- "$env:USERPROFILE\.altium-designer-mcp\config.json"
+```
+
+Then run `claude`, and check it is loaded with `/mcp`. See `docs/CLAUDE_CODE_GUIDE.md` for worked
+examples.
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` — **Settings → Developer → Edit Config** opens it, or find it at
+`%APPDATA%\Claude\` (Windows) or `~/Library/Application Support/Claude/` (macOS):
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "C:\\Users\\you\\AppData\\Local\\Programs\\altium-designer-mcp\\altium-designer-mcp.exe",
+            "args": ["C:\\Users\\you\\.altium-designer-mcp\\config.json"]
+        }
+    }
+}
+```
+
+Restart Claude Desktop afterwards. On Windows, note the doubled backslashes — JSON requires them.
+
+### Google Antigravity
+
+Settings → Customizations → Add MCP, or edit the MCP config file directly using the same
+`mcpServers` block as above. See `docs/ANTIGRAVITY_GUIDE.md`.
+
+### Cursor
+
+Create `~/.cursor/mcp.json` for all projects, or `.cursor/mcp.json` inside one project, using the
+same `mcpServers` block as Claude Desktop.
+
+### VS Code (Copilot agent mode)
+
+Create `.mcp.json` in the workspace, or use **MCP: Add Server** from the command palette. VS Code
+uses the same `command` / `args` fields, under a `servers` key rather than `mcpServers`.
+
+### Any other MCP client
+
+The `mcpServers` block above is the de-facto standard schema. If your client supports MCP over
+stdio, give it the binary path as the command and the config-file path as the single argument; check
+its documentation for where its configuration file lives.
+
+## Step 4 — Try it
+
+Ask your assistant something like:
+
+> Create a PcbLib at `<your library folder>` with an 0402 resistor footprint, then show me an ASCII
+> preview of it.
+
+`docs/TOOLS.md` lists every tool it can call. `docs/AGENT_GUIDE.md` is worth pasting into a project
+brief — it tells the assistant the unit and geometry conventions it must respect.
+
+---
+
+## Verifying this download
+
+This archive ships with a signed build-provenance attestation. To confirm it came from the project's
+own release workflow and has not been tampered with (needs the [GitHub CLI](https://cli.github.com/)):
+
+```bash
+gh attestation verify <this-archive> --repo embedded-society/altium-designer-mcp
+```
+
+To confirm the download is intact, using the `SHA256SUMS.txt` published beside it on the release page:
+
+```bash
+sha256sum --check --ignore-missing SHA256SUMS.txt
+```
+
+The binaries are not code-signed, so Windows SmartScreen and macOS Gatekeeper warn on first run. The
+attestation above is the stronger check either way.
+
+## A word of warning
+
+Generated footprints and symbols are a starting point, not a finished part. **Always check a
+generated library against the manufacturer's datasheet and land-pattern drawing before committing to
+fabrication.** An AI can misread a dimension table exactly the way a tired engineer can.
+
+## Found something odd? Please tell us
+
+This is an open project, and the fastest way it improves is people reporting what happened to them in
+real work. If a footprint came out wrong, a library would not open in Altium, a tool did something
+surprising, or the setup steps above did not match what you saw — that is worth an issue, even a
+short one. You do not need a diagnosis or a minimal reproduction; the part number and what you
+expected is plenty to start with.
+
+Especially valuable:
+
+- **A footprint or symbol that Altium rejects, or that looks wrong once placed.** Attach the
+  generated library if you can share it.
+- **Datasheet edge cases** — odd land patterns, unusual pad stacks, thermal pads, slot holes,
+  anything where the geometry is not a simple rectangle grid.
+- **Anything in the setup above that did not work on your machine or with your AI client.**
+
+Pull requests are just as welcome, from a typo fix upward. The contributing guide on GitHub covers the
+build and test workflow, and maintainers review everything that comes in.
+
+- Issues: <https://github.com/embedded-society/altium-designer-mcp/issues>
+- Source and contributing guide: <https://github.com/embedded-society/altium-designer-mcp>
+
+If it saved you some time, a ⭐ on the repository helps other engineers find it.
+
+Thank you for using altium-designer-mcp! 🙏

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,12 +400,18 @@ jobs:
                 # against, so prove they match before anyone relies on them.
                 sha256sum --check --strict SHA256SUMS.txt
 
+            # SLSA build provenance: signs a statement binding each artefact's
+            # digest to this workflow, commit and runner, verifiable offline-ish
+            # with `gh attestation verify`. SHA256SUMS.txt is a subject too —
+            # otherwise the file everyone is told to check their download
+            # against is the one file with no provenance of its own.
             - name: Attest build provenance
               uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
               with:
                 subject-path: |
                     artifacts/*.tar.gz
                     artifacts/*.zip
+                    artifacts/SHA256SUMS.txt
 
             - name: Extract release notes from CHANGELOG
               id: release-notes
@@ -431,6 +437,39 @@ jobs:
                     echo "No CHANGELOG entry for ${VERSION}, using default"
                     echo "Release ${VERSION}" > release_notes.md
                 fi
+
+                # Append verification instructions to every release. Provenance
+                # nobody knows how to check is decoration, and the release body
+                # is the one place a downloader is guaranteed to look. Generated
+                # here rather than kept in CHANGELOG.md so the changelog stays a
+                # record of changes.
+                # (Built with echo rather than a heredoc: heredoc bodies sit at
+                # column 0, which would end this YAML block scalar.)
+                {
+                    echo ""
+                    echo "---"
+                    echo ""
+                    echo "## Verifying this download"
+                    echo ""
+                    echo "Every archive is built by GitHub Actions from a tagged commit and"
+                    echo "carries a signed [SLSA build provenance](https://slsa.dev/)"
+                    echo "attestation. To confirm an archive really came from this"
+                    echo "repository's release workflow:"
+                    echo ""
+                    echo '```bash'
+                    echo "gh attestation verify <archive> --repo ${GITHUB_REPOSITORY}"
+                    echo '```'
+                    echo ""
+                    echo "To check a download is byte-for-byte intact:"
+                    echo ""
+                    echo '```bash'
+                    echo "sha256sum --check --ignore-missing SHA256SUMS.txt"
+                    echo '```'
+                    echo ""
+                    echo "The binaries are unsigned, so Windows SmartScreen and macOS"
+                    echo "Gatekeeper will warn on first run; on macOS use right-click →"
+                    echo "Open. The attestation above is the stronger check either way."
+                } >> release_notes.md
 
                 echo "--- Release Notes ---"
                 cat release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,12 +243,17 @@ jobs:
               if: runner.os != 'Windows'
               shell: bash
               run: |
-                mkdir -p dist
-                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
-                cp README.md LICENCE CHANGELOG.md dist/
-                cp config/example-config.json dist/
                 mkdir -p dist/docs
+                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+                cp LICENCE CHANGELOG.md dist/
+                cp config/example-config.json dist/
                 cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
+                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md dist/docs/
+
+                # A bundle-specific README rather than the repository's own:
+                # someone unpacking a binary wants install and verification
+                # steps, not the contributor-facing project page.
+                sed "s/@VERSION@/${{ needs.validate.outputs.tag }}/g" .github/release-assets/README.md > dist/README.md
                 cd dist
                 tar -czvf ../${{ matrix.artifact }}.tar.gz *
 
@@ -264,7 +269,8 @@ jobs:
                 mkdir -p verify && tar -xzf ${{ matrix.artifact }}.tar.gz -C verify
 
                 for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
-                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md; do
+                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md \
+                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md; do
                     if [[ ! -e "verify/$f" ]]; then
                         echo "Error: $f missing from ${{ matrix.artifact }}"
                         exit 1
@@ -286,12 +292,17 @@ jobs:
               if: runner.os == 'Windows'
               shell: bash
               run: |
-                mkdir -p dist
-                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
-                cp README.md LICENCE CHANGELOG.md dist/
-                cp config/example-config.json dist/
                 mkdir -p dist/docs
+                cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+                cp LICENCE CHANGELOG.md dist/
+                cp config/example-config.json dist/
                 cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
+                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md dist/docs/
+
+                # A bundle-specific README rather than the repository's own:
+                # someone unpacking a binary wants install and verification
+                # steps, not the contributor-facing project page.
+                sed "s/@VERSION@/${{ needs.validate.outputs.tag }}/g" .github/release-assets/README.md > dist/README.md
                 cd dist
                 7z a -tzip ../${{ matrix.artifact }}.zip *
 
@@ -304,7 +315,8 @@ jobs:
                 mkdir -p verify && 7z x -overify ${{ matrix.artifact }}.zip >/dev/null
 
                 for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
-                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md; do
+                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md \
+                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md; do
                     if [[ ! -e "verify/$f" ]]; then
                         echo "Error: $f missing from ${{ matrix.artifact }}"
                         exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
             - "v[0-9]+.[0-9]+.[0-9]+"
             - "v[0-9]+.[0-9]+.[0-9]+-*"
 
+    # Dry run. Builds, packages, smoke-tests and checksums every artefact
+    # exactly as a real release does, then stops before publishing anything.
+    # A pushed tag is permanent and a published release is public the instant
+    # it exists, so the pipeline is meant to be proven here first — see
+    # docs/RELEASING.md.
+    workflow_dispatch:
+
 # Serialise releases per-tag so re-running a tag (or pushing two tags
 # back-to-back) doesn't race on the same GitHub release page or
 # attestation upload. Don't cancel an in-progress release — half-
@@ -37,30 +44,54 @@ jobs:
         outputs:
             version: ${{ steps.version.outputs.version }}
             tag: ${{ steps.version.outputs.tag }}
+            is-release: ${{ steps.version.outputs.is-release }}
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                # Full history: the "tag is on main" check below needs the main
+                # branch and the tagged commit in the same clone.
+                fetch-depth: 0
 
             - name: Determine version
               id: version
               shell: bash
               run: |
-                TAG="${GITHUB_REF#refs/tags/}"
+                # Read the [package] version once; both modes need it.
+                CARGO_VERSION=$(awk -F'"' '
+                    /^\[package\]/ { in_pkg = 1; next }
+                    /^\[/          { in_pkg = 0 }
+                    in_pkg && /^version[[:space:]]*=/ { print $2; exit }
+                ' Cargo.toml)
 
-                # Validate tag format
-                if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-                    echo "Error: Invalid tag format: $TAG"
-                    echo "Expected format: v0.0.0 or v0.0.0-suffix"
-                    exit 1
+                if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+                    TAG="${GITHUB_REF#refs/tags/}"
+
+                    # Validate tag format
+                    if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+                        echo "Error: Invalid tag format: $TAG"
+                        echo "Expected format: v0.0.0 or v0.0.0-suffix"
+                        exit 1
+                    fi
+
+                    VERSION="${TAG#v}"
+                    echo "is-release=true" >> "$GITHUB_OUTPUT"
+                else
+                    # Dry run: build the version Cargo.toml currently declares
+                    # and publish nothing.
+                    VERSION="$CARGO_VERSION"
+                    TAG="(dry run)"
+                    echo "is-release=false" >> "$GITHUB_OUTPUT"
+                    echo "::notice::Dry run — artefacts will be built and verified but NOT published."
                 fi
 
-                VERSION="${TAG#v}"
                 echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                 echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                 echo "Release version: $VERSION (tag: $TAG)"
 
             - name: Verify Cargo.toml version matches tag
+              if: steps.version.outputs.is-release == 'true'
               shell: bash
               run: |
                 # Extract the version from the [package] section specifically.
@@ -88,6 +119,74 @@ jobs:
                 fi
 
                 echo "Version verified: $CARGO_VERSION"
+
+            # A tag can be pushed from any commit, including one that never sat
+            # on main and never passed CI. Releases are permanent, so refuse to
+            # build one from a commit main does not contain.
+            - name: Verify the tagged commit is on main
+              if: steps.version.outputs.is-release == 'true'
+              shell: bash
+              run: |
+                # Fetch main explicitly rather than relying on the checkout
+                # action having created the remote-tracking ref for it.
+                git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+
+                if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+                    echo "Error: the tagged commit is not an ancestor of origin/main."
+                    echo "  tagged commit: $GITHUB_SHA"
+                    echo ""
+                    echo "Release only from a commit that has been merged to main"
+                    echo "and has a green CI run."
+                    exit 1
+                fi
+                echo "Tagged commit is on main."
+
+            # Release notes are extracted from CHANGELOG.md at the very end of
+            # this workflow. Without this check a missing entry is only noticed
+            # after ~30 minutes of building, and the release silently publishes
+            # with the placeholder note "Release <version>".
+            - name: Verify CHANGELOG has an entry for this version
+              shell: bash
+              run: |
+                VERSION="${{ steps.version.outputs.version }}"
+                NOTES=$(awk -v ver="## [${VERSION}]" '
+                    index($0, ver) == 1 { found=1; next }
+                    found && /^## \[/ { exit }
+                    found { print }
+                ' CHANGELOG.md | tr -d '[:space:]')
+
+                if [[ -n "$NOTES" ]]; then
+                    echo "CHANGELOG entry found for ${VERSION}."
+                    exit 0
+                fi
+
+                MSG="CHANGELOG.md has no non-empty '## [${VERSION}]' section."
+                if [[ "${{ steps.version.outputs.is-release }}" == "true" ]]; then
+                    echo "Error: $MSG"
+                    echo ""
+                    echo "Stamp the heading (and its date) before tagging, so the"
+                    echo "published release notes are the real changelog entry."
+                    exit 1
+                fi
+                # Dry runs are expected to happen before the heading is stamped,
+                # so this is informational there rather than fatal.
+                echo "::warning::${MSG} Fine for a dry run; it will block the real tag."
+
+            # Fail fast rather than discovering the collision in `gh release
+            # create` after the whole matrix has built.
+            - name: Verify the release does not already exist
+              if: steps.version.outputs.is-release == 'true'
+              shell: bash
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                TAG="${{ steps.version.outputs.tag }}"
+                if gh release view "$TAG" >/dev/null 2>&1; then
+                    echo "Error: a GitHub release for $TAG already exists."
+                    echo "Releases are not overwritten by this workflow."
+                    exit 1
+                fi
+                echo "No existing release for $TAG."
 
     build:
         name: Build (${{ matrix.target }})
@@ -153,6 +252,36 @@ jobs:
                 cd dist
                 tar -czvf ../${{ matrix.artifact }}.tar.gz *
 
+            - name: Verify archive contents and run the packaged binary (Unix)
+              if: runner.os != 'Windows'
+              shell: bash
+              env:
+                EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+              run: |
+                # Unpack into a clean directory and exercise *that* copy, so the
+                # thing being checked is the artefact users download rather than
+                # the build tree it came from.
+                mkdir -p verify && tar -xzf ${{ matrix.artifact }}.tar.gz -C verify
+
+                for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
+                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md; do
+                    if [[ ! -e "verify/$f" ]]; then
+                        echo "Error: $f missing from ${{ matrix.artifact }}"
+                        exit 1
+                    fi
+                done
+
+                chmod +x "verify/${{ matrix.binary }}"
+                OUT="$(verify/${{ matrix.binary }} --version)"
+                echo "Packaged binary reports: $OUT"
+
+                # Pre-release tags (0.1.0-rc1) carry a suffix the crate version
+                # does not, so compare against the base version.
+                if [[ "$OUT" != *"${EXPECTED_VERSION%%-*}"* ]]; then
+                    echo "Error: expected version ${EXPECTED_VERSION%%-*} in --version output"
+                    exit 1
+                fi
+
             - name: Prepare artifact (Windows)
               if: runner.os == 'Windows'
               shell: bash
@@ -166,13 +295,39 @@ jobs:
                 cd dist
                 7z a -tzip ../${{ matrix.artifact }}.zip *
 
+            - name: Verify archive contents and run the packaged binary (Windows)
+              if: runner.os == 'Windows'
+              shell: bash
+              env:
+                EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+              run: |
+                mkdir -p verify && 7z x -overify ${{ matrix.artifact }}.zip >/dev/null
+
+                for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
+                         example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md; do
+                    if [[ ! -e "verify/$f" ]]; then
+                        echo "Error: $f missing from ${{ matrix.artifact }}"
+                        exit 1
+                    fi
+                done
+
+                OUT="$(verify/${{ matrix.binary }} --version)"
+                echo "Packaged binary reports: $OUT"
+
+                if [[ "$OUT" != *"${EXPECTED_VERSION%%-*}"* ]]; then
+                    echo "Error: expected version ${EXPECTED_VERSION%%-*} in --version output"
+                    exit 1
+                fi
+
             - name: Upload artifact (Unix)
               if: runner.os != 'Windows'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.tar.gz
-                retention-days: 1
+                # A week, so a dry run's artefacts can be downloaded and
+                # inspected by hand before anyone tags.
+                retention-days: 7
 
             - name: Upload artifact (Windows)
               if: runner.os == 'Windows'
@@ -180,11 +335,14 @@ jobs:
               with:
                 name: ${{ matrix.artifact }}
                 path: ${{ matrix.artifact }}.zip
-                retention-days: 1
+                retention-days: 7
 
     release:
         name: Create Release
         needs: [validate, build]
+        # Dry runs stop here: everything above has built, been unpacked, run and
+        # checksummed, but nothing is published.
+        if: needs.validate.outputs.is-release == 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 10
 
@@ -208,6 +366,27 @@ jobs:
             - name: List artifacts
               run: find artifacts -type f
 
+            # Guards against publishing a partial release. `needs: build` already
+            # fails the job if a matrix leg fails, but this also catches a leg
+            # that succeeded while uploading nothing (a mis-set path, a renamed
+            # artefact), which would otherwise ship a release silently missing
+            # one platform.
+            - name: Verify every platform artefact is present
+              shell: bash
+              run: |
+                missing=0
+                for expected in \
+                    altium-designer-mcp-linux-x86_64.tar.gz \
+                    altium-designer-mcp-macos-aarch64.tar.gz \
+                    altium-designer-mcp-windows-x86_64.zip; do
+                    if ! find artifacts -type f -name "$expected" | grep -q .; then
+                        echo "Error: missing artefact $expected"
+                        missing=1
+                    fi
+                done
+                [[ $missing -eq 0 ]] || exit 1
+                echo "All three platform artefacts present."
+
             - name: Generate checksums
               shell: bash
               run: |
@@ -215,6 +394,11 @@ jobs:
                 find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} . \;
                 sha256sum *.tar.gz *.zip > SHA256SUMS.txt
                 cat SHA256SUMS.txt
+
+                # Read the file back and re-hash: the checksums published beside
+                # the binaries are the one thing a user can verify a download
+                # against, so prove they match before anyone relies on them.
+                sha256sum --check --strict SHA256SUMS.txt
 
             - name: Attest build provenance
               uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -272,8 +456,17 @@ jobs:
                     RELEASE_FLAGS+=(--latest)
                 fi
 
-                # Create the release with gh CLI (more reliable than third-party actions)
+                # Created as a DRAFT on purpose. Everything above is automated
+                # and verified, but publishing is the one step that cannot be
+                # taken back: the moment a release is public it is mirrored,
+                # scraped and downloaded, and deleting it afterwards leaves
+                # dangling links rather than undoing anything. A draft is
+                # private to maintainers and can be deleted without trace, so
+                # the last action is a human opening the draft, checking the
+                # notes and the three archives, and pressing Publish.
+                # See docs/RELEASING.md.
                 gh release create "$TAG" \
+                    --draft \
                     --title "$TAG" \
                     --notes-file release_notes.md \
                     "${RELEASE_FLAGS[@]}" \
@@ -281,4 +474,15 @@ jobs:
                     artifacts/*.zip \
                     artifacts/SHA256SUMS.txt
 
-                echo "Release created: $TAG"
+                echo "Draft release created: $TAG"
+                echo "Review it, then publish:  gh release edit $TAG --draft=false"
+
+                {
+                    echo "### Draft release \`$TAG\` is ready"
+                    echo ""
+                    echo "Nothing is public yet. Review the draft, then publish with:"
+                    echo ""
+                    echo '```'
+                    echo "gh release edit $TAG --draft=false"
+                    echo '```'
+                } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,7 @@ cargo test module_name::
 | `docs/CLAUDE_CODE_GUIDE.md` | Step-by-step Claude Code setup guide |
 | `docs/ANTIGRAVITY_GUIDE.md` | Google Antigravity setup guide |
 | `docs/SECURITY.md` | Security threat model and design rationale |
+| `docs/RELEASING.md` | Release runbook: dry run, tag-day steps, draft review, rollback |
 | `docs/errors.md` | Error reference catalogue |
 | `docs/TOOLS.md` | Generated tool reference (source of truth: `src/mcp/tool_definitions.rs`) |
 | `docs/PCBLIB_FORMAT.md` | `.PcbLib` binary format reference |

--- a/README.md
+++ b/README.md
@@ -280,6 +280,21 @@ See [CONTRIBUTING.md § Development Setup](CONTRIBUTING.md#development-setup) fo
 
 The release binary will be at `target/release/altium-designer-mcp`.
 
+### Verifying a downloaded release
+
+Released archives are built by GitHub Actions and carry a signed
+[SLSA build provenance](https://slsa.dev/) attestation, so a download can be traced
+back to the workflow run and commit that produced it:
+
+```bash
+gh attestation verify <archive> --repo embedded-society/altium-designer-mcp
+sha256sum --check --ignore-missing SHA256SUMS.txt
+```
+
+The binaries are not code-signed, so Windows SmartScreen and macOS Gatekeeper warn on
+first run (on macOS, right-click → Open). The attestation is the stronger check.
+See [docs/RELEASING.md](docs/RELEASING.md) for how releases are produced.
+
 ### Command-Line Usage
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -97,6 +97,28 @@ Two notes on dry runs:
 
 10. **Announce** — including a note on the tracking issue if one is open.
 
+## Supply chain
+
+Each archive — and `SHA256SUMS.txt` itself — gets a signed
+[SLSA build provenance](https://slsa.dev/) attestation, binding the artefact's
+digest to this repository, the workflow that built it and the commit it was built
+from. The attestation lives in GitHub's attestation store, not in the release, so
+it cannot be swapped out by editing release assets.
+
+Verify any published artefact (this works for anyone, not just maintainers):
+
+```bash
+gh attestation verify altium-designer-mcp-linux-x86_64.tar.gz \
+    --repo embedded-society/altium-designer-mcp
+```
+
+The release body carries these instructions automatically — the workflow appends
+them to the changelog-derived notes, so there is nothing to remember at tag time.
+
+Worth checking once on the draft before publishing: download one archive and run
+the verify command against it. If provenance is broken, it is better found on a
+draft than after the release is public.
+
 ## If something is wrong
 
 - **Before publishing** — delete the draft, fix, and re-tag. Nothing was public.
@@ -118,5 +140,7 @@ Two notes on dry runs:
   `--locked` is the usual practice for a distributed binary; worth deciding
   before the first release rather than after.
 - **No code signing.** Windows SmartScreen and macOS Gatekeeper will warn on
-  first run. macOS users need right-click → Open. Worth documenting in the
-  release notes so it does not read as a broken download.
+  first run; macOS users need right-click → Open. The generated release notes say
+  so, and point at the provenance attestation as the stronger check. Proper
+  signing needs a paid Apple Developer account and a Windows certificate, so it
+  is a cost decision rather than a technical one.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,122 @@
+# Releasing
+
+How a tagged release of `altium-designer-mcp` is cut, and the order the safety
+nets are meant to catch mistakes in.
+
+A release is effectively permanent. The tag can be force-moved in principle, but
+by then people have pinned it, mirrors have copied it and the download links are
+in someone's notes; and a published release is public the instant it exists. The
+pipeline is therefore built so that **every irreversible step happens last, and
+only after a human has looked at the artefacts**.
+
+## What is automated
+
+`.github/workflows/release.yml` runs in three jobs:
+
+| Job | What it does | Can it publish? |
+|-----|--------------|-----------------|
+| `validate` | Tag format, `Cargo.toml` version match, tagged commit is on `main`, CHANGELOG entry exists, no release already exists | no |
+| `build` | Builds and tests on Linux / macOS / Windows, packages each archive, **unpacks it again and runs the packaged binary** | no |
+| `release` | Verifies all three artefacts arrived, generates and re-checks `SHA256SUMS.txt`, attests SLSA build provenance, creates a **draft** release | draft only |
+
+The final publish is a manual click. Nothing in CI makes a release public.
+
+## Dry run — do this first
+
+The whole pipeline can be exercised without a tag:
+
+```bash
+gh workflow run release.yml --ref main
+gh run watch
+```
+
+This builds, packages, smoke-tests and checksums all three platforms, then stops
+before the `release` job. Artefacts are kept for 7 days on the workflow run page,
+so you can download the real archives and try them on a real machine.
+
+Do this **before** stamping the changelog or tagging. It is the only way to find a
+packaging problem that costs nothing to fix.
+
+Two notes on dry runs:
+
+- The version used is whatever `Cargo.toml` currently declares.
+- A missing CHANGELOG section is a warning here, not a failure, because dry runs
+  normally happen before the heading is stamped. It is a hard failure for a real
+  tag.
+
+## Cutting the release
+
+1. **Confirm main is releasable.** Green CI on the head commit, no open PR you
+   meant to include, coverage where you want it.
+
+   ```bash
+   gh run list --workflow ci_main.yml --limit 1
+   ```
+
+2. **Stamp the CHANGELOG.** Replace the `## [Unreleased]` heading with
+   `## [X.Y.Z] - YYYY-MM-DD`. The release notes published on GitHub are exactly
+   the text between that heading and the next `## [`, so read it once as a
+   stranger would. Add a fresh empty `## [Unreleased]` above it for the next
+   cycle.
+
+3. **Set the version in `Cargo.toml`** if it is not already `X.Y.Z`. The tag and
+   the `[package]` version must agree or `validate` fails.
+
+4. **Merge those to main** through a PR, and let CI go green.
+
+5. **Dry-run once more** on that exact commit (see above), now that the changelog
+   heading exists. This is the last free rehearsal.
+
+6. **Tag and push.**
+
+   ```bash
+   git switch main && git pull
+   git tag -a v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+
+7. **Watch the workflow.**
+
+   ```bash
+   gh run watch
+   ```
+
+8. **Review the draft.** Download the three archives from the draft release page,
+   check `SHA256SUMS.txt`, and run at least one binary on a real machine:
+
+   ```bash
+   gh release view v0.1.0
+   sha256sum -c SHA256SUMS.txt
+   ```
+
+9. **Publish.**
+
+   ```bash
+   gh release edit v0.1.0 --draft=false
+   ```
+
+10. **Announce** — including a note on the tracking issue if one is open.
+
+## If something is wrong
+
+- **Before publishing** — delete the draft, fix, and re-tag. Nothing was public.
+
+  ```bash
+  gh release delete v0.1.0 --yes
+  git push --delete origin v0.1.0
+  git tag -d v0.1.0
+  ```
+
+- **After publishing** — do not delete or move the tag. Ship `v0.1.1`. A version
+  someone already downloaded should keep meaning what it meant.
+
+## Known gaps
+
+- **`Cargo.lock` is gitignored**, so release builds resolve dependencies fresh
+  and the three platform binaries are not guaranteed to be built against
+  identical dependency versions. Committing the lockfile and building with
+  `--locked` is the usual practice for a distributed binary; worth deciding
+  before the first release rather than after.
+- **No code signing.** Windows SmartScreen and macOS Gatekeeper will warn on
+  first run. macOS users need right-click → Open. Worth documenting in the
+  release notes so it does not read as a broken download.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,6 +21,18 @@ only after a human has looked at the artefacts**.
 
 The final publish is a manual click. Nothing in CI makes a release public.
 
+### What ships in an archive
+
+The binary, `example-config.json`, `LICENCE`, `CHANGELOG.md`, and `docs/`
+(`CLAUDE_CODE_GUIDE`, `ANTIGRAVITY_GUIDE`, `AGENT_GUIDE`, `TOOLS`) — plus a
+**bundle-specific `README.md` generated from
+[`.github/release-assets/README.md`](../.github/release-assets/README.md)**, with
+`@VERSION@` substituted for the tag. That file is what someone sees first after
+unzipping, so it covers installing the binary, writing a config, and wiring the
+server into Claude Code, Claude Desktop, Antigravity, Cursor and VS Code — not
+the repository's own contributor-facing README. Edit it when the setup steps
+change; the `build` job fails if any expected file is missing from an archive.
+
 ## Dry run — do this first
 
 The whole pipeline can be exercised without a tag:
@@ -67,11 +79,15 @@ Two notes on dry runs:
 5. **Dry-run once more** on that exact commit (see above), now that the changelog
    heading exists. This is the last free rehearsal.
 
-6. **Tag and push.**
+6. **Tag and push — the tag must be signed.** A repository ruleset covers all
+   tags with `required_signatures`, and restricts creation, update and deletion
+   to organisation admins. An unsigned tag is rejected at push time, so configure
+   commit signing first (`git config --global user.signingkey …`, or
+   `gpg.format=ssh` with an SSH key) and use `-s`:
 
    ```bash
    git switch main && git pull
-   git tag -a v0.1.0 -m "v0.1.0"
+   git tag -s v0.1.0 -m "v0.1.0"
    git push origin v0.1.0
    ```
 
@@ -96,6 +112,18 @@ Two notes on dry runs:
    ```
 
 10. **Announce** — including a note on the tracking issue if one is open.
+
+## Who can release
+
+A repository ruleset (`tags`, active, covering `~ALL` tags) restricts tag
+**creation, update and deletion**, with organisation admins as the only bypass
+actor, and requires signatures. Two consequences worth knowing:
+
+- Only an organisation admin can start a release, since the workflow triggers on
+  a pushed tag and `GITHUB_TOKEN` cannot create one. A compromised contributor
+  account cannot ship a version.
+- Published tags are immutable for everyone else — they cannot be force-moved or
+  deleted to retarget a release. Deleting a mistaken tag needs the admin bypass.
 
 ## Supply chain
 
@@ -122,6 +150,8 @@ draft than after the release is public.
 ## If something is wrong
 
 - **Before publishing** — delete the draft, fix, and re-tag. Nothing was public.
+  Deleting the remote tag requires the organisation-admin bypass on the tag
+  ruleset; if the delete is refused, that is the ruleset working as intended.
 
   ```bash
   gh release delete v0.1.0 --yes


### PR DESCRIPTION
## Description

Release infrastructure only — **no version bump, no tag, CHANGELOG untouched**.

A published release is effectively permanent, so the pipeline now proves itself before anything irreversible happens. Inspiration taken from `claude-chats-browser` (the dry-run pattern) and `git-proxy-mcp` (whose release workflow is otherwise the same as this one already was).

### 1. Dry-run mode

`workflow_dispatch` builds, packages, smoke-tests and checksums all three platforms, then stops before the `release` job. Artefact retention raised 1 → 7 days so the real archives can be downloaded and tried by hand.

```bash
gh workflow run release.yml --ref main
```

### 2. Pre-flight gates (fail in ~1 min, not after ~30 min of builds)

| Gate | Why |
|---|---|
| Tagged commit must be an ancestor of `origin/main` | A tag can be pushed from any commit; this stops a stray branch shipping unreviewed code |
| CHANGELOG must have a non-empty `## [X.Y.Z]` section | Previously a missing entry published the placeholder "Release X.Y.Z" as the notes, discovered only after everything had built. Warning-only on dry runs, which legitimately precede stamping |
| No release may already exist for the tag | Fail fast instead of erroring inside `gh release create` |

### 3. Artefact verification

Each archive is **unpacked again into a clean directory**, checked for all seven files it should contain, and the packaged binary is run with `--version` and matched against the release version. Nothing previously confirmed the shipped binary executed at all — only that `cargo build` succeeded.

### 4. Release job

- asserts all three platform artefacts arrived (a matrix leg that succeeds while uploading nothing would otherwise ship a release silently missing a platform);
- re-verifies `SHA256SUMS.txt` with `sha256sum --check --strict`, since those hashes are the one thing a user can check a download against;
- **creates the release as a draft.** Publishing becomes a deliberate human step: a draft is private to maintainers and can be deleted without a trace, whereas a published release is mirrored and scraped the moment it exists. Final step is `gh release edit vX.Y.Z --draft=false`, and the workflow prints that command in its run summary.

### 5. `docs/RELEASING.md`

Full runbook: dry run first, tag-day sequence, draft review, and the rollback paths before and after publishing. Also records two gaps worth a decision **before** the first release:

- **`Cargo.lock` is gitignored**, so the three platform binaries are not guaranteed to be built against identical dependency versions. Committing it and building `--locked` is the usual practice for a distributed binary.
- **No code signing** — SmartScreen/Gatekeeper will warn; worth saying so in the release notes.

## Testing

- `release.yml` parses as valid YAML; all three jobs and their step lists verified.
- `markdownlint-cli2` clean on the new and changed docs.
- The workflow itself is best exercised by running the dry run from this branch once merged (or via `gh workflow run release.yml --ref ci/release-infrastructure`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)