### PR TITLE
feat(pcblib): keep the primitive order the identity streams key off

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -15,20 +15,6 @@ golden, writes it back and diffs the OLE streams and every parameter block. Anyt
 still loses is listed in that test's `KNOWN_DEFECTS` and described here; the two lists are
 the same list, so an entry leaves both together.
 
-**`UniqueIDPrimitiveInformation` is not read, so it is not written back (`PcbLib`).** Every
-footprint with pads carries one, keyed by primitive index:
-
-```text
-UniqueIDPrimitiveInformation/Header : u32   record count
-UniqueIDPrimitiveInformation/Data   : count x [block_len:4]["|PRIMITIVEINDEX=n|
-                                      PRIMITIVEOBJECTID=Pad|UNIQUEID=…" + 0x00]
-```
-
-`PRIMITIVEINDEX` counts across the footprint's primitives, not within a kind, and the
-golden's indices are not contiguous (`LOCKFLAGS_PCB` runs 0–5, 7, 8), so the mapping has to
-be replayed rather than recomputed. Our writer emits the stream only when a primitive
-carries a unique id, and nothing ever populates one, so the streams vanish.
-
 **`SectionKeys` is neither read nor written (`PcbLib`, `SchLib`).** Altium encodes a
 component's storage name as the UTF-8 bytes of its name, one byte per storage-name
 character, capped at the compound-file limit of 31 UTF-16 code units. Past that cap it
@@ -42,12 +28,16 @@ keep-out layer rather than the one stored in the record.
 
 **`IndexInSheet` is renumbered (`SchLib`).** Our writer emits a symbol's primitives grouped
 by type; Altium preserves the interleaved authoring order, and `IndexInSheet` records it.
+This is the `SchLib` twin of the `PcbLib` primitive ordering that
+`Footprint::primitive_order` now carries, and it wants the same treatment.
 
-**Per-primitive GUIDs are preserved per footprint, not per primitive (`PcbLib`).** The
-`PrimitiveGuids` stream round-trips byte-for-byte, but the GUIDs hang off the footprint as
-an opaque list keyed by `(object_kind, index_within_kind)`. A structural edit — deleting a
-pad, reordering regions — shifts the indices out from under them. Attaching the GUID to the
-primitive it names touches eight primitive structs.
+**Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
+footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its
+position among all the footprint's primitives. That position is preserved across a
+read-modify-write, so both survive one — but a *structural* edit (deleting a pad, inserting
+a region) renumbers everything after it and silently re-points every later identity.
+Attaching the GUID to the primitive it names would fix it, and touches eight primitive
+structs.
 
 **A `MODEL.*` block is invented for extruded bodies (`PcbLib`).** A component body with no
 embedded model gets a `MODEL.*` block including a freshly generated `MODELID`; Altium emits

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -37,10 +37,11 @@ PcbLib files are OLE Compound Documents (CFB format, **OLE v3 with 512-byte sect
 
 > **Note:** OLE version MUST be V3 (512-byte sectors). Altium Designer rejects V4 (4096-byte) files.
 >
-> Real Altium libraries also carry `SectionKeys` (root, for >31-char names), `FileVersionInfo`,
-> `EmbeddedFonts`, `LayerKindMapping`, `PadViaLibrary`, `ComponentParamsTOC`, `Textures`,
-> `ModelsNoEmbed` and `PrimitiveGuids` streams/storages. These are **unmodelled**: the reader
-> ignores them and the writer does not emit them.
+> Real Altium libraries also carry `FileVersionInfo`, `EmbeddedFonts`, `LayerKindMapping`,
+> `PadViaLibrary`, `ComponentParamsTOC`, `Textures`, `ModelsNoEmbed`, `PrimitiveGuids` and
+> `UniqueIdPrimitiveInformation`. All of these are read and written back. `SectionKeys` (root,
+> for names past the 31-character storage limit) is **unmodelled**: the reader ignores it and
+> the writer does not emit it.
 
 ## Encoding Primitives (Building Blocks)
 
@@ -150,15 +151,40 @@ no pipe).
 
 | Field | Description |
 |-------|-------------|
-| `PRIMITIVEINDEX` | Single **global 0-based ordinal** over ALL primitives in Data-stream emit order |
+| `PRIMITIVEINDEX` | Single **global 0-based ordinal** over ALL primitives, in Data-stream order |
 | `PRIMITIVEOBJECTID` | Primitive type name (Pad, Via, Track, Arc, Text, Region, Fill, ComponentBody) |
-| `UNIQUEID` | 8-character alphanumeric identifier |
+| `UNIQUEID` | 8-character alphanumeric identifier, **often empty** |
 
 > **Note:** `PRIMITIVEINDEX` is NOT a per-type index. Every primitive consumes an ordinal in the
