### PR TITLE
fix(pcblib): write Altium's own V7_LAYER tokens

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -22,10 +22,6 @@ writes a `SectionKeys` stream mapping the real `LibRef` back to the truncated na
 (`|KeyCount=N|%UTF8%LibRef0=…|||LibRef0=…|%UTF8%SectionKey0=…|…`). Without it a component
 with a long non-ASCII name keeps only its truncated storage name.
 
-**`V7_LAYER` is re-derived rather than replayed (`PcbLib`).** Altium writes the short token
-(`TOP`); we write the long form (`TOPLAYER`), and for a board cutout we write the resolved
-keep-out layer rather than the one stored in the record.
-
 **Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
 footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its
 position among all the footprint's primitives. That position is preserved across a

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -727,7 +727,7 @@ V7_LAYER={token}|NAME={name}|KIND={kind}|SUBPOLYINDEX={spi}|UNIONINDEX={uix}|ARC
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `V7_LAYER` | Canonical layer token — `MECHANICAL{n}` for mechanical layers, else the display name upper-cased with spaces stripped (e.g. `TOPLAYER`) | matches layer byte |
+| `V7_LAYER` | Canonical layer token from Altium's own vocabulary — `TOP`, `MECHANICAL4`, `PLANE3`, … (see below) | matches the layer byte, except on a board cutout |
 | `NAME` | Region name | empty |
 | `KIND` | Region kind (0 = copper/standard, 1 = cutout, ...) | 0 |
 | `SUBPOLYINDEX` | Sub-polygon index | -1 |
@@ -742,9 +742,31 @@ captured verbatim on read and re-emitted after the canonical set, so a read-modi
 drop them.
 
 > **Warning:** Altium resolves a Region's layer from the `V7_LAYER` token, NOT the header layer
