### PR TITLE
test(mcp): cover the maintenance handler guard branches

### DIFF
--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -2120,4 +2120,247 @@ mod tests {
         assert!(lib.get("RESISTOR").is_none());
         assert!(lib.get("CAPACITOR").is_some());
     }
+
+    // ==================== error paths ====================
+
+    /// The guard branches the behavioural tests above never reach.
+    ///
+    /// `update_pad` and `update_primitive` already have their own error-path
+    /// tests; `bulk_rename` had none at all despite fourteen error returns, and
+    /// `list_backups` and `repair_library` were only ever called with valid
+    /// arguments on an existing library.
+    mod error_paths {
+        use super::*;
+        use std::path::Path;
+
+        /// Writes bytes that are not an OLE compound document, standing in for a
+        /// truncated or transfer-mangled library file.
+        fn write_corrupt(path: &Path) {
+            std::fs::write(path, b"not an OLE compound document").expect("write corrupt file");
+        }
+
+        // -------------------- bulk_rename --------------------
+
+        #[test]
+        fn bulk_rename_requires_filepath_pattern_and_replacement() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let filepath = dir.path().join("Any.PcbLib").to_string_lossy().to_string();
+
+            for (args, want) in [
+                (
+                    json!({ "pattern": "a", "replacement": "b" }),
+                    "Missing required parameter: filepath",
+                ),
+                (
+                    json!({ "filepath": filepath, "replacement": "b" }),
+                    "Missing required parameter: pattern",
+                ),
+                (
+                    json!({ "filepath": filepath, "pattern": "a" }),
+                    "Missing required parameter: replacement",
+                ),
+            ] {
+                let result = server.call_bulk_rename(&args);
+                assert!(result.is_error, "{args} must be rejected");
+                assert_eq!(get_result_text(&result), want);
+            }
+        }
+
+        #[test]
+        fn bulk_rename_rejects_a_path_outside_the_allowed_roots() {
+            let dir = test_temp_dir();
+            let other = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let outside = other.path().join("Out.PcbLib");
+            create_test_pcblib(&outside);
+
+            let result = server.call_bulk_rename(&json!({
+                "filepath": outside.to_string_lossy(),
+                "pattern": "CHIP",
+                "replacement": "PART",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Access denied"));
+        }
+
+        #[test]
+        fn bulk_rename_reports_an_invalid_regex() {
+            // The pattern reaches `Regex::new` verbatim, so a user typo must come
+            // back as a regex error rather than a panic or a silent no-op.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Rx.PcbLib");
+            create_test_pcblib(&path);
+
+            let result = server.call_bulk_rename(&json!({
+                "filepath": path.to_string_lossy(),
+                "pattern": "CHIP(",
+                "replacement": "PART",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Invalid regex pattern"));
+        }
+
+        #[test]
+        fn bulk_rename_rejects_an_unsupported_extension() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_bulk_rename(&json!({
+                "filepath": dir.path().join("Notes.txt").to_string_lossy(),
+                "pattern": "a",
+                "replacement": "b",
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Unsupported file type"));
+        }
+
+        #[test]
+        fn bulk_rename_reports_a_corrupt_library_for_both_types() {
+            // PcbLib and SchLib open the library on separate arms.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            for name in ["Corrupt.PcbLib", "Corrupt.SchLib"] {
+                let path = dir.path().join(name);
+                write_corrupt(&path);
+                let result = server.call_bulk_rename(&json!({
+                    "filepath": path.to_string_lossy(),
+                    "pattern": "A",
+                    "replacement": "B",
+                }));
+                assert!(result.is_error, "{name} must fail to read");
+                assert!(
+                    get_result_text(&result).contains("Failed to read library"),
+                    "{name} must name the read failure, got: {}",
+                    get_result_text(&result)
+                );
+            }
+        }
+
+        #[test]
+        fn bulk_rename_pcblib_reports_rename_conflicts() {
+            // The SchLib conflict arm is covered by
+            // `bulk_rename_schlib_dry_run_and_conflicts`; the PcbLib arm is a
+            // separate branch. Collapsing both fixtures onto one name is the
+            // conflict.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Clash.PcbLib");
+            create_test_pcblib(&path);
+
+            let result = server.call_bulk_rename(&json!({
+                "filepath": path.to_string_lossy(),
+                "pattern": "CHIP_0402|CHIP_0603",
+                "replacement": "CHIP",
+            }));
+            assert!(result.is_error);
+            assert!(
+                get_result_text(&result).contains("Rename conflicts detected"),
+                "got: {}",
+                get_result_text(&result)
+            );
+        }
+
+        // -------------------- list_backups --------------------
+
+        #[test]
+        fn list_backups_requires_a_filepath() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_list_backups(&json!({}));
+            assert!(result.is_error);
+            assert_eq!(
+                get_result_text(&result),
+                "Missing required parameter: filepath"
+            );
+        }
+
+        #[test]
+        fn list_backups_rejects_a_path_outside_the_allowed_roots() {
+            let dir = test_temp_dir();
+            let other = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_list_backups(&json!({
+                "filepath": other.path().join("Out.PcbLib").to_string_lossy(),
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Access denied"));
+        }
+
+        #[test]
+        fn list_backups_rejects_a_missing_parent_directory() {
+            // A missing parent must be an error, not an empty backup list — the
+            // latter reads as "nothing to restore" when the truth is "wrong path".
+            //
+            // Note this is caught by `validate_path`, not by the `read_dir` arm
+            // further down: by the time the scan runs, the parent has been proven
+            // to exist. That arm is defensive against a race or a permission
+            // change between the two, which no portable test can stage, so it is
+            // deliberately left uncovered rather than forced.
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_list_backups(&json!({
+                "filepath": dir.path().join("gone").join("Lib.PcbLib").to_string_lossy(),
+            }));
+            assert!(result.is_error);
+            assert!(
+                get_result_text(&result).contains("Parent directory"),
+                "got: {}",
+                get_result_text(&result)
+            );
+        }
+
+        // -------------------- repair_library --------------------
+
+        #[test]
+        fn repair_library_requires_a_filepath() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let result = server.call_repair_library(&json!({}));
+            assert!(result.is_error);
+            assert_eq!(
+                get_result_text(&result),
+                "Missing required parameter: filepath"
+            );
+        }
+
+        #[test]
+        fn repair_library_rejects_a_path_outside_the_allowed_roots() {
+            let dir = test_temp_dir();
+            let other = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let outside = other.path().join("Out.PcbLib");
+            create_test_pcblib(&outside);
+
+            let result = server.call_repair_library(&json!({
+                "filepath": outside.to_string_lossy(),
+            }));
+            assert!(result.is_error);
+            assert!(get_result_text(&result).contains("Access denied"));
+        }
+
+        #[test]
+        fn repair_library_reports_a_corrupt_library() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Corrupt.PcbLib");
+            write_corrupt(&path);
+
+            let result = server.call_repair_library(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            assert!(result.is_error);
+            assert!(
+                get_result_text(&result).contains("Failed to read library"),
+                "got: {}",
+                get_result_text(&result)
+            );
+        }
+    }
 }


### PR DESCRIPTION
Item 2 from #302 — tool-layer error paths, continuing from #354.

`maintenance.rs` has the second-most error returns in the tool layer (69) but its
30 tests were almost entirely behavioural. `update_pad` and `update_primitive`
already had their own error-path tests, so those are left alone; the gap was
elsewhere:

- **`bulk_rename` had no error test at all**, despite fourteen error returns.
- **`list_backups` and `repair_library`** were only ever called with valid
  arguments against an existing library.

Adds a nested `error_paths` module covering:

- **bulk_rename** — all three missing-argument guards, path outside the allowed
  roots, an invalid regex, an unsupported extension, the corrupt-library arm for
  **both** PcbLib and SchLib (separate branches), and the **PcbLib**
  rename-conflict arm. The SchLib conflict arm was already covered by
  `bulk_rename_schlib_dry_run_and_conflicts`; the PcbLib one was not.
- **list_backups** — missing filepath, path outside the allowed roots, missing
  parent directory.
- **repair_library** — missing filepath, path outside the allowed roots, corrupt
  library.

12 tests, 826 → 838 lib tests.

## One branch deliberately left uncovered

`list_backups` has a `read_dir` failure arm, and I could not reach it honestly.
`validate_path` proves the parent directory exists before the scan runs, so by
the time `read_dir` is called the only way it fails is a race or a permission
change between the two — nothing a portable test can stage. Rather than contort a
fixture to force the line, the test asserts what actually happens (a clear
`Parent directory ...` error rather than an empty backup list, which would read
as "nothing to restore" when the truth is "wrong path"), and a comment records
why the arm is not chased. Flagging it in case you'd rather that arm were
removed as dead than counted as uncovered.

## Verified by mutation

| Mutation | Caught by |
|---|---|
| invalid-regex message reworded | `bulk_rename_reports_an_invalid_regex` |
| unsupported-extension guard removed | `bulk_rename_rejects_an_unsupported_extension` |
| conflict detection disabled (`if false`) | `bulk_rename_pcblib_reports_rename_conflicts` |

`cargo fmt --check`, `cargo clippy --all-targets --all-features` with
`-Dwarnings`, and the full suite all clean locally. No local coverage delta —
`cargo llvm-cov` won't run on my machine (`profiler_builtins` is absent from the
rust-std for both the GNU and MSVC toolchains), so CI is the first real number.

Independent of #353 and #354 — branched from `main`, touches a different file.

## A note on target selection

I looked at `components.rs` first, since it is higher on your worst-files list,
but it already has a `deep_coverage` module and three `*_error_paths` tests, so
its remaining ~84 lines are scattered leftovers across 15 functions. Without
local coverage measurement I would have been guessing at which were already
green. `maintenance.rs` was the larger and more structural gap. `compare.rs`
looks like the next one worth doing — 164 uncovered, and its 36 tests are all
about diff semantics with not one argument-validation test against 16 error
returns.