-> Data-stream order (Arcs, Pads, Vias, Tracks, Text, Regions, Fills, ComponentBodies) whether or
-> not it has a unique id, so e.g. the first pad behind two silkscreen arcs is `PRIMITIVEINDEX=2`.
-> On read the entry's `PRIMITIVEOBJECTID` must match the primitive found at that ordinal; a
-> mismatch (e.g. a foreign file with a different index base) is skipped rather than mis-attached.
+> order the Data stream stores them, whether or not it has a record here, so the ordinals of the
+> records present have gaps: `LOCKFLAGS_PCB` in the golden runs 0–5, 7, 8, because ordinal 6 is a
+> track. On read the entry's `PRIMITIVEOBJECTID` must match the primitive found at that ordinal;
+> a mismatch (e.g. a foreign file with a different index base) is skipped rather than
+> mis-attached.
+>
+> An **empty `UNIQUEID` is normal** — every record in the golden has one. The record marks the
+> primitive as tracked; the value is filled in by a board, not a library. Treating an empty value
+> as "no record" discards the stream.
+
+### `/{component}/PrimitiveGuids`
+
+**Header:** `[record_count:4 LE u32]`
+
+**Data:** `record_count` fixed-width 24-byte records, no framing of their own:
+
+```text
+[object_kind:4 LE u32][ordinal:4 LE u32][guid:16 bytes]
+```
+
+`object_kind` is Altium's object id — 1 arc, 2 pad, 3 via, 4 track, 5 text, 6 fill, 85 the
+footprint record itself, 89 region, 90 component body. The GUID's first three fields are
+little-endian (the Windows `GUID` struct layout).
+
+`ordinal` is the **same global ordinal** `UniqueIdPrimitiveInformation` calls `PRIMITIVEINDEX`,
+not a per-kind index: across the 22 golden footprints the ordinals are a permutation of `0..n-1`
+once the kind-85 record (always ordinal 0) is set aside, and `PRIMPROPS` has its regions at 0, 4,
+5 and 6 with a pad at 1 and texts at 2 and 3. Both streams are therefore meaningless unless the
+Data stream keeps the primitive order the file was written with.
 
 ## Data Stream Format
 
@@ -889,7 +915,12 @@ recomputed body checksum that disagreed with the Models/Data record would be wor
 
 ## Primitive Writing Order
 
-When writing footprint data, primitives are encoded in this specific order:
+Altium stores primitives in **authoring order**, interleaving the kinds:
+`LOCKFLAGS_PCB` in the golden runs pad x6, track, pad x2, track, arc x2, fill x2. That order is
+the ordinal space both identity streams key off, so a footprint read from a file is written back
+in the order it came in.
+
+A footprint with no order of its own — one built in memory — is written kind by kind:
 
 1. Arcs (0x01)
 2. Pads (0x02)
@@ -899,6 +930,9 @@ When writing footprint data, primitives are encoded in this specific order:
 6. Regions (0x0B)
 7. Fills (0x06)
 8. ComponentBodies (0x0C)
+
+`WideStrings` is indexed over the text primitives alone, in their own relative order, so
+interleaving does not disturb the `ENCODEDTEXT{n}` numbering.
 
 There is **no** end marker after the last primitive (issue #68).
 
@@ -910,7 +944,7 @@ There is **no** end marker after the last primitive (issue #68).
 - **3D model embedding**: zlib-compressed STEP files, referenced by GUID
 - **Pad hole shapes**: Round (0), Square (1), Slot (2) — stored at offset 262 of the 651-byte size/shape block, NOT in the main geometry block
 - **Net information**: modelled via the common-header indices; used in board files, not library files
-- **Unique IDs**: 8-character alphanumeric, keyed by a single global 0-based `PRIMITIVEINDEX` over all primitives in Data order
+- **Unique IDs**: 8-character alphanumeric or empty, keyed by a global 0-based `PRIMITIVEINDEX` over all primitives in Data order — the ordinal `PrimitiveGuids` also uses
 - **Default layer mapping**: unknown layer IDs default to Multi-Layer (74)
 - **Default stack mode**: unknown stack mode IDs default to Simple (0)
 - **Internal OLE entries filtered on read**: FileHeader, Library, Models, Textures, ModelsNoEmbed, PadViaLibrary, LayerKindMapping,

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -142,24 +142,102 @@ pub struct Footprint {
     /// across edits; dropping them makes every primitive look new. They are held
     /// as read rather than attached to the primitives themselves, so a
     /// read-modify-write that leaves the primitive collections alone reproduces
-    /// them exactly. Adding or removing a primitive shifts the indices its kind
-    /// uses, and the writer drops any entry that no longer points at one.
+    /// them exactly. Adding or removing a primitive shifts the ordinals, and the
+    /// writer drops any entry that no longer points at a primitive.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub primitive_guids: Vec<PrimitiveGuid>,
+
+    /// The order the primitives are stored in, one entry per primitive.
+    ///
+    /// Altium interleaves kinds in authoring order — `LOCKFLAGS_PCB` in the
+    /// golden runs pad x6, track, pad x2, track, arc x2, fill x2 — and both
+    /// identity streams key off a primitive's position in that sequence:
+    /// `PrimitiveGuids` stores it as a record's second `u32`, and
+    /// `UniqueIDPrimitiveInformation` as `PRIMITIVEINDEX`. Emitting the kinds
+    /// in blocks would renumber every primitive and detach both.
+    ///
+    /// An entry names one of the lists above; its n-th occurrence refers to
+    /// that list's n-th element, so the sequence alone reconstructs the
+    /// interleaving. It is maintained by the `add_*` methods, which is how
+    /// reading a footprint records the file's order. Empty when the primitive
+    /// lists were populated directly, in which case the writer falls back to
+    /// [`PrimitiveKind::WRITE_ORDER`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub primitive_order: Vec<PrimitiveKind>,
+}
+
+/// One of a [`Footprint`]'s primitive lists, as named by `primitive_order`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrimitiveKind {
+    /// [`Footprint::arcs`].
+    Arc,
+    /// [`Footprint::pads`].
+    Pad,
+    /// [`Footprint::vias`].
+    Via,
+    /// [`Footprint::tracks`].
+    Track,
+    /// [`Footprint::text`].
+    Text,
+    /// [`Footprint::regions`].
+    Region,
+    /// [`Footprint::fills`].
+    Fill,
+    /// [`Footprint::component_bodies`].
+    ComponentBody,
+}
+
+impl PrimitiveKind {
+    /// The order a footprint with no recorded order of its own is written in.
+    pub const WRITE_ORDER: [Self; 8] = [
+        Self::Arc,
+        Self::Pad,
+        Self::Via,
+        Self::Track,
+        Self::Text,
+        Self::Region,
+        Self::Fill,
+        Self::ComponentBody,
+    ];
+
+    /// The `PRIMITIVEOBJECTID` token Altium writes for this kind in a
+    /// `UniqueIDPrimitiveInformation` record.
+    #[must_use]
+    pub const fn object_id(self) -> &'static str {
+        match self {
+            Self::Arc => "Arc",
+            Self::Pad => "Pad",
+            Self::Via => "Via",
+            Self::Track => "Track",
+            Self::Text => "Text",
+            Self::Region => "Region",
+            Self::Fill => "Fill",
+            Self::ComponentBody => "ComponentBody",
+        }
+    }
 }
 
 /// One `PrimitiveGuids` record: which primitive it names, and its GUID.
 ///
 /// The stream is a `u32` count followed by that many 24-byte records of
