### PR TITLE
feat(schlib): keep the record order IndexInSheet numbers

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -26,11 +26,6 @@ with a long non-ASCII name keeps only its truncated storage name.
 (`TOP`); we write the long form (`TOPLAYER`), and for a board cutout we write the resolved
 keep-out layer rather than the one stored in the record.
 
-**`IndexInSheet` is renumbered (`SchLib`).** Our writer emits a symbol's primitives grouped
-by type; Altium preserves the interleaved authoring order, and `IndexInSheet` records it.
-This is the `SchLib` twin of the `PcbLib` primitive ordering that
-`Footprint::primitive_order` now carries, and it wants the same treatment.
-
 **Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
 footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its
 position among all the footprint's primitives. That position is preserved across a

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -409,7 +409,11 @@ the regenerated fixture and real Altium-authored libraries):
   (RECORD=41, `OwnerPartId=-1`) records carry the `IndexInSheet=-1` sentinel and do **not**
   consume a counter slot (the golden DISPMODE system Comment stores `IndexInSheet=-1` while the
   rectangles keep slots 0 and 1); RECORD=44/46/48 carry no token and RECORD=45 carries `-1`.
-- The value is purely positional, so this crate derives it on write rather than storing it.
+- The value is purely positional, so this crate derives it on write rather than storing it. That
+  makes the counter only as good as the record order: Altium stores the content records in
+  **authoring order**, interleaving the kinds (the golden's `LOCKFLAGS2` runs line, arc, ellipse,
+  round-rect, polyline, polygon, pie, bezier, label), so a symbol read from a file is written back
+  in the order it came in. See [Symbol Writing Order](#symbol-writing-order).
 
 ## Common Text Record Fields
 
@@ -761,9 +765,12 @@ Read-side defaults when properties are absent:
 
 ## Symbol Writing Order
 
-When writing symbol data, this crate encodes records in this specific order (the shared
-`IndexInSheet` counter runs across steps 2-17; the designator and system parameters keep the
-`-1` sentinel and consume no slot):
+A symbol read from a file is written back in **its own record order**, because that is the order
+the shared `IndexInSheet` counter numbers and Altium interleaves the kinds freely.
+
+A symbol with no record order of its own — one built in memory — is written kind by kind, in the
+order below (the shared `IndexInSheet` counter runs across steps 2-17; the designator and system
+parameters keep the `-1` sentinel and consume no slot):
 
 1. Component header (RECORD=1)
 2. Rectangles (RECORD=14) — before the pins so a solid body does not paint over pin names
@@ -787,6 +794,9 @@ When writing symbol data, this crate encodes records in this specific order (the
 19. System parameters (RECORD=41, `OwnerPartId = -1`) — after the designator, as the golden
     orders them
 20. Implementation list (RECORD=44), then per footprint model: RECORD=45 + RECORD=46 + RECORD=48
+
+Steps 18-20 keep their positions either way: the designator, the system parameters and the
+implementation list follow the content records regardless of how those were ordered.
 
 The stream ends with the last record's payload — there is **no** trailing end marker (see the Data
 Stream Format section and issue #68).

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -344,6 +344,90 @@ pub struct Symbol {
     /// Footprint model references.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub footprints: Vec<FootprintModel>,
+
+    /// The order the content records are stored in, one entry per record.
+    ///
+    /// Altium interleaves the record kinds in authoring order — the golden's
+    /// `LOCKFLAGS2` runs line, arc, ellipse, round-rect, polyline, polygon,
+    /// pie, bezier, label — and numbers them with one shared `IndexInSheet`
+    /// counter in exactly that sequence. Emitting the kinds in blocks
+    /// renumbers every record.
+    ///
+    /// An entry names one of the lists above; its n-th occurrence refers to
+    /// that list's n-th element, so the sequence alone reconstructs the
+    /// interleaving. It is maintained by the `add_*` methods, which is how
+    /// reading a symbol records the file's order. Empty when the lists were
+    /// populated directly, in which case the writer falls back to
+    /// [`SchPrimitiveKind::WRITE_ORDER`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub primitive_order: Vec<SchPrimitiveKind>,
+}
+
+/// One of a [`Symbol`]'s content-record lists, as named by `primitive_order`.
+///
+/// Footprint models are absent on purpose: they are written in the
+/// implementation section after the content records and take no `IndexInSheet`
+/// slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchPrimitiveKind {
+    /// [`Symbol::rectangles`].
+    Rectangle,
+    /// [`Symbol::pins`].
+    Pin,
+    /// [`Symbol::lines`].
+    Line,
+    /// [`Symbol::polylines`].
+    Polyline,
+    /// [`Symbol::polygons`].
+    Polygon,
+    /// [`Symbol::arcs`].
+    Arc,
+    /// [`Symbol::pies`].
+    Pie,
+    /// [`Symbol::images`].
+    Image,
+    /// [`Symbol::text_frames`].
+    TextFrame,
+    /// [`Symbol::beziers`].
+    Bezier,
+    /// [`Symbol::ellipses`].
+    Ellipse,
+    /// [`Symbol::round_rects`].
+    RoundRect,
+    /// [`Symbol::elliptical_arcs`].
+    EllipticalArc,
+    /// [`Symbol::labels`].
+    Label,
+    /// [`Symbol::text`].
+    Text,
+    /// [`Symbol::parameters`].
+    Parameter,
+}
+
+impl SchPrimitiveKind {
+    /// The order a symbol with no recorded order of its own is written in.
+    ///
+    /// Rectangles lead so a solid-filled body sits behind the pins; emitting
+    /// pins first lets the body paint over the pin names inside it.
+    pub const WRITE_ORDER: [Self; 16] = [
+        Self::Rectangle,
+        Self::Pin,
+        Self::Line,
+        Self::Polyline,
+        Self::Polygon,
+        Self::Arc,
+        Self::Pie,
+        Self::Image,
+        Self::TextFrame,
+        Self::Bezier,
+        Self::Ellipse,
+        Self::RoundRect,
+        Self::EllipticalArc,
+        Self::Label,
+        Self::Text,
+        Self::Parameter,
+    ];
 }
 
 const fn default_part_count() -> u32 {
@@ -389,21 +473,25 @@ impl Symbol {
     /// Adds a pin to the symbol.
     pub fn add_pin(&mut self, pin: Pin) {
         self.pins.push(pin);
+        self.primitive_order.push(SchPrimitiveKind::Pin);
     }
 
     /// Adds a rectangle to the symbol.
     pub fn add_rectangle(&mut self, rect: Rectangle) {
         self.rectangles.push(rect);
+        self.primitive_order.push(SchPrimitiveKind::Rectangle);
     }
 
     /// Adds a line to the symbol.
     pub fn add_line(&mut self, line: Line) {
         self.lines.push(line);
+        self.primitive_order.push(SchPrimitiveKind::Line);
     }
 
     /// Adds a parameter to the symbol.
     pub fn add_parameter(&mut self, param: Parameter) {
         self.parameters.push(param);
+        self.primitive_order.push(SchPrimitiveKind::Parameter);
     }
 
     /// Adds a footprint model reference.
@@ -414,61 +502,128 @@ impl Symbol {
     /// Adds a polyline to the symbol.
     pub fn add_polyline(&mut self, polyline: Polyline) {
         self.polylines.push(polyline);
+        self.primitive_order.push(SchPrimitiveKind::Polyline);
     }
 
     /// Adds a polygon to the symbol.
     pub fn add_polygon(&mut self, polygon: Polygon) {
         self.polygons.push(polygon);
+        self.primitive_order.push(SchPrimitiveKind::Polygon);
     }
 
     /// Adds an arc to the symbol.
     pub fn add_arc(&mut self, arc: Arc) {
         self.arcs.push(arc);
+        self.primitive_order.push(SchPrimitiveKind::Arc);
     }
 
     /// Adds a pie (filled sector) to the symbol.
     pub fn add_pie(&mut self, pie: Pie) {
         self.pies.push(pie);
+        self.primitive_order.push(SchPrimitiveKind::Pie);
     }
 
     /// Adds an image to the symbol.
     pub fn add_image(&mut self, image: Image) {
         self.images.push(image);
+        self.primitive_order.push(SchPrimitiveKind::Image);
     }
 
     /// Adds a text frame to the symbol.
     pub fn add_text_frame(&mut self, text_frame: TextFrame) {
         self.text_frames.push(text_frame);
+        self.primitive_order.push(SchPrimitiveKind::TextFrame);
     }
 
     /// Adds a Bezier curve to the symbol.
     pub fn add_bezier(&mut self, bezier: Bezier) {
         self.beziers.push(bezier);
+        self.primitive_order.push(SchPrimitiveKind::Bezier);
     }
 
     /// Adds an ellipse to the symbol.
     pub fn add_ellipse(&mut self, ellipse: Ellipse) {
         self.ellipses.push(ellipse);
+        self.primitive_order.push(SchPrimitiveKind::Ellipse);
     }
 
     /// Adds a rounded rectangle to the symbol.
     pub fn add_round_rect(&mut self, round_rect: RoundRect) {
         self.round_rects.push(round_rect);
+        self.primitive_order.push(SchPrimitiveKind::RoundRect);
     }
 
     /// Adds an elliptical arc to the symbol.
     pub fn add_elliptical_arc(&mut self, elliptical_arc: EllipticalArc) {
         self.elliptical_arcs.push(elliptical_arc);
+        self.primitive_order.push(SchPrimitiveKind::EllipticalArc);
     }
 
     /// Adds a label to the symbol.
     pub fn add_label(&mut self, label: Label) {
         self.labels.push(label);
+        self.primitive_order.push(SchPrimitiveKind::Label);
     }
 
     /// Adds a text annotation to the symbol.
     pub fn add_text(&mut self, text: Text) {
         self.text.push(text);
+        self.primitive_order.push(SchPrimitiveKind::Text);
+    }
+
+    /// The symbol's content records in the order they are written, as
+    /// `(kind, index into that kind's list)` pairs.
+    ///
+    /// [`Self::primitive_order`] is advisory: the lists are public, so a caller
+    /// can push to or truncate one without it. Entries pointing past the end of
+    /// their list are therefore dropped, and any record the sequence never
+    /// reaches is appended in [`SchPrimitiveKind::WRITE_ORDER`] — so a symbol
+    /// with no recorded order, or one edited behind its back, still writes
+    /// every record exactly once.
+    #[must_use]
+    pub fn write_sequence(&self) -> Vec<(SchPrimitiveKind, usize)> {
+        let mut taken: std::collections::HashMap<SchPrimitiveKind, usize> =
+            std::collections::HashMap::new();
+        let mut sequence = Vec::new();
+
+        for &kind in &self.primitive_order {
+            let next = taken.entry(kind).or_insert(0);
+            if *next < self.count_of(kind) {
+                sequence.push((kind, *next));
+                *next += 1;
+            }
+        }
+        for kind in SchPrimitiveKind::WRITE_ORDER {
+            let next = taken.entry(kind).or_insert(0);
+            while *next < self.count_of(kind) {
+                sequence.push((kind, *next));
+                *next += 1;
+            }
+        }
+        sequence
+    }
+
+    /// How many content records of one kind the symbol holds.
+    #[must_use]
+    pub fn count_of(&self, kind: SchPrimitiveKind) -> usize {
+        match kind {
+            SchPrimitiveKind::Rectangle => self.rectangles.len(),
+            SchPrimitiveKind::Pin => self.pins.len(),
+            SchPrimitiveKind::Line => self.lines.len(),
+            SchPrimitiveKind::Polyline => self.polylines.len(),
+            SchPrimitiveKind::Polygon => self.polygons.len(),
+            SchPrimitiveKind::Arc => self.arcs.len(),
+            SchPrimitiveKind::Pie => self.pies.len(),
+            SchPrimitiveKind::Image => self.images.len(),
+            SchPrimitiveKind::TextFrame => self.text_frames.len(),
+            SchPrimitiveKind::Bezier => self.beziers.len(),
+            SchPrimitiveKind::Ellipse => self.ellipses.len(),
+            SchPrimitiveKind::RoundRect => self.round_rects.len(),
+            SchPrimitiveKind::EllipticalArc => self.elliptical_arcs.len(),
+            SchPrimitiveKind::Label => self.labels.len(),
+            SchPrimitiveKind::Text => self.text.len(),
+            SchPrimitiveKind::Parameter => self.parameters.len(),
+        }
     }
 }
 

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -25,7 +25,7 @@ use super::primitives::{
     Arc, Bezier, Ellipse, EllipticalArc, FootprintModel, Image, Label, Line, Parameter, Pie, Pin,
     Polygon, Polyline, Rectangle, RoundRect, ShapeDisplayFlags, Text, TextFrame, TextJustification,
 };
-use super::Symbol;
+use super::{SchPrimitiveKind, Symbol};
 use crate::altium::framing::{write_cstring_param_block, write_pascal_string};
 
 /// Writes a record frame to the output: Altium's `[u24 length LE][u8 flags]`
@@ -1253,126 +1253,57 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
     let header = encode_component_header(symbol);
     write_text_record(&mut data, &header)?;
 
-    // 3. Rectangles — written before the pins so the body shape sits at the
-    //    back. Emitting pins first lets a solid-filled body paint over the pin
-    //    names that sit inside it (names vanish). This matches Altium's own
-    //    ordering (body rectangle precedes pins in its symbol records).
-    for rect in &symbol.rectangles {
-        let record = encode_rectangle(rect, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 4. Pins (binary format)
-    for pin in &symbol.pins {
-        write_binary_pin(&mut data, pin)?;
-        // Pins consume an IndexInSheet counter slot even though the binary pin
-        // record stores no such field — confirmed against real Altium-authored
-        // libraries, where a symbol with parameters 0..2, two pins, then a
-        // rectangle stores IndexInSheet=5 on the rectangle (slots 3 and 4 are
-        // the pins).
-        index_counter += 1;
-    }
-
-    // 5. Lines
-    for line in &symbol.lines {
-        let record = encode_line(line, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 6. Polylines
-    for polyline in &symbol.polylines {
-        let record = encode_polyline(polyline, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 7. Polygons
-    for polygon in &symbol.polygons {
-        let record = encode_polygon(polygon, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 8. Arcs
-    for arc in &symbol.arcs {
-        let record = encode_arc(arc, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 8b. Pies (filled sectors, RECORD=9)
-    for pie in &symbol.pies {
-        let record = encode_pie(pie, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 8c. Images (RECORD=30)
-    for image in &symbol.images {
-        let record = encode_image(image, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 8d. Text frames (RECORD=28) share the content counter like every other
-    // shape (the golden frame carries no token only because it sits at slot 0,
-    // which the shared 0-omitted rule drops).
-    for text_frame in &symbol.text_frames {
-        let record = encode_text_frame(text_frame, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 9. Bezier curves
-    for bezier in &symbol.beziers {
-        let record = encode_bezier(bezier, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 10. Ellipses
-    for ellipse in &symbol.ellipses {
-        let record = encode_ellipse(ellipse, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 11. Rounded rectangles
-    for round_rect in &symbol.round_rects {
-        let record = encode_round_rect(round_rect, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 12. Elliptical arcs
-    for elliptical_arc in &symbol.elliptical_arcs {
-        let record = encode_elliptical_arc(elliptical_arc, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 13. Labels
-    for label in &symbol.labels {
-        let record = encode_label(label, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 14. Text annotations
-    for text in &symbol.text {
-        let record = encode_text(text, index_counter);
-        write_text_record(&mut data, &record)?;
-        index_counter += 1;
-    }
-
-    // 14b. USER parameters (owner_part_id >= 1) — emitted after the graphic
-    // content, matching the golden stream order (JUSTIFY stores its labels at
-    // content slots 0..3 and its user parameters at 4..5). Each consumes a
-    // shared-counter slot like any other content record.
-    for param in symbol.parameters.iter().filter(|p| p.owner_part_id != -1) {
-        let record = encode_parameter(param, index_counter);
+    // 3. Content records, in the symbol's own order — Altium's authoring
+    //    order for anything read from a file (see `Symbol::primitive_order`)
+    //    and the canonical kind order otherwise, which leads with the
+    //    rectangles so a solid-filled body sits behind the pins.
+    //
+    //    System parameters (owner_part_id == -1, the Altium-authored
+    //    Comment-class records) are skipped here: they belong after the
+    //    designator and carry the IndexInSheet=-1 sentinel instead of a
+    //    counter slot.
+    for (kind, index) in symbol.write_sequence() {
+        let record = match kind {
+            SchPrimitiveKind::Pin => {
+                // A binary pin record has no IndexInSheet field of its own but
+                // still consumes a counter slot — confirmed against real
+                // Altium-authored libraries, where a symbol with parameters
+                // 0..2, two pins, then a rectangle stores IndexInSheet=5 on the
+                // rectangle.
+                write_binary_pin(&mut data, &symbol.pins[index])?;
+                index_counter += 1;
+                continue;
+            }
+            SchPrimitiveKind::Parameter => {
+                let param = &symbol.parameters[index];
+                if param.owner_part_id == -1 {
+                    continue;
+                }
+                encode_parameter(param, index_counter)
+            }
+            SchPrimitiveKind::Rectangle => {
+                encode_rectangle(&symbol.rectangles[index], index_counter)
+            }
+            SchPrimitiveKind::Line => encode_line(&symbol.lines[index], index_counter),
+            SchPrimitiveKind::Polyline => encode_polyline(&symbol.polylines[index], index_counter),
+            SchPrimitiveKind::Polygon => encode_polygon(&symbol.polygons[index], index_counter),
+            SchPrimitiveKind::Arc => encode_arc(&symbol.arcs[index], index_counter),
+            SchPrimitiveKind::Pie => encode_pie(&symbol.pies[index], index_counter),
+            SchPrimitiveKind::Image => encode_image(&symbol.images[index], index_counter),
+            SchPrimitiveKind::TextFrame => {
+                encode_text_frame(&symbol.text_frames[index], index_counter)
+            }
+            SchPrimitiveKind::Bezier => encode_bezier(&symbol.beziers[index], index_counter),
+            SchPrimitiveKind::Ellipse => encode_ellipse(&symbol.ellipses[index], index_counter),
+            SchPrimitiveKind::RoundRect => {
+                encode_round_rect(&symbol.round_rects[index], index_counter)
+            }
+            SchPrimitiveKind::EllipticalArc => {
+                encode_elliptical_arc(&symbol.elliptical_arcs[index], index_counter)
+            }
+            SchPrimitiveKind::Label => encode_label(&symbol.labels[index], index_counter),
+            SchPrimitiveKind::Text => encode_text(&symbol.text[index], index_counter),
+        };
         write_text_record(&mut data, &record)?;
         index_counter += 1;
     }
@@ -1662,10 +1593,10 @@ mod tests {
         // Golden-confirmed against real Altium-authored libraries: binary pins
         // store no IndexInSheet token but DO consume counter slots (a real
         // symbol with parameters 0..2, two pins, then a rectangle stores
-        // IndexInSheet=5 on the rectangle). Emission order here is rectangle
-        // (slot 0, omitted), two pins (1, 2), line (3), then the user
-        // parameter (4) — user parameters follow the graphic content,
-        // matching the golden stream order (JUSTIFY).
+        // IndexInSheet=5 on the rectangle). The records go out in the order
+        // they were added — parameter (slot 0, token omitted), rectangle (1),
+        // two pins (2, 3), line (4) — because `add_*` records the order, the
+        // same way reading a symbol records the file's.
         let mut symbol = Symbol::new("PINSLOTS");
         symbol.add_parameter(Parameter::new("Value", "10k"));
         symbol.add_rectangle(Rectangle::new(-5, -5, 5, 5));
@@ -1675,29 +1606,67 @@ mod tests {
 
         let data = encode_data_stream(&symbol).expect("encode");
         let records = stream_records(&data);
+        let param = records
+            .iter()
+            .find(|t| t.starts_with("|RECORD=41") && !t.contains("OwnerPartId=-1"))
+            .expect("user parameter present");
+        assert!(
+            !param.contains("IndexInSheet"),
+            "the parameter was added first, so it holds slot 0: {param}"
+        );
         let rect = records
             .iter()
             .find(|t| t.starts_with("|RECORD=14"))
             .expect("rectangle present");
         assert!(
-            !rect.contains("IndexInSheet"),
-            "slot-0 rectangle omits the token: {rect}"
+            rect.contains("|IndexInSheet=1|"),
+            "rectangle takes slot 1: {rect}"
         );
         let line = records
             .iter()
             .find(|t| t.starts_with("|RECORD=13"))
             .expect("line present");
         assert!(
-            line.contains("|IndexInSheet=3|"),
-            "line after two pins takes slot 3 (pins consumed 1 and 2): {line}"
+            line.contains("|IndexInSheet=4|"),
+            "line after two pins takes slot 4 (pins consumed 2 and 3): {line}"
         );
-        let param = records
-            .iter()
-            .find(|t| t.starts_with("|RECORD=41") && !t.contains("OwnerPartId=-1"))
-            .expect("user parameter present");
+    }
+
+    #[test]
+    fn a_symbol_with_no_recorded_order_leads_with_the_rectangles() {
+        // Populating the lists directly leaves `primitive_order` empty, which is
+        // what a symbol deserialised from a `write_schlib` call looks like. The
+        // canonical order applies, and it puts the rectangles first so a
+        // solid-filled body sits behind the pins rather than painting over the
+        // pin names inside it.
+        let symbol = Symbol {
+            pins: vec![Pin::new("A", "1", -10, 0, 5, PinOrientation::Left)],
+            rectangles: vec![Rectangle::new(-5, -5, 5, 5)],
+            lines: vec![Line::new(-5, 0, 5, 0)],
+            ..Symbol::new("CANONICAL")
+        };
         assert!(
-            param.contains("|IndexInSheet=4|"),
-            "user parameter follows the shapes at slot 4: {param}"
+            symbol.primitive_order.is_empty(),
+            "direct construction records no order"
+        );
+
+        let data = encode_data_stream(&symbol).expect("encode");
+        let records = stream_records(&data);
+        let kinds: Vec<&str> = records
+            .iter()
+            .filter_map(|t| t.strip_prefix("|RECORD="))
+            .filter_map(|t| t.split('|').next())
+            .collect();
+        // 1 = header, 14 = rectangle, 13 = line; the pin is binary and does not
+        // appear among the text records.
+        assert_eq!(
+            kinds.iter().position(|k| *k == "14"),
+            Some(1),
+            "the rectangle is the first content record: {kinds:?}"
+        );
+        assert!(
+            kinds.iter().position(|k| *k == "13") > kinds.iter().position(|k| *k == "14"),
+            "the line follows it: {kinds:?}"
         );
     }
 

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -86,11 +86,6 @@ const KNOWN_DEFECTS: &[(&str, &str)] = &[
          encoded; we neither read nor write it, so those components lose their \
          real name and keep only the truncated storage name",
     ),
-    (
-        "INDEXINSHEET",
-        "our SchLib writer emits primitives grouped by type, renumbering them; \
-         Altium preserves the original interleaved order",
-    ),
 ];
 
 /// A component whose name leaves ASCII is written under a storage name that
@@ -317,6 +312,37 @@ fn pcblib_golden_survives_a_round_trip() {
     );
 }
 
+/// The kind of every record in a `SchLib` `Data` stream, in stream order.
+///
+/// Framing is `[len: 3 bytes LE][flags: 1]` then the payload; `flags == 1`
+/// marks the binary pin record, which has no `RECORD=` key of its own.
+fn record_kinds(data: &[u8]) -> Vec<String> {
+    let mut kinds = Vec::new();
+    let mut offset = 0;
+    while offset + 4 <= data.len() {
+        let len = usize::from(data[offset])
+            | usize::from(data[offset + 1]) << 8
+            | usize::from(data[offset + 2]) << 16;
+        let flags = data[offset + 3];
+        offset += 4;
+        let Some(payload) = data.get(offset..offset + len) else {
+            break;
+        };
+        offset += len;
+        if flags == 1 {
+            kinds.push("pin".to_string());
+            continue;
+        }
+        let text: String = payload.iter().map(|&b| b as char).collect();
+        let kind = text
+            .split('|')
+            .find_map(|p| p.strip_prefix("RECORD="))
+            .unwrap_or("?");
+        kinds.push(kind.to_string());
+    }
+    kinds
+}
+
 #[test]
 fn schlib_golden_survives_a_round_trip() {
     let src = sample("symbols.SchLib");
@@ -344,6 +370,19 @@ fn schlib_golden_survives_a_round_trip() {
                 .into_iter()
                 .filter(|d| !is_known(d)),
         );
+
+        // The record sequence itself. `IndexInSheet` is one shared counter over
+        // the content records in stream order, so the values only line up if
+        // the order does — and a block-level diff pairs records by content, not
+        // by position, so it cannot see a reordering on its own.
+        let (gk, ok) = (record_kinds(&g), record_kinds(&o));
+        if gk != ok && !is_known(&name) {
+            failures.push(format!(
+                "{name}: record order changed\n  golden: {}\n  ours:   {}",
+                gk.join(" "),
+                ok.join(" ")
+            ));
+        }
     }
 
     assert!(


### PR DESCRIPTION
The `SchLib` twin of #371, and the last of the ordering defects.

## The defect

`IndexInSheet` is one shared 0-based counter over a symbol's content records — every graphic shape, every user label and parameter, and every binary pin — in stream order. The writer derives it positionally rather than storing it, which makes it only as good as the order it walks.

Altium stores those records in **authoring order**, interleaving the kinds. From the golden:

| Symbol | Record sequence |
|--------|-----------------|
| `LOCKFLAGS2` | line, arc, ellipse, round-rect, polyline, polygon, pie, bezier, label |
| `SHAPECOLOR` | line, rectangle, round-rect, arc, ellipse, polyline, polygon, pie, bezier, label |
| `SHAPESTYLE` | line, line, rectangle, rectangle, polygon, ellipse |

We emitted kind by kind, so every record after the first divergence was renumbered on a read-modify-write.

## The fix

`Symbol::primitive_order`, maintained by the `add_*` methods — the same shape as `Footprint::primitive_order` from #371, so reading a symbol records the file's order with no reader change. `write_sequence()` resolves it against the live lists, dropping entries past the end and appending anything missed in the canonical kind order.

System parameters (`OwnerPartId=-1`) are skipped in that walk: they keep the `IndexInSheet=-1` sentinel and their place after the designator, and take no counter slot. The designator, system parameters and implementation list keep their positions either way.

## One behaviour change worth flagging

A symbol built with `add_*` is now written **in the order things were added**, where it used to be re-sorted with the rectangles first. That mattered for one reason — a solid-filled body emitted after the pins paints over the pin names inside it — so that guarantee is now the caller's to keep by adding the body first.

Symbols whose lists are populated directly are unaffected, and that is every symbol `write_schlib` deserialises, so the MCP-facing output is unchanged (the readability oracle confirms it). `a_symbol_with_no_recorded_order_leads_with_the_rectangles` pins that half; `index_in_sheet_pins_consume_counter_slots` pins the other, and still pins the rule it was written for — binary pins carry no token but do consume a slot.

## Tests

`golden_fidelity` now compares the record-type sequence per symbol. A block-level diff cannot see a reordering, because it pairs records by content rather than by position.

**Mutation-checked**: forcing the kind-grouped order fails it with 21 divergences — three `record order changed` (`SHAPECOLOR`, `LOCKFLAGS2`, `SHAPESTYLE`) plus the `IndexInSheet` values that follow from them.

## Verification

- full suite green (861 unit + all integration), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean
- pyaltiumlib oracle: 13 passed, 0 regressions

## Where that leaves the debt

`KNOWN_DEFECTS` is down to **two**: `SectionKeys` and the `V7_LAYER` long form. `docs/COVERAGE_AUDIT.md` § Outstanding tracks those plus the two follow-ups that are not round-trip failures — identities keyed by ordinal survive a read-modify-write but not a structural edit, and the spurious `MODEL.*` block on extruded bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)