### PR TITLE
test(altium): verify what Altium does with each mask-expansion cache state

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ oracle in [`tests/integration/`](../tests/integration/).)
 | [`Verify-Libraries.ps1`](Verify-Libraries.ps1) | Launch Altium to confirm a `.PcbLib`/`.SchLib` opens cleanly | **Yes** |
 | [`Generate-Samples.ps1`](Generate-Samples.ps1) | Launch Altium to author the sample libraries | **Yes** |
 | [`Verify-RoundTrip.ps1`](Verify-RoundTrip.ps1) | Write libraries through the MCP server, then check Altium resolves every component name | **Yes** |
+| [`Verify-MaskCacheState.ps1`](Verify-MaskCacheState.ps1) | Write pads carrying each mask-expansion cache state, then show what Altium makes of them | **Yes** |
 | [`Resolve-AltiumExe.ps1`](Resolve-AltiumExe.ps1) | Shared helper: read `ALTIUM_EXE` from the repo-root `.env.local` | — |
 | [`altium/`](altium/) | The DelphiScript automation the launchers run | **Yes** |
 | [`samples/`](samples/) | Altium-authored sample libraries (ground truth for the tests) | No |
@@ -37,6 +38,7 @@ through Altium's `RunScript` CLI. Because it needs the GUI application and a lic
 | Path | Role |
 |------|------|
 | [`altium/verify/`](altium/verify/) | `AltiumVerify.pas` — opens each library and reports PASS/FAIL plus the component names Altium resolved (run by `Verify-Libraries.ps1`) |
+| [`altium/verify/`](altium/verify/) | `AltiumMaskCache.pas` — reports every pad's mask-expansion cache state and re-saves the library (run by `Verify-MaskCacheState.ps1`) |
 | [`altium/generate/`](altium/generate/) | `GenerateSamples.pas` — authors the sample libraries (run by `Generate-Samples.ps1`) |
 
 The `RunScript` launch and the file-based request/response bridge are adapted from
@@ -59,6 +61,28 @@ ground truth the reader and round-trip tests validate against. See
 Hard-won behaviour of Altium, DelphiScript and Windows PowerShell 5.1. Each cost real
 debugging time here; several made a *correct* change look broken, which is the expensive
 kind. Read this before writing or trusting a script in this folder.
+
+### Altium recomputes a rule-driven mask expansion on load
+
+The mask-expansion tri-state is `TCacheState = (eCacheInvalid, eCacheValid,
+eCacheManual)`. Only `eCacheManual` survives a trip through Altium.
+`Verify-MaskCacheState.ps1` hands Altium a library whose three pads differ only in that
+state and shows what comes back:
+
+| written | Altium reports after load | Altium re-saves |
+|---------|---------------------------|-----------------|
+| `none` (0) + 0.0 | valid=1, 40000 (4 mil) | `from_rule`, 4 mil |
+| `from_rule` (1) + 0.0 | valid=1, 40000 (4 mil) | `from_rule`, 4 mil |
+| `manual` (2) + 7 mil | valid=2, 70000 | `manual`, 7 mil |
+
+The first two are indistinguishable afterwards: Altium discards whatever number a
+rule-driven pad carries and computes the expansion from its own rule. A zero expansion
+paired with `eCacheValid` therefore does **not** suppress the mask opening — worth knowing
+before treating a wrong state here as a fabrication risk. It is a fidelity bug, not an
+output one.
+
+The corollary for fixtures: a re-saved library is not byte-comparable to the one handed in
+even when nothing was edited, because opening it resolves caches.
 
 ### Altium's own RTTI answers enum questions without a run
 