-> byte. Mechanical layers MUST use their `MECHANICAL{n}` token (e.g. Top Courtyard →
-> `MECHANICAL4`); the space-stripped display name is not a valid token and makes Altium silently
-> drop the region onto Top Layer.
+> byte, and the token is a **fixed vocabulary** rather than the display name with the spaces taken
+> out. `TOPLAYER` and `BOTTOMLAYER` resolve to nothing, and an unresolved token leaves the region
+> on Top Layer — so the bottom-side case is a silent side swap.
+
+**The vocabulary**, held in `Advpcb.dll` as UTF-16LE strings. `MECHANICAL`, `MID` and `PLANE` take
+a number; the rest are literals.
+
+| Layer id | Token | | Layer id | Token |
+|----------|-------|-|----------|-------|
+| 1 | `TOP` | | 39-54 | `PLANE1`-`PLANE16` |
+| 2-31 | `MID1`-`MID30` | | 55 | `DRILLGUIDE` |
+| 32 | `BOTTOM` | | 56 | `KEEPOUT` |
+| 33 | `TOPOVERLAY` | | 57-72 | `MECHANICAL1`-`MECHANICAL16` |
+| 34 | `BOTTOMOVERLAY` | | 73 | `DRILLDRAWING` |
+| 35 | `TOPPASTE` | | 74 | `MULTILAYER` |
+| 36 | `BOTTOMPASTE` | | 75 | `CONNECT` |
+| 37 | `TOPSOLDER` | | 186-201 | `MECHANICAL17`-`MECHANICAL32` |
+| 38 | `BOTTOMSOLDER` | | | |
+
+**Board cutouts are the one case where the token and the layer byte disagree.** AD24 saves a
+cutout authored on the top layer with layer byte 56 (keep-out) and
+`LAYER=KEEPOUT|KEEPOUT=TRUE|ISBOARDCUTOUT=TRUE`, but leaves `V7_LAYER=TOP` — the layer it was
+drawn on, recorded nowhere else in the record. The golden's `REGION_CUTOUT` and `PRIMPROPS`
+cutouts both show this. Deriving the token from the layer byte would write `KEEPOUT` and lose it,
+so a divergent token is kept as read.
 
 **Vertex format:** each vertex is two IEEE 754 doubles (X then Y) in internal units. Values are
 whole internal units in real files; the reader rounds to integers before converting to mm.

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -335,6 +335,19 @@ pub struct Region {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The `V7_LAYER` token exactly as Altium wrote it, kept only when it names
+    /// a different layer than [`Self::layer`].
+    ///
+    /// The two normally agree, and the token is derived from `layer` when this
+    /// is `None` — every from-scratch region. A board cutout is the case where
+    /// they diverge: AD24 moves the region's layer byte to the keep-out layer
+    /// and records that in `LAYER=KEEPOUT|KEEPOUT=TRUE|ISBOARDCUTOUT=TRUE`,
+    /// while `V7_LAYER` stays on the layer the region was drawn on. The golden
+    /// authors its cutouts with `Rgn.Layer := eTopLayer` and AD24 saves them as
+    /// layer byte 56 (keep-out) with `V7_LAYER=TOP`, so the drawn layer is
+    /// recoverable from nowhere else.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v7_layer: Option<String>,
     /// Unmodelled parameter keys read verbatim from the nested `KEY=VALUE|...`
     /// block, in read order. Altium regions carry board-region keys the typed
     /// model does not recognise (e.g. `LAYER`, `KEEPOUT`, `ISBOARDCUTOUT`,
@@ -390,6 +403,7 @@ impl Default for Region {
             vertices: Vec::new(),
             holes: Vec::new(),
             layer: Layer::default(),
+            v7_layer: None,
             flags: PcbFlags::empty(),
             kind: RegionKind::Copper,
             name: String::new(),

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1249,6 +1249,15 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     // is "additional".
     let additional_parameters = capture_additional_params(&params_str, REGION_MODELLED_PARAM_KEYS);
 
+    // Keep `V7_LAYER` only when it disagrees with the layer byte, which is what
+    // a board cutout does — see `Region::v7_layer`. Deriving it back from
+    // `layer` covers every other region, and leaving it `None` there means a
+    // caller that moves a region to another layer still gets the right token.
+    let v7_layer = params
+        .get("V7_LAYER")
+        .filter(|token| **token != crate::altium::pcblib::writer::v7_layer_token(layer))
+        .cloned();
+
     // Vertex data follows the parameter string.
     let vertex_offset = param_end;
 
@@ -1309,6 +1318,7 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         vertices,
         holes,
         layer,
+        v7_layer,
         flags,
         kind,
         name,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1287,16 +1287,48 @@ fn encode_region(data: &mut Vec<u8>, region: &Region) {
 
 /// Returns the canonical Altium `V7_LAYER` token for a layer.
 ///
-/// Altium identifies a Region's layer by this parameter string, NOT the
-/// common-header layer byte. Mechanical and component-pair layers must use their
-/// `MECHANICAL{n}` token (e.g. Top Courtyard -> `MECHANICAL4`). The display name
-/// with spaces stripped (`TOPCOURTYARD`) is not a valid token, so Altium fails to
-/// resolve the layer and silently drops the region onto Top Layer (copper). The
-/// 3D-body encoder already hardcodes `MECHANICAL6`/`MECHANICAL7` for this reason.
-fn region_v7_layer_token(layer: Layer) -> String {
+/// Altium identifies a Region's or `ComponentBody`'s layer by this parameter
+/// string, NOT the common-header layer byte, and it is a fixed vocabulary
+/// rather than the display name: `TOP`, not `TOPLAYER`; `PLANE3`, not
+/// `INTERNALPLANE3`. A token Altium cannot resolve leaves the primitive on Top
+/// Layer (copper), so `BOTTOMLAYER` — which is what stripping the spaces out of
+/// the display name produces — silently moves a bottom-side region to the top.
+///
+/// The vocabulary is `Advpcb.dll`'s own, held there as UTF-16LE strings:
+/// `MECHANICAL`, `MID` and `PLANE` are prefixes taking a number, alongside
+/// `TOP`, `BOTTOM`, `TOPOVERLAY`, `BOTTOMOVERLAY`, `TOPPASTE`, `BOTTOMPASTE`,
+/// `TOPSOLDER`, `BOTTOMSOLDER`, `DRILLGUIDE`, `DRILLDRAWING`, `KEEPOUT`,
+/// `MULTILAYER` and `CONNECT`. The golden confirms `TOP`, `MECHANICAL1` and
+/// `MECHANICAL13`.
+pub(super) fn v7_layer_token(layer: Layer) -> String {
     match layer_to_id(layer) {
+        1 => "TOP".to_string(),
+        id @ 2..=31 => format!("MID{}", id - 1),
+        32 => "BOTTOM".to_string(),
+        33 => "TOPOVERLAY".to_string(),
+        34 => "BOTTOMOVERLAY".to_string(),
+        35 => "TOPPASTE".to_string(),
+        36 => "BOTTOMPASTE".to_string(),
+        37 => "TOPSOLDER".to_string(),
+        38 => "BOTTOMSOLDER".to_string(),
+        id @ 39..=54 => format!("PLANE{}", id - 38),
+        55 => "DRILLGUIDE".to_string(),
+        56 => "KEEPOUT".to_string(),
         id @ 57..=72 => format!("MECHANICAL{}", id - 56),
+        73 => "DRILLDRAWING".to_string(),
+        74 => "MULTILAYER".to_string(),
+        75 => "CONNECT".to_string(),
+        76 => "BACKGROUND".to_string(),
+        77 => "DRCERRORS".to_string(),
+        78 => "SELECTIONS".to_string(),
+        79 => "VISIBLEGRID1X".to_string(),
+        80 => "VISIBLEGRID10X".to_string(),
+        81 => "PADHOLES".to_string(),
+        82 => "VIAHOLES".to_string(),
         id @ 186..=201 => format!("MECHANICAL{}", id - 169),
+        // The pad masters and the DRC detail layer have no token in the
+        // vocabulary. Nothing a library can hold sits on them, so the display
+        // name stands in rather than a guess dressed up as a fact.
         _ => layer.as_str().replace(' ', "").to_uppercase(),
     }
 }
@@ -1338,7 +1370,10 @@ fn encode_region_properties(region: &Region) -> Vec<u8> {
     // canonical key set (matching AltiumSharp `BuildRegionParamText`). Each value is
     // now taken from the typed field; a default region reproduces the historical
     // hard-coded string byte-for-byte (KIND=0, NAME=, ARCRESOLUTION=0mil, ...).
-    let layer_name = region_v7_layer_token(region.layer);
+    let layer_name = region
+        .v7_layer
+        .clone()
+        .unwrap_or_else(|| v7_layer_token(region.layer));
     let params = format!(
         "V7_LAYER={layer_name}|NAME={name}|KIND={kind}|SUBPOLYINDEX={spi}|UNIONINDEX={uix}\
          |ARCRESOLUTION={arc}|ISSHAPEBASED={shape}|CAVITYHEIGHT={cav}",
@@ -1592,7 +1627,7 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     // MECHANICAL{n} token for any mechanical layer (Top3DBody=MECHANICAL6,
     // Mechanical1=MECHANICAL1, etc.) instead of hardcoding one — a mismatch
     // between the param string and the layer byte makes Altium drop the body.
-    params.push(format!("V7_LAYER={}", region_v7_layer_token(body.layer)));
+    params.push(format!("V7_LAYER={}", v7_layer_token(body.layer)));
 
     // Standard parameters. Each field's default reproduces the prior hard-coded
     // literal exactly, so a template-default body stays byte-identical (the oracle
@@ -2955,7 +2990,7 @@ mod tests {
         ] {
             let n = v7_layer_id(layer_to_id(layer)) - 0x0102_0000;
             assert_eq!(
-                region_v7_layer_token(layer),
+                v7_layer_token(layer),
                 format!("MECHANICAL{n}"),
                 "{layer:?}: id and token must reference the same mechanical layer"
             );
@@ -2963,18 +2998,32 @@ mod tests {
     }
 
     #[test]
-    fn test_region_v7_layer_token() {
+    fn test_v7_layer_token() {
         use crate::altium::pcblib::primitives::Vertex;
         // Component-pair / mechanical layers must use the MECHANICAL{n} token,
         // not the display name (which Altium can't resolve -> falls back to Top Layer).
-        assert_eq!(region_v7_layer_token(Layer::TopCourtyard), "MECHANICAL4");
-        assert_eq!(region_v7_layer_token(Layer::TopAssembly), "MECHANICAL2");
-        assert_eq!(region_v7_layer_token(Layer::Mechanical1), "MECHANICAL1");
-        assert_eq!(region_v7_layer_token(Layer::Mechanical17), "MECHANICAL17");
-        assert_eq!(region_v7_layer_token(Layer::Mechanical32), "MECHANICAL32");
-        // Non-mechanical layers keep the stripped/uppercased display token.
-        assert_eq!(region_v7_layer_token(Layer::TopLayer), "TOPLAYER");
-        assert_eq!(region_v7_layer_token(Layer::TopOverlay), "TOPOVERLAY");
+        assert_eq!(v7_layer_token(Layer::TopCourtyard), "MECHANICAL4");
+        assert_eq!(v7_layer_token(Layer::TopAssembly), "MECHANICAL2");
+        assert_eq!(v7_layer_token(Layer::Mechanical1), "MECHANICAL1");
+        assert_eq!(v7_layer_token(Layer::Mechanical17), "MECHANICAL17");
+        assert_eq!(v7_layer_token(Layer::Mechanical32), "MECHANICAL32");
+        // The rest of the vocabulary is equally its own: the token is not the
+        // display name with the spaces taken out. `TOPLAYER` and `BOTTOMLAYER`
+        // resolve to nothing, and an unresolved token leaves the primitive on
+        // Top Layer — so the bottom-side case is a silent side swap.
+        assert_eq!(v7_layer_token(Layer::TopLayer), "TOP");
+        assert_eq!(v7_layer_token(Layer::BottomLayer), "BOTTOM");
+        assert_eq!(v7_layer_token(Layer::MidLayer1), "MID1");
+        assert_eq!(v7_layer_token(Layer::MidLayer30), "MID30");
+        assert_eq!(v7_layer_token(Layer::InternalPlane3), "PLANE3");
+        assert_eq!(v7_layer_token(Layer::KeepOut), "KEEPOUT");
+        assert_eq!(v7_layer_token(Layer::MultiLayer), "MULTILAYER");
+        assert_eq!(v7_layer_token(Layer::DrillDrawing), "DRILLDRAWING");
+        assert_eq!(v7_layer_token(Layer::DrillGuide), "DRILLGUIDE");
+        // These two do keep their display spelling, because that is what the
+        // vocabulary happens to use.
+        assert_eq!(v7_layer_token(Layer::TopOverlay), "TOPOVERLAY");
+        assert_eq!(v7_layer_token(Layer::BottomSolder), "BOTTOMSOLDER");
 
         // A region on Top Courtyard must serialize V7_LAYER=MECHANICAL4.
         let region = Region {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -655,10 +655,7 @@ impl McpServer {
             })
             .unwrap_or_default();
 
-        let unique_id = json
-            .get("unique_id")
-            .and_then(Value::as_str)
-            .map(str::to_string);
+        let text_field = |key: &str| json.get(key).and_then(Value::as_str).map(str::to_string);
 
         // Round-trip unmodelled board-region keys captured on read (a `read_pcblib`
         // emits `additional_parameters` as an array of `[key, value]` pairs; accept
@@ -670,6 +667,9 @@ impl McpServer {
             vertices,
             holes,
             layer,
+            // Derived from `layer` unless a read supplied a divergent token
+            // (a board cutout); the tool schema does not expose it.
+            v7_layer: text_field("v7_layer"),
             flags: json_flags(json),
             kind,
             name,
@@ -681,7 +681,7 @@ impl McpServer {
             sub_poly_index,
             union_index,
             is_shape_based,
-            unique_id,
+            unique_id: text_field("unique_id"),
             additional_parameters,
         })
     }

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -72,21 +72,13 @@ const BY_DESIGN: &[(&str, &str)] = &[
 /// an entry as its fix lands. It is spelled out here rather than left implicit
 /// so the cost is visible in code review instead of being discovered in a
 /// corrupted library.
-const KNOWN_DEFECTS: &[(&str, &str)] = &[
-    (
-        "V7_LAYER",
-        "Altium writes the short layer name (TOP); we write the long form \
-         (TOPLAYER), and for a board cutout we write the resolved keep-out layer \
-         rather than the stored one",
-    ),
-    (
-        "sectionkeys",
-        "Altium emits a SectionKeys stream mapping LibRef -> storage name for \
+const KNOWN_DEFECTS: &[(&str, &str)] = &[(
+    "sectionkeys",
+    "Altium emits a SectionKeys stream mapping LibRef -> storage name for \
          every component whose name does not fit the CFB 31-character cap once \
          encoded; we neither read nor write it, so those components lose their \
          real name and keep only the truncated storage name",
-    ),
-];
+)];
 
 /// A component whose name leaves ASCII is written under a storage name that
 /// differs from the golden's, so its streams read as missing here.

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -1136,9 +1136,8 @@ fn samples_pcblib_region_cutout() {
         "the board-cutout flag is preserved in additional_parameters, got {:?}",
         r.additional_parameters
     );
-    // Altium also silently MOVED the authored eTopLayer region onto the
-    // keep-out layer (LAYER=KEEPOUT + KEEPOUT=TRUE in the same param block) —
-    // the authored layer is not preserved for a board cutout. Assert the real
+    // Altium also MOVED the authored eTopLayer region onto the keep-out layer
+    // (LAYER=KEEPOUT + KEEPOUT=TRUE in the same param block). Assert the real
     // on-disk placement so the relocation is documented ground truth.
     assert_eq!(
         r.layer,
@@ -1151,6 +1150,37 @@ fn samples_pcblib_region_cutout() {
             .any(|(k, v)| k == "KEEPOUT" && v == "TRUE"),
         "the KEEPOUT flag is preserved in additional_parameters, got {:?}",
         r.additional_parameters
+    );
+    // The layer it was drawn on survives after all, in V7_LAYER: the layer byte
+    // says keep-out, the token still says TOP. Nothing else in the record
+    // records it, so deriving the token from `layer` would lose it.
+    assert_eq!(
+        r.v7_layer.as_deref(),
+        Some("TOP"),
+        "V7_LAYER keeps the authored layer even though the layer byte does not"
+    );
+}
+
+#[test]
+fn samples_pcblib_cutout_v7_layer_survives_a_read_modify_write() {
+    use std::io::Cursor;
+
+    let mut lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open golden");
+    let mut buffer = Cursor::new(Vec::new());
+    lib.write(&mut buffer).expect("write the golden back");
+    buffer.set_position(0);
+    let after = PcbLib::read(&mut buffer).expect("read back");
+
+    let r = &after
+        .get("REGION_CUTOUT")
+        .expect("REGION_CUTOUT survives")
+        .regions[0];
+    assert_eq!(r.layer, Layer::KeepOut);
+    assert_eq!(
+        r.v7_layer.as_deref(),
+        Some("TOP"),
+        "re-deriving the token from the layer byte would write KEEPOUT and lose \
+         the layer the cutout was drawn on"
     );
 }
 


### PR DESCRIPTION
## The defect

Altium resolves a Region's and a `ComponentBody`'s layer from the `V7_LAYER` token, **not** the header layer byte, and an unresolved token leaves the primitive on Top Layer.

We derived that token by upper-casing the display name and dropping the spaces. That happens to be right for `TOPOVERLAY` and wrong for most of the rest:

| Layer | We wrote | Altium's token |
|-------|----------|----------------|
| Top Layer | `TOPLAYER` | `TOP` |
| Bottom Layer | `BOTTOMLAYER` | `BOTTOM` |
| Mid-Layer 1 | `MID-LAYER1` | `MID1` |
| Internal Plane 3 | `INTERNALPLANE3` | `PLANE3` |
| Keep-Out Layer | `KEEP-OUTLAYER` | `KEEPOUT` |

`TOPLAYER` fails to resolve and falls back to Top Layer, which is where the region already was — so the top-side case looked fine. **`BOTTOMLAYER` fails the same way and silently swaps the region to the top.** Only the mechanical layers were special-cased, because `MECHANICAL{n}` is where this had already bitten once.

## Where the tokens come from

`Advpcb.dll` holds the vocabulary as UTF-16LE strings, in the same way `ScriptingSystem.dll` holds the identifier table. `MECHANICAL`, `MID` and `PLANE` are prefixes taking a number; the rest are literals: `TOP`, `BOTTOM`, `TOPOVERLAY`, `BOTTOMOVERLAY`, `TOPPASTE`, `BOTTOMPASTE`, `TOPSOLDER`, `BOTTOMSOLDER`, `DRILLGUIDE`, `DRILLDRAWING`, `KEEPOUT`, `MULTILAYER`, `CONNECT`. The golden independently confirms `TOP`, `MECHANICAL1` and `MECHANICAL13`.

The pad masters and the DRC detail layer have no token in that vocabulary. Nothing a library can hold sits on them, so the display name stands in rather than a guess dressed up as a fact — and the code says so.

## Board cutouts: the case where deriving is wrong at all

Fixing the table left two divergences:

```
REGION_CUTOUT: V7_LAYER golden="TOP" ours=Some("KEEPOUT")
PRIMPROPS:     V7_LAYER golden="TOP" ours=Some("KEEPOUT")
```

AD24 saves a cutout authored with `Rgn.Layer := eTopLayer` as **layer byte 56 (keep-out)** plus `LAYER=KEEPOUT|KEEPOUT=TRUE|ISBOARDCUTOUT=TRUE`, while leaving `V7_LAYER=TOP` — the layer it was drawn on, recorded nowhere else in the record.

Both golden cutouts were authored on the top layer, so I can't tell from the fixture whether the rule is "the drawn layer" or "always `TOP` for a cutout". Rather than pick one, `Region::v7_layer` keeps a token that disagrees with the layer byte and the writer replays it. Every other region still derives, so moving one to a different layer writes the right token rather than a stale one.

This also corrects `samples_pcblib_region_cutout`, which asserted the authored layer "is not preserved for a board cutout". It is — just not where we were looking.

## Verification

- `golden_fidelity` with `V7_LAYER` enforced: clean. **`KNOWN_DEFECTS` is down to one entry** — `SectionKeys`.
- full suite green (861 unit + all integration), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean
- pyaltiumlib oracle: 13 passed, 0 regressions
- `docs/PCBLIB_FORMAT.md` now carries the full token table and the cutout exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)