### PR TITLE
feat: model SectionKeys and match Altium's non-ASCII text rule

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -15,12 +15,18 @@ golden, writes it back and diffs the OLE streams and every parameter block. Anyt
 still loses is listed in that test's `KNOWN_DEFECTS` and described here; the two lists are
 the same list, so an entry leaves both together.
 
-**`SectionKeys` is neither read nor written (`PcbLib`, `SchLib`).** Altium encodes a
-component's storage name as the UTF-8 bytes of its name, one byte per storage-name
-character, capped at the compound-file limit of 31 UTF-16 code units. Past that cap it
-writes a `SectionKeys` stream mapping the real `LibRef` back to the truncated name
-(`|KeyCount=N|%UTF8%LibRef0=…|||LibRef0=…|%UTF8%SectionKey0=…|…`). Without it a component
-with a long non-ASCII name keeps only its truncated storage name.
+**`PinWideText` is neither read nor written (`SchLib`).** Altium writes a per-symbol
+`PinWideText` stream when a pin's text leaves Windows-1252: the same container as the root
+icon `/Storage` stream (`[len]["|HEADER=PinWideText|Weight=1"+NUL]` then one zlib entry per
+pin, named by pin ordinal). We drop it on a read-modify-write. The golden carries 52 of
+them, one per i18n symbol.
+
+**Five i18n fixture symbols are internally inconsistent** (`_JV`, `_BN`, `_CR`, `_IU`,
+`_SB`): `DelphiScript` mangled their source literals, and the damage differs by location —
+the golden's CFB storage name folds to the *correct* word while the record inside stores a
+shifted string, so no self-consistent writer can reproduce both. The cure is regenerating
+these five with literals built from character codes (`Chr()`), not source text; needs an
+Altium run.
 
 **Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
 footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -38,10 +38,10 @@ PcbLib files are OLE Compound Documents (CFB format, **OLE v3 with 512-byte sect
 > **Note:** OLE version MUST be V3 (512-byte sectors). Altium Designer rejects V4 (4096-byte) files.
 >
 > Real Altium libraries also carry `FileVersionInfo`, `EmbeddedFonts`, `LayerKindMapping`,
-> `PadViaLibrary`, `ComponentParamsTOC`, `Textures`, `ModelsNoEmbed`, `PrimitiveGuids` and
-> `UniqueIdPrimitiveInformation`. All of these are read and written back. `SectionKeys` (root,
-> for names past the 31-character storage limit) is **unmodelled**: the reader ignores it and
-> the writer does not emit it.
+> `PadViaLibrary`, `ComponentParamsTOC`, `Textures`, `ModelsNoEmbed`, `PrimitiveGuids`,
+> `UniqueIdPrimitiveInformation` and — when a component name exceeds the 31-unit storage cap —
+> a root `SectionKeys` stream mapping each real name to its plain-truncated storage name. All of
+> these are read and written back (`SectionKeys` format: see `SCHLIB_FORMAT.md`, identical here).
 
 ## Encoding Primitives (Building Blocks)
 

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -46,13 +46,33 @@ instead of being repeated:
   below).
 - **`IndexInSheet`:** one shared sequential 0-based counter over all content records (see
   [IndexInSheet](#indexinsheet)).
-- **`%UTF8%` keys:** a text value that Windows-1252 cannot represent (Cyrillic, CJK, Greek `Ω`,
-  ...) is stored under a `%UTF8%<Key>` key (e.g. `%UTF8%Text`) holding the raw UTF-8 bytes,
-  INSTEAD of the lossy plain `<Key>` — only one of the two is ever written. Applies to `Text` on
-  Label, Text, Parameter, Designator and TextFrame records.
+- **`%UTF8%` keys:** any **non-ASCII** text value is written twice: the plain `<Key>` carrying
+  the value's raw UTF-8 bytes, plus a `%UTF8%<Key>` companion. The gate is ASCII, not
+  Windows-1252-representability — the golden stores `Résistance` this way even though `é` has a
+  single-byte form. The companion's on-disk content in an Altium-authored file is the UTF-8 bytes
+  re-decoded through the authoring machine's ANSI code page (a locale artefact; Windows-1250 for
+  the golden); this crate writes the same bytes under both keys, which every reader resolves to
+  the same value. Applies to every text field: `LibReference`, `ComponentDescription`, `Text` on
+  Label/Text/Parameter/Designator/TextFrame, and the FileHeader's `LibRef{N}`/`CompDescr{N}`.
 - **`UniqueID`:** 8-character alphanumeric per-record id, emitted as the LAST key.
 - **Encoding:** records are Windows-1252, with a leading `|`, no trailing `|`, and a trailing
   `0x00` (the record length includes the null).
+
+## SectionKeys Stream
+
+A root stream, present only when at least one component's name does not fit the CFB 31-UTF-16-unit
+storage cap. Storage names for such components are the name's wire bytes **plain-truncated at the
+cap** (the golden's Sinhala symbol is cut mid-codepoint, so the cut is bytewise); this stream maps
+each real `LibRef` to its truncated `SectionKey` (storage name):
+
+```text
+[u32 len]["|KeyCount=N|%UTF8%LibRef0=…|||LibRef0=…|%UTF8%SectionKey0=…|||SectionKey0=…" + 0x00]
+```
+
+Values follow the `%UTF8%` twin convention above; the `|||` after each twin value is Altium's own
+separator, reproduced verbatim. The `FileHeader`'s `LibRef{N}` entries hold the **full untruncated
+name** — the golden stores a 33-byte Khmer name there against a 31-unit storage — so lookup for a
+long name goes `FileHeader` → `SectionKeys` → storage.
 
 ## FileHeader Stream
 

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -186,18 +186,22 @@ pub fn from_wire_text(raw: &str) -> Option<String> {
 
 /// Generates a safe OLE storage name for a component.
 ///
-/// OLE Compound File names are limited to 31 characters. This function:
+/// OLE Compound File names are limited to 31 UTF-16 code units. This function:
 /// - Returns the name as-is if it fits within the limit
-/// - Truncates longer names and adds a unique suffix to avoid collisions
+/// - Plain-truncates a longer name to the limit, as Altium does — the
+///   `SectionKeys` stream carries the mapping back to the real name, so the
+///   storage name has to match Altium's or the mapping misses
+/// - Falls back to a `~NNN` suffix only when the truncation collides with a
+///   name already taken
 ///
 /// # Arguments
 ///
-/// * `name` - The full component name
+/// * `name` - The full component name (wire form)
 /// * `used_names` - Set of OLE names already in use (to avoid collisions)
 ///
 /// # Returns
 ///
-/// A safe OLE name (≤31 chars) that doesn't collide with existing names.
+/// A safe OLE name (≤31 units) that doesn't collide with existing names.
 #[must_use]
 pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String, S>) -> String {
     // OLE/CFB storage names cannot contain the path separator '/'; a component
@@ -215,10 +219,20 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
         return name.to_string();
     }
 
-    // Truncate, leaving room for a "~NNN" suffix, measuring in UTF-16 units.
-    let prefix = truncate_utf16(name, MAX_OLE_NAME_LEN - SUFFIX_LEN);
+    // Altium's own rule: cut the name at the limit and record the mapping in
+    // `SectionKeys`. The golden's Sinhala symbol is cut mid-codepoint on disk,
+    // so the cut is on wire bytes with no regard for character boundaries; for
+    // a wire name (one byte per char) truncating by UTF-16 unit is the same
+    // cut, minus the ability to split a char in two.
+    let plain = truncate_utf16(name, MAX_OLE_NAME_LEN);
+    if !used_names.contains(&plain) {
+        return plain;
+    }
 
-    // Find a unique suffix
+    // Two names sharing their first 31 units: fall back to a "~NNN" suffix for
+    // the later one. Altium's behaviour here is unobserved; uniqueness matters
+    // more than matching it, and SectionKeys still maps the name back.
+    let prefix = truncate_utf16(name, MAX_OLE_NAME_LEN - SUFFIX_LEN);
     for i in 1..1000 {
         let candidate = format!("{prefix}~{i:03}");
         if !used_names.contains(&candidate) {
@@ -273,6 +287,78 @@ where
         out.push(ole);
     }
     out
+}
+
+/// Encodes the root `/SectionKeys` stream: the map from a component's real
+/// `LibRef` back to its truncated storage name.
+///
+/// Altium writes one entry per component whose name does not survive the
+/// 31-unit storage cap. Layout, pinned by the golden `SchLib` (`KeyCount=5`,
+/// one entry per over-cap name):
+///
+/// ```text
+/// [u32 len]["|KeyCount=N|%UTF8%LibRef0=…|||LibRef0=…|%UTF8%SectionKey0=…|||SectionKey0=…" + 0x00]
+/// ```
+///
+/// Values are wire strings (a non-Windows-1252 name is its raw UTF-8 bytes).
+/// A non-ASCII value gets a `%UTF8%` twin, written **before** the plain key and
+/// followed by two empty segments — the `|||` is Altium's own separator, kept
+/// so the stream matches theirs byte-for-byte given the same values. The twin
+/// carries the same bytes as the plain key: Altium builds its twin by decoding
+/// the UTF-8 bytes through the authoring machine's ANSI code page, which makes
+/// the golden's twin content a locale artefact (Windows-1250 there), not a
+/// format rule — identical bytes are correct on every machine and every reader
+/// recovers the same name from either key.
+///
+/// Returns `None` when no name was truncated, so no stream is written — the
+/// common case, and byte-identical to Altium's output for such a library.
+pub(crate) fn encode_section_keys(pairs: &[(String, String)]) -> Option<Vec<u8>> {
+    use std::fmt::Write as _;
+
+    if pairs.is_empty() {
+        return None;
+    }
+
+    let mut text = format!("|KeyCount={}", pairs.len());
+    let field = |key: &str, value: &str, out: &mut String| {
+        if value.is_ascii() {
+            let _ = write!(out, "|{key}={value}");
+        } else {
+            let _ = write!(out, "|%UTF8%{key}={value}|||{key}={value}");
+        }
+    };
+    for (i, (lib_ref, section_key)) in pairs.iter().enumerate() {
+        field(&format!("LibRef{i}"), lib_ref, &mut text);
+        field(&format!("SectionKey{i}"), section_key, &mut text);
+    }
+
+    let mut data = Vec::new();
+    framing::write_cstring_param_block(&mut data, &encode_windows1252(&text));
+    Some(data)
+}
+
+/// Parses a `/SectionKeys` stream into `(LibRef, SectionKey)` pairs, both in
+/// wire form. Inverse of [`encode_section_keys`]; the plain keys are read and
+/// the `%UTF8%` twins ignored, since the plain key already holds the raw UTF-8
+/// bytes and the twin's encoding depends on the locale that authored the file.
+pub(crate) fn parse_section_keys(data: &[u8]) -> Vec<(String, String)> {
+    let Some((block, _)) = framing::read_block(data, 0) else {
+        return Vec::new();
+    };
+    let text = decode_windows1252(block.strip_suffix(&[0x00]).unwrap_or(block));
+    let params = parse_pipe_params_raw(&text);
+
+    let count = params
+        .get("KeyCount")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    (0..count)
+        .filter_map(|i| {
+            let lib_ref = params.get(&format!("LibRef{i}"))?;
+            let section_key = params.get(&format!("SectionKey{i}"))?;
+            Some((lib_ref.clone(), section_key.clone()))
+        })
+        .collect()
 }
 
 /// Creates an Altium-mandated OLE v3 (512-byte sector) compound file.
@@ -534,12 +620,13 @@ mod tests {
 
     #[test]
     fn long_name_truncated() {
+        // Altium's rule: a plain cut at the limit, with SectionKeys carrying
+        // the mapping back; the ~NNN suffix appears only on a collision.
         let used = HashSet::new();
         let name = "VERY_LONG_COMPONENT_NAME_THAT_EXCEEDS_LIMIT";
         let result = generate_ole_name(name, &used);
-        assert!(result.len() <= MAX_OLE_NAME_LEN);
-        assert!(result.starts_with("VERY_LONG_COMPONENT_NAME_TH"));
-        assert!(result.contains('~'));
+        assert_eq!(result, "VERY_LONG_COMPONENT_NAME_THAT_E");
+        assert_eq!(result.len(), MAX_OLE_NAME_LEN);
     }
 
     #[test]
@@ -563,7 +650,9 @@ mod tests {
         // by byte-slicing inside a multi-byte char.
         let name = "\u{00B5}".repeat(32); // 'µ': 1 UTF-16 unit each, 32 > 31
         let prefix = "\u{00B5}".repeat(MAX_OLE_NAME_LEN - SUFFIX_LEN);
-        let used: HashSet<String> = (1..1000).map(|i| format!("{prefix}~{i:03}")).collect();
+        let mut used: HashSet<String> = (1..1000).map(|i| format!("{prefix}~{i:03}")).collect();
+        // Also occupy the plain 31-unit truncation so the suffix path runs.
+        used.insert("\u{00B5}".repeat(MAX_OLE_NAME_LEN));
         let result = generate_ole_name(&name, &used);
         assert!(result.encode_utf16().count() <= MAX_OLE_NAME_LEN);
         assert!(result.contains('~'));

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -40,6 +40,21 @@ impl PcbLib {
         // Write Library storage (Header + Data for Altium compatibility)
         self.write_library(&mut cfb, &ole_names)?;
 
+        // Root SectionKeys stream: the LibRef -> storage-name map for every
+        // footprint whose name did not survive the storage cap. The real name
+        // still travels in the footprint's own PATTERN parameter; this stream
+        // is how Altium maps it to the truncated storage. Not written when no
+        // name was truncated — which includes the whole golden.
+        let truncated: Vec<(String, String)> = wire_names
+            .iter()
+            .zip(ole_names.iter())
+            .filter(|(wire, ole)| wire != ole)
+            .map(|(wire, ole)| (wire.clone(), ole.clone()))
+            .collect();
+        if let Some(section_keys) = crate::altium::encode_section_keys(&truncated) {
+            crate::altium::write_stream(&mut cfb, "/SectionKeys", &section_keys)?;
+        }
+
         // Write embedded 3D models if present (under /Library/Models/)
         self.write_models(&mut cfb)?;
 

--- a/src/altium/schlib/read_io.rs
+++ b/src/altium/schlib/read_io.rs
@@ -46,12 +46,39 @@ impl SchLib {
             .collect();
 
         // Header order first (so `list_components` keeps the library's own
-        // ordering), then any storage the header does not mention.
+        // ordering), then any storage the header does not mention. A header
+        // name is matched to its storage three ways, in decreasing directness:
+        // as-is (ASCII names), through its wire form (a non-Windows-1252 name
+        // is stored under its UTF-8 bytes one char per byte), and through the
+        // root SectionKeys stream (a name past the 31-unit storage cap is
+        // stored truncated, and SectionKeys is the authoritative map back).
+        // An Altium file authored on a non-1252 locale can still widen its
+        // storage names through a code page we cannot reconstruct; such
+        // storages simply fall through to the extras pass below.
+        let section_keys: std::collections::HashMap<String, String> =
+            crate::altium::read_stream_opt(&mut cfb, "/SectionKeys")
+                .map(|data| {
+                    crate::altium::parse_section_keys(&data)
+                        .into_iter()
+                        .collect()
+                })
+                .unwrap_or_default();
         let mut ordered: Vec<String> = header
             .component_names
             .iter()
-            .filter(|n| storages.contains(n))
-            .cloned()
+            .filter_map(|n| {
+                if storages.contains(n) {
+                    return Some(n.clone());
+                }
+                let wire = crate::altium::to_wire_text(n);
+                if storages.contains(&wire) {
+                    return Some(wire);
+                }
+                section_keys
+                    .get(&wire)
+                    .filter(|sk| storages.contains(*sk))
+                    .cloned()
+            })
             .collect();
         let extras: Vec<String> = storages
             .iter()

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -17,20 +17,21 @@ impl SchLib {
 
         let symbols: Vec<&Symbol> = self.symbols.values().collect();
 
-        // A name outside Windows-1252 becomes the storage name in Altium's own
-        // form: its UTF-8 bytes carried one char per byte. That keeps the storage
-        // name and the FileHeader's `LibRef{i}` consistent, because the header is
+        // A non-ASCII name becomes the storage name in Altium's own form: its
+        // UTF-8 bytes carried one char per byte. That keeps the storage name
+        // and the FileHeader's `LibRef{i}` consistent, because the header is
         // a Windows-1252 block and encoding this form back yields exactly those
-        // UTF-8 bytes — which is what Altium's library browser reads. Writing the
-        // real Unicode string instead leaves `LibRef{i}` as `?` per character.
-        // A Windows-1252 name is passed through untouched.
+        // UTF-8 bytes — which is what Altium's library browser reads. The gate
+        // is ASCII to match `text_field`: the golden stores `Résistance` this
+        // way despite `é` having a single-byte form, so the storage name and
+        // the record's `LibReference` stay the same bytes.
         let storage_names: Vec<String> = symbols
             .iter()
             .map(|s| {
-                if crate::altium::requires_utf8(&s.name) {
-                    crate::altium::encode_utf8_param_value(&s.name)
-                } else {
+                if s.name.is_ascii() {
                     s.name.clone()
+                } else {
+                    crate::altium::encode_utf8_param_value(&s.name)
                 }
             })
             .collect();
@@ -43,6 +44,20 @@ impl SchLib {
             "/FileHeader",
             &writer::encode_file_header(&symbols, &ole_names),
         )?;
+
+        // Root SectionKeys stream: the LibRef -> storage-name map for every
+        // symbol whose name did not survive the storage cap, so the real name
+        // stays recoverable by Altium and by our own reader's ordering pass.
+        // With no truncated name the stream is not written, as in Altium.
+        let truncated: Vec<(String, String)> = storage_names
+            .iter()
+            .zip(ole_names.iter())
+            .filter(|(wire, ole)| wire != ole)
+            .map(|(wire, ole)| (wire.clone(), ole.clone()))
+            .collect();
+        if let Some(section_keys) = crate::altium::encode_section_keys(&truncated) {
+            crate::altium::write_stream(&mut cfb, "/SectionKeys", &section_keys)?;
+        }
 
         // One Data stream per symbol, under its own storage.
         for (symbol, ole_name) in symbols.iter().zip(ole_names.iter()) {

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -289,19 +289,22 @@ fn encode_component_header(symbol: &Symbol) -> String {
 /// the pre-UTF-8 output, so the common case (and everything in the golden library)
 /// is unchanged.
 ///
-/// A value with non-Windows-1252 characters (Cyrillic, CJK, Greek `Ω`, …) would be
-/// corrupted to `?` by the record's Windows-1252 encoder, so it is written **twice**,
-/// as Altium does: the plain `<key>` carrying the value's raw UTF-8 bytes, and a
-/// `%UTF8%<key>` companion. Altium reads the plain key, so omitting it leaves the
-/// name `?`-mangled in Altium even though our own reader recovers it; the companion
-/// is what `AltiumSharp` and older readers look for. Both are the same bytes on the
-/// wire, since the record is encoded as Windows-1252.
+/// A non-ASCII value is written **twice**, as Altium does: the plain `<key>`
+/// carrying the value's raw UTF-8 bytes, and a `%UTF8%<key>` companion. Altium
+/// reads the plain key, so omitting it leaves the name `?`-mangled in Altium
+/// even though our own reader recovers it; the companion is what `AltiumSharp`
+/// and older readers look for. Both are the same bytes on the wire, since the
+/// record is encoded as Windows-1252.
+///
+/// The gate is ASCII, not Windows-1252-representability: the golden stores
+/// `Résistance` as its UTF-8 bytes with a twin, even though `é` has a
+/// perfectly good single-byte form — AD promotes any non-ASCII value.
 fn text_field(key: &str, value: &str) -> String {
-    if crate::altium::requires_utf8(value) {
+    if value.is_ascii() {
+        format!("{key}={value}")
+    } else {
         let bytes = crate::altium::encode_utf8_param_value(value);
         format!("{key}={bytes}|%UTF8%{key}={bytes}")
-    } else {
-        format!("{key}={value}")
     }
 }
 
@@ -1387,11 +1390,16 @@ pub fn encode_file_header(symbols: &[&Symbol], ole_names: &[String]) -> Vec<u8> 
         format!("CompCount={}", symbols.len()),
     ];
 
-    // Add component references using OLE-safe names for storage lookup
-    for (i, (symbol, ole_name)) in symbols.iter().zip(ole_names.iter()).enumerate() {
-        // LibRef uses the OLE-safe name (for storage path lookup)
-        parts.push(format!("LibRef{i}={ole_name}"));
-        parts.push(format!("CompDescr{}={}", i, symbol.description));
+    // LibRef{i} is the component's REAL name — the golden stores the full
+    // 33-byte Khmer name here while its storage name is cut at 31 — with a
+    // %UTF8% twin when the name leaves Windows-1252. The root SectionKeys
+    // stream, not this list, is what maps a truncated storage name back.
+    // `ole_names` still decides which entries need that map; it is unused here
+    // beyond keeping the two lists in lockstep by construction.
+    debug_assert_eq!(symbols.len(), ole_names.len());
+    for (i, symbol) in symbols.iter().enumerate() {
+        parts.push(text_field(&format!("LibRef{i}"), &symbol.name));
+        parts.push(text_field(&format!("CompDescr{i}"), &symbol.description));
         parts.push(format!("PartCount{}={}", i, symbol.part_count + 1));
     }
 
@@ -1944,17 +1952,22 @@ mod tests {
 
     #[test]
     fn test_encode_file_header_long_name() {
+        // LibRef carries the REAL name however long — the golden stores the
+        // full 33-byte Khmer name here against a 31-unit storage. The map from
+        // name to truncated storage lives in the root SectionKeys stream, not
+        // in this list.
         let long_name = "A".repeat(64);
         let symbol = Symbol::new(&long_name);
         let symbols = vec![&symbol];
-        // OLE name is truncated
-        let ole_names = vec!["AAAAAAAAAAAAAAAAAAAAAAAAAAA~001".to_string()];
+        let ole_names = vec!["A".repeat(31)];
 
         let data = encode_file_header(&symbols, &ole_names);
 
-        // LibRef should use the OLE-safe name
         let text = String::from_utf8_lossy(&data[4..]);
-        assert!(text.contains("LibRef0=AAAAAAAAAAAAAAAAAAAAAAAAAAA~001"));
+        assert!(
+            text.contains(&format!("LibRef0={long_name}")),
+            "LibRef must hold the untruncated name"
+        );
     }
 
     #[test]
@@ -2410,24 +2423,29 @@ mod tests {
     }
 
     #[test]
-    fn win1252_text_stays_byte_identical_no_utf8_key() {
-        // A pure-Windows-1252 value (the common case, and everything in the golden
-        // library) must emit the plain `Text=` key exactly as before the UTF-8 fix
-        // — no `%UTF8%Text` key, so the record bytes are unchanged (oracle-clean).
-        // `µ` (U+00B5) is representable in Windows-1252, so it stays plain.
+    fn ascii_text_stays_plain_and_non_ascii_promotes() {
+        // The promotion gate is ASCII, not Windows-1252-representability. The
+        // golden's `Résistance_L1` record stores its LibReference and labels as
+        // raw UTF-8 bytes with a `%UTF8%` twin even though `é` has a
+        // single-byte Windows-1252 form, so `µ`/`é` values promote too; only a
+        // pure-ASCII value keeps the bare single key.
         let mut p = Parameter::new("Value", "10\u{00B5}F"); // "10µF"
         p.unique_id = Some("ABCD1234".to_string());
         let s = encode_parameter(&p, 1);
-        assert!(s.contains("|Text=10\u{00B5}F|"), "plain Text key: {s}");
+        let expected = crate::altium::encode_utf8_param_value("10\u{00B5}F");
         assert!(
-            !s.contains("%UTF8%"),
-            "no %UTF8% key for Win-1252 value: {s}"
+            s.contains(&format!("|Text={expected}|")),
+            "plain Text carries the UTF-8 bytes: {s}"
+        );
+        assert!(
+            s.contains(&format!("%UTF8%Text={expected}")),
+            "non-ASCII value gets the %UTF8% twin: {s}"
         );
 
         let mut label = Label {
             x: 0.0,
             y: 0.0,
-            text: "caf\u{00E9}".to_string(), // "café" — all Windows-1252
+            text: "caf\u{00E9}".to_string(), // "café" — non-ASCII, so promoted
             font_id: 1,
             color: 0,
             justification: TextJustification::BottomLeft,
@@ -2439,13 +2457,9 @@ mod tests {
             unique_id: Some("ABCD1234".to_string()),
         };
         let s = encode_label(&label, 1);
-        assert!(s.contains("|Text=caf\u{00E9}|"), "plain Text key: {s}");
-        assert!(
-            !s.contains("%UTF8%"),
-            "no %UTF8% key for Win-1252 label: {s}"
-        );
+        assert!(s.contains("%UTF8%Text="), "café promotes: {s}");
 
-        // And an ASCII label is byte-identical to the pre-change output.
+        // An ASCII label is byte-identical to the historical output.
         label.text = "R".to_string();
         let s = encode_label(&label, 1);
         assert!(s.contains("|Text=R|"), "plain ASCII Text: {s}");

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -433,11 +433,14 @@ fn pcblib_non_ascii_description_is_windows1252() {
     );
 }
 
-/// The `SchLib` `FileHeader` (component description) must likewise be Windows-1252.
+/// A non-ASCII `SchLib` description is stored as its raw UTF-8 bytes with a
+/// `%UTF8%` twin — the same promotion every text field gets. The golden's
+/// `Résistance_L1` record settled the rule: AD promotes any non-ASCII value,
+/// even one (like `é` or `µ`) that Windows-1252 could hold in a single byte.
 #[test]
-fn schlib_non_ascii_description_is_windows1252() {
+fn schlib_non_ascii_description_promotes_to_utf8() {
     let temp_dir = test_temp_dir();
-    let file_path = temp_dir.path().join("test_win1252.SchLib");
+    let file_path = temp_dir.path().join("test_desc_utf8.SchLib");
 
     let mut lib = SchLib::new();
     let mut sym = Symbol::new("RES");
@@ -452,12 +455,16 @@ fn schlib_non_ascii_description_is_windows1252() {
 
     let raw = std::fs::read(&file_path).expect("read raw file");
     assert!(
-        contains_bytes(&raw, b"10\xb5F"),
-        "description should be Windows-1252 (0xB5 for µ)"
+        contains_bytes(&raw, b"10\xc2\xb5F"),
+        "description travels as raw UTF-8 bytes (0xC2 0xB5 for \u{00B5})"
     );
     assert!(
-        !contains_bytes(&raw, b"10\xc2\xb5F"),
-        "description must NOT be UTF-8 (0xC2 0xB5 for µ)"
+        contains_bytes(&raw, b"%UTF8%CompDescr0="),
+        "the FileHeader entry carries the %UTF8% twin"
+    );
+    assert!(
+        contains_bytes(&raw, b"%UTF8%ComponentDescription="),
+        "the RECORD=1 entry carries the %UTF8% twin"
     );
 }
 

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -19,7 +19,7 @@
 
 use altium_designer_mcp::altium::pcblib::PcbLib;
 use altium_designer_mcp::altium::schlib::SchLib;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 fn sample(name: &str) -> PathBuf {
@@ -48,7 +48,13 @@ const VOLATILE_KEYS: &[&str] = &[
 ];
 
 fn is_volatile_key(key: &str) -> bool {
-    VOLATILE_KEYS.contains(&key)
+    // A %UTF8% twin's content depends on the ANSI code page of the machine
+    // that wrote the file — Altium builds it by decoding the value's UTF-8
+    // bytes through the authoring locale (Windows-1250 for the golden), we
+    // write the raw bytes — while the plain key beside it carries the
+    // authoritative value on every machine. The plain key is still compared,
+    // so the value itself cannot silently change.
+    VOLATILE_KEYS.contains(&key) || key.starts_with("%UTF8%")
 }
 
 /// Differences that are correct by design and will not change.
@@ -73,52 +79,105 @@ const BY_DESIGN: &[(&str, &str)] = &[
 /// so the cost is visible in code review instead of being discovered in a
 /// corrupted library.
 const KNOWN_DEFECTS: &[(&str, &str)] = &[(
-    "sectionkeys",
-    "Altium emits a SectionKeys stream mapping LibRef -> storage name for \
-         every component whose name does not fit the CFB 31-character cap once \
-         encoded; we neither read nor write it, so those components lose their \
-         real name and keep only the truncated storage name",
+    "pinwidetext",
+    "Altium writes a per-symbol PinWideText stream for pins whose text leaves \
+     Windows-1252 — the icon-storage container framing, one zlib entry per pin \
+     ordinal; we neither read nor write it, so a read-modify-write drops it",
 )];
 
-/// A component whose name leaves ASCII is written under a storage name that
-/// differs from the golden's, so its streams read as missing here.
+/// The five fixture symbols `DelphiScript` mangled before Altium saw them.
 ///
-/// Altium encodes a storage name as the name's UTF-8 bytes, one byte per
-/// character, capped at the compound-file limit of 31; ours are derived
-/// differently, and for names past that cap Altium also writes a `SectionKeys`
-/// stream mapping the real `LibRef` back — a stream we neither read nor write.
-///
-/// This is about matching Altium's *file layout*, not about whether the format
-/// layer supports the scripts: `writing_systems_survive_a_write_read_cycle`
-/// writes Cherokee, Bengali, Inuktitut, beyond-BMP Han and Adlam, and a Khmer
-/// name of 57 UTF-8 bytes through our own writer and reads every one back
-/// intact. Four of the golden's own i18n symbols carry mojibake because a
-/// `DelphiScript` literal is mangled before Altium sees it, which is a limit of
-/// how the fixture is authored rather than of the code under test.
-const fn is_non_ascii_name_defect(what: &str) -> bool {
-    !what.is_ascii()
+/// Each is internally inconsistent IN THE GOLDEN ITSELF: the CFB storage name
+/// folds to the correct word (Javanese, Bengali, Cherokee, Inuktitut,
+/// beyond-BMP Han) while the record inside stores a different, shifted string —
+/// so no self-consistent writer can reproduce both at once. The cure is
+/// regenerating these five with literals built from character codes rather than
+/// source-file text; until then their storage names cannot match and their
+/// stream paths are excused here, precisely, by suffix.
+const FIXTURE_INCONSISTENT: &[&str] = &["_jv", "_bn", "_cr", "_iu", "_sb"];
+
+/// Whether a canonical path belongs to one of the five damaged fixtures.
+fn is_fixture_inconsistent(what: &str) -> bool {
+    let component = what.split('/').next().unwrap_or(what);
+    FIXTURE_INCONSISTENT
+        .iter()
+        .any(|suffix| component.ends_with(suffix))
 }
 
 fn is_known(what: &str) -> bool {
     let lower = what.to_lowercase();
-    is_non_ascii_name_defect(what)
+    is_fixture_inconsistent(&lower)
         || BY_DESIGN
             .iter()
             .chain(KNOWN_DEFECTS)
             .any(|(key, _)| lower.contains(&key.to_lowercase()))
 }
 
-/// Every stream path in an OLE file, lower-cased for case-insensitive compare.
-fn stream_paths(path: &Path) -> BTreeSet<String> {
+/// Folds one path segment to a locale-independent form.
+///
+/// A CFB storage name for a non-Windows-1252 component is the name's UTF-8
+/// bytes widened one-per-byte through the ANSI code page of the machine that
+/// wrote the file — the golden was authored on a Windows-1250 box, we widen
+/// through Windows-1252 — so the same component gets different UTF-16 storage
+/// names on different machines while the underlying bytes are identical. This
+/// inverts the widening by trying each plausible code page and keeping the
+/// first whose bytes decode as UTF-8, which recovers the real name; the lossy
+/// decode also absorbs a name the 31-unit cap cut mid-codepoint (the golden's
+/// Sinhala symbol), identically on both sides.
+fn canonical_segment(seg: &str) -> String {
+    if seg.is_ascii() {
+        return seg.to_lowercase();
+    }
+    for enc in [
+        encoding_rs::WINDOWS_1252,
+        encoding_rs::WINDOWS_1250,
+        encoding_rs::WINDOWS_1251,
+        encoding_rs::WINDOWS_1253,
+        encoding_rs::WINDOWS_1254,
+        encoding_rs::WINDOWS_1255,
+        encoding_rs::WINDOWS_1256,
+        encoding_rs::WINDOWS_1257,
+        encoding_rs::WINDOWS_1258,
+        encoding_rs::WINDOWS_874,
+    ] {
+        let (bytes, _, had_errors) = enc.encode(seg);
+        if had_errors {
+            continue;
+        }
+        let sound = match std::str::from_utf8(&bytes) {
+            Ok(s) => !s.is_ascii(),
+            // A tail the 31-unit cap cut mid-codepoint is not an arbitrary
+            // decode failure: accept the fold when everything up to the cut is
+            // sound UTF-8 and only the end is incomplete.
+            Err(e) => e.error_len().is_none() && e.valid_up_to() > 0,
+        };
+        if sound {
+            return String::from_utf8_lossy(&bytes).to_lowercase();
+        }
+    }
+    seg.to_lowercase()
+}
+
+/// Folds a whole stream path segment-by-segment.
+fn canonical_path(path: &str) -> String {
+    path.trim_start_matches('/')
+        .split(['/', '\\'])
+        .map(canonical_segment)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Every stream in an OLE file, keyed by its canonical path (see
+/// [`canonical_segment`]) with the actual path as the value, so two files can
+/// be compared component-by-component regardless of the authoring locale.
+fn stream_map(path: &Path) -> BTreeMap<String, String> {
     let file = std::fs::File::open(path).expect("open library");
     let cfb = cfb::CompoundFile::open(file).expect("parse OLE");
     cfb.walk()
         .filter(cfb::Entry::is_stream)
         .map(|e| {
-            e.path()
-                .to_string_lossy()
-                .trim_start_matches('/')
-                .to_lowercase()
+            let actual = e.path().to_string_lossy().into_owned();
+            (canonical_path(&actual), actual)
         })
         .collect()
 }
@@ -233,9 +292,10 @@ fn pcblib_golden_survives_a_round_trip() {
 
     let mut failures = Vec::new();
 
-    // 1. Streams the golden has that we did not write back.
-    let (before, after) = (stream_paths(&src), stream_paths(&out));
-    for missing in before.difference(&after) {
+    // 1. Streams the golden has that we did not write back, compared by
+    //    canonical path so a locale-widened storage name meets its twin.
+    let (before, after) = (stream_map(&src), stream_map(&out));
+    for missing in before.keys().filter(|k| !after.contains_key(*k)) {
         if !is_known(missing) {
             failures.push(format!("stream dropped entirely: {missing}"));
         }
@@ -253,14 +313,24 @@ fn pcblib_golden_survives_a_round_trip() {
         );
     }
 
-    // 3. Parameter values inside each footprint's Data stream.
-    for name in lib.names() {
-        let stream = format!("/{name}/Data");
-        let (Some(g), Some(o)) = (stream_bytes(&src, &stream), stream_bytes(&out, &stream)) else {
+    // 3. Parameter values inside each footprint's Data stream — every
+    //    footprint the two files share, including the ones whose storage names
+    //    differ only by authoring locale.
+    for (canonical, g_path) in &before {
+        let Some(fp) = canonical
+            .strip_suffix("/data")
+            .filter(|fp| !fp.contains('/') && *fp != "library")
+        else {
+            continue;
+        };
+        let Some(o_path) = after.get(canonical) else {
+            continue; // already reported as dropped
+        };
+        let (Some(g), Some(o)) = (stream_bytes(&src, g_path), stream_bytes(&out, o_path)) else {
             continue;
         };
         failures.extend(
-            block_divergences(&g, &o, &name)
+            block_divergences(&g, &o, fp)
                 .into_iter()
                 .filter(|d| !is_known(d)),
         );
@@ -272,25 +342,24 @@ fn pcblib_golden_survives_a_round_trip() {
     //    equality there means the replay is intact; the unique-id records are
     //    rebuilt from the write sequence, so equality there means the order the
     //    ordinals refer to survived.
-    for name in lib.names() {
-        for stream in ["PrimitiveGuids/Data", "UniqueIDPrimitiveInformation/Data"] {
-            let path = format!("/{name}/{stream}");
-            let Some(g) = stream_bytes(&src, &path) else {
-                continue;
-            };
-            let what = format!("{name}: {stream}");
-            if is_known(&what) {
-                continue;
-            }
-            match stream_bytes(&out, &path) {
-                Some(o) if o == g => {}
-                Some(o) => failures.push(format!(
-                    "{what} differs: {} bytes golden, {} ours",
-                    g.len(),
-                    o.len()
-                )),
-                None => failures.push(format!("{what} was not written back")),
-            }
+    for (canonical, g_path) in &before {
+        if !canonical.ends_with("primitiveguids/data")
+            && !canonical.ends_with("uniqueidprimitiveinformation/data")
+        {
+            continue;
+        }
+        if is_known(canonical) {
+            continue;
+        }
+        let g = stream_bytes(&src, g_path).expect("walked stream exists");
+        match after.get(canonical).and_then(|p| stream_bytes(&out, p)) {
+            Some(o) if o == g => {}
+            Some(o) => failures.push(format!(
+                "{canonical} differs: {} bytes golden, {} ours",
+                g.len(),
+                o.len()
+            )),
+            None => failures.push(format!("{canonical} was not written back")),
         }
     }
 
@@ -345,20 +414,28 @@ fn schlib_golden_survives_a_round_trip() {
 
     let mut failures = Vec::new();
 
-    let (before, after) = (stream_paths(&src), stream_paths(&out));
-    for missing in before.difference(&after) {
+    let (before, after) = (stream_map(&src), stream_map(&out));
+    for missing in before.keys().filter(|k| !after.contains_key(*k)) {
         if !is_known(missing) {
             failures.push(format!("stream dropped entirely: {missing}"));
         }
     }
 
-    for name in lib.names() {
-        let stream = format!("/{name}/Data");
-        let (Some(g), Some(o)) = (stream_bytes(&src, &stream), stream_bytes(&out, &stream)) else {
+    for (canonical, g_path) in &before {
+        let Some(name) = canonical
+            .strip_suffix("/data")
+            .filter(|name| !name.contains('/'))
+        else {
+            continue;
+        };
+        let Some(o_path) = after.get(canonical) else {
+            continue; // already reported as dropped
+        };
+        let (Some(g), Some(o)) = (stream_bytes(&src, g_path), stream_bytes(&out, o_path)) else {
             continue;
         };
         failures.extend(
-            block_divergences(&g, &o, &name)
+            block_divergences(&g, &o, name)
                 .into_iter()
                 .filter(|d| !is_known(d)),
         );
@@ -368,7 +445,7 @@ fn schlib_golden_survives_a_round_trip() {
         // the order does — and a block-level diff pairs records by content, not
         // by position, so it cannot see a reordering on its own.
         let (gk, ok) = (record_kinds(&g), record_kinds(&o));
-        if gk != ok && !is_known(&name) {
+        if gk != ok && !is_known(name) {
             failures.push(format!(
                 "{name}: record order changed\n  golden: {}\n  ours:   {}",
                 gk.join(" "),

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -1705,3 +1705,86 @@ fn samples_schlib_manual_parameter_properties() {
     );
     assert!(rule.hidden, "the rule parameter is hidden");
 }
+
+/// The `SectionKeys` stream — the real-name -> truncated-storage-name map for
+/// components past the 31-unit cap — must survive a read-modify-write with the
+/// same pairs, and the truncated storage names must match Altium's plain cut.
+#[test]
+fn samples_schlib_section_keys_survive_a_read_modify_write() {
+    use std::io::{Cursor, Read as _};
+
+    /// `(LibRef, SectionKey)` pairs from a library's `/SectionKeys` stream, as
+    /// a set — entry numbering is Altium's iteration order, which we do not
+    /// promise to reproduce.
+    fn pairs(bytes: &[u8]) -> std::collections::BTreeSet<(String, String)> {
+        let mut cfb = cfb::CompoundFile::open(Cursor::new(bytes)).expect("parse OLE");
+        let mut data = Vec::new();
+        cfb.open_stream("/SectionKeys")
+            .expect("SectionKeys stream present")
+            .read_to_end(&mut data)
+            .expect("read SectionKeys");
+        // [u32 len][text + NUL]: split the pipe list, keep LibRefN/SectionKeyN.
+        let text: String = data[4..].iter().map(|&b| b as char).collect();
+        let text = text.trim_end_matches('\0');
+        let mut lib_refs = std::collections::BTreeMap::new();
+        let mut section_keys = std::collections::BTreeMap::new();
+        for part in text.split('|') {
+            let Some((key, value)) = part.split_once('=') else {
+                continue;
+            };
+            if let Some(n) = key.strip_prefix("LibRef") {
+                if let Ok(n) = n.parse::<usize>() {
+                    lib_refs.insert(n, value.to_string());
+                }
+            } else if let Some(n) = key.strip_prefix("SectionKey") {
+                if let Ok(n) = n.parse::<usize>() {
+                    section_keys.insert(n, value.to_string());
+                }
+            }
+        }
+        lib_refs
+            .into_iter()
+            .filter_map(|(n, lr)| section_keys.get(&n).map(|sk| (lr, sk.clone())))
+            .collect()
+    }
+
+    let golden = std::fs::read(sample("symbols.SchLib")).expect("read golden");
+    let golden_pairs = pairs(&golden);
+    assert_eq!(
+        golden_pairs.len(),
+        5,
+        "the golden truncates five names (Khmer, Malayalam, Thai, Sinhala, Lao)"
+    );
+    for (lib_ref, section_key) in &golden_pairs {
+        assert_eq!(
+            section_key.as_bytes(),
+            &lib_ref.as_bytes()[..section_key.len()],
+            "a SectionKey is its LibRef plain-cut at the storage cap"
+        );
+        // The pair strings hold one char per wire byte, so the cap is counted
+        // in chars, not in this string's own UTF-8 length.
+        assert!(section_key.chars().count() <= 31, "storage cap is 31 units");
+    }
+
+    let lib = SchLib::read(Cursor::new(golden.as_slice())).expect("read golden");
+    let mut rewritten = Cursor::new(Vec::new());
+    lib.write(&mut rewritten).expect("write the golden back");
+
+    // The Inuktitut fixture is one of the five DelphiScript-mangled symbols:
+    // its RECORD name (what any reader gets) is a 45-byte mangled string that
+    // needs truncating, while Altium's in-memory name was the real 9-unit word
+    // and needed no entry. Golden and rewrite legitimately disagree there, so
+    // the damaged fixtures are excluded and everything else must match.
+    let damaged = ["_JV", "_BN", "_CR", "_IU", "_SB"];
+    let clean = |set: std::collections::BTreeSet<(String, String)>| {
+        set.into_iter()
+            .filter(|(lr, _)| !damaged.iter().any(|d| lr.ends_with(d)))
+            .collect::<std::collections::BTreeSet<_>>()
+    };
+    assert_eq!(
+        clean(pairs(rewritten.get_ref())),
+        clean(golden_pairs),
+        "every LibRef -> SectionKey pair must come back; a changed pair breaks \
+         Altium's name resolution for that component"
+    );
+}


### PR DESCRIPTION
Closes the **last entry** in `golden_fidelity`'s `KNOWN_DEFECTS` — and removes the test's last blanket excuse while doing it. Three linked fixes, because the stream only means anything if the names around it behave like Altium's.

## 1. SectionKeys itself

- **Storage names** past the CFB 31-unit cap are now **plain-truncated at the cap**, as Altium does (the golden's Sinhala symbol is cut mid-codepoint — the cut is bytewise). The `~NNN` suffix survives only as a collision fallback.
- The root **`/SectionKeys` stream** maps each real `LibRef` to its truncated storage name, in Altium's own layout (`KeyCount`, `%UTF8%` twins, the `|||` separators), for both `PcbLib` and `SchLib`; parsed back on read for the ordering pass.
- The SchLib **`FileHeader` now stores the real name** in `LibRef{i}` — the golden holds a full 33-byte Khmer name there against a 31-unit storage — where we used to write the storage name. Lookup goes `FileHeader` → `SectionKeys` → storage.

## 2. The %UTF8% promotion gate was wrong

We promoted a value to UTF-8+twin only when Windows-1252 could not hold it. The golden stores `Résistance` as raw UTF-8 with a twin even though `é` has a single-byte form: **AD promotes any non-ASCII value.** Every SchLib text field now follows that rule, including `CompDescr` and the RECORD=1 description. Two tests pinning the old belief were corrected against this golden evidence.

## 3. The fidelity test got materially stronger

Streams are now matched by **canonical path**: each segment folded back to its UTF-8 bytes through the plausible ANSI code pages. A CFB storage name is the name's UTF-8 bytes widened through the *authoring machine's* code page — Windows-1250 for the golden, 1252 for us — so byte-identical names differ as UTF-16 across locales. With the fold in place:

- the i18n components are **compared for the first time** instead of skipped by a blanket "non-ASCII is excused" rule (which this PR deletes);
- `%UTF8%` twin *values* are treated as volatile — they are provably locale artefacts — while their plain keys stay fully checked.

Under the strictest checking the test has ever run, the golden survives.

## What the excuses became

Blanket exclusions are gone; what remains is precisely named:

1. **`PinWideText`** (new discovery): a per-symbol stream AD writes for pins whose text leaves Windows-1252 — icon-storage container framing, one zlib entry per pin ordinal, 52 in the golden. We don't model it yet. Next PR.
2. **Five fixture symbols are internally inconsistent in the golden itself** (`_JV`, `_BN`, `_CR`, `_IU`, `_SB`): DelphiScript mangled their literals, and the damage differs by location — the CFB storage name folds to the *correct* word while the record inside stores a shifted string. No self-consistent writer can reproduce both at once. Cure: regenerate those five with `Chr()`-built literals (needs an Altium run; queued).

## Tests

- `samples_schlib_section_keys_survive_a_read_modify_write` — pins the golden's five pairs (Khmer, Malayalam, Thai, Sinhala, Lao), the plain-cut prefix property, the 31-unit cap, and pair survival across RMW.
- Full suite green (12 suites), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean.
- pyaltiumlib oracle: 13 passed, 0 regressions.
- Docs updated: `SCHLIB_FORMAT.md` gains the SectionKeys section and the corrected promotion rule; `PCBLIB_FORMAT.md` root-stream note; `COVERAGE_AUDIT.md` § Outstanding now lists PinWideText + the fixture regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)