### PR TITLE
test(scripts): add a reproducible Altium round-trip verification

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,7 @@ oracle in [`tests/integration/`](../tests/integration/).)
 |------|------------|---------------|
 | [`Verify-Libraries.ps1`](Verify-Libraries.ps1) | Launch Altium to confirm a `.PcbLib`/`.SchLib` opens cleanly | **Yes** |
 | [`Generate-Samples.ps1`](Generate-Samples.ps1) | Launch Altium to author the sample libraries | **Yes** |
+| [`Verify-RoundTrip.ps1`](Verify-RoundTrip.ps1) | Write libraries through the MCP server, then check Altium resolves every component name | **Yes** |
 | [`Resolve-AltiumExe.ps1`](Resolve-AltiumExe.ps1) | Shared helper: read `ALTIUM_EXE` from the repo-root `.env.local` | — |
 | [`altium/`](altium/) | The DelphiScript automation the launchers run | **Yes** |
 | [`samples/`](samples/) | Altium-authored sample libraries (ground truth for the tests) | No |
@@ -35,7 +36,7 @@ through Altium's `RunScript` CLI. Because it needs the GUI application and a lic
 
 | Path | Role |
 |------|------|
-| [`altium/verify/`](altium/verify/) | `AltiumVerify.pas` — opens each library and reports PASS/FAIL (run by `Verify-Libraries.ps1`) |
+| [`altium/verify/`](altium/verify/) | `AltiumVerify.pas` — opens each library and reports PASS/FAIL plus the component names Altium resolved (run by `Verify-Libraries.ps1`) |
 | [`altium/generate/`](altium/generate/) | `GenerateSamples.pas` — authors the sample libraries (run by `Generate-Samples.ps1`) |
 
 The `RunScript` launch and the file-based request/response bridge are adapted from

--- a/scripts/Verify-Libraries.ps1
+++ b/scripts/Verify-Libraries.ps1
@@ -98,6 +98,11 @@ foreach ($r in @($results)) {
     }
 }
 
