### PR TITLE
fix(schlib): make Altium itself resolve Unicode symbol names

### DIFF
--- a/scripts/altium/verify/AltiumVerify.pas
+++ b/scripts/altium/verify/AltiumVerify.pas
@@ -26,9 +26,18 @@ const
 
 // Escapes a string for embedding in JSON (paths contain backslashes).
 function JsonEscape(const S : String) : String;
+var
+    i, C : Integer;
 begin
-    Result := StringReplace(S, '\', '\\', REPLACEALL);
-    Result := StringReplace(Result, '"', '\"', REPLACEALL);
+    Result := '';
+    for i := 1 to Length(S) do
+    begin
+        C := Ord(S[i]);
+        if (C > 126) or (C < 32) then Result := Result + '\u' + IntToHex(C, 4)
+        else if S[i] = '\' then Result := Result + '\\'
+        else if S[i] = '"' then Result := Result + '\"'
+        else Result := Result + S[i];
+    end;
 end;
 
 

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -16,8 +16,26 @@ impl SchLib {
         let mut cfb = crate::altium::create_ole(writer)?;
 
         let symbols: Vec<&Symbol> = self.symbols.values().collect();
+
+        // A name outside Windows-1252 becomes the storage name in Altium's own
+        // form: its UTF-8 bytes carried one char per byte. That keeps the storage
+        // name and the FileHeader's `LibRef{i}` consistent, because the header is
+        // a Windows-1252 block and encoding this form back yields exactly those
+        // UTF-8 bytes — which is what Altium's library browser reads. Writing the
+        // real Unicode string instead leaves `LibRef{i}` as `?` per character.
+        // A Windows-1252 name is passed through untouched.
+        let storage_names: Vec<String> = symbols
+            .iter()
+            .map(|s| {
+                if crate::altium::requires_utf8(&s.name) {
+                    crate::altium::encode_utf8_param_value(&s.name)
+                } else {
+                    s.name.clone()
+                }
+            })
+            .collect();
         // OLE-safe storage names (handles long names + collisions).
-        let ole_names = crate::altium::generate_ole_names(symbols.iter().map(|s| s.name.as_str()));
+        let ole_names = crate::altium::generate_ole_names(storage_names.iter().map(String::as_str));
 
         // FileHeader stream.
         crate::altium::write_stream(

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -287,17 +287,19 @@ fn encode_component_header(symbol: &Symbol) -> String {
 ///
 /// A pure-Windows-1252 value emits the plain `<key>=<value>` — byte-identical to
 /// the pre-UTF-8 output, so the common case (and everything in the golden library)
-/// is unchanged. A value with non-Windows-1252 characters (Cyrillic, CJK, Greek
-/// `Ω`, …) would otherwise be silently corrupted to `?` by the record's
-/// Windows-1252 encoder; instead it is emitted as `%UTF8%<key>=<utf8-bytes>` so
-/// the true value survives, matching Altium / `AltiumSharp`. Only one of the two
-/// keys is ever written (never both), mirroring `AltiumSharp`'s writer.
+/// is unchanged.
+///
+/// A value with non-Windows-1252 characters (Cyrillic, CJK, Greek `Ω`, …) would be
+/// corrupted to `?` by the record's Windows-1252 encoder, so it is written **twice**,
+/// as Altium does: the plain `<key>` carrying the value's raw UTF-8 bytes, and a
+/// `%UTF8%<key>` companion. Altium reads the plain key, so omitting it leaves the
+/// name `?`-mangled in Altium even though our own reader recovers it; the companion
+/// is what `AltiumSharp` and older readers look for. Both are the same bytes on the
+/// wire, since the record is encoded as Windows-1252.
 fn text_field(key: &str, value: &str) -> String {
     if crate::altium::requires_utf8(value) {
-        format!(
-            "%UTF8%{key}={}",
-            crate::altium::encode_utf8_param_value(value)
-        )
+        let bytes = crate::altium::encode_utf8_param_value(value);
+        format!("{key}={bytes}|%UTF8%{key}={bytes}")
     } else {
         format!("{key}={value}")
     }
@@ -2440,24 +2442,26 @@ mod tests {
     }
 
     #[test]
-    fn non_win1252_text_emits_only_utf8_key() {
-        // Greek Ω (U+03A9) is NOT in Windows-1252. The writer must emit the value
-        // behind `%UTF8%Text` (never a lossy plain `Text=10k?`), matching Altium.
-        let mut p = Parameter::new("Value", "10k\u{03A9}"); // "10kΩ"
+    fn non_win1252_text_emits_both_keys_carrying_utf8_bytes() {
+        // Greek omega (U+03A9) is NOT in Windows-1252. Altium writes such a value
+        // twice — the plain key holding its raw UTF-8 bytes, plus a `%UTF8%`
+        // companion — and reads the plain one, so emitting only the companion
+        // leaves the value `?`-mangled in Altium.
+        let mut p = Parameter::new("Value", "10k\u{03A9}");
         p.unique_id = Some("ABCD1234".to_string());
         let s = encode_parameter(&p, 1);
-        assert!(s.contains("|%UTF8%Text="), "emit %UTF8%Text key: {s}");
-        // Exactly one Text key, and no lossy plain `Text=...?`.
-        assert!(
-            !s.contains("|Text="),
-            "must not also emit a lossy plain Text: {s}"
-        );
-        // The stored value is the UTF-8 byte sequence mapped one-char-per-byte.
+
+        // Both keys, carrying the same UTF-8 bytes mapped one char per byte.
         let expected = crate::altium::encode_utf8_param_value("10k\u{03A9}");
         assert!(
-            s.contains(&format!("|%UTF8%Text={expected}|")),
-            "stored UTF-8 form: {s}"
+            s.contains(&format!("|Text={expected}|")),
+            "plain Text must carry the UTF-8 bytes: {s}"
         );
+        assert!(
+            s.contains(&format!("|%UTF8%Text={expected}|")),
+            "%UTF8%Text companion: {s}"
+        );
+        assert!(!s.contains("10k?"), "no `?`-mangled value anywhere: {s}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #326. Verified with `scripts/Verify-RoundTrip.ps1` (#325) rather than by inspection.

## The gap

Our reader recovered these names after #324, but **Altium did not** — a library we wrote showed `????????` in its browser. A byte comparison against an Altium-authored library showed two differences:

| | Altium | Ours (before) |
|---|---|---|
| record key | `LibReference=<utf8 bytes>` **and** `%UTF8%LibReference=…` | only the `%UTF8%` companion |
| storage name | the name's UTF-8 bytes, one char per byte | the real Unicode string |

Altium reads the **plain** key, so it saw nothing usable. And it derives the FileHeader's `LibRef{i}` from the storage name — that header is a Windows-1252 block, so a real Unicode storage name encodes to `?` per character.

## The fix

- `text_field` writes **both** keys. They are the same bytes on the wire, since the record is Windows-1252.
- The SchLib writer stores a name that needs it in Altium's own form. A Windows-1252 name is untouched, so the golden library stays byte-identical.

## The harness was lying

The first attempt looked like it had failed. It had not — `AltiumVerify.pas` built its JSON by string concatenation, and DelphiScript flattens a non-ANSI string to `?` per character (the same truncation that makes `Chr(N > 255)` unusable, recorded earlier in `GenerateSamples.pas`). The measurement destroyed exactly what it was measuring.

It now emits `\uXXXX` escapes from `Ord()`, so the response carries real codepoints and a failure blames the library rather than the bridge. Without that, this PR would have been abandoned as not working.

## Result

```text
Altium:
  ok    SchLib as resolved by Altium (5 components)
```

Cyrillic, CJK and Greek names all read back **by Altium** from a library we wrote.

The `PcbLib` half of the script still fails — that is #327, untouched by this change.

Full suite green: 819 lib tests plus every integration suite. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)