### PR TITLE
fix(schlib): reject a PcbLib instead of reading it as an empty library

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -1455,6 +1455,39 @@ mod tests {
     }
 
     #[test]
+    fn wrong_file_type_real_pcblib_as_schlib() {
+        // Regression for #310. The test above hand-builds a hybrid — a
+        // SchLib-format length-prefixed FileHeader whose *text* names a PCB
+        // library — and that shape was already detected. A real PcbLib's
+        // FileHeader is a binary version-string block, so it yielded no
+        // properties at all and the reader returned Ok with zero symbols: the
+        // wrong-type guard never fired on the only file shape that occurs in
+        // practice. An append-style caller would then have saved an empty
+        // library over a real one.
+        use crate::altium::pcblib::{Footprint, Pad, PcbLib};
+
+        let mut lib = PcbLib::new();
+        let mut fp = Footprint::new("R0402");
+        fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+        lib.add(fp);
+
+        let mut buffer = Cursor::new(Vec::new());
+        lib.write(&mut buffer).expect("write a genuine PcbLib");
+
+        buffer.set_position(0);
+        let err = SchLib::read(&mut buffer).expect_err("a PcbLib must not read as a SchLib");
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("Wrong file type") && err_str.contains("expected SchLib"),
+            "got: {err_str}"
+        );
+        assert!(
+            err_str.contains("PcbLib"),
+            "the error should name what the file actually is, got: {err_str}"
+        );
+    }
+
+    #[test]
     fn roundtrip_line_fractional_and_negative_coords() {
         // Off-grid endpoints — including a negative fractional coordinate, the
         // case the elliptical-arc encoder never exercised — must survive a

--- a/src/altium/schlib/read_io.rs
+++ b/src/altium/schlib/read_io.rs
@@ -114,6 +114,20 @@ struct FileHeader {
 /// # Errors
 ///
 /// Returns an error if the file is not a valid `SchLib` (wrong file type).
+/// Recognises a `PcbLib`'s `/FileHeader` so it can be rejected by name rather
+/// than parsed as an empty `SchLib`.
+///
+/// The layout is `[u32 len][u8 len]["PCB <v> Binary Library File"]`, so the
+/// version string starts at offset 5. Both markers are required: `PCB ` alone
+/// is short enough to appear by chance in a corrupt block, whereas the pair
+/// only occurs in a genuine footprint-library header.
+fn looks_like_pcblib_header(data: &[u8]) -> bool {
+    const SCAN: usize = 64;
+    let window = &data[..data.len().min(SCAN)];
+    let contains = |needle: &[u8]| window.windows(needle.len()).any(|w| w == needle);
+    contains(b"PCB ") && contains(b"Binary Library File")
+}
+
 fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<FileHeader> {
     // A `SchLib` without a readable FileHeader is invalid, so map the shared
     // optional read onto a hard error.
@@ -123,6 +137,18 @@ fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<F
     // Parse header: [length:4 LE][pipe-delimited key=value pairs]
     if data.len() < 4 {
         return Err(AltiumError::parse_error(0, "FileHeader too short"));
+    }
+
+    // A PcbLib's FileHeader is a binary version-string block, not a
+    // length-prefixed pipe list, so it yields no properties at all and used to
+    // fall straight through to "zero symbols". Detect it positively: reading a
+    // footprint library as a symbol library must fail, not look empty, because
+    // any append-style caller would then save an empty library over the file.
+    if looks_like_pcblib_header(&data) {
+        return Err(AltiumError::wrong_file_type(
+            "SchLib",
+            "PcbLib (PCB Footprint Library)",
+        ));
     }
 
     let length = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
@@ -136,17 +162,25 @@ fn read_file_header<R: Read + Seek>(cfb: &mut CompoundFile<R>) -> AltiumResult<F
     let text = text.trim_end_matches('\u{0}');
     let props = crate::altium::parse_pipe_params(text);
 
-    // Validate file type - must be a Schematic Library
-    if let Some(header) = props.get("header") {
-        if !header.contains("Schematic Library") {
-            // Detect what type it actually is for a helpful error message
-            let actual_type = if header.contains("PCB Library") {
-                "PcbLib (PCB Footprint Library)"
-            } else {
-                header
-            };
-            return Err(AltiumError::wrong_file_type("SchLib", actual_type));
-        }
+    // Validate file type - must be a Schematic Library. The HEADER property is
+    // required rather than optional: Altium always writes it and so do we (see
+    // `schlib::writer`), so its absence means this is not a SchLib, and treating
+    // that as an empty-but-valid library is the same silent-data-loss trap as
+    // the PcbLib case above.
+    let Some(header) = props.get("header") else {
+        return Err(AltiumError::wrong_file_type(
+            "SchLib",
+            "unrecognised file (FileHeader has no HEADER property)",
+        ));
+    };
+    if !header.contains("Schematic Library") {
+        // Detect what type it actually is for a helpful error message
+        let actual_type = if header.contains("PCB Library") {
+            "PcbLib (PCB Footprint Library)"
+        } else {
+            header
+        };
+        return Err(AltiumError::wrong_file_type("SchLib", actual_type));
     }
 
     // Get component count


### PR DESCRIPTION
Closes #310. Found by @ande2407 while writing the tests in #306, and confirmed independently before filing.

## The bug

`PcbLib::open` detects a wrong-type file and fails cleanly. `SchLib::open` did not — for the file shape that actually occurs — and returned `Ok` with **zero symbols**.

A PcbLib's `/FileHeader` is a binary version-string block (`[u32 len][u8 len]["PCB 6.0 Binary Library File"]`, then a `f64` and a UniqueId), not the length-prefixed pipe list a SchLib carries. Parsed as the latter it yields no properties at all, so the `if let Some(header)` validation was skipped entirely and the reader carried on with `COMPCOUNT` defaulting to 0.

## Why it matters

For `delete_component` it is benign — nothing matches, so nothing is written. The risk is any **append-style path**, which reads the existing library and then saves: it would start from an empty library and overwrite the real contents. Silent data loss on a file the user believed was being appended to.

## Why the existing test never caught it

`wrong_file_type_pcblib_as_schlib` passes, and always did. It hand-builds a hybrid — a **SchLib-format** length-prefixed `FileHeader` whose *text* contains the PcbLib header string. That shape is detected. A real PcbLib never produces it, so the guard was only ever tested against a file no tool writes.

## The fix

- **Detect the PcbLib header positively.** Both the `PCB ` and `Binary Library File` markers are required, within the first 64 bytes, so a corrupt block cannot trip it by chance. Fails with the same `WrongFileType` error `PcbLib::open` already produces, naming what the file actually is.
- **Require the `HEADER` property** instead of validating it only when present. Altium always writes it, and so does our writer (`schlib/writer.rs`); its absence means the file is not a SchLib, and treating that as empty-but-valid is the same silent-empty trap. Checked the Altium-authored golden fixture directly — it carries `HEADER=Protel for Windows - Schematic Library Editor…` as expected.

## Testing

New `wrong_file_type_real_pcblib_as_schlib` writes a **genuine** `PcbLib` (footprint with a pad) and reads it back as a SchLib, asserting the error names both the expected and the actual type. The original hybrid test is kept and still passes.

Full suite green: 816 lib tests plus every integration suite — including the golden-fixture read tests, which is the check that requiring `HEADER` did not break reading real Altium files. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