+# Emit the parsed results so a caller can assert on more than PASS/FAIL — the
+# per-file `components` array is what Verify-RoundTrip.ps1 compares against.
+# Progress above goes through Write-Host, so this is the only pipeline output.
+@($results)
+
 if ($allOk) {
     Write-Host "`nAll libraries opened in Altium." -ForegroundColor Green
 } else {

--- a/scripts/Verify-RoundTrip.ps1
+++ b/scripts/Verify-RoundTrip.ps1
@@ -1,0 +1,269 @@
+﻿<#
+.SYNOPSIS
+    On-site: prove that a library this server writes can be opened by a real
+    Altium Designer, with its component names intact.
+
+.DESCRIPTION
+    Closes the loop the other two scripts each cover half of. Generate-Samples.ps1
+    proves we can READ what Altium writes; the pyaltiumlib oracle in CI proves our
+    output parses independently. Neither proves that Altium itself opens a file we
+    wrote and resolves the components inside it.
+
+    The whole path is exercised end to end, through the shipped binary rather than
+    library internals:
+
+      1. build the MCP server
+      2. drive it over stdio with real `write_schlib` / `write_pcblib` tool calls
+      3. read the libraries back through `read_schlib` / `read_pcblib`
+      4. hand the files to Altium via Verify-Libraries.ps1
+      5. compare the component names Altium resolved against what was authored
+
+    Step 5 is the point. "Opened" alone only proves the file parses; a name
+    comparison proves the components are reachable and their text survived.
+    Non-ASCII names are included deliberately — that is where the encodings in
+    play (Windows-1252 records, UTF-16 storage names, %UTF8% promotion) disagree,
+    and where a regression would otherwise be invisible.
+
+    On-site only: needs Altium Designer installed (developed against AD24). Never CI.
+
+.PARAMETER AltiumExe
+    Path to X2.EXE. Read from the repo-root .env.local (ALTIUM_EXE) when omitted.
+
+.PARAMETER WorkDir
+    Where the generated libraries are written. Defaults to a fresh timestamped
+    directory under the system temp folder, kept afterwards for inspection.
+
+.PARAMETER KeepAltiumOpen
+    Leave Altium running afterwards, with both libraries open for inspection.
+    By default it is closed, since this is an automated pass/fail check.
+
+.PARAMETER SkipBuild
+    Reuse an existing debug binary instead of running cargo build.
+
+.PARAMETER TimeoutSeconds
+    How long to wait for Altium (default 180).
+
+.EXAMPLE
+    .\Verify-RoundTrip.ps1
+
+.EXAMPLE
+    .\Verify-RoundTrip.ps1 -SkipBuild -WorkDir C:\tmp\rt
+#>
+param(
+    [string]$AltiumExe,
+    [string]$WorkDir,
+    [switch]$SkipBuild,
+    [switch]$KeepAltiumOpen,
+    [int]$TimeoutSeconds = 180
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+
+# The names under test. ASCII first as a control: if these fail too, the problem
+# is the harness, not encoding. The rest cover the scripts a user might plausibly
+# name a part in, plus an ohm sign, which is outside Windows-1252 but common on
+# any resistor legend.
+$SymbolNames = @('PLAIN_ASCII', 'Резистор', '電阻', 'Ωmega', 'Ελλάδα')
+$FootprintNames = @('PLAIN_0402', 'Резистор_0402')
+
+if (-not $WorkDir) {
+    $stamp   = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) "adm_roundtrip_$stamp"
+}
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+Write-Host "Work dir : $WorkDir"
+
+# ---------------------------------------------------------------------------
+# 1. Build the server
+# ---------------------------------------------------------------------------
+$Exe = Join-Path $RepoRoot 'target\debug\altium-designer-mcp.exe'
+if (-not $SkipBuild) {
+    Write-Host 'Building  : cargo build'
+    Push-Location $RepoRoot
+    try {
+        # No 2>&1 here: in Windows PowerShell 5.1 redirecting a native command's
+        # stderr wraps each line in an ErrorRecord, which $ErrorActionPreference
+        # = 'Stop' then treats as a failure even when cargo exits 0.
+        & cargo build --quiet
+        if ($LASTEXITCODE -ne 0) { throw "cargo build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+}
+if (-not (Test-Path $Exe)) { throw "binary not found: $Exe (run without -SkipBuild)" }
+
+# ---------------------------------------------------------------------------
+# 2. Drive the server over stdio
+# ---------------------------------------------------------------------------
+# allowed_paths confines the server; point it at the work directory only, which
+# also exercises the sandbox on the path this test uses.
+$ConfigPath = Join-Path $WorkDir 'config.json'
+@{
+    allowed_paths = @($WorkDir -replace '\\', '/')
+    logging       = @{ level = 'warn'; audit_log_path = $null }
+} | ConvertTo-Json -Depth 5 | ForEach-Object {
+    # WriteAllText, not Set-Content: PowerShell 5.1's -Encoding utf8 emits a BOM,
+    # and a leading BOM makes the server's JSON parser reject the config.
+    [System.IO.File]::WriteAllText($ConfigPath, $_, (New-Object System.Text.UTF8Encoding $false))
+}
+
+$SchLibPath = Join-Path $WorkDir 'RoundTrip.SchLib'
+$PcbLibPath = Join-Path $WorkDir 'RoundTrip.PcbLib'
+
+# One JSON-RPC message per line, in the order the protocol requires.
+$requests = New-Object System.Collections.Generic.List[string]
+function Add-Request([int]$Id, [string]$Method, $Params) {
+    $msg = [ordered]@{ jsonrpc = '2.0'; method = $Method }
+    if ($Id -ge 0) { $msg['id'] = $Id }
+    if ($null -ne $Params) { $msg['params'] = $Params }
+    $requests.Add(($msg | ConvertTo-Json -Depth 20 -Compress))
+}
+
+Add-Request 1 'initialize' @{
+    protocolVersion = '2024-11-05'
+    capabilities    = @{}
+    clientInfo      = @{ name = 'verify-roundtrip'; version = '1.0.0' }
+}
+Add-Request -1 'notifications/initialized' $null
+
+# A symbol per name: one pin each, enough for Altium to treat it as a real part.
+$symbols = @()
+foreach ($n in $SymbolNames) {
+    $symbols += @{
+        name        = $n
+        designator  = 'U?'
+        description = "$n description"
+        pins        = @(@{ designator = '1'; name = 'A'; x = -30; y = 0; length = 30; orientation = 'left' })
+        rectangles  = @(@{ x1 = -20; y1 = -10; x2 = 20; y2 = 10 })
+    }
+}
+Add-Request 2 'tools/call' @{
+    name      = 'write_schlib'
+    arguments = @{ filepath = $SchLibPath; symbols = $symbols }
+}
+
+$footprints = @()
+foreach ($n in $FootprintNames) {
+    $footprints += @{
+        name = $n
+        pads = @(
+            @{ designator = '1'; x = -0.5; y = 0; width = 0.6; height = 0.5 },
+            @{ designator = '2'; x = 0.5; y = 0; width = 0.6; height = 0.5 }
+        )
+    }
+}
+Add-Request 3 'tools/call' @{
+    name      = 'write_pcblib'
+    arguments = @{ filepath = $PcbLibPath; footprints = $footprints }
+}
+
+Add-Request 4 'tools/call' @{ name = 'read_schlib'; arguments = @{ filepath = $SchLibPath } }
+Add-Request 5 'tools/call' @{ name = 'read_pcblib'; arguments = @{ filepath = $PcbLibPath } }
+
+$RequestPath = Join-Path $WorkDir 'requests.jsonl'
+# UTF-8 without BOM: a BOM on the first line is not valid JSON-RPC framing.
+[System.IO.File]::WriteAllLines($RequestPath, $requests, (New-Object System.Text.UTF8Encoding $false))
+
+Write-Host 'MCP       : writing and reading back libraries'
+$OutPath = Join-Path $WorkDir 'responses.jsonl'
+$ErrPath = Join-Path $WorkDir 'server.log'
+$proc = Start-Process -FilePath $Exe -ArgumentList "`"$ConfigPath`"" -NoNewWindow -PassThru `
+    -RedirectStandardInput $RequestPath -RedirectStandardOutput $OutPath -RedirectStandardError $ErrPath
+$proc | Wait-Process -Timeout 120
+
+$responses = @(Get-Content -Path $OutPath -Encoding utf8 | Where-Object { $_.Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
+
+function Get-ToolText([int]$Id) {
+    $r = $responses | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+    if (-not $r) { throw "no response for request $Id (see $ErrPath)" }
+    if ($r.PSObject.Properties.Name -contains 'error') { throw "request $Id failed: $($r.error.message)" }
+    if ($r.result.isError) { throw "request ${Id}: tool reported an error: $($r.result.content[0].text)" }
+    $r.result.content[0].text
+}
+
+# ---------------------------------------------------------------------------
+# 3. What the server itself read back
+# ---------------------------------------------------------------------------
+$schRead = Get-ToolText 4 | ConvertFrom-Json
+$pcbRead = Get-ToolText 5 | ConvertFrom-Json
+$serverSymbols    = @($schRead.symbols    | ForEach-Object { $_.name })
+$serverFootprints = @($pcbRead.footprints | ForEach-Object { $_.name })
+
+# ---------------------------------------------------------------------------
+# 4. What Altium resolves
+# ---------------------------------------------------------------------------
+Write-Host 'Altium    : opening both libraries'
+$verifyArgs = @{ Files = @($SchLibPath, $PcbLibPath); TimeoutSeconds = $TimeoutSeconds }
+if ($AltiumExe) { $verifyArgs['AltiumExe'] = $AltiumExe }
+$altium = & (Join-Path $ScriptDir 'Verify-Libraries.ps1') @verifyArgs
+
+function Get-AltiumResult([string]$Path) {
+    $r = $altium | Where-Object { $_.file -eq $Path } | Select-Object -First 1
+    if (-not $r) { throw "Altium returned no result for $Path" }
+    $r
+}
+
+# ---------------------------------------------------------------------------
+# 5. Compare
+# ---------------------------------------------------------------------------
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Compare-Names([string]$Label, [string[]]$Expected, [string[]]$Actual) {
+    $missing = @($Expected | Where-Object { $Actual -notcontains $_ })
+    $extra   = @($Actual   | Where-Object { $Expected -notcontains $_ })
+    if ($missing.Count -or $extra.Count) {
+        $script:failures.Add("${Label}: missing [$($missing -join ', ')] unexpected [$($extra -join ', ')]")
+        Write-Host "  FAIL  $Label" -ForegroundColor Red
+        Write-Host "        expected: $($Expected -join ', ')"
+        Write-Host "        actual  : $($Actual -join ', ')"
+    } else {
+        Write-Host "  ok    $Label ($($Expected.Count) components)" -ForegroundColor Green
+    }
+}
+
+Write-Host ''
+Write-Host 'Server read-back:'
+Compare-Names 'SchLib via read_schlib' $SymbolNames    $serverSymbols
+Compare-Names 'PcbLib via read_pcblib' $FootprintNames $serverFootprints
+
+Write-Host ''
+Write-Host 'Altium:'
+foreach ($pair in @(@{ P = $SchLibPath; N = $SymbolNames; L = 'SchLib' },
+                    @{ P = $PcbLibPath; N = $FootprintNames; L = 'PcbLib' })) {
+    $res = Get-AltiumResult $pair.P
+    if (-not $res.opened) {
+        $failures.Add("$($pair.L): Altium could not open it — $($res.detail)")
+        Write-Host "  FAIL  $($pair.L) did not open: $($res.detail)" -ForegroundColor Red
+        continue
+    }
+    Compare-Names "$($pair.L) as resolved by Altium" $pair.N @($res.components)
+}
+
+# Close Altium unless asked otherwise. Verify-Libraries.ps1 deliberately leaves
+# the documents open for a human to look at; this script is a pass/fail check, so
+# the default is the other way round. Loop-kill: Altium takes a moment to exit and
+# can spawn helper X2 processes.
+if (-not $KeepAltiumOpen) {
+    $deadline = (Get-Date).AddSeconds(15)
+    while ((Get-Process X2 -ErrorAction SilentlyContinue) -and (Get-Date) -lt $deadline) {
+        Get-Process X2 -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Milliseconds 500
+    }
+    if (Get-Process X2 -ErrorAction SilentlyContinue) {
+        Write-Host 'Altium still running (could not fully close).' -ForegroundColor Yellow
+    } else {
+        Write-Host 'Closed Altium.'
+    }
+}
+
+Write-Host ''
+if ($failures.Count) {
+    Write-Host "FAILED ($($failures.Count))" -ForegroundColor Red
+    $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    Write-Host "Artefacts kept in $WorkDir"
+    exit 1
+}
+
+Write-Host 'PASS — every component round-tripped through the server and Altium.' -ForegroundColor Green
+Write-Host "Artefacts kept in $WorkDir"

--- a/scripts/altium/verify/AltiumVerify.pas
+++ b/scripts/altium/verify/AltiumVerify.pas
@@ -31,11 +31,70 @@ begin
     Result := StringReplace(Result, '"', '\"', REPLACEALL);
 end;
 
+
+{ Returns the currently-open library's component names as a JSON array. Altium
+  resolves these itself, so they are ground truth for what it actually parsed —
+  "opened" alone does not prove a component is reachable or that its name
+  survived. Returns [] for a kind with no reachable library. }
+function ComponentNames(const Kind : String) : String;
+var
+    PcbLib  : IPCB_Library;
+    SchLib  : ISch_Lib;
+    SchIter : ISch_Iterator;
+    SchComp : ISch_Component;
+    PcbComp : IPCB_LibComponent;
+    PcbIter : IPCB_LibraryIterator;
+    First   : Boolean;
+begin
+    Result := '[';
+    First  := True;
+    try
+        if Kind = 'PCBLIB' then
+        begin
+            PcbLib := PCBServer.GetCurrentPCBLibrary;
+            if PcbLib <> nil then
+            begin
+                PcbIter := PcbLib.LibraryIterator_Create;
+                PcbIter.SetState_FilterAll;
+                PcbComp := PcbIter.FirstPCBObject;
+                while PcbComp <> nil do
+                begin
+                    if not First then Result := Result + ',';
+                    Result := Result + '"' + JsonEscape(PcbComp.Name) + '"';
+                    First := False;
+                    PcbComp := PcbIter.NextPCBObject;
+                end;
+                PcbLib.LibraryIterator_Destroy(PcbIter);
+            end;
+        end
+        else if Kind = 'SCHLIB' then
+        begin
+            SchLib := SchServer.GetCurrentSchDocument;
+            if SchLib <> nil then
+            begin
+                SchIter := SchLib.SchLibIterator_Create;
+                SchIter.AddFilter_ObjectSet(MkSet(eSchComponent));
+                SchComp := SchIter.FirstSchObject;
+                while SchComp <> nil do
+                begin
+                    if not First then Result := Result + ',';
+                    Result := Result + '"' + JsonEscape(SchComp.LibReference) + '"';
+                    First := False;
+                    SchComp := SchIter.NextSchObject;
+                end;
+                SchLib.SchIterator_Destroy(SchIter);
+            end;
+        end;
+    except
+    end;
+    Result := Result + ']';
+end;
+
 procedure Run;
 var
     RequestFile, ResponseFile : String;
     Requests, Response : TStringList;
-    Json, Path, Ext, Kind, Detail : String;
+    Json, Path, Ext, Kind, Detail, Names : String;
     i, Emitted : Integer;
     Doc : IServerDocument;
     Opened : Boolean;
@@ -68,6 +127,7 @@ begin
             else                         Kind := '';
 
             Opened := False;
+            Names  := '[]';
             Detail := '';
 
             if not FileExists(Path) then
@@ -83,6 +143,7 @@ begin
                         Client.ShowDocument(Doc);
                         Opened := True;
                         Detail := 'opened';
+                        Names := ComponentNames(Kind);
                         // Leave the document open so it stays visible for inspection
                         // (e.g. to check a footprint's 3D body).
                     end
@@ -97,7 +158,11 @@ begin
             if Emitted > 0 then Json := Json + ',';
             Json := Json + '{"file":"' + JsonEscape(Path) + '","kind":"' + Kind + '","opened":';
             if Opened then Json := Json + 'true' else Json := Json + 'false';
-            Json := Json + ',"detail":"' + JsonEscape(Detail) + '"}';
+            Json := Json + ',"detail":"' + JsonEscape(Detail) + '"';
+            // The component names Altium itself resolved. "Opened" only proves the
+            // file parses; a name check proves the components are reachable and
+            // their text survived, which is what a round-trip claim needs.
+            Json := Json + ',"components":' + Names + '}';
             Inc(Emitted);
         end;
         Json := Json + ']';


### PR DESCRIPTION
Turns the "open it in Altium and see" check into a repeatable script, and it found two real bugs on its first run.

## Why

`Generate-Samples.ps1` proves we can **read** what Altium writes. The pyaltiumlib oracle in CI proves our output **parses** independently. Neither proves that **Altium itself opens a file we wrote and resolves the components inside it** — that was a manual click-through, so it happened rarely and proved nothing reproducible.

## What it does

`Verify-RoundTrip.ps1` runs the whole path through the **shipped binary**, not library internals:

1. build the MCP server
2. drive it over stdio with real `write_schlib` / `write_pcblib` tool calls
3. read the libraries back through `read_schlib` / `read_pcblib`
4. hand the files to Altium via `Verify-Libraries.ps1`
5. compare the component names **Altium resolved** against what was authored

Step 5 is the point. "Opened" only proves the file parses; a name comparison proves the components are reachable and their text survived. Names under test are an ASCII control plus Cyrillic, CJK and Greek — where the encodings in play (Windows-1252 records, UTF-16 storage names, `%UTF8%` promotion) disagree.

Supporting changes:

- **`AltiumVerify.pas`** now reports each library's component names, iterating the library Altium has open, instead of only `opened: true/false`.
- **`Verify-Libraries.ps1`** emits its parsed results to the pipeline so a caller can assert on them. Console output is unchanged — progress already went through `Write-Host`.
- Altium is **closed** when the run finishes, with `-KeepAltiumOpen` to leave the libraries up. `Verify-Libraries.ps1` keeps the opposite default, which suits a human eyeballing a footprint.

## Findings from the first run

The script fails today, which is the correct result — it is reporting two genuine bugs, both filed separately:

| Check | Result |
|---|---|
| SchLib via `read_schlib` | ✅ all five names |
| PcbLib via `read_pcblib` | ❌ `Резистор_0402` → `????????_0402` |
| SchLib as resolved by **Altium** | ❌ `????????`, `??????`, `?mega`, `??` |
| PcbLib as resolved by **Altium** | ❌ `????????_0402` |

Both libraries **open** in Altium; the names are what fail.

## PowerShell 5.1 traps, handled and commented

Each bit once during development and is noted where it applies:

- the script needs a **UTF-8 BOM**, or PowerShell reads it as ANSI and mangles the script's own non-ASCII literals;
- `2>&1` on `cargo` wraps stderr lines in ErrorRecords, turning a clean exit into a failure under `$ErrorActionPreference = 'Stop'`;
- `Set-Content -Encoding utf8` writes a BOM, and a leading BOM makes the server's config parser reject the file.

## Verification

Run end to end on this machine: reports per-component PASS/FAIL, prints a per-name diff, closes Altium, and exits non-zero. Artefacts (config, JSON-RPC transcript, server log, libraries) are kept in a timestamped temp directory for inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
