### PR TITLE
feat(schlib): model the PinWideText stream — KNOWN_DEFECTS is empty

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -15,12 +15,6 @@ golden, writes it back and diffs the OLE streams and every parameter block. Anyt
 still loses is listed in that test's `KNOWN_DEFECTS` and described here; the two lists are
 the same list, so an entry leaves both together.
 
-**`PinWideText` is neither read nor written (`SchLib`).** Altium writes a per-symbol
-`PinWideText` stream when a pin's text leaves Windows-1252: the same container as the root
-icon `/Storage` stream (`[len]["|HEADER=PinWideText|Weight=1"+NUL]` then one zlib entry per
-pin, named by pin ordinal). We drop it on a read-modify-write. The golden carries 52 of
-them, one per i18n symbol.
-
 **Five i18n fixture symbols are internally inconsistent** (`_JV`, `_BN`, `_CR`, `_IU`,
 `_SB`): `DelphiScript` mangled their source literals, and the damage differs by location —
 the golden's CFB storage name folds to the *correct* word while the record inside stores a

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -74,6 +74,18 @@ separator, reproduced verbatim. The `FileHeader`'s `LibRef{N}` entries hold the 
 name** — the golden stores a 33-byte Khmer name there against a 31-unit storage — so lookup for a
 long name goes `FileHeader` → `SectionKeys` → storage.
 
+## PinWideText Stream
+
+Per-component, alongside `PinFrac` / `PinSymbolLineWidth`, in the shared compressed-storage
+framing (see the `/Storage` section): one zlib entry per pin whose name leaves ASCII, keyed by pin
+ordinal, payload a Unicode parameter block `[u32 LE byte_len][UTF-16LE "|NAME=<text>"]`.
+
+This is the pin name's authoritative wide form — the binary pin record narrows the name through
+the writing machine's ANSI code page, so a name typed as real Unicode survives only here. In an
+Altium-authored file the value can itself be the ANSI-widened form of the name's UTF-8 bytes (the
+golden's 52 streams all are, courtesy of script authoring); a reader folds such a value back
+through the plausible code pages and applies it only when the binary record yielded a lossy husk.
+
 ## FileHeader Stream
 
 A single C-string parameter block:

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -184,6 +184,47 @@ pub fn from_wire_text(raw: &str) -> Option<String> {
     std::str::from_utf8(&bytes).ok().map(str::to_string)
 }
 
