### PR TITLE
fix(pcblib): replay the library's own layer stack instead of ours

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -10,35 +10,48 @@
 
 ## Outstanding
 
-**Per-primitive GUIDs are dropped on read (`PcbLib`).** Every footprint storage carries a
-`PrimitiveGuids` stream that the reader ignores entirely, so a read-modify-write discards
-Altium's stable identity for every pad, via, track, arc, region, text and body in the
-library. `write_io.rs` calls it "the editor's optional per-primitive GUID cache", but every
-Altium-authored footprint in the golden has one.
+Read-modify-write fidelity is enforced by `tests/golden_fidelity.rs`, which reads each
+golden, writes it back and diffs the OLE streams and every parameter block. Anything it
+still loses is listed in that test's `KNOWN_DEFECTS` and described here; the two lists are
+the same list, so an entry leaves both together.
 
-The format is fixed-width and fully decoded:
+**`UniqueIDPrimitiveInformation` is not read, so it is not written back (`PcbLib`).** Every
+footprint with pads carries one, keyed by primitive index:
 
 ```text
-PrimitiveGuids/Header : u32   record count
-PrimitiveGuids/Data   : count x 24 bytes
-                        [object_kind : u32][index_within_kind : u32][guid : 16 bytes, LE]
+UniqueIDPrimitiveInformation/Header : u32   record count
+UniqueIDPrimitiveInformation/Data   : count x [block_len:4]["|PRIMITIVEINDEX=n|
+                                      PRIMITIVEOBJECTID=Pad|UNIQUEID=…" + 0x00]
 ```
 
-`object_kind` is Altium's object id (1 arc, 2 pad, 3 via, 5 text, 89 region, 90 component
-body) and `index_within_kind` is the primitive's position among its own kind. Kind 85
-appears exactly once per footprint at index 0 — the footprint record itself. Counts match:
-`PRIMPROPS` has four regions, one body, two texts, one via and one pad, and its header
-reads 10.
+`PRIMITIVEINDEX` counts across the footprint's primitives, not within a kind, and the
+golden's indices are not contiguous (`LOCKFLAGS_PCB` runs 0–5, 7, 8), so the mapping has to
+be replayed rather than recomputed. Our writer emits the stream only when a primitive
+carries a unique id, and nothing ever populates one, so the streams vanish.
 
-Closing it needs a stream reader, a per-primitive field to hold the GUID, and a writer that
-re-emits the stream in the same fixed-width form. Nothing else in the format layer is known
-to be lost on read or unreachable on write.
+**`SectionKeys` is neither read nor written (`PcbLib`, `SchLib`).** Altium encodes a
+component's storage name as the UTF-8 bytes of its name, one byte per storage-name
+character, capped at the compound-file limit of 31 UTF-16 code units. Past that cap it
+writes a `SectionKeys` stream mapping the real `LibRef` back to the truncated name
+(`|KeyCount=N|%UTF8%LibRef0=…|||LibRef0=…|%UTF8%SectionKey0=…|…`). Without it a component
+with a long non-ASCII name keeps only its truncated storage name.
 