-/// `[object_kind: u32][index_within_kind: u32][guid: 16 bytes, little-endian]`.
+/// `[object_kind: u32][ordinal: u32][guid: 16 bytes, little-endian]`.
 /// `object_kind` is Altium's object id — 1 arc, 2 pad, 3 via, 4 track, 5 text,
-/// 6 fill, 85 the footprint itself, 89 region, 90 component body — and `index`
-/// counts within that kind.
+/// 6 fill, 85 the footprint itself, 89 region, 90 component body.
+///
+/// `index` is the primitive's position among **all** the footprint's
+/// primitives, not among its own kind: across the 22 golden footprints the
+/// indices are a permutation of `0..n-1` once the footprint's own record (kind
+/// 85, always index 0) is set aside, and `PRIMPROPS` puts its regions at 0, 4,
+/// 5 and 6 with a pad at 1 and its texts at 2 and 3. It is the same ordinal
+/// `UniqueIDPrimitiveInformation` calls `PRIMITIVEINDEX`, which is why
+/// [`Footprint::primitive_order`] has to survive a write for either to mean
+/// anything.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrimitiveGuid {
     /// Altium object id of the primitive this GUID belongs to.
     pub object_kind: u32,
-    /// Position of the primitive among others of the same kind.
+    /// Position of the primitive among all of the footprint's primitives.
     pub index: u32,
     /// The GUID, formatted `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`.
     pub guid: String,