+/// Recovers real text from an ANSI-widened byte string, whatever single-byte
+/// code page did the widening.
+///
+/// Altium widens a value's raw UTF-8 bytes one-per-char through the *authoring
+/// machine's* ANSI code page (`PinWideText` values, CFB storage names), so the
+/// same file reads differently by locale. Each plausible code page is tried:
+/// the one that encodes `text` losslessly back to bytes forming valid
+/// non-ASCII UTF-8 is the one that widened it, and those bytes decode to the
+/// real value. Returns `None` when no code page fits — which is what happens
+/// for text that is already real (its characters do not narrow to a UTF-8 byte
+/// pattern), so a real value passed in is left for the caller to use verbatim.
+#[must_use]
+pub fn fold_ansi_widened(text: &str) -> Option<String> {
+    if text.is_ascii() {
+        return None;
+    }
+    for enc in [
+        encoding_rs::WINDOWS_1252,
+        encoding_rs::WINDOWS_1250,
+        encoding_rs::WINDOWS_1251,
+        encoding_rs::WINDOWS_1253,
+        encoding_rs::WINDOWS_1254,
+        encoding_rs::WINDOWS_1255,
+        encoding_rs::WINDOWS_1256,
+        encoding_rs::WINDOWS_1257,
+        encoding_rs::WINDOWS_1258,
+        encoding_rs::WINDOWS_874,
+    ] {
+        let (bytes, _, had_errors) = enc.encode(text);
+        if had_errors {
+            continue;
+        }
+        if let Ok(real) = std::str::from_utf8(&bytes) {
+            if !real.is_ascii() {
+                return Some(real.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Generates a safe OLE storage name for a component.
 ///
 /// OLE Compound File names are limited to 31 UTF-16 code units. This function:

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -67,6 +67,14 @@ use std::path::Path;
 use super::{AltiumError, AltiumResult};
 pub use primitives::*;
 
+/// Test-only re-export of [`pin_aux::apply_pin_wide_text`], so the golden
+/// fidelity test can resolve a `PinWideText` stream through the same fold the
+/// reader uses rather than reimplementing it.
+#[doc(hidden)]
+pub fn apply_pin_wide_text_for_test(pins: &mut [Pin], raw: &[u8]) {
+    pin_aux::apply_pin_wide_text(pins, raw);
+}
+
 /// A schematic symbol library.
 ///
 /// # Example

--- a/src/altium/schlib/pin_aux.rs
+++ b/src/altium/schlib/pin_aux.rs
@@ -1,6 +1,7 @@
-//! Per-component pin auxiliary OLE streams (`PinFrac`, `PinSymbolLineWidth`).
+//! Per-component pin auxiliary OLE streams (`PinFrac`, `PinSymbolLineWidth`,
+//! `PinWideText`).
 //!
-//! Alongside a symbol's `Data` stream, Altium may store two optional sibling
+//! Alongside a symbol's `Data` stream, Altium may store optional sibling
 //! streams that carry data the binary pin record cannot hold:
 //!
 //! - **`PinFrac`** — the fractional part of each off-grid pin's `X` / `Y` /
@@ -8,6 +9,9 @@
 //!   so a pin sitting between grid points keeps its sub-unit remainder here.
 //! - **`PinSymbolLineWidth`** — a `SYMBOL_LINEWIDTH=N` parameter per pin whose
 //!   symbol line width is non-default.
+//! - **`PinWideText`** — a `|NAME=<text>` Unicode parameter block per pin
+//!   whose name leaves ASCII: the name's authoritative wide form, since the
+//!   binary record narrows it through the writing machine's ANSI code page.
 //!
 //! Both use Altium's *compressed-storage* framing (shared with the embedded
 //! icon-image `/Storage` stream — see [`super::storage`] for the byte layout);
@@ -111,6 +115,82 @@ pub(super) fn encode_pin_symbol_line_widths(
     Ok(Some(out))
 }
 
+/// Encodes the `PinWideText` stream: one entry per pin whose name leaves
+/// ASCII, keyed by pin ordinal, payload `[u32 len][UTF-16LE "|NAME=<name>"]`.
+///
+/// This stream is the pin name's authoritative wide form. The binary pin
+/// record narrows the name through the writing machine's ANSI code page, so a
+/// name typed as real Unicode in the AD UI survives only here — which is the
+/// stream's whole purpose. We hold real Unicode in memory and write it as real
+/// UTF-16; the golden's own entries instead carry the ANSI-widened form of the
+/// name's UTF-8 bytes, because its script-authored pins were mangled to
+/// exactly that before Altium stored them (see `apply_pin_wide_text` for how
+/// both shapes read back).
+///
+/// Only `NAME` is emitted: it is the only key the golden's 52 streams carry,
+/// and inventing sibling keys (a designator, say) without evidence would write
+/// fiction into every i18n library.
+pub(super) fn encode_pin_wide_text(
+    pins: &[Pin],
+) -> crate::altium::error::AltiumResult<Option<Vec<u8>>> {
+    let entries: Vec<(usize, &str)> = pins
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| !p.name.is_ascii())
+        .map(|(i, p)| (i, p.name.as_str()))
+        .collect();
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    let mut out = storage::start_stream("PinWideText", entries.len());
+    for (index, name) in entries {
+        let payload = encode_unicode_param_block(&format!("|NAME={name}"));
+        storage::write_entry(&mut out, &index.to_string(), &payload)?;
+    }
+    Ok(Some(out))
+}
+
+/// Applies a parsed `PinWideText` stream onto `pins`, keyed by pin ordinal.
+///
+/// The stream's value wins only when it genuinely knows more than the binary
+/// record did:
+///
+/// - A record that carried the name's raw UTF-8 bytes already decoded to the
+///   real name (the golden's case), so a non-ASCII in-memory name is kept.
+/// - A record the ANSI narrowing reduced to `?`s leaves an ASCII husk, and the
+///   wide value replaces it — the UI-authored case the stream exists for.
+/// - A wide value that is itself the ANSI-widened form of UTF-8 bytes (the
+///   golden again) is folded back to the real name first, so applying it can
+///   only ever improve the husk, never install mojibake.
+pub(super) fn apply_pin_wide_text(pins: &mut [Pin], raw: &[u8]) {
+    for_each_entry(raw, |idx, payload| {
+        let Some(text) = decode_unicode_param_block(payload) else {
+            return;
+        };
+        let params = crate::altium::parse_pipe_params(&text);
+        let Some(wide) = params.get("name") else {
+            return;
+        };
+        let Some(pin) = pins.get_mut(idx) else {
+            return;
+        };
+        if !pin.name.is_ascii() {
+            // The record already yielded a real (or at least non-degenerate)
+            // name; the wide copy adds nothing.
+            return;
+        }
+        // Fold a widened-bytes value back to the real name where some ANSI
+        // code page provably widened it (the authoring locale's — Windows-1250
+        // for the golden). A real Unicode value folds through none of them and
+        // is applied verbatim.
+        let resolved = crate::altium::fold_ansi_widened(wide).unwrap_or_else(|| wide.clone());
+        if !resolved.is_empty() && resolved != pin.name {
+            pin.name = resolved;
+        }
+    });
+}
+
 /// Encodes a Unicode (UTF-16LE) parameter block: `[u32 LE byte_len][utf16le]`.
 /// The length counts the UTF-16 byte count (not including its own 4 bytes),
 /// matching `AltiumSharp`'s `WriteUnicodeParameterBlock` / `ReadUnicodeParameterBlock`.
@@ -184,6 +264,62 @@ mod tests {
 
     fn pin() -> Pin {
         Pin::new("A", "1", 0, 0, 10, PinOrientation::Right)
+    }
+
+    #[test]
+    fn ascii_pin_names_emit_no_wide_text() {
+        let pins = vec![pin(), pin()];
+        assert!(encode_pin_wide_text(&pins).unwrap().is_none());
+    }
+
+    #[test]
+    fn wide_text_round_trips_a_real_unicode_name() {
+        // The UI-authored case the stream exists for: the binary record can
+        // only hold the ANSI narrowing (a `?` husk), so the wide stream is the
+        // sole carrier of the real name.
+        let mut authored = pin();
+        authored.name = "\u{7535}\u{963B}".to_string(); // 电阻
+        let raw = encode_pin_wide_text(&[pin(), authored])
+            .unwrap()
+            .expect("non-ASCII name emits the stream");
+
+        let mut read_back = vec![pin(), pin()];
+        read_back[1].name = "??".to_string(); // the record's ANSI husk
+        apply_pin_wide_text(&mut read_back, &raw);
+        assert_eq!(read_back[1].name, "\u{7535}\u{963B}");
+        assert_eq!(read_back[0].name, "A", "pin without an entry is untouched");
+    }
+
+    #[test]
+    fn wide_text_never_overwrites_a_recovered_name() {
+        // The golden's case: the record carried raw UTF-8 bytes and already
+        // decoded to the real name; the wide copy (whatever its locale shape)
+        // must not replace it.
+        let mut authored = pin();
+        authored.name = "\u{7535}\u{963B}".to_string();
+        let raw = encode_pin_wide_text(std::slice::from_ref(&authored))
+            .unwrap()
+            .unwrap();
+
+        let mut pins = vec![authored.clone()];
+        apply_pin_wide_text(&mut pins, &raw);
+        assert_eq!(pins[0].name, authored.name);
+    }
+
+    #[test]
+    fn widened_wide_text_is_folded_back_to_the_real_name() {
+        // An Altium-authored stream can carry the ANSI-widened form of the
+        // name's UTF-8 bytes (the golden's 52 streams all do). Applied onto a
+        // husk, it must resolve to the real name, not install the mojibake.
+        let widened = crate::altium::encode_utf8_param_value("\u{7535}\u{963B}");
+        let mut out = storage::start_stream("PinWideText", 1);
+        let payload = encode_unicode_param_block(&format!("|NAME={widened}"));
+        storage::write_entry(&mut out, "0", &payload).unwrap();
+
+        let mut pins = vec![pin()];
+        pins[0].name = "??".to_string();
+        apply_pin_wide_text(&mut pins, &out);
+        assert_eq!(pins[0].name, "\u{7535}\u{963B}");
     }
 
     #[test]

--- a/src/altium/schlib/read_io.rs
+++ b/src/altium/schlib/read_io.rs
@@ -121,20 +121,7 @@ impl SchLib {
 
             reader::parse_data_stream(&mut symbol, &data);
 
-            // Apply the optional per-component pin auxiliary streams. They sit
-            // alongside `Data` in the same storage and are keyed by pin ordinal,
-            // so they must be applied AFTER the pins are parsed. Absent streams
-            // (the common case, incl. the whole golden) leave the pins untouched.
-            if let Some(frac) =
-                crate::altium::read_stream_opt(&mut cfb, format!("{comp_name}/PinFrac"))
-            {
-                pin_aux::apply_pin_frac(&mut symbol.pins, &frac);
-            }
-            if let Some(widths) =
-                crate::altium::read_stream_opt(&mut cfb, format!("{comp_name}/PinSymbolLineWidth"))
-            {
-                pin_aux::apply_pin_symbol_line_widths(&mut symbol.pins, &widths);
-            }
+            apply_pin_aux_streams(&mut cfb, &comp_name, &mut symbol);
 
             // Use the symbol's actual name (from LibReference) as the key
             // This handles long names that were truncated in the OLE storage path
@@ -163,6 +150,30 @@ impl SchLib {
         }
 
         Ok(lib)
+    }
+}
+
+/// Applies the optional per-component pin auxiliary streams. They sit
+/// alongside `Data` in the same storage and are keyed by pin ordinal, so they
+/// must be applied AFTER the pins are parsed. Absent streams (the common case)
+/// leave the pins untouched.
+fn apply_pin_aux_streams<R: Read + Seek>(
+    cfb: &mut CompoundFile<R>,
+    comp_name: &str,
+    symbol: &mut Symbol,
+) {
+    if let Some(frac) = crate::altium::read_stream_opt(&mut *cfb, format!("{comp_name}/PinFrac")) {
+        pin_aux::apply_pin_frac(&mut symbol.pins, &frac);
+    }
+    if let Some(widths) =
+        crate::altium::read_stream_opt(&mut *cfb, format!("{comp_name}/PinSymbolLineWidth"))
+    {
+        pin_aux::apply_pin_symbol_line_widths(&mut symbol.pins, &widths);
+    }
+    if let Some(wide) =
+        crate::altium::read_stream_opt(&mut *cfb, format!("{comp_name}/PinWideText"))
+    {
+        pin_aux::apply_pin_wide_text(&mut symbol.pins, &wide);
     }
 }
 

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -79,6 +79,9 @@ impl SchLib {
                     &widths,
                 )?;
             }
+            if let Some(wide) = pin_aux::encode_pin_wide_text(&symbol.pins)? {
+                crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/PinWideText"), &wide)?;
+            }
         }
 
         // Root Storage stream (Altium's icon storage). Always present. EVERY

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -78,12 +78,7 @@ const BY_DESIGN: &[(&str, &str)] = &[
 /// an entry as its fix lands. It is spelled out here rather than left implicit
 /// so the cost is visible in code review instead of being discovered in a
 /// corrupted library.
-const KNOWN_DEFECTS: &[(&str, &str)] = &[(
-    "pinwidetext",
-    "Altium writes a per-symbol PinWideText stream for pins whose text leaves \
-     Windows-1252 — the icon-storage container framing, one zlib entry per pin \
-     ordinal; we neither read nor write it, so a read-modify-write drops it",
-)];
+const KNOWN_DEFECTS: &[(&str, &str)] = &[];
 
 /// The five fixture symbols `DelphiScript` mangled before Altium saw them.
 ///

--- a/tests/samples_schlib.rs
+++ b/tests/samples_schlib.rs
@@ -1788,3 +1788,107 @@ fn samples_schlib_section_keys_survive_a_read_modify_write() {
          Altium's name resolution for that component"
     );
 }
+
+/// The golden's 52 `PinWideText` streams — the authoritative wide form of each
+/// non-ASCII pin name — must come back from a read-modify-write for the same
+/// components, resolving to the same names.
+#[test]
+fn samples_schlib_pin_wide_text_survives_a_read_modify_write() {
+    use std::io::{Cursor, Read as _};
+
+    /// Canonical component -> resolved pin names from every `PinWideText` stream.
+    /// Payload values are folded the way the reader folds them, so a golden
+    /// stream (ANSI-widened bytes) and ours (real UTF-16) compare equal.
+    fn wide_names(bytes: &[u8]) -> std::collections::BTreeMap<String, Vec<String>> {
+        let mut cfb = cfb::CompoundFile::open(Cursor::new(bytes)).expect("parse OLE");
+        let paths: Vec<std::path::PathBuf> = cfb
+            .walk()
+            .filter(cfb::Entry::is_stream)
+            .filter(|e| e.name() == "PinWideText")
+            .map(|e| e.path().to_path_buf())
+            .collect();
+        let mut map = std::collections::BTreeMap::new();
+        for path in paths {
+            let mut raw = Vec::new();
+            cfb.open_stream(&path)
+                .expect("open PinWideText")
+                .read_to_end(&mut raw)
+                .expect("read PinWideText");
+
+            // Resolve through the reader itself: husk pins + apply = the names.
+            let mut pins: Vec<Pin> = (0..64)
+                .map(|i| Pin::new("?", i.to_string(), 0, 0, 10, PinOrientation::Right))
+                .collect();
+            altium_designer_mcp::altium::schlib::apply_pin_wide_text_for_test(&mut pins, &raw);
+            let names: Vec<String> = pins
+                .into_iter()
+                .map(|p| p.name)
+                .filter(|n| n != "?")
+                .collect();
+
+            // Fold the component storage name to a locale-free key: its bytes
+            // are the name's UTF-8 widened through the authoring code page.
+            let seg = path
+                .parent()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            map.insert(canonical(&seg), names);
+        }
+        map
+    }
+
+    /// Locale-free fold of a storage name (1250 for the golden, 1252 for us).
+    /// A truncated storage name can end mid-codepoint, so an incomplete tail
+    /// is accepted and folded lossily — identically on both sides.
+    fn canonical(seg: &str) -> String {
+        for enc in [encoding_rs::WINDOWS_1252, encoding_rs::WINDOWS_1250] {
+            let (bytes, _, had_errors) = enc.encode(seg);
+            if had_errors {
+                continue;
+            }
+            let sound = match std::str::from_utf8(&bytes) {
+                Ok(s) => !s.is_ascii(),
+                Err(e) => e.error_len().is_none() && e.valid_up_to() > 0,
+            };
+            if sound {
+                return String::from_utf8_lossy(&bytes).to_lowercase();
+            }
+        }
+        seg.to_lowercase()
+    }
+
+    let golden = std::fs::read(sample("symbols.SchLib")).expect("read golden");
+    let golden_names = wide_names(&golden);
+    assert_eq!(
+        golden_names.len(),
+        52,
+        "one PinWideText stream per i18n symbol"
+    );
+
+    let lib = SchLib::read(Cursor::new(golden.as_slice())).expect("read golden");
+    let mut rewritten = Cursor::new(Vec::new());
+    lib.write(&mut rewritten).expect("write the golden back");
+    let ours = wide_names(rewritten.get_ref());
+
+    assert_eq!(ours.len(), 52, "the rewrite emits a stream per i18n symbol");
+
+    // The five DelphiScript-damaged fixtures resolve differently on purpose
+    // (their storage names and record names disagree in the golden itself), so
+    // golden-side subset equality is asserted over the other 47: every clean
+    // golden component must come back with the same resolved pin names.
+    let damaged = ["_jv", "_bn", "_cr", "_iu", "_sb"];
+    let mut checked = 0;
+    for (component, names) in &golden_names {
+        if damaged.iter().any(|d| component.ends_with(d)) {
+            continue;
+        }
+        assert_eq!(
+            ours.get(component),
+            Some(names),
+            "{component}: wide pin names must survive the rewrite"
+        );
+        checked += 1;
+    }
+    assert_eq!(checked, 47, "all clean components were compared");
+}


### PR DESCRIPTION
The stream #374 discovered, closed — and with it, **`golden_fidelity`'s `KNOWN_DEFECTS` list is empty.**

## What PinWideText is

The pin name's authoritative wide form. The binary pin record narrows the name through the writing machine's ANSI code page, so a name typed as real Unicode in the AD UI reaches the record as a `?` husk — this stream is what preserves the real text. Per-symbol, shared compressed-storage framing (same container as `/Storage`, `PinFrac`, `PinSymbolLineWidth`): one zlib entry per pin ordinal, payload `[u32 len][UTF-16LE "|NAME=<text>"]`. The golden carries 52, one per i18n symbol; we dropped all of them on a read-modify-write.

## Writer

One entry per pin whose name leaves ASCII, carrying **real UTF-16**. The golden's own entries hold the ANSI-widened form of the name's UTF-8 bytes instead — but that is because its script-authored pins were mangled to exactly that in AD's memory before it stored them, i.e. AD faithfully wrote *its* in-memory string, and so do we. Only `NAME` is emitted: it is the only key the golden's 52 streams carry, and inventing sibling keys without evidence would write fiction into every i18n library.

## Reader

Conservative application, three cases proven by unit tests:

- record already recovered the name (raw UTF-8 bytes — the golden's case) → **kept**;
- record yielded a lossy ASCII husk (the UI-authored case the stream exists for) → **replaced**;
- the wide value is itself ANSI-widened (a golden-shaped stream applied to a husk) → **folded back to the real name first**, via the new `fold_ansi_widened`, which tries each plausible code page and keeps the one whose bytes decode as non-ASCII UTF-8 — so a Windows-1250-authored file now reads correctly on any machine, and real Unicode folds through none of them and applies verbatim.

## Tests

- Four unit tests covering emit-gating and all three apply cases.
- `samples_schlib_pin_wide_text_survives_a_read_modify_write` — resolves all 52 golden streams *and* all 52 rewritten streams through the reader's own fold and requires the 47 clean components to match name-for-name (the five DelphiScript-damaged fixtures legitimately differ; they remain queued for regeneration).
- `golden_fidelity` with `KNOWN_DEFECTS = &[]` — both goldens now survive a read-modify-write with **zero** excused defects.
- Full suite green (12 suites), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean; pyaltiumlib oracle 13 passed, 0 regressions.

## Where the debt now lives

Nothing in `KNOWN_DEFECTS`. `docs/COVERAGE_AUDIT.md` § Outstanding still tracks the two non-round-trip items (ordinal-keyed identities vs structural edits; the invented `MODEL.*` block) plus the five-fixture regeneration, which needs an Altium run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)