### PR TITLE
docs: scripted regeneration of the five damaged fixtures is a negative

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -16,11 +16,13 @@ still loses is listed in that test's `KNOWN_DEFECTS` and described here; the two
 the same list, so an entry leaves both together.
 
 **Five i18n fixture symbols are internally inconsistent** (`_JV`, `_BN`, `_CR`, `_IU`,
-`_SB`): `DelphiScript` mangled their source literals, and the damage differs by location —
-the golden's CFB storage name folds to the *correct* word while the record inside stores a
-shifted string, so no self-consistent writer can reproduce both. The cure is regenerating
-these five with literals built from character codes (`Chr()`), not source text; needs an
-Altium run.
+`_SB`) — and scripted regeneration is a **verified negative** (three runs, 2026-08-16).
+Source literals: the engine mis-decodes exactly these five sequences (storage name correct,
+records shifted). Wide `Chr($A997)`: truncates to the low byte — the engine's strings are
+ANSI. UTF-8 byte `Chr($EA)+…`: storage names and `SectionKeys` come out byte-perfect but
+every text record double-widens. No scripted construction remains; the cure is renaming
+the five once by hand in the AD UI. Until then `tests/golden_fidelity.rs` excuses exactly
+these five, by suffix (`FIXTURE_INCONSISTENT`).
 
 **Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
 footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its

--- a/scripts/altium/generate/GenerateSamples.pas
+++ b/scripts/altium/generate/GenerateSamples.pas
@@ -3052,6 +3052,25 @@ begin
     end;
 
 
+    { DOCUMENTED NEGATIVE (AD24, three runs, 2026-08-16): five of the symbols
+      below (_JV, _BN, _CR, _IU, _SB) are internally inconsistent in the saved
+      library NO MATTER how their words are constructed, and the damage is the
+      script ENGINE's, not this file's:
+
+      1. Source literals (this file's encoding is clean UTF-8): the engine
+         mis-decodes exactly these five sequences -- the CFB storage name comes
+         out correct while the text records hold a shifted string.
+      2. Wide Chr() (Chr($A997) + ...): Chr truncates to its LOW BYTE -- the
+         engine's strings are ANSI -- so every field degrades to byte garbage.
+      3. UTF-8 byte Chr() (Chr($EA) + Chr($A6) + ...): storage names and
+         SectionKeys come out byte-perfect, but every TEXT record re-encodes
+         the byte-chars as UTF-8, double-widening the name.
+
+      There is no scripted construction left to try: the engine either
+      mis-decodes the source or double-encodes the string. Fixing these five
+      requires renaming the symbols once by hand in the AD UI. Until then the
+      Rust side excuses exactly these five, by suffix, in
+      tests/golden_fidelity.rs (FIXTURE_INCONSISTENT). Do NOT retry Chr(). }
     { ---- I18N — one symbol per writing system, so a non-Latin name is a
       tested case rather than an assumption. See AddI18nSymbol for why the
       list is shaped the way it is. ---- }


### PR DESCRIPTION
Closes the fixture-regeneration question from #374/#375 with a verified answer: **it cannot be done from the script.** Three Altium runs today, three different failure shapes:

| Construction | Storage name / SectionKeys | Text records |
|---|---|---|
| Source literals (clean UTF-8 file) | ✅ correct | ❌ shifted string — the engine mis-decodes exactly these five sequences |
| Wide `Chr($A997) + …` | ❌ byte garbage | ❌ byte garbage — `Chr` truncates to its low byte; the engine's strings are ANSI |
| UTF-8 byte `Chr($EA) + Chr($A6) + …` | ✅ **byte-perfect** | ❌ double-widened — text records re-encode the byte-chars as UTF-8 |

The engine either mis-decodes the source or double-encodes the string; there is no scripted construction left. The cure is renaming the five symbols once by hand in the AD UI, which stays on the fixture worklist.

The committed goldens are untouched (restored to the merged state after the experiment runs); the `.pas` gains a `DOCUMENTED NEGATIVE` block at the i18n section — where any retry would start — and `COVERAGE_AUDIT.md` records the same, so `golden_fidelity`'s five-suffix `FIXTURE_INCONSISTENT` excusal keeps its justification on the record.

One incidental positive from run 3: the UTF-8-byte-`Chr` run proved our `SectionKeys`/storage-name pipeline handles a byte-built name perfectly — the file's storage names came out identical to the true UTF-8 encoding.

Full suite green (12 suites); no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)