-The SchLib Parameter display properties are settled: `NotAutoPosition` and
-`Justification` are covered by a hand-authored fixture
-(`scripts/samples/manual/parameters.SchLib` — see that folder's README to rebuild it).
-`IsRule`, `IsSystemParameter` and `TextHorzAnchor`/`TextVertAnchor` are listed among the
-negatives below.
+**`V7_LAYER` is re-derived rather than replayed (`PcbLib`).** Altium writes the short token
+(`TOP`); we write the long form (`TOPLAYER`), and for a board cutout we write the resolved
+keep-out layer rather than the one stored in the record.
+
+**`IndexInSheet` is renumbered (`SchLib`).** Our writer emits a symbol's primitives grouped
+by type; Altium preserves the interleaved authoring order, and `IndexInSheet` records it.
+
+**Per-primitive GUIDs are preserved per footprint, not per primitive (`PcbLib`).** The
+`PrimitiveGuids` stream round-trips byte-for-byte, but the GUIDs hang off the footprint as
+an opaque list keyed by `(object_kind, index_within_kind)`. A structural edit — deleting a
+pad, reordering regions — shifts the indices out from under them. Attaching the GUID to the
+primitive it names touches eight primitive structs.
+
+**A `MODEL.*` block is invented for extruded bodies (`PcbLib`).** A component body with no
+embedded model gets a `MODEL.*` block including a freshly generated `MODELID`; Altium emits
+none.
 
 ## How to re-verify before trusting this
 
@@ -91,7 +104,7 @@ authoring it and reading the saved bytes back.
 | SchLib `TextHorzAnchor` / `TextVertAnchor` | absent from every parameter record in an authored library |
 | SchLib `IsNotAccesible` = false (Altium's spelling) | every graphic record in a library carries `=T`; no library case omits it |
 | SchLib arc fill (`IsSolid` / `AreaColor`) | `Arc.IsSolid` does not compile — an `ISch_Arc` is a stroked shape with no fill |
-| SchLib pie `Transparent` | `Pie.Transparent` does not compile — real on rectangle/round-rect/ellipse/polygon, absent from `ISch_Pie` |
+| SchLib pie `Transparent` | `Pie.Transparent` does not compile — real on rectangle/round-rect/ellipse/polygon, absent from `ISch_Pie` |
 | SchLib round-rect `LineStyle` | accepted without error, but the saved `RECORD=10` carries no `LineStyle` key — `ISch_Line` and `ISch_Polyline` both persist it |
 | SchLib text-frame `Orientation` | not on `ISch_TextFrame` — `Frm.Orientation` does not compile, though it is real on label/parameter/pin |
 | SchLib image `ShowBorder` | not on `ISch_Image` — `Img.ShowBorder` does not compile, though it is real on `ISch_TextFrame` |

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -96,6 +96,16 @@ Contains library-level parameters and the component directory:
 The parameter block uses the standard `WriteCStringParameterBlock` encoding. `VERSION=3.00`
 requires the `V9_MASTERSTACK` + `V9_STACK_LAYER` layer-stack entries in the same block.
 
+Beyond those, the block is the library's whole board configuration: `LAYER_V8_{n}NAME`,
+`…MECHKIND` and `…MECHENABLED` per mechanical layer, `V9_CACHE_LAYER{n}_*` and
+`V9_STACK_LAYER{n}_*` for the stack, `LAYERSET{n}LAYERS` for the layer sets, plus the view
+state. Almost none of it is modelled, and the names in it are a designer's choice
+(`Mechanical 15 = Assembly Top`), so a library read from disk has its block replayed
+byte-for-byte on write — only `FILENAME`, `DATE` and `TIME` are rewritten. A library built
+in memory has no block to replay and gets a template stack captured from a real
+Altium-authored library; a synthesised one is rejected with "Catastrophic failure whilst
+loading section Library".
+
 ## Per-Component Streams
 
 ### `/{component}/Header`

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -325,6 +325,19 @@ pub struct LibraryMetadata {
 
     /// Component descriptions by index from `CompDescr{N}` fields.
     pub component_descriptions: Vec<String>,
+
+    /// The `/Library/Data` parameter block exactly as it was read, without its
+    /// length prefix or trailing null.
+    ///
+    /// This block is the library's own board configuration: the V9 layer stack,
+    /// every mechanical layer's name, kind and enabled flag, the layer sets and
+    /// the view state. Almost none of it is modelled here, and a library
+    /// routinely carries names a designer chose (`Mechanical 15 = Assembly
+    /// Top`), so it is carried through byte-for-byte on a read-modify-write
+    /// rather than replaced by the template stack a from-scratch library gets.
+    ///
+    /// `None` for a library built in memory, which has no stack to preserve.
+    pub library_params: Option<Vec<u8>>,
 }
 
 /// A `PcbLib` footprint library.

--- a/src/altium/pcblib/read_io.rs
+++ b/src/altium/pcblib/read_io.rs
@@ -266,10 +266,14 @@ impl PcbLib {
             return;
         };
 
-        // Skip the leading parameter block, then read the component count.
-        let Some((_, mut offset)) = read_block(&data, 0) else {
+        // Keep the leading parameter block verbatim — it is the library's own
+        // layer stack and board configuration, which the writer replays rather
+        // than rebuilding (see `LibraryMetadata::library_params`) — then read
+        // the component count that follows it.
+        let Some((params, mut offset)) = read_block(&data, 0) else {
             return;
         };
+        metadata.library_params = Some(params.strip_suffix(&[0x00]).unwrap_or(params).to_vec());
         let Some(comp_count) = read_u32_le(&data, offset) else {
             return;
         };

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -320,12 +320,9 @@ impl PcbLib {
 
         // Build Library/Data content: a C-string parameter block, then the
         // component count + names.
-        let params = Self::build_library_params(self.filepath.as_deref().unwrap_or(""));
+        let params = self.library_params();
         let mut data = Vec::new();
-        crate::altium::framing::write_cstring_param_block(
-            &mut data,
-            &crate::altium::encode_windows1252(&params),
-        );
+        crate::altium::framing::write_cstring_param_block(&mut data, &params);
 
         // Component count
         #[allow(clippy::cast_possible_truncation)]
@@ -456,13 +453,77 @@ impl PcbLib {
         Self::write_meta_storage(cfb, "/FileVersionInfo", 1, &data)
     }
 
-    /// Builds the pipe-delimited parameter string for `/Library/Data`.
+    /// The encoded parameter block for `/Library/Data`.
     ///
     /// Format: `|KEY=VAL|KEY=VAL|...` (leading pipe, NO trailing pipe).
     ///
-    /// Altium Designer requires `VERSION=3.00` plus a minimal V9 layer stack
-    /// definition to consider the file valid.
-    fn build_library_params(filename: &str) -> String {
+    /// A library read from a file replays its own block, so the stack a
+    /// designer configured — custom mechanical layer names, which layers are
+    /// enabled, the layer sets, the view state — comes back out unchanged.
+    /// Only the three keys that describe *this* save are rewritten. A library
+    /// built in memory has no stack to preserve and gets the template one.
+    fn library_params(&self) -> Vec<u8> {
+        // A library path is as free to leave Windows-1252 as any other string
+        // Altium stores, so it goes on the wire the same way.
+        let filename = crate::altium::to_wire_text(self.filepath.as_deref().unwrap_or(""));
+        let now = chrono::Local::now();
+        let (date, time) = (
+            now.format("%d. %m. %Y").to_string(),
+            now.format("%H:%M:%S").to_string(),
+        );
+
+        if let Some(stored) = self.metadata.library_params.as_deref() {
+            let block = Self::override_param(stored, "FILENAME", &filename);
+            let block = Self::override_param(&block, "DATE", &date);
+            return Self::override_param(&block, "TIME", &time);
+        }
+
+        crate::altium::encode_windows1252(&Self::template_library_params(&filename, &date, &time))
+    }
+
+    /// Replaces one key's value inside a raw `|KEY=VALUE|` block, leaving every
+    /// other byte exactly as it was.
+    ///
+    /// Works on bytes rather than text because the block is replayed verbatim:
+    /// decoding and re-encoding it would round a handful of Windows-1252 byte
+    /// values through `?`. A key Altium did not write is appended.
+    fn override_param(block: &[u8], key: &str, value: &str) -> Vec<u8> {
+        let value = crate::altium::encode_windows1252(value);
+        let mut replaced = false;
+
+        let mut segments: Vec<Vec<u8>> = block
+            .split(|&b| b == b'|')
+            .map(|seg| {
+                let matches_key = seg
+                    .iter()
+                    .position(|&b| b == b'=')
+                    .is_some_and(|eq| seg[..eq].eq_ignore_ascii_case(key.as_bytes()));
+                if !matches_key {
+                    return seg.to_vec();
+                }
+                replaced = true;
+                let mut out = key.as_bytes().to_vec();
+                out.push(b'=');
+                out.extend_from_slice(&value);
+                out
+            })
+            .collect();
+
+        if !replaced {
+            let mut appended = key.as_bytes().to_vec();
+            appended.push(b'=');
+            appended.extend_from_slice(&value);
+            segments.push(appended);
+        }
+
+        segments.join(&b'|')
+    }
+
+    /// The parameter block a from-scratch library gets.
+    ///
+    /// Altium Designer requires `VERSION=3.00` plus a V9 layer stack definition
+    /// to consider the file valid.
+    fn template_library_params(filename: &str, date: &str, time: &str) -> String {
         use std::fmt::Write;
 
         let mut p = String::with_capacity(4096);
@@ -471,9 +532,8 @@ impl PcbLib {
         let _ = write!(p, "|FILENAME={filename}");
         p.push_str("|KIND=Protel_Advanced_PCB_Library");
         p.push_str("|VERSION=3.00");
-        let now = chrono::Local::now();
-        let _ = write!(p, "|DATE={}", now.format("%d. %m. %Y"));
-        let _ = write!(p, "|TIME={}", now.format("%H:%M:%S"));
+        let _ = write!(p, "|DATE={date}");
+        let _ = write!(p, "|TIME={time}");
 
         // V9 layer stack + full board configuration. A synthesised stack is
         // rejected by Altium ("Catastrophic failure whilst loading section

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -30,37 +30,29 @@ fn sample(name: &str) -> PathBuf {
 }
 
 /// Keys whose value is expected to differ on every write and carries no
-/// fidelity meaning: identities Altium regenerates, and the absolute path of
-/// the file being written.
+/// fidelity meaning: identities Altium regenerates, the timestamp of the save
+/// itself, and the absolute path of the file being written.
+///
+/// The per-layer GUID caches are *not* here. They are stable now that the
+/// library's own parameter block is replayed byte-for-byte, and leaving them
+/// checked is what proves the replay happened.
 const VOLATILE_KEYS: &[&str] = &[
     "UNIQUEID",
     "ITEMGUID",
     "REVISIONGUID",
     "FILENAME",
+    "DATE",
+    "TIME",
     "MODELID",
     "MODEL.CHECKSUM",
-    "VP.HX",
 ];
 
-/// Key *prefix/suffix* patterns whose values are regenerated identities: the
-/// per-layer GUID caches Altium rewrites on every save.
 fn is_volatile_key(key: &str) -> bool {
-    if VOLATILE_KEYS.contains(&key) {
-        return true;
-    }
-    (key.starts_with("V9_CACHE_LAYER")
-        || key.starts_with("V9_STACK_LAYER")
-        || key.starts_with("LAYER_V8_"))
-        && key.ends_with("ID")
+    VOLATILE_KEYS.contains(&key)
 }
 
 /// Differences that are correct by design and will not change.
 const BY_DESIGN: &[(&str, &str)] = &[
-    (
-        "library/data",
-        "holds the absolute source path and library-wide identities, both \
-         regenerated on write",
-    ),
     (
         "library/padvialibrary/data",
         "an empty pad/via template cache with a fresh library id; no template is \
@@ -93,12 +85,11 @@ const KNOWN_DEFECTS: &[(&str, &str)] = &[
          rather than the stored one",
     ),
     (
-        "Library:",
-        "our writer rebuilds the library layer stack rather than preserving it:          mechanical layers are renamed to their alias names (Mechanical 2 -> Top          Assembly), disabled layers are enabled, USEDBYPRIMS is recomputed and          LAYERSET1LAYERS gains every layer we know about. A library with custom          mechanical layer names loses them on a read-modify-write",
-    ),
-    (
         "sectionkeys",
-        "Altium emits a SectionKeys stream mapping LibRef -> storage name for          every component whose name does not fit the CFB 31-character cap once          encoded; we neither read nor write it, so those components lose their          real name and keep only the truncated storage name",
+        "Altium emits a SectionKeys stream mapping LibRef -> storage name for \
+         every component whose name does not fit the CFB 31-character cap once \
+         encoded; we neither read nor write it, so those components lose their \
+         real name and keep only the truncated storage name",
     ),
     (
         "INDEXINSHEET",

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -1450,6 +1450,85 @@ fn samples_pcblib_golden_survives_a_read_modify_write() {
 }
 
 #[test]
+fn samples_pcblib_layer_stack_survives_a_read_modify_write() {
+    use std::io::Cursor;
+
+    /// The value of one key in a raw `|KEY=VALUE|` parameter block.
+    fn param(block: &[u8], key: &str) -> Option<String> {
+        block.split(|&b| b == b'|').find_map(|seg| {
+            let eq = seg.iter().position(|&b| b == b'=')?;
+            (seg[..eq] == *key.as_bytes())
+                .then(|| String::from_utf8_lossy(&seg[eq + 1..]).into_owned())
+        })
+    }
+
+    /// The block minus the three keys that describe one particular save.
+    fn stack_only(block: &[u8]) -> Vec<Vec<u8>> {
+        block
+            .split(|&b| b == b'|')
+            .filter(|seg| {
+                let key = seg.split(|&b| b == b'=').next().unwrap_or_default();
+                !["FILENAME", "DATE", "TIME"]
+                    .iter()
+                    .any(|k| key == k.as_bytes())
+            })
+            .map(<[u8]>::to_vec)
+            .collect()
+    }
+
+    let mut lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open golden");
+    let before = lib
+        .metadata()
+        .library_params
+        .clone()
+        .expect("the golden carries a layer stack");
+
+    // Altium named this layer; our template stack calls slot 12 "Top Assembly".
+    // Keeping the authored name is the point — a designer's "Mechanical 15 =
+    // Assembly Top" must not be renamed by a read-modify-write.
+    assert_eq!(
+        param(&before, "LAYER_V8_12NAME").as_deref(),
+        Some("Mechanical 2"),
+        "the golden's own name for mechanical layer 2"
+    );
+
+    let mut buffer = Cursor::new(Vec::new());
+    lib.write(&mut buffer).expect("write the golden back");
+    buffer.set_position(0);
+    let after = PcbLib::read(&mut buffer)
+        .expect("read back")
+        .metadata()
+        .library_params
+        .clone()
+        .expect("the rewritten library carries a layer stack");
+
+    assert_eq!(
+        stack_only(&after),
+        stack_only(&before),
+        "the library's own board configuration must come back byte-for-byte: \
+         layer names, enabled flags, USEDBYPRIMS, layer sets and per-layer ids"
+    );
+
+    // A library with no stack of its own falls back to the template, which is
+    // what makes the assertion above meaningful rather than tautological.
+    let mut fresh = PcbLib::new();
+    let mut buffer = Cursor::new(Vec::new());
+    fresh.write(&mut buffer).expect("write an empty library");
+    buffer.set_position(0);
+    let template = PcbLib::read(&mut buffer)
+        .expect("read back")
+        .metadata()
+        .library_params
+        .clone()
+        .expect("a written library always has a stack");
+    assert_eq!(
+        param(&template, "LAYER_V8_12NAME").as_deref(),
+        Some("Top Assembly"),
+        "the template stack names slot 12 differently from the golden"
+    );
+}
+
+#[test]
 fn samples_pcblib_padmask_expansions() {
     // Manual paste / solder-mask expansion, authored by Altium.
     //


### PR DESCRIPTION
## The defect

A read-modify-write threw away `/Library/Data`'s parameter block and wrote a template in its place — a stack captured verbatim from one Altium-authored library. That block is the library's whole board configuration, and none of it is modelled, so none of it survived:

| Key | Golden | Ours (before) |
|-----|--------|---------------|
| `LAYER_V8_12NAME` | `Mechanical 2` | `Top Assembly` |
| `LAYER_V8_13NAME` | `Mechanical 3` | `Bottom Assembly` |
| `V9_CACHE_LAYER72_NAME` | `Mechanical 4` | `Top Courtyard` |
| `LAYER_V8_25MECHENABLED` | `FALSE` | `TRUE` |
| `V9_STACK_LAYER3_USEDBYPRIMS` | `FALSE` | `TRUE` |
| `LAYERSET1LAYERS` | …`Mechanical1,DrillDrawing` | …`Mechanical1,…,Mechanical15,DrillDrawing` |

Custom mechanical layer names are routine in a professional library — `Mechanical 15 = Assembly Top`, `Mechanical 2 = Fab Notes`. Every mutating tool goes through this path, so adding a pad to an existing library renamed its layers.

## The fix

The reader keeps the block verbatim in `LibraryMetadata::library_params`; the writer replays it and rewrites only `FILENAME`, `DATE` and `TIME`. A library built in memory has no block to replay and still gets the template.

`override_param` works on bytes, not text: the block is replayed as-is, and decoding then re-encoding would round the handful of Windows-1252 byte values our decoder has no mapping for through `?`.

## Why the test is stronger now, not just greener

`golden_fidelity` used to excuse the whole `/Library/Data` block via `KNOWN_DEFECTS`, and treated every `V9_CACHE_LAYER*_ID` / `V9_STACK_LAYER*_ID` / `LAYER_V8_*ID` and `VP.HX` as a volatile identity. All of those are now compared. They pass because the replay is byte-for-byte — that is the assertion. `VOLATILE_KEYS` keeps only what genuinely changes per save, with `DATE`/`TIME` added alongside `FILENAME`.

`samples_pcblib_layer_stack_survives_a_read_modify_write` pins it directly: the golden's `Mechanical 2` comes back, the block is identical minus the three save keys, and an in-memory library still gets `Top Assembly` — so the first assertion cannot pass by accident.

## Verification

- full suite green (860 unit + all integration)
- clippy `-D warnings`, `cargo fmt`, `cargo doc`, markdownlint clean
- pyaltiumlib oracle: 13 passed, 0 regressions
- a rewritten golden parses exactly as far as the golden itself does under pyaltiumlib (both stop at the same i18n storage name — a limit of that reader, identical on input and output)

## Follow-ups

`KNOWN_DEFECTS` is down to four, now mirrored in `docs/COVERAGE_AUDIT.md` § Outstanding: `UniqueIDPrimitiveInformation`, `SectionKeys`, `V7_LAYER` long-form, and SchLib `IndexInSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)