### PR TITLE
fix(altium): decode binary strings as UTF-8 when they are UTF-8

### DIFF
--- a/src/altium/framing.rs
+++ b/src/altium/framing.rs
@@ -86,7 +86,7 @@ pub fn read_pascal_string(data: &[u8], offset: usize) -> (String, usize) {
     let start = offset + 1;
     let end = start + len;
     let s = if len > 0 && end <= data.len() {
-        crate::altium::decode_windows1252(&data[start..end])
+        crate::altium::decode_altium_text(&data[start..end])
     } else {
         String::new()
     };

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -83,6 +83,29 @@ pub fn decode_windows1252(bytes: &[u8]) -> String {
     encoding_rs::WINDOWS_1252.decode(bytes).0.into_owned()
 }
 
+/// Decodes an Altium binary string, preferring UTF-8 when the bytes are UTF-8.
+///
+/// Altium writes a name that Windows-1252 cannot hold — CJK, Cyrillic, Thai,
+/// any of them — as its raw UTF-8 bytes inside a record that is otherwise
+/// Windows-1252. Decoding such a pin name as Windows-1252 yields mojibake:
+/// `电阻` comes back as `ç”µé˜»`.
+///
+/// Multi-byte UTF-8 is a narrow subset of arbitrary byte pairs, so treating
+/// valid non-ASCII UTF-8 as UTF-8 is safe in practice: a real Windows-1252
+/// string like `Ohm é` is not valid UTF-8 and falls through unchanged. The
+/// ambiguity is Altium's own — the same tradeoff [`decode_utf8_param_value`]
+/// already makes for parameter values — and the `TEXT_WIN1252` golden pins the
+/// Windows-1252 side of it.
+#[must_use]
+pub fn decode_altium_text(bytes: &[u8]) -> String {
+    if !bytes.is_ascii() {
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            return text.to_string();
+        }
+    }
+    decode_windows1252(bytes)
+}
+
 /// Returns `true` when `value` cannot be represented losslessly in Windows-1252,
 /// so it must be stored behind a `%UTF8%` key to avoid silent `?` corruption.
 ///

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -915,6 +915,56 @@ fn samples_schlib_parameter_type() {
 }
 
 #[test]
+fn samples_schlib_writing_systems_decode() {
+    let lib = SchLib::open(sample("symbols.SchLib")).expect("failed to open symbols.SchLib");
+
+    // Altium writes text outside Windows-1252 as its raw UTF-8 bytes inside a
+    // record that is otherwise Windows-1252. Decoding those as Windows-1252
+    // yields mojibake: the pin name of the Han symbol read back as `ç”µé˜»`
+    // rather than `电阻` until the binary string reader learned to prefer UTF-8.
+    //
+    // Expectations are spelled out here rather than derived from the file. A
+    // check that compares the file against itself passes even when every field
+    // is mojibake, which is exactly the mistake this table avoids.
+    let cases: &[(&str, &str)] = &[
+        ("Resistor_LA", "Resistor"),     // ASCII control
+        ("Résistance_L1", "Résistance"), // Latin-1 supplement
+        ("Điện trở_VI", "Điện trở"),     // Latin, precomposed diacritics
+        ("Резистор_RU", "Резистор"),     // Cyrillic
+        ("Αντίσταση_EL", "Αντίσταση"),   // Greek
+        ("电阻_ZH", "电阻"),             // Han
+        ("저항기_KO", "저항기"),         // Hangul
+        ("مقاومة_AR", "مقاومة"),         // Arabic, right to left
+        ("נגד_HE", "נגד"),               // Hebrew, right to left
+        ("प्रतिरोधक_HI", "प्रतिरोधक"),     // Devanagari, combining marks
+        ("ตัวต้านทาน_TH", "ตัวต้านทาน"),     // Thai, no word spacing
+        ("រេស៊ីស្ទ័រ_KM", "រេស៊ីស្ទ័រ"),           // Khmer, stacked consonants
+        ("𞤀𞤣𞤤𞤢𞤥_AD", "𞤀𞤣𞤤𞤢𞤥"),           // Adlam, beyond the BMP
+    ];
+
+    for (symbol, word) in cases {
+        let sym = lib
+            .get(symbol)
+            .unwrap_or_else(|| panic!("symbol {symbol:?} not found"));
+
+        // The pin name is a length-prefixed string in the binary pin record —
+        // a different decode path from the parameter blocks below.
+        let pin = sym.pins.first().expect("one pin");
+        assert_eq!(&pin.name.as_str(), word, "{symbol}: pin name");
+
+        let label = sym.labels.first().expect("one label");
+        assert_eq!(&label.text.as_str(), word, "{symbol}: label text");
+
+        let param = sym
+            .parameters
+            .iter()
+            .find(|p| p.name == "Value")
+            .unwrap_or_else(|| panic!("{symbol}: no Value parameter"));
+        assert_eq!(&param.value.as_str(), word, "{symbol}: parameter value");
+    }
+}
+
+#[test]
 fn samples_schlib_lockflags() {
     let lib = SchLib::open(sample("symbols.SchLib")).expect("failed to open symbols.SchLib");
     let sym = lib.get("LOCKFLAGS").expect("LOCKFLAGS symbol not found");


### PR DESCRIPTION
Non-Latin pin names read back as mojibake: the Han symbol's pin was `ç”µé˜»`, not `电阻`.

## Cause

Altium writes text that Windows-1252 cannot hold as its **raw UTF-8 bytes**, inside a record that is otherwise Windows-1252. Parameter values already recovered from that (`recover_utf8_bytes`), but **length-prefixed binary strings did not** — and pin names live in the binary pin record, a different path entirely.

`read_pascal_string` now goes through `decode_altium_text`, which prefers UTF-8 for non-ASCII bytes and falls back to Windows-1252. Multi-byte UTF-8 is a narrow subset of arbitrary byte pairs, so a genuine Windows-1252 string is not valid UTF-8 and passes through untouched — the existing `TEXT_WIN1252` golden pins that side of the tradeoff, and still passes.

## Result

Pin name, label text and parameter value now all decode correctly across twelve writing systems, chosen for **behaviour** rather than appearance: ASCII, Latin-1, precomposed Vietnamese, Cyrillic, Greek, Han, Hangul, right-to-left Arabic and Hebrew, combining-mark Devanagari, unspaced Thai, stacked Khmer, and **Adlam beyond the BMP**.

## A methodological note

My first version of this test compared the file against itself — deriving the expected word from the component name — and cheerfully reported **53 of 53 fields correct while every one of them was mojibake**. The committed test states every expectation as a literal. A round-trip test that sources its expectations from the thing under test proves only self-consistency, which is the same trap that let `CAVITYHEIGHT` and `PrimitiveGuids` survive.

## Still open

Four components whose encoded name exceeds the CFB 31-character storage-name cap remain unreachable by name: Bengali, Cherokee, Inuktitut and the CJK-ext-B pair. Altium records the real name in a `SectionKeys` stream for exactly these, which is the next fix and is already tracked in the fidelity test's defect list.

## Verification

1070 tests pass, `cargo fmt` / `clippy -D warnings` clean, readability oracle 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
