### PR TITLE
test(mcp): cover the manage_schlib_* handler error paths

### DIFF
--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -883,4 +883,292 @@ mod tests {
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("Unknown operation: swap"));
     }
+
+    // ==================== error paths ====================
+
+    /// The branches the round-trip and `*_error_paths` tests above cannot reach:
+    /// the corrupt-library arms, the argument checks that only the mutating
+    /// operations perform, and the whole guard set on `manage_schlib_footprints`,
+    /// which until now was only exercised through `manage_schlib_parameters`.
+    mod error_paths {
+        use super::*;
+        use std::path::Path;
+
+        /// Writes bytes that are not an OLE compound document, standing in for a
+        /// truncated or transfer-mangled library file.
+        fn write_corrupt_schlib(path: &Path) {
+            std::fs::write(path, b"not an OLE compound document").expect("write corrupt file");
+        }
+
+        /// A server whose only allowed path holds a corrupt `.SchLib`.
+        fn corrupt_library() -> (tempfile::TempDir, crate::mcp::server::McpServer, String) {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Corrupt.SchLib");
+            write_corrupt_schlib(&path);
+            let filepath = path.to_string_lossy().to_string();
+            (dir, server, filepath)
+        }
+
+        #[test]
+        fn parameters_report_a_corrupt_library_on_read() {
+            // `list` and `get` open the library read-only; `set`, `add` and
+            // `delete` open it again on a separate arm, so both need covering.
+            let (_dir, server, filepath) = corrupt_library();
+
+            for operation in ["list", "get"] {
+                let result = server.call_manage_schlib_parameters(&json!({
+                    "filepath": filepath,
+                    "component_name": "RESISTOR",
+                    "operation": operation,
+                    "parameter_name": "Value",
+                }));
+                assert!(
+                    result.is_error,
+                    "{operation} must fail on a corrupt library"
+                );
+                assert!(
+                    get_result_text(&result).contains("Failed to read library"),
+                    "{operation} must name the read failure, got: {}",
+                    get_result_text(&result)
+                );
+            }
+        }
+
+        #[test]
+        fn parameters_report_a_corrupt_library_on_mutation() {
+            let (_dir, server, filepath) = corrupt_library();
+
+            for operation in ["set", "add", "delete"] {
+                let result = server.call_manage_schlib_parameters(&json!({
+                    "filepath": filepath,
+                    "component_name": "RESISTOR",
+                    "operation": operation,
+                    "parameter_name": "Value",
+                    "value": "1k",
+                }));
+                assert!(
+                    result.is_error,
+                    "{operation} must fail on a corrupt library"
+                );
+                assert!(
+                    get_result_text(&result).contains("Failed to read library"),
+                    "{operation} must name the read failure, got: {}",
+                    get_result_text(&result)
+                );
+            }
+        }
+
+        #[test]
+        fn parameters_get_requires_a_parameter_name() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("GetNoName.SchLib");
+            create_test_schlib(&path);
+
+            let result = server.call_manage_schlib_parameters(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "operation": "get",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result)
+                .contains("Missing required parameter: parameter_name (required for get"));
+        }
+
+        #[test]
+        fn parameters_mutations_require_a_parameter_name() {
+            // A separate check from the `get` one above, and it names the
+            // operation in the message, so each arm is worth asserting.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("MutNoName.SchLib");
+            create_test_schlib(&path);
+            let filepath = path.to_string_lossy().to_string();
+
+            for operation in ["set", "add", "delete"] {
+                let result = server.call_manage_schlib_parameters(&json!({
+                    "filepath": filepath,
+                    "component_name": "RESISTOR",
+                    "operation": operation,
+                }));
+                assert!(result.is_error, "{operation} must require parameter_name");
+                assert!(
+                    get_result_text(&result).contains(&format!(
+                        "Missing required parameter: parameter_name (required for {operation}"
+                    )),
+                    "{operation} must name itself in the message, got: {}",
+                    get_result_text(&result)
+                );
+            }
+        }
+
+        #[test]
+        fn parameters_mutations_report_an_unknown_symbol() {
+            // The read path resolves the symbol through `get`, the mutating path
+            // through `get_mut` — a second, separately uncovered branch.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("MutNoSym.SchLib");
+            create_test_schlib(&path);
+            let filepath = path.to_string_lossy().to_string();
+
+            for operation in ["set", "add", "delete"] {
+                let result = server.call_manage_schlib_parameters(&json!({
+                    "filepath": filepath,
+                    "component_name": "NOPE",
+                    "operation": operation,
+                    "parameter_name": "Value",
+                    "value": "1k",
+                }));
+                assert!(result.is_error, "{operation} must reject an unknown symbol");
+                assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+            }
+        }
+
+        #[test]
+        fn parameters_add_rejects_an_out_of_range_y() {
+            // The x guard is covered above; y is a separate branch.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("RangeY.SchLib");
+            create_test_schlib(&path);
+
+            let result = server.call_manage_schlib_parameters(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "operation": "add",
+                "parameter_name": "Voltage",
+                "value": "50V",
+                "y": 999_999.0,
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("parameter y"));
+        }
+
+        #[test]
+        fn footprints_require_filepath_and_component_name() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_manage_schlib_footprints(&json!({
+                "component_name": "RESISTOR",
+                "operation": "list",
+            }));
+            assert!(result.is_error);
+            assert_eq!(
+                get_result_text(&result),
+                "Missing required parameter: filepath"
+            );
+
+            let result = server.call_manage_schlib_footprints(&json!({
+                "filepath": dir.path().join("Any.SchLib").to_string_lossy(),
+                "operation": "list",
+            }));
+            assert!(result.is_error);
+            assert_eq!(
+                get_result_text(&result),
+                "Missing required parameter: component_name"
+            );
+        }
+
+        #[test]
+        fn footprints_reject_a_non_schlib_extension() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_manage_schlib_footprints(&json!({
+                "filepath": dir.path().join("Lib.PcbLib").to_string_lossy(),
+                "component_name": "RESISTOR",
+                "operation": "list",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("only supports SchLib files"));
+        }
+
+        #[test]
+        fn footprints_reject_a_path_outside_the_allowed_roots() {
+            let dir = test_temp_dir();
+            let other = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let outside = other.path().join("Out.SchLib");
+            create_test_schlib(&outside);
+
+            let result = server.call_manage_schlib_footprints(&json!({
+                "filepath": outside.to_string_lossy(),
+                "component_name": "RESISTOR",
+                "operation": "list",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Access denied"));
+        }
+
+        #[test]
+        fn footprints_report_a_corrupt_library() {
+            // `list` and the `add`/`remove` pair open the library on separate arms.
+            let (_dir, server, filepath) = corrupt_library();
+
+            for (operation, name) in [("list", None), ("add", Some("FP")), ("remove", Some("FP"))] {
+                let mut args = json!({
+                    "filepath": filepath,
+                    "component_name": "RESISTOR",
+                    "operation": operation,
+                });
+                if let Some(name) = name {
+                    args["footprint_name"] = json!(name);
+                }
+                let result = server.call_manage_schlib_footprints(&args);
+                assert!(
+                    result.is_error,
+                    "{operation} must fail on a corrupt library"
+                );
+                assert!(
+                    get_result_text(&result).contains("Failed to read library"),
+                    "{operation} must name the read failure, got: {}",
+                    get_result_text(&result)
+                );
+            }
+        }
+
+        #[test]
+        fn footprints_mutations_report_an_unknown_symbol() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("FpNoSym.SchLib");
+            create_test_schlib(&path);
+            let filepath = path.to_string_lossy().to_string();
+
+            for operation in ["add", "remove"] {
+                let result = server.call_manage_schlib_footprints(&json!({
+                    "filepath": filepath,
+                    "component_name": "NOPE",
+                    "operation": operation,
+                    "footprint_name": "SOIC-8",
+                }));
+                assert!(result.is_error, "{operation} must reject an unknown symbol");
+                assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+            }
+        }
+
+        #[test]
+        fn footprints_add_rejects_a_duplicate_link() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("FpDup.SchLib");
+            create_test_schlib(&path);
+            let filepath = path.to_string_lossy().to_string();
+
+            let args = json!({
+                "filepath": filepath,
+                "component_name": "RESISTOR",
+                "operation": "add",
+                "footprint_name": "SOIC-8",
+            });
+            assert!(!server.call_manage_schlib_footprints(&args).is_error);
+
+            let result = server.call_manage_schlib_footprints(&args);
+            assert!(result.is_error, "the second add must be rejected");
+            assert!(get_result_text(&result).contains("already linked"));
+        }
+    }
 }


