### PR TITLE
ci: batch Dependabot Actions and npm updates into weekly grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,58 @@
 version: 2
 updates:
-    # GitHub Actions: small dependency surface, easy to review
-    # individually — keep daily.
+    # GitHub Actions: a small, stable surface (checkout, setup-node, cache,
+    # rust-toolchain, install-action, attest-build-provenance). Individually
+    # they are trivial to review, but daily ungrouped updates produced a
+    # steady drip of near-identical PRs — mostly install-action patch bumps —
+    # each needing its own CI run and merge. One grouped weekly PR keeps the
+    # same freshness with a fraction of the churn.
+    #
+    # Cadence does not delay security fixes: Dependabot security updates are
+    # raised as soon as an advisory lands, independently of this schedule.
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "saturday"
         time: "00:00"
+        timezone: "Europe/Ljubljana"
+      groups:
+        github-actions:
+          patterns: ["*"]
+          update-types: ["major", "minor", "patch"]
+      labels: ["dependencies", "github_actions"]
 
-    # npm: markdownlint-cli2 tooling only.
+    # npm: markdownlint-cli2 tooling only. Same weekly batch as Actions —
+    # it is lint tooling, so there is nothing to gain from same-day bumps.
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-        interval: "daily"
+        interval: "weekly"
+        day: "saturday"
         time: "00:00"
+        timezone: "Europe/Ljubljana"
+      groups:
+        npm:
+          patterns: ["*"]
+          update-types: ["major", "minor", "patch"]
+      labels: ["dependencies", "javascript"]
 
     # Cargo: large transitive dependency surface. Weekly cadence +
     # grouping keeps PR noise manageable while still catching security
     # advisories within ~7 days. Grouping all updates into one PR per
     # week avoids the rebase-cascade that a per-crate flow produces.
+    # Kept on Monday, away from the two light PRs above, because a grouped
+    # crate bump is the one that occasionally needs real review.
     - package-ecosystem: "cargo"
       directory: "/"
       schedule:
         interval: "weekly"
         day: "monday"
         time: "00:00"
+        timezone: "Europe/Ljubljana"
       open-pull-requests-limit: 5
       groups:
         cargo-dependencies:
           patterns:
             - "*"
+      labels: ["dependencies", "rust"]


### PR DESCRIPTION
## Description

Actions and npm were **daily and ungrouped**, which is where the recent PR churn came from — six `taiki-e/install-action` bumps merged in the last few days, each a separate PR with its own CI run. Cargo was already grouped weekly; this brings the other two ecosystems in line.

Pattern taken from the sibling `arm-cmake-toolchains` repo.

| Ecosystem | Before | After |
|---|---|---|
| github-actions | daily, ungrouped | **weekly (Sat), one grouped PR** |
| npm | daily, ungrouped | **weekly (Sat), one grouped PR** |
| cargo | weekly (Mon), grouped | unchanged |

Actions and npm land Saturday; cargo stays Monday, since the grouped crate bump is the one that occasionally needs real review and is better kept away from the two light ones. Expected volume drops from a near-daily drip to at most three PRs a week.

All three schedules now pin `timezone: Europe/Ljubljana`, so "00:00" is local midnight rather than drifting an hour with DST.

### Does this delay security fixes?

No. Dependabot **security** updates are raised as soon as an advisory is published, independently of the version-update schedule configured here. This only affects routine version bumps.

### Labels

Explicit `dependencies` + ecosystem labels so grouped PRs stay filterable. All four labels (`dependencies`, `github_actions`, `javascript`, `rust`) already exist on the repository — verified via `gh label list`.

## Testing

- `dependabot.yml` parses as valid YAML; all three entries verified for interval, day, timezone, group patterns and labels.
- No open Dependabot PRs to supersede at the time of writing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)