### PR TITLE
fix(pcblib): read /WideStrings per component, not from the root

### DIFF
--- a/scripts/altium/generate/GenerateSamples.pas
+++ b/scripts/altium/generate/GenerateSamples.pas
@@ -499,7 +499,7 @@ end;
 { ---- PcbLib authoring -------------------------------------------------------
 
   Footprints: PAD_SHAPES, PAD_HOLES, VIAS, TRACKS, ARCS, REGIONS, FILLS, TEXT_STROKE,
-  TEXT_WIN1252. Each new footprint is wrapped in try/except so one failing primitive
+  TEXT_WIN1252, TEXT_UNICODE. Each new footprint is wrapped in try/except so one failing primitive
   doesn't abort the whole script (a missing footprint then shows up as a failed read
   test). Blind/buried vias, stacks and 3D bodies follow in later batches. }
 procedure GeneratePcbLib;
@@ -651,6 +651,31 @@ begin
         PCBServer.PreProcess;
         AddText(Comp, 0,   0, '10' + Chr(181) + 'F', 50, 0, eTopOverlay);
         AddText(Comp, 0, 100, Chr(177) + '5%',       50, 0, eTopOverlay);
+        PCBServer.PostProcess;
+    except
+    end;
+
+    // TEXT_UNICODE: characters that Windows-1252 CANNOT represent, so Altium has to fall
+    // back on the out-of-line /{component}/WideStrings stream for the real content. Every
+    // text in the samples so far is Win1252-representable and Altium duplicates it inline
+    // in block 1, which means the reader's WideStrings path has never been proven against
+    // a real Altium file (see issue #314).
+    //
+    // Built with Chr() for the same reason as TEXT_WIN1252 — a literal high codepoint was
+    // not interpreted. Chr(937)=Greek capital omega (the ohm sign on a resistor legend),
+    // Chr(956)=Greek small mu, Chr(1050)/Chr(1054)/Chr(1053) = Cyrillic KON, and
+    // Chr(20013)=CJK 'zhong'. If AD24 rejects any of these the try/except leaves the rest
+    // of the library intact; record the negative here and in docs/FIXTURE_COVERAGE.md
+    // rather than retrying blindly.
+    try
+        Comp := PCBServer.CreatePCBLibComp;
+        Comp.Name := 'TEXT_UNICODE';
+        Lib.RegisterComponent(Comp);
+        PCBServer.PreProcess;
+        AddText(Comp, 0,   0, '100' + Chr(937),                  50, 0, eTopOverlay);
+        AddText(Comp, 0, 100, '4' + Chr(956) + '7',              50, 0, eTopOverlay);
+        AddText(Comp, 0, 200, Chr(1050) + Chr(1054) + Chr(1053), 50, 0, eTopOverlay);
+        AddText(Comp, 0, 300, Chr(20013),                        50, 0, eTopOverlay);
         PCBServer.PostProcess;
     except
     end;