--- a/scripts/Verify-MaskCacheState.ps1
+++ b/scripts/Verify-MaskCacheState.ps1
@@ -1,0 +1,262 @@
+﻿<#
+.SYNOPSIS
+    Establishes what Altium does with the mask-expansion cache state this server writes.
+
+.DESCRIPTION
+    The mask-expansion mode is Altium's TCacheState = (eCacheInvalid, eCacheValid,
+    eCacheManual) — ordinals 0/1/2, from the Advpcb.dll RTTI. It records whether a
+    *cached* expansion is authoritative, so a pad claiming eCacheValid asserts that its
+    stored number is a rule result Altium should honour verbatim. Paired with a zero
+    expansion that reads as "the rule resolved to zero", which would suppress the mask
+    opening rather than defer to the rule.
+
+    This drives the whole question end to end and repeatably:
+
+      1. the MCP server writes a library whose pads carry each of the three states,
+         including the suspect eCacheValid-with-zero combination;
+      2. Altium opens it, reports the state it sees on every pad, and re-saves;
+      3. the two files' states are compared, showing whether Altium accepts them as
+         written or replaces them with its own.
+
+    Pad 1 (none) and pad 2 (from_rule) differ ONLY in that byte, so any difference in
+    what Altium reports or writes is attributable to the cache state alone. Pad 3
+    (manual, 7 mil) is the control that proves the reporting path works at all.
+
+    Both readings go through the server's own read_pcblib rather than hand-parsed
+    record offsets, so the comparison uses the shipped code path.
+
+.PARAMETER AltiumExe
+    Path to X2.EXE. Defaults to the ALTIUM_EXE entry in .env.local at the repo root.
+
+.PARAMETER WorkDir
+    Where the libraries are written. Defaults to a temp directory.
+
+.PARAMETER SkipBuild
+    Reuse an existing release binary instead of rebuilding.
+
+.PARAMETER KeepAltiumOpen
+    Leave Altium running afterwards. By default it is closed once the response arrives.
+
+.EXAMPLE
+    .\Verify-MaskCacheState.ps1
+#>
+param(
+    [string]$AltiumExe,
+    [string]$WorkDir,
+    [switch]$SkipBuild,
+    [switch]$KeepAltiumOpen,
+    [int]$TimeoutSeconds = 180
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+
+if (-not $WorkDir) { $WorkDir = Join-Path $env:TEMP 'altium_mcp_maskcache' }
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+$LibPath = Join-Path $WorkDir 'MaskCache.PcbLib'
+# Must match the name AltiumMaskCache.pas derives for its re-saved copy.
+$AltiumSavedPath = Join-Path $WorkDir 'MaskCache_Altium.PcbLib'
+foreach ($stale in @($LibPath, $AltiumSavedPath)) {
+    if (Test-Path $stale) { Remove-Item $stale -Force }
+}
+
+# ---------------------------------------------------------------------------
+# 1. Build the server
+# ---------------------------------------------------------------------------
+$Exe = Join-Path $RepoRoot 'target\release\altium-designer-mcp.exe'
+if (-not $SkipBuild) {
+    Write-Host 'Build     : cargo build --release'
+    Push-Location $RepoRoot
+    try {
+        # No 2>&1 here: redirecting a native command's stderr in Windows PowerShell
+        # wraps each line in an ErrorRecord, so a clean build with warnings would
+        # be treated as a failure.
+        & cargo build --release --quiet
+        if ($LASTEXITCODE -ne 0) { throw "cargo build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+}
+if (-not (Test-Path $Exe)) { throw "Server binary not found: $Exe" }
+
+# ---------------------------------------------------------------------------
+# 2. Write the library through the MCP server
+# ---------------------------------------------------------------------------
+$ConfigPath = Join-Path $WorkDir 'config.json'
+$config = @{
+    allowed_paths = @($WorkDir -replace '\\', '/')
+    logging       = @{ level = 'warn'; audit_log_path = $null }
+} | ConvertTo-Json -Depth 5
+# UTF8Encoding($false): Set-Content -Encoding utf8 emits a BOM, which the config
+# parser rejects.
+[System.IO.File]::WriteAllText($ConfigPath, $config, (New-Object System.Text.UTF8Encoding $false))
+
+$requests = New-Object System.Collections.Generic.List[string]
+function Add-Request([int]$Id, [string]$Method, $Params) {
+    $msg = [ordered]@{ jsonrpc = '2.0'; method = $Method }
+    if ($Id -ge 0) { $msg['id'] = $Id }
+    if ($null -ne $Params) { $msg['params'] = $Params }
+    $requests.Add(($msg | ConvertTo-Json -Depth 20 -Compress))
+}
+
+Add-Request 1 'initialize' @{
+    protocolVersion = '2024-11-05'
+    capabilities    = @{}
+    clientInfo      = @{ name = 'verify-mask-cache'; version = '1.0.0' }
+}
+Add-Request -1 'notifications/initialized' $null
+
+# Pads 1 and 2 differ only in the cache state; pad 3 is the manual control.
+$pads = @(
+    @{ designator = '1'; x = -1.0; y = 0; width = 0.6; height = 0.5
+       solder_mask_expansion_mode = 'none' },
+    @{ designator = '2'; x = 0.0; y = 0; width = 0.6; height = 0.5
+       solder_mask_expansion_mode = 'from_rule' },
+    @{ designator = '3'; x = 1.0; y = 0; width = 0.6; height = 0.5
+       solder_mask_expansion_mode = 'manual'; solder_mask_expansion = 0.1778 }
+)
+Add-Request 2 'tools/call' @{
+    name      = 'write_pcblib'
+    arguments = @{ filepath = $LibPath; footprints = @(@{ name = 'MASKCACHE'; pads = $pads }) }
+}
+
+$RequestPath = Join-Path $WorkDir 'requests.jsonl'
+[System.IO.File]::WriteAllLines($RequestPath, $requests, (New-Object System.Text.UTF8Encoding $false))
+
+Write-Host 'MCP       : writing MaskCache.PcbLib'
+$OutPath = Join-Path $WorkDir 'responses.jsonl'
+$ErrPath = Join-Path $WorkDir 'server.log'
+$proc = Start-Process -FilePath $Exe -ArgumentList "`"$ConfigPath`"" -NoNewWindow -PassThru `
+    -RedirectStandardInput $RequestPath -RedirectStandardOutput $OutPath -RedirectStandardError $ErrPath
+$proc | Wait-Process -Timeout 120
+
+$responses = @(Get-Content -Path $OutPath -Encoding utf8 |
+    Where-Object { $_.Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
+$write = $responses | Where-Object { $_.id -eq 2 } | Select-Object -First 1
+if (-not $write) { throw "no write_pcblib response (see $ErrPath)" }
+if ($write.PSObject.Properties.Name -contains 'error') { throw "write_pcblib failed: $($write.error.message)" }
+if ($write.result.isError) { throw "write_pcblib reported an error: $($write.result.content[0].text)" }
+if (-not (Test-Path $LibPath)) { throw "server reported success but $LibPath is missing" }
+
+# ---------------------------------------------------------------------------
+# 3. Read the states back through the server's own reader
+# ---------------------------------------------------------------------------
+# Reading through read_pcblib rather than hand-parsing the record offsets: it is the
+# shipped code path, and its decoding of this tri-state is already pinned to
+# Altium-authored bytes by the golden tests.
+function Get-PadModes([string]$Path) {
+    $reqs = New-Object System.Collections.Generic.List[string]
+    $reqs.Add((@{ jsonrpc = '2.0'; id = 1; method = 'initialize'; params = @{
+        protocolVersion = '2024-11-05'; capabilities = @{}
+        clientInfo = @{ name = 'verify-mask-cache'; version = '1.0.0' } } } |
+        ConvertTo-Json -Depth 20 -Compress))
+    $reqs.Add((@{ jsonrpc = '2.0'; method = 'notifications/initialized' } |
+        ConvertTo-Json -Depth 20 -Compress))
+    $reqs.Add((@{ jsonrpc = '2.0'; id = 2; method = 'tools/call'; params = @{
+        name = 'read_pcblib'; arguments = @{ filepath = $Path } } } |
+        ConvertTo-Json -Depth 20 -Compress))
+
+    $rp = Join-Path $WorkDir 'read_requests.jsonl'
+    $op = Join-Path $WorkDir 'read_responses.jsonl'
+    [System.IO.File]::WriteAllLines($rp, $reqs, (New-Object System.Text.UTF8Encoding $false))
+    $pr = Start-Process -FilePath $Exe -ArgumentList "`"$ConfigPath`"" -NoNewWindow -PassThru `
+        -RedirectStandardInput $rp -RedirectStandardOutput $op -RedirectStandardError $ErrPath
+    $pr | Wait-Process -Timeout 120
+
+    $rs = @(Get-Content -Path $op -Encoding utf8 |
+        Where-Object { $_.Trim() } | ForEach-Object { $_ | ConvertFrom-Json })
+    $hit = $rs | Where-Object { $_.id -eq 2 } | Select-Object -First 1
+    if (-not $hit) { throw "no read_pcblib response for $Path (see $ErrPath)" }
+    if ($hit.result.isError) { throw "read_pcblib failed on ${Path}: $($hit.result.content[0].text)" }
+    $lib = $hit.result.content[0].text | ConvertFrom-Json
+    @($lib.footprints | ForEach-Object { $_.pads } | ForEach-Object {
+        [pscustomobject]@{
+            designator = $_.designator
+            solder     = $_.solder_mask_expansion_mode
+            solder_mm  = $_.solder_mask_expansion
+            paste      = $_.paste_mask_expansion_mode
+        }
+    })
+}
+
+$before = Get-PadModes $LibPath
+Write-Host "`nWritten by the server:"
+foreach ($p in $before) {
+    Write-Host ("  pad {0}  solder={1} ({2} mm)  paste={3}" -f $p.designator, $p.solder, $p.solder_mm, $p.paste)
+}
+
+# 4. Hand it to Altium
+# ---------------------------------------------------------------------------
+$BridgeDir    = 'C:\Users\Public\altium_designer_mcp'
+$RequestFile  = Join-Path $BridgeDir 'maskcache_request.txt'
+$ResponseFile = Join-Path $BridgeDir 'maskcache_response.json'
+$PrjScr       = Join-Path $ScriptDir 'altium\verify\AltiumMaskCache.PrjScr'
+if (-not (Test-Path $PrjScr)) { throw "Script project not found: $PrjScr" }
+
+. (Join-Path $ScriptDir 'Resolve-AltiumExe.ps1')
+$AltiumExe = Resolve-AltiumExe -Override $AltiumExe -EnvFile (Join-Path $RepoRoot '.env.local')
+Write-Host "`nAltium    : $AltiumExe"
+
+New-Item -ItemType Directory -Force -Path $BridgeDir | Out-Null
+[System.IO.File]::WriteAllLines($RequestFile, [string[]]@($LibPath))
+if (Test-Path $ResponseFile) { Remove-Item $ResponseFile -Force }
+
+# The `^|` separator RunScript expects survives most reliably through a .bat.
+$bat = Join-Path $env:TEMP 'altium_designer_mcp_maskcache_launch.bat'
+"`"$AltiumExe`" -RScriptingSystem:RunScript(ProjectName=`"$PrjScr`"^|ProcName=`"AltiumMaskCache>Run`")" |
+    Set-Content -Path $bat -Encoding ASCII
+Start-Process -FilePath $bat -WindowStyle Hidden
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+while (-not (Test-Path $ResponseFile) -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 500 }
+if (-not (Test-Path $ResponseFile)) {
+    throw "Timed out after $TimeoutSeconds s. Altium may be showing a modal dialog — check its window."
+}
+
+$raw = Get-Content $ResponseFile -Raw
+$results = $raw | ConvertFrom-Json
+if ($raw.TrimStart([char]0xFEFF, ' ', "`t", "`r", "`n").StartsWith('{')) {
+    throw "Altium script error: $($results.error)"
+}
+$r = @($results)[0]
+if (-not $r.opened) { throw "Altium could not open the library: $($r.detail)" }
+
+Write-Host "`nAs Altium reports it (TCacheState ordinal: 0=eCacheInvalid, 1=eCacheValid, 2=eCacheManual):"
+foreach ($p in @($r.primitives)) {
+    Write-Host ("  pad {0}  solder_valid={1} solder_coord={2}  paste_valid={3} paste_coord={4}" -f `
+        $p.designator, $p.solder_valid, $p.solder_coord, $p.paste_valid, $p.paste_coord)
+}
+
+# ---------------------------------------------------------------------------
+# 5. Compare what Altium wrote back
+# ---------------------------------------------------------------------------
+$verdict = 'inconclusive'
+if ($r.saved -and (Test-Path $AltiumSavedPath)) {
+    $after = Get-PadModes $AltiumSavedPath
+    Write-Host "`nRe-saved by Altium:"
+    $changed = $false
+    foreach ($p in $after) {
+        $b = $before | Where-Object { $_.designator -eq $p.designator } | Select-Object -First 1
+        $note = ''
+        if ($b -and ($b.solder -ne $p.solder -or $b.paste -ne $p.paste)) {
+            $note = ("   <- changed from solder={0} paste={1}" -f $b.solder, $b.paste)
+            $changed = $true
+        }
+        Write-Host ("  pad {0}  solder={1} ({2} mm)  paste={3}{4}" -f `
+            $p.designator, $p.solder, $p.solder_mm, $p.paste, $note)
+    }
+    if ($changed) {
+        $verdict = 'Altium rewrote the cache states, so it does not take them at face value'
+    } else {
+        $verdict = 'Altium preserved every cache state, so the byte we write is the byte it carries forward'
+    }
+} else {
+    Write-Host "`nAltium did not produce a re-saved copy ($($r.detail))." -ForegroundColor Yellow
+}
+
+Write-Host "`nVerdict   : $verdict" -ForegroundColor Cyan
+
+if (-not $KeepAltiumOpen) {
+    Get-Process -Name 'X2' -ErrorAction SilentlyContinue | Stop-Process -Force
+    Write-Host 'Altium    : closed'
+}

--- a/scripts/altium/verify/AltiumMaskCache.PrjScr
+++ b/scripts/altium/verify/AltiumMaskCache.PrjScr
@@ -1,0 +1,7 @@
+[Design]
+Version=1.0
+DefaultPcbProtel=1
+DefaultPcbPcad=0
+
+[Document1]
+DocumentPath=AltiumMaskCache.pas

--- a/scripts/altium/verify/AltiumMaskCache.pas
+++ b/scripts/altium/verify/AltiumMaskCache.pas
@@ -1,0 +1,205 @@
+{ AltiumMaskCache.pas
+
+  Reports what Altium makes of the mask-expansion cache state on every pad of a
+  library, and re-saves the library so the on-disk result can be compared with what
+  was handed in. Pads only: the cache record is reached through IPCB_Pad, and the
+  tri-state it carries is the same one a via stores.
+
+  The mask-expansion mode is Altium's TCacheState = (eCacheInvalid, eCacheValid,
+  eCacheManual) — ordinals 0/1/2, taken from the Advpcb.dll RTTI. It says whether a
+  *cached* expansion is authoritative, so a primitive claiming eCacheValid asserts
+  that its stored number is a rule result Altium should honour verbatim. This script
+  exists to establish whether Altium acts on that claim or overwrites it, which
+  decides whether writing the wrong state is merely untidy or actually changes the
+  mask a fabricator receives.
+
+  Reads one absolute .PcbLib path per line from the bridge request file and writes a
+  JSON array to the response file: one entry per library, each carrying every pad's
+  cache state as Altium reports it after the load, plus the path of the Altium
+  re-saved copy.
+
+  The cache state is reported through Ord() rather than compared against the enum
+  identifiers. eCacheManual is proven to resolve in DelphiScript; eCacheInvalid and
+  eCacheValid are known only from the RTTI, and an identifier that does not resolve
+  aborts the whole script at COMPILE time, where a try/except cannot help. Ord()
+  keeps the reading numeric and the script compilable.
+
+  The RunScript launch mechanism and the file-based request/response bridge are
+  adapted from coffeenmusic/altium-mcp (MIT) — https://github.com/coffeenmusic/altium-mcp
+
+  Run via:
+    X2.EXE -RScriptingSystem:RunScript(ProjectName="...\AltiumMaskCache.PrjScr"^|ProcName="AltiumMaskCache>Run") }
+
+const
+    BRIDGE_DIR = 'C:\Users\Public\altium_designer_mcp\';
+
+// Escapes a string for embedding in JSON. Non-ASCII goes out as \uXXXX from Ord():
+// concatenating a non-ANSI character into the response flattens it to '?', which
+// would corrupt the very paths this reports.
+function JsonEscape(const S : String) : String;
+var
+    i, C : Integer;
+begin
+    Result := '';
+    for i := 1 to Length(S) do
+    begin
+        C := Ord(S[i]);
+        if (C > 126) or (C < 32) then Result := Result + '\u' + IntToHex(C, 4)
+        else if S[i] = '\' then Result := Result + '\\'
+        else if S[i] = '"' then Result := Result + '\"'
+        else Result := Result + S[i];
+    end;
+end;
+
+
+{ Every pad and via in the open PcbLib, as a JSON array of cache-state readings.
+  Coordinates are reported in Altium's internal units so the caller can compare
+  them exactly against the bytes it wrote, without a mils round-trip. }
+function CacheStates : String;
+var
+    PcbLib   : IPCB_Library;
+    PcbIter  : IPCB_LibraryIterator;
+    PcbComp  : IPCB_LibComponent;
+    GIter    : IPCB_GroupIterator;
+    Prim     : IPCB_Primitive;
+    Pad      : IPCB_Pad;
+    Cache    : TPadCache;
+    First    : Boolean;
+    CompName : String;
+begin
+    Result := '[';
+    First  := True;
+    try
+        PcbLib := PCBServer.GetCurrentPCBLibrary;
+        if PcbLib = nil then
+        begin
+            Result := Result + ']';
+            Exit;
+        end;
+
+        PcbIter := PcbLib.LibraryIterator_Create;
+        PcbIter.SetState_FilterAll;
+        PcbComp := PcbIter.FirstPCBObject;
+        while PcbComp <> nil do
+        begin
+            CompName := PcbComp.Name;
+
+            GIter := PcbComp.GroupIterator_Create;
+            GIter.AddFilter_ObjectSet(MkSet(ePadObject));
+            Prim := GIter.FirstPCBObject;
+            while Prim <> nil do
+            begin
+                Pad   := Prim;
+                Cache := Pad.GetState_Cache;
+
+                if not First then Result := Result + ',';
+                First := False;
+                Result := Result +
+                    '{"component":"' + JsonEscape(CompName) + '"' +
+                    ',"kind":"pad"' +
+                    ',"designator":"' + JsonEscape(Pad.Name) + '"' +
+                    ',"solder_valid":'  + IntToStr(Ord(Cache.SolderMaskExpansionValid)) +
+                    ',"solder_coord":'  + IntToStr(Cache.SolderMaskExpansion) +
+                    ',"paste_valid":'   + IntToStr(Ord(Cache.PasteMaskExpansionValid)) +
+                    ',"paste_coord":'   + IntToStr(Cache.PasteMaskExpansion) + '}';
+
+                Prim := GIter.NextPCBObject;
+            end;
+            PcbComp.GroupIterator_Destroy(GIter);
+
+            PcbComp := PcbIter.NextPCBObject;
+        end;
+        PcbLib.LibraryIterator_Destroy(PcbIter);
+    except
+    end;
+    Result := Result + ']';
+end;
+
+
+procedure Run;
+var
+    RequestFile, ResponseFile : String;
+    Requests, Response : TStringList;
+    Json, Path, Detail, States, SavedAs : String;
+    i, Emitted : Integer;
+    Doc : IServerDocument;
+    Opened, Saved : Boolean;
+begin
+    RequestFile  := BRIDGE_DIR + 'maskcache_request.txt';
+    ResponseFile := BRIDGE_DIR + 'maskcache_response.json';
+    if not DirectoryExists(BRIDGE_DIR) then ForceDirectories(BRIDGE_DIR);
+
+    Requests := TStringList.Create;
+    Response := TStringList.Create;
+    try
+        if not FileExists(RequestFile) then
+        begin
+            Response.Text := '{"error":"no request file at ' + JsonEscape(RequestFile) + '"}';
+            Response.SaveToFile(ResponseFile);
+            Exit;
+        end;
+        Requests.LoadFromFile(RequestFile);
+
+        Json := '[';
+        Emitted := 0;
+        for i := 0 to Requests.Count - 1 do
+        begin
+            Path := Trim(Requests[i]);
+            if Path = '' then Continue;
+
+            Opened  := False;
+            Saved   := False;
+            States  := '[]';
+            SavedAs := '';
+            Detail  := '';
+
+            if not FileExists(Path) then
+                Detail := 'file not found'
+            else
+            begin
+                try
+                    Doc := Client.OpenDocument('PCBLIB', Path);
+                    if Doc <> nil then
+                    begin
+                        Client.ShowDocument(Doc);
+                        Opened := True;
+                        Detail := 'opened';
+                        States := CacheStates;
+
+                        // Re-save under a sibling name. Comparing those bytes with
+                        // the handed-in file shows whether Altium accepts the cache
+                        // states as written or replaces them with its own.
+                        // IServerDocument has no DoFileSaveAs; DoSafeChangeFileNameAndSave
+                        // is the "Save As to a path" call (second arg is the kind).
+                        SavedAs := ChangeFileExt(Path, '') + '_Altium.PcbLib';
+                        Doc.DoSafeChangeFileNameAndSave(SavedAs, 'PCBLIB');
+                        Saved  := FileExists(SavedAs);
+                        if Saved then Detail := 'opened and re-saved'
+                        else Detail := 'opened; re-save produced no file';
+                    end
+                    else
+                        Detail := 'Altium OpenDocument returned nil (could not parse)';
+                except
+                    Detail := 'exception while opening or saving';
+                end;
+            end;
+
+            if Emitted > 0 then Json := Json + ',';
+            Json := Json + '{"file":"' + JsonEscape(Path) + '","opened":';
+            if Opened then Json := Json + 'true' else Json := Json + 'false';
+            Json := Json + ',"saved":';
+            if Saved then Json := Json + 'true' else Json := Json + 'false';
+            Json := Json + ',"saved_as":"' + JsonEscape(SavedAs) + '"';
+            Json := Json + ',"detail":"' + JsonEscape(Detail) + '"';
+            Json := Json + ',"primitives":' + States + '}';
+            Inc(Emitted);
+        end;
+        Json := Json + ']';
+
+        Response.Text := Json;
+        Response.SaveToFile(ResponseFile);
+    finally
+        Requests.Free;
+        Response.Free;
+    end;
+end;

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -487,16 +487,19 @@ pub enum ViaStackMode {
 /// *cached* expansion rather than an on/off switch. The stored expansion value
 /// is only authoritative when the state says so:
 ///
-/// - `None` (0, `eCacheInvalid`) — the cached value is stale and Altium
-///   recomputes the expansion from the design rule. This is what a fresh
-///   Altium pad or via carries, so it is also our default.
+/// - `None` (0, `eCacheInvalid`) — the cached value is stale. This is what a
+///   fresh Altium pad or via carries, so it is also our default.
 /// - `FromRule` (1, `eCacheValid`) — the stored value is a rule result Altium
-///   already computed and will honour as-is.
+///   already computed. This is what Altium leaves behind once it has opened a
+///   library and resolved the expansion itself.
 /// - `Manual` (2, `eCacheManual`) — the stored value was specified by hand.
 ///
-/// The distinction matters on write: pairing `FromRule` with a zero expansion
-/// tells Altium the rule genuinely resolved to zero, which suppresses the mask
-/// opening instead of deferring to the rule.
+/// Only `Manual` survives a trip through Altium. `scripts/Verify-MaskCacheState.ps1`
+/// hands Altium a library carrying all three states and shows it recomputing the
+/// rule-driven ones on load: a pad written as `None`/0.0 and a pad written as
+/// `FromRule`/0.0 both come back as `FromRule` with the rule's 4 mil, while the
+/// `Manual` pad keeps its own number. So the state a rule-driven pad is written
+/// with is a fidelity question, not a fabrication-outcome one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MaskExpansionMode {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -273,9 +273,9 @@ impl McpServer {
             .map(|s| match s.to_lowercase().as_str() {
                 "manual" => MaskExpansionMode::Manual,
                 "from_rule" => MaskExpansionMode::FromRule,
-                // Anything else, "none" included, defers to the design rule —
-                // the safe direction, since FromRule tells Altium to honour the
-                // stored value verbatim.
+                // Anything else, "none" included, maps to the state a fresh
+                // Altium pad carries, so an unrecognised value produces the
+                // same bytes as saying nothing at all.
                 _ => MaskExpansionMode::None,
             })
             .unwrap_or_default();
@@ -285,9 +285,9 @@ impl McpServer {
             .map(|s| match s.to_lowercase().as_str() {
                 "manual" => MaskExpansionMode::Manual,
                 "from_rule" => MaskExpansionMode::FromRule,
-                // Anything else, "none" included, defers to the design rule —
-                // the safe direction, since FromRule tells Altium to honour the
-                // stored value verbatim.
+                // Anything else, "none" included, maps to the state a fresh
+                // Altium pad carries, so an unrecognised value produces the
+                // same bytes as saying nothing at all.
                 _ => MaskExpansionMode::None,
             })
             .unwrap_or_default();
@@ -950,9 +950,9 @@ impl McpServer {
             via.solder_mask_expansion_mode = match s.to_lowercase().as_str() {
                 "manual" => MaskExpansionMode::Manual,
                 "from_rule" => MaskExpansionMode::FromRule,
-                // Anything else, "none" included, defers to the design rule —
-                // the safe direction, since FromRule tells Altium to honour the
-                // stored value verbatim.
+                // Anything else, "none" included, maps to the state a fresh
+                // Altium pad carries, so an unrecognised value produces the
+                // same bytes as saying nothing at all.
                 _ => MaskExpansionMode::None,
             };
         }

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -1200,10 +1200,10 @@ fn samples_pcblib_via_mask_state_is_altium_factory_default() {
     // `TCacheState = (eCacheInvalid, eCacheValid, eCacheManual)`.
     //
     // An Altium-authored via carries byte @66 = 0 (`eCacheInvalid`), meaning the
-    // stored expansion is stale and Altium recomputes it from the design rule.
-    // Our from-scratch via writes the same byte, so this pins the two together:
-    // defaulting to `FromRule` instead would claim the 4 mil below is a rule
-    // result Altium must honour verbatim.
+    // stored expansion is stale. Our from-scratch via writes the same byte, so
+    // this pins the two together. Altium recomputes a rule-driven expansion on
+    // load either way (`scripts/Verify-MaskCacheState.ps1`), so what this
+    // protects is fidelity with a factory via, not the resulting mask.
     let lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open footprints.PcbLib");
     let fp = lib.get("VIAS").expect("footprint VIAS not found");
     assert_eq!(fp.vias.len(), 2);


### PR DESCRIPTION
Follow-up to #338, which corrected the mask-expansion tri-state but **overstated the
consequence**. This measures it, and the measurement contradicts the claim.

#338 said that pairing `FromRule` (`eCacheValid`) with a zero expansion tells Altium the
rule resolved to zero, suppressing the mask opening. I flagged that as reasoned rather
than observed. It is wrong.

## What Altium actually does

`scripts/Verify-MaskCacheState.ps1` drives it end to end: the MCP server writes a library
whose three pads differ **only** in the cache state, Altium opens it and reports what it
sees, then re-saves so the result can be compared with the input.

| written | Altium reports after load | Altium re-saves |
|---------|---------------------------|-----------------|
| `none` (0) + 0.0 | `valid=1`, 40000 (4 mil) | `from_rule`, 4 mil |
| `from_rule` (1) + **0.0** | `valid=1`, 40000 (4 mil) | `from_rule`, 4 mil |
| `manual` (2) + 7 mil | `valid=2`, 70000 | `manual`, 7 mil |

The first two rows are **indistinguishable afterwards**. Altium discards whatever number a
rule-driven pad carries and recomputes the expansion from its own rule; only
`eCacheManual` survives. The zero never reaches a fabricator.

So writing the wrong state is a fidelity defect, not a fabrication-outcome one. The enum
docs, the three tool-layer comments and the golden test's rationale now say that instead.

**The fix in #338 still stands** — matching Altium's factory byte and mapping unknown
input to it remain correct. Only the severity claimed for it was wrong.

## Two things worth keeping

`Verify-MaskCacheState.ps1` is repeatable, so the next person asking "does this byte
matter?" runs a script instead of reasoning. It closes Altium when done and takes
`-SkipBuild` / `-KeepAltiumOpen` / `-WorkDir`.

`AltiumMaskCache.pas` reports the state through `Ord()` rather than comparing against
`eCacheInvalid`/`eCacheValid`. Those two are known from the RTTI but **not** proven to
resolve in DelphiScript, and an unresolved identifier aborts the whole script at compile
time — where a `try/except` cannot help.

Also documented in `scripts/README.md`: a re-saved library is not byte-comparable to the
one handed in even when nothing was edited, because opening it resolves caches. That
would otherwise look like a writer bug.

## Testing

1035 tests green across 11 suites; `cargo fmt --all --check`, `clippy -D warnings` and
markdownlint clean. The table above is this script's actual output on AD24. No fixture
bytes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
