### PR TITLE
fix(pcblib): write text over 255 bytes instead of refusing the save

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -1402,6 +1402,70 @@ mod tests {
     }
 
     #[test]
+    fn library_roundtrip_text_longer_than_the_block_1_limit() {
+        // Block 1 of a Text record is a Pascal SHORT string, so a text over 255
+        // bytes cannot be stored inline: Altium truncates block 1 and carries
+        // the full value in /WideStrings, addressed by the index in the
+        // geometry block. A library Altium can author must therefore survive a
+        // write -> read cycle here, rather than the save being refused.
+        //
+        // Two texts, so a mis-addressed index resolves to the wrong entry
+        // instead of coincidentally matching.
+        use std::io::Cursor;
+
+        let long = "A".repeat(260) + "_END";
+        let text_at = |content: &str, y: f64| Text {
+            x: 0.0,
+            y,
+            text: content.to_string(),
+            height: 1.0,
+            layer: Layer::TopOverlay,
+            kind: TextKind::Stroke,
+            rotation: 0.0,
+            stroke_font: None,
+            stroke_width: None,
+            italic: false,
+            bold: false,
+            mirror: false,
+            is_comment: false,
+            is_designator: false,
+            font_name: "Arial".to_string(),
+            justification: TextJustification::default(),
+            is_inverted: false,
+            inverted_border: None,
+            use_inverted_rectangle: false,
+            inverted_rect_width: None,
+            inverted_rect_height: None,
+            inverted_rect_text_offset: None,
+            flags: PcbFlags::default(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
+            unique_id: None,
+        };
+
+        let mut fp = Footprint::new("LONG_TEXT");
+        fp.add_text(text_at(&long, 0.0));
+        fp.add_text(text_at("SHORT", -2.0));
+        let mut lib = PcbLib::new();
+        lib.add(fp);
+
+        let mut buffer = Cursor::new(Vec::new());
+        lib.write(&mut buffer)
+            .expect("a 264-character text must be writable");
+        buffer.set_position(0);
+        let read_back = PcbLib::read(&mut buffer).expect("read back");
+
+        let fp = read_back.get("LONG_TEXT").expect("footprint");
+        let contents: Vec<&str> = fp.text.iter().map(|t| t.text.as_str()).collect();
+        assert_eq!(
+            contents,
+            vec![long.as_str(), "SHORT"],
+            "both texts must survive, the long one in full"
+        );
+    }
+
+    #[test]
     fn binary_roundtrip_common_indices() {
         // A board-context Track and Text carrying a net/component association must
         // survive encode -> decode via the common-header indices (@3 net, @5

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -329,7 +329,7 @@ pub fn encode_data_stream(footprint: &Footprint) -> crate::altium::error::Altium
             wide_index += 1;
             Some(current)
         };
-        encode_text(&mut data, text, index)?;
+        encode_text(&mut data, text, index);
     }
 
     for region in &footprint.regions {
@@ -1057,19 +1057,21 @@ fn encode_arc(data: &mut Vec<u8>, arc: &Arc) {
 /// Text has 2 blocks:
 /// - Block 0: Geometry/metadata (layer, position, height, rotation, font info)
 /// - Block 1: Text content (length-prefixed string)
-fn encode_text(
-    data: &mut Vec<u8>,
-    text: &Text,
-    wide_index: Option<u32>,
-) -> crate::altium::error::AltiumResult<()> {
+fn encode_text(data: &mut Vec<u8>, text: &Text, wide_index: Option<u32>) {
     // Block 0: Geometry
     let geometry = encode_text_geometry(text, wide_index);
     write_block(data, &geometry);
 
-    // Block 1: Text content
-    write_string_block(data, &text.text, "text.text")?;
-
-    Ok(())
+    // Block 1: Text content, a Pascal short string capped at 255 bytes.
+    //
+    // Longer text is truncated here rather than rejected, because the full
+    // value is carried by `/WideStrings` and addressed by the index stamped in
+    // the geometry block above — which is how Altium itself stores it, and the
+    // only way a text that Altium can author survives a read-modify-write.
+    // Windows-1252 is single-byte, so the cut cannot split a character.
+    let encoded = crate::altium::encode_windows1252(&text.text);
+    let truncated = &encoded[..encoded.len().min(255)];
+    crate::altium::framing::write_string_block(data, truncated);
 }
 
 /// Canonical 252-byte text SubRecord-1 (offsets 0-251), ported from

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -1102,3 +1102,33 @@ fn samples_pcblib_text_special() {
         "INV text offset was not authored (zero on disk reads back None)"
     );
 }
+
+#[test]
+fn samples_pcblib_golden_survives_a_read_modify_write() {
+    // The whole library is read from the Altium-authored golden and written
+    // back through our writer, in memory. A footprint Altium can author must be
+    // saveable: TEXT_LONG's 264-character string exceeds the 255-byte Pascal
+    // short string in block 1, so the writer has to truncate that block and let
+    // /WideStrings carry the full value, exactly as Altium does.
+    use std::io::Cursor;
+
+    let mut lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open golden");
+    let before = lib.len();
+
+    let mut buffer = Cursor::new(Vec::new());
+    lib.write(&mut buffer)
+        .expect("the golden library must be writable");
+    buffer.set_position(0);
+    let round_tripped = PcbLib::read(&mut buffer).expect("read back");
+
+    assert_eq!(round_tripped.len(), before, "no footprint lost");
+
+    let long = round_tripped
+        .get("TEXT_LONG")
+        .expect("TEXT_LONG survives")
+        .text
+        .iter()
+        .find(|t| t.text.len() > 255)
+        .expect("the 264-character text keeps its full length");
+    assert_eq!(long.text, "A".repeat(260) + "_END");
+}


### PR DESCRIPTION
Closes #319. Found by hunting the write side after #317 fixed the read side.

## The bug

Reading the golden `TEXT_LONG` footprint returns its full 264-character string. Saving the library back fails:

```text
Invalid parameter 'text.text': String 'AAAAAAAAAAAAAAAAAAAA...' length 264 exceeds maximum of 255 bytes
```

Block 1 of a Text record is a Pascal **short** string, so `write_string_block` refused it. Altium does not — it truncates block 1 and carries the full value in `/{component}/WideStrings`.

**Our own Altium-authored fixture could not be round-tripped.** Read-modify-write is the normal mode of every update, import, append and delete path, so any library containing one long text was unsaveable, with a hard error on an operation the user expects to succeed.

## The fix

Truncate block 1 at 255 bytes for **text content only**, matching Altium. This is lossless now that #317 made the writer emit the full string to `/WideStrings` with the correct entry index, and the reader prefer that entry over block 1. Windows-1252 is single-byte, so the cut cannot split a character.

Identity fields (`footprint.name`, `pad.designator`) keep the hard 255-byte error, where silently truncating a name would be wrong.

`encode_text` becomes infallible and drops its `Result`.

## Tests

Following the project convention — write tests write to an in-memory buffer and read straight back; read tests use the golden:

- `library_roundtrip_text_longer_than_the_block_1_limit`: a 264-character text alongside a short one (so a mis-addressed index resolves to the wrong entry rather than coincidentally matching), written to a `Cursor` and read back.
- `samples_pcblib_golden_survives_a_read_modify_write`: the whole golden library read, written to a `Cursor` and read back — no footprint lost, `TEXT_LONG` intact at 264 characters.

**Verified by mutation:** restoring the rejection fails the write test with the original `exceeds maximum of 255 bytes` error.

Full suite green: 817 lib tests plus every integration suite. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)