### PR DESCRIPTION
Item 2 from #302 — tool-layer error paths.

`schlib_manage.rs` had the worst error-branch-to-test ratio in the tool layer:
32 `ToolCallResult::error` returns against 9 tests. It isn't on your worst-files
list, but it was the largest gap I could close properly in the time rather than
half-do `components.rs` (72 error returns, 1,975 lines) — happy to take that one
next.

The existing `parameters_error_paths` / `footprints_error_paths` tests only
exercised the read path, which left whole classes of branch unreachable. Adds a
nested `error_paths` module covering:

- **The corrupt-library arms.** `list`/`get` and `set`/`add`/`delete` open the
  library on separate arms, as do footprints `list` and `add`/`remove`, so each
  needs its own probe.
- **Argument checks only the mutating operations perform** — the
  `parameter_name` guard for `set`/`add`/`delete`, which names the operation in
  its message, plus the separate `get` guard.
- **Unknown-symbol resolution through `get_mut`**, a distinct branch from the
  `get` the read path uses, and previously uncovered on both handlers.
- **The `y` coordinate guard** — only `x` was covered.
- **Every guard on `manage_schlib_footprints`** that was previously only
  exercised through `manage_schlib_parameters`: missing `filepath`, missing
  `component_name`, non-SchLib extension, and path outside the allowed roots.
- **The duplicate footprint-link rejection.**

12 tests, 826 → 838 lib tests.

**Verified by mutation**, not just by going green — these tests all passed on
first run, so I checked they weren't vacuous:

| Mutation | Caught by |
|---|---|
| `y` guard mislabelled `"parameter x"` | `parameters_add_rejects_an_out_of_range_y` |
| `"Failed to read library: {e}"` reworded | all three corrupt-library tests |
| duplicate-link check always misses | `footprints_add_rejects_a_duplicate_link` + the existing round-trip |

`cargo fmt --check`, `cargo clippy --all-targets --all-features` with
`-Dwarnings`, and the full suite all clean locally. No local coverage delta —
`cargo llvm-cov` won't run on my machine (`profiler_builtins` is absent from the
rust-std for both the GNU and MSVC toolchains), so CI is the first real number.

Independent of #353 — branched from `main`, touches a different file.