@@ -260,47 +338,116 @@ impl Footprint {
             component_bodies: Vec::new(),
             model_3d: None,
             primitive_guids: Vec::new(),
+            primitive_order: Vec::new(),
         }
     }
 
     /// Adds a pad to the footprint.
     pub fn add_pad(&mut self, pad: Pad) {
         self.pads.push(pad);
+        self.primitive_order.push(PrimitiveKind::Pad);
     }
 
     /// Adds a via to the footprint.
     pub fn add_via(&mut self, via: Via) {
         self.vias.push(via);
+        self.primitive_order.push(PrimitiveKind::Via);
     }
 
     /// Adds a track to the footprint.
     pub fn add_track(&mut self, track: Track) {
         self.tracks.push(track);
+        self.primitive_order.push(PrimitiveKind::Track);
     }
 
     /// Adds an arc to the footprint.
     pub fn add_arc(&mut self, arc: Arc) {
         self.arcs.push(arc);
+        self.primitive_order.push(PrimitiveKind::Arc);
     }
 
     /// Adds a region to the footprint.
     pub fn add_region(&mut self, region: Region) {
         self.regions.push(region);
+        self.primitive_order.push(PrimitiveKind::Region);
     }
 
     /// Adds text to the footprint.
     pub fn add_text(&mut self, text: Text) {
         self.text.push(text);
+        self.primitive_order.push(PrimitiveKind::Text);
     }
 
     /// Adds a fill to the footprint.
     pub fn add_fill(&mut self, fill: primitives::Fill) {
         self.fills.push(fill);
+        self.primitive_order.push(PrimitiveKind::Fill);
     }
 
     /// Adds a component body (3D model) to the footprint.
     pub fn add_component_body(&mut self, body: primitives::ComponentBody) {
         self.component_bodies.push(body);
+        self.primitive_order.push(PrimitiveKind::ComponentBody);
+    }
+
+    /// The footprint's primitives in the order they are written, as
+    /// `(kind, index into that kind's list)` pairs.
+    ///
+    /// [`Self::primitive_order`] is advisory: the primitive lists are public,
+    /// so a caller can push to or truncate one without it. Entries pointing
+    /// past the end of their list are therefore dropped, and any primitive the
+    /// sequence never reaches is appended in [`PrimitiveKind::WRITE_ORDER`] —
+    /// so a footprint with no recorded order, or one edited behind its back,
+    /// still writes every primitive exactly once.
+    #[must_use]
+    pub fn write_sequence(&self) -> Vec<(PrimitiveKind, usize)> {
+        let mut taken: std::collections::HashMap<PrimitiveKind, usize> =
+            std::collections::HashMap::new();
+        let mut sequence = Vec::with_capacity(self.primitive_count());
+
+        for &kind in &self.primitive_order {
+            let next = taken.entry(kind).or_insert(0);
+            if *next < self.count_of(kind) {
+                sequence.push((kind, *next));
+                *next += 1;
+            }
+        }
+        for kind in PrimitiveKind::WRITE_ORDER {
+            let next = taken.entry(kind).or_insert(0);
+            while *next < self.count_of(kind) {
+                sequence.push((kind, *next));
+                *next += 1;
+            }
+        }
+        sequence
+    }
+
+    /// How many primitives of one kind the footprint holds.
+    #[must_use]
+    pub fn count_of(&self, kind: PrimitiveKind) -> usize {
+        match kind {
+            PrimitiveKind::Arc => self.arcs.len(),
+            PrimitiveKind::Pad => self.pads.len(),
+            PrimitiveKind::Via => self.vias.len(),
+            PrimitiveKind::Track => self.tracks.len(),
+            PrimitiveKind::Text => self.text.len(),
+            PrimitiveKind::Region => self.regions.len(),
+            PrimitiveKind::Fill => self.fills.len(),
+            PrimitiveKind::ComponentBody => self.component_bodies.len(),
+        }
+    }
+
+    /// How many primitives the footprint holds in total.
+    #[must_use]
+    pub fn primitive_count(&self) -> usize {
+        self.pads.len()
+            + self.vias.len()
+            + self.tracks.len()
+            + self.arcs.len()
+            + self.regions.len()
+            + self.text.len()
+            + self.fills.len()
+            + self.component_bodies.len()
     }
 }
 

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -233,18 +233,20 @@ fn parse_unique_id_record(record: &str) -> Option<UniqueIdEntry> {
     let params = crate::altium::parse_pipe_params_raw(record);
     let primitive_index: usize = params.get("PRIMITIVEINDEX")?.parse().ok()?;
     let primitive_type = params.get("PRIMITIVEOBJECTID")?.clone();
-    let unique_id = params.get("UNIQUEID")?.clone();
-    // Only return if all required fields are present and the id is non-empty.
-    (!unique_id.is_empty()).then_some(UniqueIdEntry {
+    // An empty `UNIQUEID` is not a missing record. Every pad in the golden has
+    // one, value and all, and Altium writes the stream regardless — the record
+    // is what marks the primitive as tracked, so dropping the empty ones threw
+    // the whole stream away.
+    Some(UniqueIdEntry {
         primitive_index,
         primitive_type,
-        unique_id,
+        unique_id: params.get("UNIQUEID")?.clone(),
     })
 }
 
 /// Parses a footprint's `PrimitiveGuids/Data` stream.
 ///
-/// Layout: 24-byte records of `[object_kind: u32][index_within_kind: u32][guid:
+/// Layout: 24-byte records of `[object_kind: u32][ordinal: u32][guid:
 /// 16 bytes]`, packed with no header of their own — the record count lives in
 /// the sibling `PrimitiveGuids/Header` stream, so the data is chunked instead.
 /// The GUID's first three fields are little-endian, the Windows `GUID` struct
@@ -284,47 +286,53 @@ fn format_guid(b: &[u8]) -> String {
 
 /// Applies unique IDs from the `UniqueIDPrimitiveInformation` stream to footprint primitives.
 ///
-/// `PRIMITIVEINDEX` is a single global 0-based ordinal over all primitives in
-/// `Data`-stream emit order (Arc, Pad, Via, Track, Text, Region, Fill,
-/// `ComponentBody`) — NOT a per-type index. This walks that exact order, mirroring
-/// `encode_unique_id_stream`, so a written-then-read footprint round-trips.
+/// `PRIMITIVEINDEX` is a single global 0-based ordinal over all of the
+/// footprint's primitives, in the order the `Data` stream stores them — NOT a
+/// per-type index. This walks `Footprint::write_sequence`, the same order
+/// `encode_unique_id_stream` writes, so a footprint round-trips.
 ///
 /// # Arguments
 ///
 /// * `footprint` - The footprint to update with unique IDs
 /// * `unique_ids` - The parsed unique ID map from `parse_unique_id_stream`
 pub fn apply_unique_ids(footprint: &mut Footprint, unique_ids: &UniqueIdMap) {
+    use crate::altium::pcblib::PrimitiveKind;
+
     // Map global ordinal -> (type, uid). Type is kept only to disambiguate a foreign
     // file whose ordinal base doesn't line up: we skip rather than mis-attach.
-    let mut by_ordinal: HashMap<usize, (&str, &str)> = HashMap::new();
-    for entry in unique_ids {
-        by_ordinal.insert(
-            entry.primitive_index,
-            (entry.primitive_type.as_str(), entry.unique_id.as_str()),
-        );
-    }
+    let by_ordinal: HashMap<usize, (&str, &str)> = unique_ids
+        .iter()
+        .map(|entry| {
+            (
+                entry.primitive_index,
+                (entry.primitive_type.as_str(), entry.unique_id.as_str()),
+            )
+        })
+        .collect();
 
-    let mut ordinal = 0usize;
-    macro_rules! apply {
-        ($iter:expr, $ty:literal) => {
-            for prim in $iter {
-                if let Some(&(ty, uid)) = by_ordinal.get(&ordinal) {
-                    if ty == $ty {
-                        prim.unique_id = Some(uid.to_string());
-                    }
-                }
-                ordinal += 1;
-            }
+    let assignments: Vec<(PrimitiveKind, usize, String)> = footprint
+        .write_sequence()
+        .into_iter()
+        .enumerate()
+        .filter_map(|(ordinal, (kind, index))| {
+            let &(ty, uid) = by_ordinal.get(&ordinal)?;
+            (ty == kind.object_id()).then(|| (kind, index, uid.to_string()))
+        })
+        .collect();
+
+    for (kind, index, uid) in assignments {
+        let slot = match kind {
+            PrimitiveKind::Arc => &mut footprint.arcs[index].unique_id,
+            PrimitiveKind::Pad => &mut footprint.pads[index].unique_id,
+            PrimitiveKind::Via => &mut footprint.vias[index].unique_id,
+            PrimitiveKind::Track => &mut footprint.tracks[index].unique_id,
+            PrimitiveKind::Text => &mut footprint.text[index].unique_id,
+            PrimitiveKind::Region => &mut footprint.regions[index].unique_id,
+            PrimitiveKind::Fill => &mut footprint.fills[index].unique_id,
+            PrimitiveKind::ComponentBody => &mut footprint.component_bodies[index].unique_id,
         };
+        *slot = Some(uid);
     }
-    apply!(footprint.arcs.iter_mut(), "Arc");
-    apply!(footprint.pads.iter_mut(), "Pad");
-    apply!(footprint.vias.iter_mut(), "Via");
-    apply!(footprint.tracks.iter_mut(), "Track");
-    apply!(footprint.text.iter_mut(), "Text");
-    apply!(footprint.regions.iter_mut(), "Region");
-    apply!(footprint.fills.iter_mut(), "Fill");
-    apply!(footprint.component_bodies.iter_mut(), "ComponentBody");
 
     tracing::trace!(
         footprint = %footprint.name,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -17,7 +17,7 @@ use super::primitives::{
     Arc, ComponentBody, Fill, HoleShape, Layer, Pad, PadShape, PadStackMode, PcbFlags, Region,
     StrokeFont, Text, TextJustification, TextKind, Track, Via, ViaStackMode,
 };
-use super::Footprint;
+use super::{Footprint, PrimitiveKind};
 
 use super::units::{from_mm, mm_to_mil};
 
@@ -310,58 +310,53 @@ pub fn encode_data_stream(footprint: &Footprint) -> crate::altium::error::Altium
         "footprint.name",
     )?;
 
-    // Write primitives
-    // Order: Arcs, Pads, Tracks (following typical Altium ordering)
+    // Primitives go out in the footprint's own order, which is Altium's
+    // authoring order for anything read from a file (see
+    // `Footprint::primitive_order`) and the canonical kind order otherwise.
+    //
+    // `WideStrings` is indexed over `footprint.text` alone, so the index each
+    // text record carries is resolved up front rather than counted along the
+    // way — the sequence below may put other kinds between two texts, but it
+    // never reorders the texts themselves.
+    let wide_indices = wide_string_indices(footprint);
 
-    for arc in &footprint.arcs {
-        data.push(0x01); // Arc record type
-        encode_arc(&mut data, arc);
-    }
-
-    for pad in &footprint.pads {
-        data.push(0x02); // Pad record type
-        encode_pad(&mut data, pad)?;
-    }
-
-    for via in &footprint.vias {
-        data.push(0x03); // Via record type
-        encode_via(&mut data, via);
-    }
-
-    for track in &footprint.tracks {
-        data.push(0x04); // Track record type
-        encode_track(&mut data, track);
-    }
-
-    // Counts only the texts `encode_component_wide_strings` emits an entry for,
-    // so the index stamped in each record addresses the right one.
-    let mut wide_index: u32 = 0;
-    for text in &footprint.text {
-        data.push(0x05); // Text record type
-        let index = if text.text.starts_with('.') || text.text.is_empty() {
-            None
-        } else {
-            let current = wide_index;
-            wide_index += 1;
-            Some(current)
-        };
-        encode_text(&mut data, text, index);
-    }
-
-    for region in &footprint.regions {
-        data.push(0x0B); // Region record type
-        encode_region(&mut data, region);
-    }
-
-    for fill in &footprint.fills {
-        data.push(0x06); // Fill record type
-        encode_fill(&mut data, fill);
-    }
-
-    for body in &footprint.component_bodies {
-        data.push(0x0C); // ComponentBody record type
-        let outline = resolve_body_outline(body, footprint);
-        encode_component_body(&mut data, body, &outline);
+    for (kind, index) in footprint.write_sequence() {
+        match kind {
+            PrimitiveKind::Arc => {
+                data.push(0x01);
+                encode_arc(&mut data, &footprint.arcs[index]);
+            }
+            PrimitiveKind::Pad => {
+                data.push(0x02);
+                encode_pad(&mut data, &footprint.pads[index])?;
+            }
+            PrimitiveKind::Via => {
+                data.push(0x03);
+                encode_via(&mut data, &footprint.vias[index]);
+            }
+            PrimitiveKind::Track => {
+                data.push(0x04);
+                encode_track(&mut data, &footprint.tracks[index]);
+            }
+            PrimitiveKind::Text => {
+                data.push(0x05);
+                encode_text(&mut data, &footprint.text[index], wide_indices[index]);
+            }
+            PrimitiveKind::Region => {
+                data.push(0x0B);
+                encode_region(&mut data, &footprint.regions[index]);
+            }
+            PrimitiveKind::Fill => {
+                data.push(0x06);
+                encode_fill(&mut data, &footprint.fills[index]);
+            }
+            PrimitiveKind::ComponentBody => {
+                let body = &footprint.component_bodies[index];
+                data.push(0x0C);
+                let outline = resolve_body_outline(body, footprint);
+                encode_component_body(&mut data, body, &outline);
+            }
+        }
     }
 
     // No end marker: Altium reads exactly the primitive count from the component
@@ -1853,32 +1848,17 @@ pub fn encode_unique_id_stream(footprint: &Footprint) -> Option<Vec<u8>> {
     let mut data = Vec::new();
     let mut has_any_id = false;
 
-    // `PRIMITIVEINDEX` is a single global 0-based ordinal over ALL primitives in
-    // `Data`-stream emit order (see `encode_data_stream`): Arc, Pad, Via, Track,
-    // Text, Region, Fill, ComponentBody. Every primitive consumes an ordinal whether
-    // or not it carries a unique id (a record is emitted only when it does) — so e.g.
-    // the first pad behind two silkscreen arcs is `PRIMITIVEINDEX=2`, matching Altium.
-    // `apply_unique_ids` MUST walk this exact order to round-trip.
-    let mut ordinal: usize = 0;
-    macro_rules! emit {
-        ($iter:expr, $ty:literal) => {
-            for prim in $iter {
-                if let Some(ref uid) = prim.unique_id {
-                    encode_unique_id_record(&mut data, ordinal, $ty, uid);
-                    has_any_id = true;
-                }
-                ordinal += 1;
-            }
-        };
+    // `PRIMITIVEINDEX` is a single global 0-based ordinal over ALL of the
+    // footprint's primitives, in the order the `Data` stream stores them — the
+    // same ordinal a `PrimitiveGuids` record carries. Every primitive consumes
+    // one whether or not it has a record here, so the sequence has to be the
+    // one `encode_data_stream` writes, not a per-kind walk.
+    for (ordinal, (kind, index)) in footprint.write_sequence().into_iter().enumerate() {
+        if let Some(uid) = unique_id_of(footprint, kind, index) {
+            encode_unique_id_record(&mut data, ordinal, kind.object_id(), uid);
+            has_any_id = true;
+        }
     }
-    emit!(&footprint.arcs, "Arc");
-    emit!(&footprint.pads, "Pad");
-    emit!(&footprint.vias, "Via");
-    emit!(&footprint.tracks, "Track");
-    emit!(&footprint.text, "Text");
-    emit!(&footprint.regions, "Region");
-    emit!(&footprint.fills, "Fill");
-    emit!(&footprint.component_bodies, "ComponentBody");
 
     has_any_id.then_some(data)
 }
@@ -1913,7 +1893,7 @@ fn encode_unique_id_record(
 /// identities to write.
 ///
 /// The inverse of `reader::parse_primitive_guids`: 24-byte records of
-/// `[object_kind: u32][index_within_kind: u32][guid: 16 bytes]`, the GUID's
+/// `[object_kind: u32][ordinal: u32][guid: 16 bytes]`, the GUID's
 /// first three fields little-endian. A malformed GUID string is skipped rather
 /// than written as zeroes, which would claim an identity Altium never issued.
 ///
@@ -1962,16 +1942,7 @@ fn parse_guid(text: &str) -> Option<[u8; 16]> {
 /// 4-byte little-endian unsigned integer containing the exact primitive count.
 #[allow(clippy::cast_possible_truncation)]
 pub fn encode_component_header(footprint: &Footprint) -> Vec<u8> {
-    let count = footprint.arcs.len()
-        + footprint.pads.len()
-        + footprint.vias.len()
-        + footprint.tracks.len()
-        + footprint.text.len()
-        + footprint.regions.len()
-        + footprint.fills.len()
-        + footprint.component_bodies.len();
-
-    (count as u32).to_le_bytes().to_vec()
+    (footprint.primitive_count() as u32).to_le_bytes().to_vec()
 }
 
 /// Generates a random GUID as 16 bytes (little-endian UUID format).
@@ -1995,6 +1966,35 @@ fn guid_bytes_from_string(guid: &str) -> Option<[u8; 16]> {
 // Per-Component WideStrings Writing
 // =============================================================================
 
+/// Whether a text primitive gets a `WideStrings` entry of its own.
+///
+/// A special string (`.Designator` and friends) is resolved by Altium at draw
+/// time and an empty one has nothing to carry, so neither is encoded.
+fn carries_wide_string(text: &Text) -> bool {
+    !text.text.starts_with('.') && !text.text.is_empty()
+}
+
+/// The `WideStrings` entry index for each text primitive, positionally.
+///
+/// `None` where the text carries no entry. Kept separate from the emit loop so
+/// the indices stay tied to `footprint.text`'s own order, which is what
+/// [`encode_component_wide_strings`] numbers, however the primitives are
+/// interleaved in the `Data` stream.
+fn wide_string_indices(footprint: &Footprint) -> Vec<Option<u32>> {
+    let mut next = 0u32;
+    footprint
+        .text
+        .iter()
+        .map(|text| {
+            carries_wide_string(text).then(|| {
+                let current = next;
+                next += 1;
+                current
+            })
+        })
+        .collect()
+}
+
 /// Encodes the per-component `WideStrings` stream.
 ///
 /// # Format
@@ -2011,13 +2011,12 @@ pub fn encode_component_wide_strings(footprint: &Footprint) -> Vec<u8> {
     use std::fmt::Write;
 
     // Collect text content from this footprint
-    let mut texts: Vec<&str> = Vec::new();
-
-    for text in &footprint.text {
-        if !text.text.starts_with('.') && !text.text.is_empty() {
-            texts.push(&text.text);
-        }
-    }
+    let texts: Vec<&str> = footprint
+        .text
+        .iter()
+        .filter(|t| carries_wide_string(t))
+        .map(|t| t.text.as_str())
+        .collect();
 
     // Build the parameter string: `|ENCODEDTEXT0=...|ENCODEDTEXT1=...` — a leading
     // pipe per entry and NO trailing pipe (matching AltiumSharp). With no entries the
@@ -2056,52 +2055,29 @@ pub fn encode_unique_id_header(footprint: &Footprint) -> Vec<u8> {
     (count as u32).to_le_bytes().to_vec()
 }
 
-/// Counts primitives with unique IDs.
+/// The unique id one primitive carries, addressed the way
+/// [`Footprint::write_sequence`] names it.
+fn unique_id_of(footprint: &Footprint, kind: PrimitiveKind, index: usize) -> Option<&str> {
+    match kind {
+        PrimitiveKind::Arc => footprint.arcs[index].unique_id.as_deref(),
+        PrimitiveKind::Pad => footprint.pads[index].unique_id.as_deref(),
+        PrimitiveKind::Via => footprint.vias[index].unique_id.as_deref(),
+        PrimitiveKind::Track => footprint.tracks[index].unique_id.as_deref(),
+        PrimitiveKind::Text => footprint.text[index].unique_id.as_deref(),
+        PrimitiveKind::Region => footprint.regions[index].unique_id.as_deref(),
+        PrimitiveKind::Fill => footprint.fills[index].unique_id.as_deref(),
+        PrimitiveKind::ComponentBody => footprint.component_bodies[index].unique_id.as_deref(),
+    }
+}
+
+/// Counts the primitives that carry a unique id, so the header can never
+/// disagree with the records [`encode_unique_id_stream`] writes.
 fn count_unique_ids(footprint: &Footprint) -> usize {
-    let mut count = 0;
-
-    for pad in &footprint.pads {
-        if pad.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for via in &footprint.vias {
-        if via.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for track in &footprint.tracks {
-        if track.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for arc in &footprint.arcs {
-        if arc.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for text in &footprint.text {
-        if text.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for region in &footprint.regions {
-        if region.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for fill in &footprint.fills {
-        if fill.unique_id.is_some() {
-            count += 1;
-        }
-    }
-    for body in &footprint.component_bodies {
-        if body.unique_id.is_some() {
-            count += 1;
-        }
-    }
-
-    count
+    footprint
+        .write_sequence()
+        .into_iter()
+        .filter(|&(kind, index)| unique_id_of(footprint, kind, index).is_some())
+        .count()
 }
 
 #[cfg(test)]

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -74,11 +74,6 @@ const BY_DESIGN: &[(&str, &str)] = &[
 /// corrupted library.
 const KNOWN_DEFECTS: &[(&str, &str)] = &[
     (
-        "uniqueidprimitiveinformation",
-        "written only when primitives carry unique ids, and the reader does not \
-         populate them from this stream, so authored ids are lost",
-    ),
-    (
         "V7_LAYER",
         "Altium writes the short layer name (TOP); we write the long form \
          (TOPLAYER), and for a board cutout we write the resolved keep-out layer \
@@ -282,6 +277,34 @@ fn pcblib_golden_survives_a_round_trip() {
                 .into_iter()
                 .filter(|d| !is_known(d)),
         );
+    }
+
+    // 4. The identity streams, byte for byte. Both key a primitive by its
+    //    ordinal among all of the footprint's primitives, and a block-level
+    //    diff cannot see a reordering. `PrimitiveGuids` is replayed as read, so
+    //    equality there means the replay is intact; the unique-id records are
+    //    rebuilt from the write sequence, so equality there means the order the
+    //    ordinals refer to survived.
+    for name in lib.names() {
+        for stream in ["PrimitiveGuids/Data", "UniqueIDPrimitiveInformation/Data"] {
+            let path = format!("/{name}/{stream}");
+            let Some(g) = stream_bytes(&src, &path) else {
+                continue;
+            };
+            let what = format!("{name}: {stream}");
+            if is_known(&what) {
+                continue;
+            }
+            match stream_bytes(&out, &path) {
+                Some(o) if o == g => {}
+                Some(o) => failures.push(format!(
+                    "{what} differs: {} bytes golden, {} ours",
+                    g.len(),
+                    o.len()
+                )),
+                None => failures.push(format!("{what} was not written back")),
+            }
+        }
     }
 
     assert!(

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -7,7 +7,7 @@
 
 use altium_designer_mcp::altium::pcblib::{
     DrillLayerPairType, HoleShape, Layer, MaskExpansionMode, PadShape, PadStackMode, PcbFlags,
-    PcbLib, RegionKind, StrokeFont, TextKind,
+    PcbLib, PrimitiveKind, RegionKind, StrokeFont, TextKind,
 };
 use std::path::PathBuf;
 
@@ -1447,6 +1447,114 @@ fn samples_pcblib_golden_survives_a_read_modify_write() {
         .find(|t| t.text.len() > 255)
         .expect("the 264-character text keeps its full length");
     assert_eq!(long.text, "A".repeat(260) + "_END");
+}
+
+#[test]
+fn samples_pcblib_read_order_matches_the_guid_ordinals() {
+    // Altium's object ids, as they appear in a PrimitiveGuids record.
+    fn kind_of(object_kind: u32) -> Option<PrimitiveKind> {
+        match object_kind {
+            1 => Some(PrimitiveKind::Arc),
+            2 => Some(PrimitiveKind::Pad),
+            3 => Some(PrimitiveKind::Via),
+            4 => Some(PrimitiveKind::Track),
+            5 => Some(PrimitiveKind::Text),
+            6 => Some(PrimitiveKind::Fill),
+            89 => Some(PrimitiveKind::Region),
+            90 => Some(PrimitiveKind::ComponentBody),
+            // 85 is the footprint record itself, which is not a primitive and
+            // sits outside the ordinal space (always index 0).
+            _ => None,
+        }
+    }
+
+    // PrimitiveGuids keys each GUID by the primitive's ordinal among ALL of the
+    // footprint's primitives — not among its own kind. Checking our read order
+    // against that ordinal space is a cross-check between two independent
+    // streams of the same file: if they disagreed, every GUID we write back
+    // would name a different primitive than Altium meant.
+    let lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open footprints.PcbLib");
+
+    let mut checked = 0;
+    let mut interleaved = 0;
+    for footprint in lib.iter() {
+        if footprint.primitive_guids.is_empty() {
+            continue;
+        }
+        let mut by_ordinal: Vec<(u32, PrimitiveKind)> = footprint
+            .primitive_guids
+            .iter()
+            .filter_map(|g| kind_of(g.object_kind).map(|k| (g.index, k)))
+            .collect();
+        by_ordinal.sort_unstable_by_key(|&(ordinal, _)| ordinal);
+
+        let ordinals: Vec<u32> = by_ordinal.iter().map(|&(o, _)| o).collect();
+        assert_eq!(
+            ordinals,
+            (0..u32::try_from(by_ordinal.len()).expect("footprint fits u32")).collect::<Vec<_>>(),
+            "{}: PrimitiveGuids ordinals are a permutation of 0..n-1",
+            footprint.name
+        );
+
+        let from_guids: Vec<PrimitiveKind> = by_ordinal.into_iter().map(|(_, k)| k).collect();
+        assert_eq!(
+            footprint.primitive_order, from_guids,
+            "{}: the order we read the primitives in must be the order the \
+             GUID ordinals describe",
+            footprint.name
+        );
+
+        // A footprint whose kinds come out in blocks would pass the check above
+        // even if we grouped by type, so at least one has to actually interleave
+        // for this to be worth anything.
+        let mut seen: Vec<PrimitiveKind> = Vec::new();
+        if from_guids.windows(2).any(|w| w[0] != w[1]) {
+            for kind in &from_guids {
+                if seen.last() != Some(kind) {
+                    if seen.contains(kind) {
+                        interleaved += 1;
+                        break;
+                    }
+                    seen.push(*kind);
+                }
+            }
+        }
+        checked += 1;
+    }
+
+    assert!(checked >= 20, "only {checked} footprints carried GUIDs");
+    assert!(
+        interleaved > 0,
+        "no golden footprint interleaves its primitive kinds, so this test \
+         cannot tell a preserved order from a type-grouped one"
+    );
+}
+
+#[test]
+fn samples_pcblib_primitive_order_survives_a_read_modify_write() {
+    use std::io::Cursor;
+
+    let mut lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open golden");
+    let before: Vec<(String, Vec<PrimitiveKind>)> = lib
+        .iter()
+        .map(|f| (f.name.clone(), f.primitive_order.clone()))
+        .collect();
+
+    let mut buffer = Cursor::new(Vec::new());
+    lib.write(&mut buffer).expect("write the golden back");
+    buffer.set_position(0);
+    let after = PcbLib::read(&mut buffer).expect("read back");
+
+    for (name, order) in before {
+        let rewritten = after
+            .get(&name)
+            .unwrap_or_else(|| panic!("{name} missing after rewrite"));
+        assert_eq!(
+            rewritten.primitive_order, order,
+            "{name}: primitives came back in a different order, which \
+             renumbers every PrimitiveGuids ordinal and PRIMITIVEINDEX"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## A wrong assumption, found while closing the next defect

Our code documents a `PrimitiveGuids` record's second `u32` as an index *within the primitive's own kind*. It is not — it is the primitive's ordinal among **all** of the footprint's primitives.

Two independent pieces of evidence, both from the golden:

- Across all 22 footprints the ordinals are a permutation of `0..n-1` once the kind-85 record (the footprint itself) is set aside. `PRIMPROPS` has its regions at 0, 4, 5 and 6, a pad at 1, texts at 2 and 3 — under a within-kind reading the regions would be 0–3.
- `UniqueIDPrimitiveInformation`'s `PRIMITIVEINDEX` uses the same space. `PRIMPROPS` names its only pad `1` in both streams; `LOCKFLAGS_PCB`'s pad records run 0–5, 7, 8, and ordinal 6 is a track.

Altium builds that space from **authoring order**, interleaving the kinds — `LOCKFLAGS_PCB` is pad ×6, track, pad ×2, track, arc ×2, fill ×2.

## What that broke

We write primitives grouped by kind. So:

- the GUIDs preserved in #368 were replayed against an ordinal space we no longer reproduced — inert rather than corrupting (a record carries its kind too, so a mismatch fails to resolve), but not reattaching either;
- `UniqueIDPrimitiveInformation` could not be reproduced at all.

## The fix

`Footprint::primitive_order` records the sequence, maintained by the `add_*` methods — so reading a footprint captures the file's order for free, with no reader change. `write_sequence()` resolves it against the live primitive lists: the lists are `pub`, so entries pointing past the end are dropped and any primitive the sequence misses is appended in the canonical kind order. A footprint built in memory has no recorded order and is written exactly as before, which is why the MCP `write_pcblib` path and the readability oracle are unchanged.

`WideStrings` indices are now resolved up front from `footprint.text` rather than counted along the emit loop, so interleaving cannot disturb `ENCODEDTEXT{n}`.

With the ordinals meaningful again, `UniqueIDPrimitiveInformation` follows: `parse_unique_id_record` no longer discards a record whose `UNIQUEID` is empty. Every record in the golden is empty — the record marks the primitive as *tracked*; the value is a board's to fill in. Dropping the empty ones threw the whole stream away, which is why nothing was ever written back.

`count_unique_ids` and the record writer now share one accessor, so the header can't disagree with the data.

## Tests

- `samples_pcblib_read_order_matches_the_guid_ordinals` — cross-checks our read order against the GUID ordinals in the same file, two independent streams. Also asserts the ordinals really are a permutation, and that at least one golden footprint actually interleaves, so the test can tell a preserved order from a type-grouped one.
- `samples_pcblib_primitive_order_survives_a_read_modify_write`
- `golden_fidelity` gained a byte-for-byte comparison of both identity streams per footprint. `PrimitiveGuids` is replayed as read, so equality proves the replay; the unique-id records are rebuilt from the write sequence, so equality proves the order survived.

**Mutation-checked**: forcing a kind-grouped sequence fails `golden_fidelity` on `LOCKFLAGS_PCB` (432 golden bytes vs 324) and `PRIMPROPS` (stream not written), and fails the order test. Both assertions bite.

## Verification

- full suite green (860 unit + all integration), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean
- pyaltiumlib oracle: 13 passed, 0 regressions

## Follow-ups

`KNOWN_DEFECTS` is down to three — `SectionKeys`, `V7_LAYER` long-form and SchLib `IndexInSheet`, the last being this same problem on the schematic side. `docs/COVERAGE_AUDIT.md` § Outstanding now also records the remaining identity weakness: the ordinals survive a read-modify-write, but a *structural* edit renumbers everything after the edit point and silently re-points later identities. Fixing that means attaching a GUID to the primitive it names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)