--- a/src/altium/pcblib/read_io.rs
+++ b/src/altium/pcblib/read_io.rs
@@ -28,9 +28,6 @@ impl PcbLib {
         // Note: This is currently a stub - the format is not fully documented
         Self::read_storage_stream(&mut cfb);
 
-        // Read WideStrings stream if present (contains text content for Text primitives)
-        let wide_strings = Self::read_wide_strings(&mut cfb);
-
         // Read embedded 3D models if present
         library.models = Self::read_models(&mut cfb);
 
@@ -63,12 +60,7 @@ impl PcbLib {
 
                 if !component_name.is_empty() && !is_internal {
                     // Read the component data
-                    match Self::read_footprint(
-                        &mut cfb,
-                        &entry_path,
-                        &component_name,
-                        &wide_strings,
-                    ) {
+                    match Self::read_footprint(&mut cfb, &entry_path, &component_name) {
                         Ok(footprint) => {
                             footprints_by_ole_name.insert(component_name.clone(), footprint);
                         }
@@ -337,14 +329,19 @@ impl PcbLib {
         }
     }
 
-    /// Reads the `WideStrings` stream if present.
+    /// Reads a component's `WideStrings` stream if present.
+    ///
+    /// The stream is **per component** (`/{component}/WideStrings`), matching
+    /// Altium and our own writer. This used to read a library-wide
+    /// `/WideStrings`, which no `PcbLib` contains, so the table was always empty
+    /// and every out-of-line text resolved to nothing.
     fn read_wide_strings<F: std::io::Read + std::io::Seek>(
         cfb: &mut cfb::CompoundFile<F>,
+        path: &std::path::Path,
     ) -> reader::WideStrings {
-        if let Some(data) = crate::altium::read_stream_opt(cfb, "/WideStrings") {
-            return reader::parse_wide_strings(&data);
-        }
-        reader::WideStrings::new()
+        crate::altium::read_stream_opt(cfb, path)
+            .map(|data| reader::parse_wide_strings(&data))
+            .unwrap_or_default()
     }
 
     /// Reads embedded 3D models from `/Library/Models/` storage.
@@ -423,9 +420,12 @@ impl PcbLib {
         cfb: &mut cfb::CompoundFile<F>,
         storage_path: &std::path::Path,
         name: &str,
-        wide_strings: &reader::WideStrings,
     ) -> AltiumResult<Footprint> {
         let mut footprint = Footprint::new(name);
+
+        // This component's out-of-line text, read here rather than library-wide
+        // because that is where Altium puts it.
+        let wide_strings = Self::read_wide_strings(cfb, &storage_path.join("WideStrings"));
 
         // Read parameters if present
         let params_path = storage_path.join("Parameters");
@@ -444,7 +444,7 @@ impl PcbLib {
                 AltiumError::invalid_ole(format!("Failed to read Data stream: {e}"))
             })?;
 
-            Self::parse_primitives(&mut footprint, &data, wide_strings);
+            Self::parse_primitives(&mut footprint, &data, &wide_strings);
         }
 
         // Read UniqueIDPrimitiveInformation stream if present (contains unique IDs for primitives)


### PR DESCRIPTION
Closes #314. Found while verifying the #309 fix end to end.

## The mismatch

The writer stores the stream **per component** (`/{ole_name}/WideStrings`), matching Altium and `docs/PCBLIB_FORMAT.md`. The reader looked for a library-wide `/WideStrings`. No PcbLib contains one, so the table handed to every text parse was **always empty**.

Consequences:

1. **Out-of-line text was unreachable.** A text primitive whose content block is empty carries its content in `/WideStrings`, named by the index at geometry offset 115. `extract_text_from_block` implements that lookup correctly, but against an empty table it returned `String::new()` — the marking silently disappears from the footprint.
2. **Unicode text always degraded** to whatever the Windows-1252 block held, which is the very thing `/WideStrings` exists to avoid.
3. **It masked #309.** That content-as-index heuristic could never fire, because every lookup missed. #309 landed first deliberately: fixing this plumbing without it would have turned a latent corruption into a live one.

## The fix

`read_footprint` already receives the component's storage path, so it reads the stream there and passes that component's table to its own primitives. The library-wide read is gone. `parse_wide_strings` itself was already correct and tested — this is plumbing only.

## What this does and does not prove

**No golden assertion changed.** Every text in the current samples is Windows-1252-representable, and Altium duplicates it inline in block 1, so the fixtures read identically before and after. I confirmed that by dumping the sample `Data` streams rather than assuming it:

```text
TEXT_WIN1252/Data -> [... b'10\xb5F' ...]      # inline, so block 1 wins either way
TEXT_STROKE/Data  -> [... b'REF' ...]
```

So this fix is currently a correctness repair with no observable change against our fixtures — and that is precisely the gap: **the WideStrings path still has no proof against a real Altium file.**

`GenerateSamples.pas` therefore gains a `TEXT_UNICODE` footprint whose content Windows-1252 cannot represent — Greek omega and mu, Cyrillic, CJK — which should force Altium to store the text out of line. Built with `Chr()` for the same reason `TEXT_WIN1252` is, and wrapped in the usual `try/except` so a rejected codepoint cannot abort the rest of the library.

Exact assertions follow in a second commit once the samples are regenerated and the actual on-disk shape is known — including whether Altium empties block 1 or writes a lossy placeholder. Per `docs/FIXTURE_COVERAGE.md`, if a codepoint turns out not to be persistable, that negative gets recorded rather than retried blindly.

## Testing

Full suite green: 816 lib tests plus every integration suite, including the golden-fixture read tests. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
