### PR TITLE
test(pcblib): close the net-index rows as structurally absent

### DIFF
--- a/docs/FIXTURE_COVERAGE.md
+++ b/docs/FIXTURE_COVERAGE.md
@@ -40,19 +40,35 @@ field. The fix is always to enrich them (see the workflow below).
 ## Coverage map
 
 Legend: ✅ authored + asserted · ❌ not exercised (self-round-trip only) · 🚫 documented
-negative (Altium does not persist it — do not retry).
+negative (Altium does not persist it — do not retry) · 🔒 structurally absent from a
+library (see below — no fixture is possible, and none is needed).
+
+### Structurally absent: the net index
+
+`net_index` (common header @3) indexes a **board's** net list. A `PcbLib` has no net
+table — the golden's 24 top-level OLE entries are `FileHeader`, `FileVersionInfo`,
+`Library` and the footprint storages, with nothing for the index to point at — so every
+primitive in every library reads the `0xFFFF` "no net" sentinel. All 33 pads, tracks and
+vias in the golden do.
+
+No golden can therefore exercise a non-sentinel value, and none needs to: the reader does
+not branch on it beyond the short-header fallback, which a well-formed file never takes.
+Both paths are covered by `common_indices_decode_values_sentinels_and_short_headers` (real
+values, the sentinel, and every truncation point) and by `binary_roundtrip_common_indices`
+for the board-context encode/decode. The rows below are marked 🔒 rather than ❌ so the
+distinction stays visible: this is not an authoring gap waiting on an Altium run.
 
 ### PcbLib (`footprints.PcbLib`)
 
 | Primitive | Exercised today | Not exercised (❌) |
 |-----------|-----------------|--------------------|
 | Pad | shape (round/rect/oct/rrect), TH holes (round/square/slot), local stack, rotation, negative/far coords, ✅ manual paste/solder-mask expansion (`PADMASK`, authored via the pad cache), ✅ locked + keepout flags, ✅ drill tolerances (`LOCKFLAGS_PCB`) | testpoint flags, slot geometry on SMD, jumper id, locked/keepout flags; 🚫 corner-radius `CRPercentage` (crashes on a fresh Simple pad — needs correct pad-stack init first); 🚫 **FINAL** thermal-relief / power-plane setters (`PowerPlaneConnectStyle` / `ReliefConductorWidth` / `ReliefEntries` / `ReliefAirGap` / `PowerPlaneClearance` crash AD24's ScriptingSystem.DLL with a native access violation in **every** scripted sequence tried — pre- and post-registration, with and without the `GetState_Cache` block; batch 4a + 4b bisects. `PAD_THERMAL` cannot be authored by script in AD24 and stays disabled in the `.pas`) |
-| Via | simple TH, two pad/hole sizes | thermal-relief, power-plane, net index, paste-mask expansion, GUID; 🚫 tenting flags (`IsTenting_Top`/`_Bottom` author fine but AD24 does not persist them on a library via — the saved flag word is empty and the reader decodes those bits correctly elsewhere) |
-| Track | silk box + copper track, two widths, two layers; ✅ multi-layer spread (`MULTILAYER`: six tracks on Mechanical 2 / Mid-Layer 5 / Drill Guide / Drill Drawing / Internal Plane 1 / Keep-Out — real golden coverage for `layer_from_id`'s exotic arms; ID 58 reads as the documented `TopAssembly` alias, `samples_pcblib_multilayer`) | locked/keepout flags, net index |
-| Arc | full circle + quarter arc | fill/area colour, locked/keepout, net index |
+| Via | simple TH, two pad/hole sizes | thermal-relief, power-plane, paste-mask expansion, GUID; 🔒 net index; 🚫 tenting flags (`IsTenting_Top`/`_Bottom` author fine but AD24 does not persist them on a library via — the saved flag word is empty and the reader decodes those bits correctly elsewhere) |
+| Track | silk box + copper track, two widths, two layers; ✅ multi-layer spread (`MULTILAYER`: six tracks on Mechanical 2 / Mid-Layer 5 / Drill Guide / Drill Drawing / Internal Plane 1 / Keep-Out — real golden coverage for `layer_from_id`'s exotic arms; ID 58 reads as the documented `TopAssembly` alias, `samples_pcblib_multilayer`) | locked/keepout flags; 🔒 net index |
+| Arc | full circle + quarter arc | fill/area colour, locked/keepout; 🔒 net index |
 | Region | copper box + mechanical box; ✅ board-cutout representation (`ISBOARDCUTOUT=TRUE` + `KEEPOUT=TRUE`, relocated to the keep-out layer — `samples_pcblib_region_cutout`) | named region, net, arc-resolution/cavity/subpoly/union params |
-| Fill | axis-aligned + 45°-rotated copper | locked/keepout, net index |
-| Text | stroke text, Win-1252 chars, vertical (90°); ✅ TrueType `font_name`='Arial' + bold + italic + mirror (`TEXT_STYLE`); ✅ kind=BarCode (`TEXT_SPECIAL` 'BC128'); ✅ inverted (knockout) text + inverted-rect descriptor (`TEXT_SPECIAL` 'INV': `is_inverted`, `use_inverted_rectangle`, `inverted_border`=10 mil, auto-computed rect width/height exact-asserted) | justification, stroke_font variants, barcode sizing block (not modelled), char_set, union_index, net/component index, flags |
+| Fill | axis-aligned + 45°-rotated copper | locked/keepout; 🔒 net index |
+| Text | stroke text, Win-1252 chars, vertical (90°); ✅ TrueType `font_name`='Arial' + bold + italic + mirror (`TEXT_STYLE`); ✅ kind=BarCode (`TEXT_SPECIAL` 'BC128'); ✅ inverted (knockout) text + inverted-rect descriptor (`TEXT_SPECIAL` 'INV': `is_inverted`, `use_inverted_rectangle`, `inverted_border`=10 mil, auto-computed rect width/height exact-asserted) | justification, stroke_font variants, barcode sizing block (not modelled), char_set, union_index, component index, flags; 🔒 net index |
 | ComponentBody | one extruded box (Mechanical); ✅ embedded STEP model (`EMBSTEP`: `MODELID`/`MODEL.CHECKSUM`/`MODEL.NAME` on the body + zlib model stream in `/Library/Models/0`, decompressed `ISO-10303-21` bytes exact-asserted — `samples_pcblib_embstep`) | cavity height, model 2D location/rotation, non-default colour/opacity, raw-outline precision |
 
 ### SchLib (`symbols.SchLib`)

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1682,6 +1682,34 @@ mod tests {
     /// Millimetre comparison tolerance — coordinates are quantised to 1 nm.
     const EPS: f64 = 1e-9;
 
+    #[test]
+    fn common_indices_decode_values_sentinels_and_short_headers() {
+        // Real associations at @3/@5/@7 survive as themselves.
+        let mut header = vec![0u8; 9];
+        header[3..5].copy_from_slice(&7u16.to_le_bytes());
+        header[5..7].copy_from_slice(&9u16.to_le_bytes());
+        header[7..9].copy_from_slice(&4u16.to_le_bytes());
+        assert_eq!(read_common_indices(&header), (7, 9, 4));
+
+        // The `0xFFFF` sentinel is "none": the indices keep it, the component
+        // index maps to `-1` because that is its from-scratch default.
+        assert_eq!(read_common_indices(&[0xFF; 9]), (0xFFFF, 0xFFFF, -1));
+
+        // A header too short for a field falls back to the same "none" default
+        // rather than panicking, at every truncation point.
+        for len in 0..9 {
+            assert_eq!(
+                read_common_indices(&vec![0u8; len]),
+                match len {
+                    0..=4 => (0xFFFF, 0xFFFF, -1),
+                    5..=6 => (0, 0xFFFF, -1),
+                    _ => (0, 0, -1),
+                },
+                "truncated to {len} bytes"
+            );
+        }
+    }
+
     /// Wraps `payload` in the `[u32 len][payload]` framing every `PcbLib` record
     /// block uses, so a test can hand-build a record without the writer.
     /// A Pascal short string as the text content block holds it:


### PR DESCRIPTION
Sixth batch off the `FIXTURE_COVERAGE.md` list — and like #336, one that ends in a
conclusion rather than a fixture. This one closes **five rows at once**.

## A `PcbLib` has no nets

`net_index` (common header @3) indexes a **board's** net list. A library has no net
table — the golden's 24 top-level OLE entries are `FileHeader`, `FileVersionInfo`,
`Library` and the footprint storages, with nothing for the index to point at:

```text
primitives=33  with a non-default net index=0
```

Every pad, track and via in the golden reads the `0xFFFF` "no net" sentinel, and always
will. So no amount of Altium authoring can produce a fixture here — this was never a
gap waiting on a run, and the four remaining rows (Track, Arc, Fill, Text) would each
have cost a run to rediscover that.

They are now marked 🔒 **structurally absent** rather than ❌, a new legend entry, with
one shared explanation instead of five copies of it.

## What actually needed covering

Checking *why* no fixture was possible turned up the real gap. The reader does not branch
on the net index at all — it is a plain field read — except for one fallback:

```rust
let net_index = read_u16(header, 3).unwrap_or(0xFFFF);
```

That short-header path is unreachable from a well-formed file, so a golden could never
have reached it, and `read_common_indices` had **no unit test of its own**. It now has
one, pinning real values, the `0xFFFF` sentinel (including its mapping to `-1` for the
component index) and every truncation point from 0 to 8 bytes.

So the honest tally is a row that could never be closed by a fixture, closed properly by
the test that suits it — which is the point of separating the two tiers.

## Testing

Full suite green: 11 suites, 820 unit tests, 0 failures. `cargo fmt --all --check`,
`clippy -D warnings` and `markdownlint-cli2` clean. No fixture bytes touched.

Next: Via paste-mask expansion (likely the pad-style cache), then Region and Text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
