### PR TITLE
test(schlib): prove the hard scripts survive our own write/read

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -489,6 +489,60 @@ mod tests {
     }
 
     #[test]
+    fn writing_systems_survive_a_write_read_cycle() {
+        // Our own writer and reader, deliberately without Altium in the loop.
+        //
+        // The Altium-authored golden cannot cover these: a DelphiScript string
+        // literal is mangled before Altium ever sees it for byte sequences the
+        // scripting host's code page cannot represent, so four of the fixture's
+        // symbols carry mojibake that Altium itself stored faithfully. That is a
+        // limit of how the fixture is authored, not of the format layer — and
+        // this test is what tells the two apart.
+        //
+        // Every entry is a name that cannot be written in Windows-1252, and the
+        // last is long enough that its UTF-8 encoding exceeds the 31-character
+        // cap on a compound-file storage name.
+        let words = [
+            "ᏣᎳᎩ",          // Cherokee
+            "রোধক",         // Bengali
+            "ᐃᓄᒃᑎᑐᑦ",       // Inuktitut syllabics
+            "𠮷野",         // Han beyond the BMP: surrogate pairs
+            "𞤀𞤣𞤤𞤢𞤥",        // Adlam beyond the BMP, right to left
+            "ការធ្វើតេស្តយូនីកូដ", // Khmer, 19 chars and 57 UTF-8 bytes
+        ];
+
+        let mut lib = SchLib::new();
+        for word in words {
+            let mut symbol = Symbol::new(word);
+            symbol.description = format!("desc {word}");
+            symbol.add_parameter(Parameter::new("Value", word));
+            lib.add(symbol);
+        }
+
+        let mut buffer = Cursor::new(Vec::new());
+        lib.write(&mut buffer).expect("write");
+        buffer.set_position(0);
+        let read_lib = SchLib::read(buffer).expect("read");
+
+        for word in words {
+            let symbol = read_lib
+                .get(word)
+                .unwrap_or_else(|| panic!("symbol {word:?} not found; got {:?}", read_lib.names()));
+            assert_eq!(
+                symbol.description,
+                format!("desc {word}"),
+                "{word}: description"
+            );
+            let param = symbol
+                .parameters
+                .iter()
+                .find(|p| p.name == "Value")
+                .unwrap_or_else(|| panic!("{word}: no Value parameter"));
+            assert_eq!(param.value, word, "{word}: parameter value");
+        }
+    }
+
+    #[test]
     fn parameter_display_properties_round_trip() {
         // AUTOPOSITION / ISRULE / ISSYSTEMPARAMETER / TEXTHORZANCHOR / TEXTVERTANCHOR.
         // Written in memory and read back, because no golden carries them: AD24 does

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -122,14 +122,21 @@ const KNOWN_DEFECTS: &[(&str, &str)] = &[
     ),
 ];
 
-/// KNOWN DEFECT: a component whose name leaves Windows-1252 is written under a
-/// differently-encoded storage name, so its streams read as missing.
+/// A component whose name leaves ASCII is written under a storage name that
+/// differs from the golden's, so its streams read as missing here.
 ///
-/// Altium maps the name's UTF-8 bytes through the authoring machine's ANSI
-/// codepage (CP1250 on the box that made this golden); we map them through
-/// Latin-1. Reproducing Altium exactly would make our output depend on the
-/// local codepage, so the fix is to preserve the original storage name on read
-/// rather than re-derive it on write.
+/// Altium encodes a storage name as the name's UTF-8 bytes, one byte per
+/// character, capped at the compound-file limit of 31; ours are derived
+/// differently, and for names past that cap Altium also writes a `SectionKeys`
+/// stream mapping the real `LibRef` back — a stream we neither read nor write.
+///
+/// This is about matching Altium's *file layout*, not about whether the format
+/// layer supports the scripts: `writing_systems_survive_a_write_read_cycle`
+/// writes Cherokee, Bengali, Inuktitut, beyond-BMP Han and Adlam, and a Khmer
+/// name of 57 UTF-8 bytes through our own writer and reads every one back
+/// intact. Four of the golden's own i18n symbols carry mojibake because a
+/// `DelphiScript` literal is mangled before Altium sees it, which is a limit of
+/// how the fixture is authored rather than of the code under test.
 const fn is_non_ascii_name_defect(what: &str) -> bool {
     !what.is_ascii()
 }


### PR DESCRIPTION
Four of the golden's i18n symbols carry mojibake, and in [#364](https://github.com/embedded-society/altium-designer-mcp/pull/364) I recorded that as a reader defect. **It is not, and I want to correct that plainly.**

A DelphiScript string literal is mangled *before Altium ever sees it* for byte sequences the scripting host's code page cannot represent. Altium then stores that mojibake faithfully — its own `%UTF8%LibReference` holds the corrupted form. The fixture is wrong; the code under test is not.

## The test that distinguishes them

Cherokee, Bengali, Inuktitut, beyond-BMP Han and Adlam, and a Khmer name of 57 UTF-8 bytes, written through our own writer with **Altium out of the loop** and read back. All intact — names, descriptions and parameter values.

That last one matters on its own: 57 bytes is well past the 31-character compound-file storage-name cap, so it exercises the overflow path our writer takes.

## Why it belongs here

A golden fixture cannot tell a fixture-authoring limitation apart from a format-layer bug — both look like "the field came back wrong". An in-memory round-trip through our own code can, because there is no third party to blame or to blame us. The two tiers answer different questions, and I had been treating the golden as if it answered both.

The fidelity test's note on non-ASCII names is corrected to say what actually remains: matching Altium's storage-name layout and its `SectionKeys` stream — file-layout parity, not script support.

## Verification

1071 tests pass, `cargo fmt` / `clippy -D warnings` clean, readability oracle 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)