### PR TITLE
fix(pcblib): stop inventing a MODEL block on extruded bodies

### DIFF
--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -32,10 +32,6 @@ a region) renumbers everything after it and silently re-points every later ident
 Attaching the GUID to the primitive it names would fix it, and touches eight primitive
 structs.
 
-**A `MODEL.*` block is invented for extruded bodies (`PcbLib`).** A component body with no
-embedded model gets a `MODEL.*` block including a freshly generated `MODELID`; Altium emits
-none.
-
 ## How to re-verify before trusting this
 
 An earlier edition went badly stale — 103 of its 129 entries named fields that had since

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -810,7 +810,7 @@ snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 | `BODYOPACITY3D` | 3D body opacity | `1.000` |
 | `IDENTIFIER` | Identifier (comma-separated codepoint list — deferred, emitted empty) | `` |
 | `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields (fixed defaults) | |
-| `MODELID` | Model GUID (synthesised for extruded bodies when absent) | `{GUID}` |
+| `MODELID` | Model GUID (model-backed bodies ONLY) | `{GUID}` |
 | `MODEL.CHECKSUM` | Model integrity checksum (round-tripped verbatim, see below) | `0` |
 | `MODEL.EMBED` | `TRUE` / `FALSE` | |
 | `MODEL.NAME` | Model filename | `RESC1005X04L.step` |
@@ -818,15 +818,15 @@ snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 | `MODEL.2D.ROTATION` | 2D rotation (degrees, 3 decimals) | `0.000` |
 | `MODEL.3D.ROTX/Y/Z` | 3D rotations (degrees, 3 decimals) | `0.000` |
 | `MODEL.3D.DZ` | Z offset (mil-suffixed) | `15.748mil` |
-| `MODEL.MODELTYPE` | `0` = extruded, `1` = model-backed (STEP) | |
-| `MODEL.EXTRUDED.MINZ` / `MAXZ` | Extrusion Z range (extruded bodies ONLY) | `0mil` / `15.748mil` |
-| `MODEL.MODELSOURCE` | Model source (model-backed bodies ONLY) | `Undefined` |
+| `MODEL.MODELTYPE` | `1` = model-backed (STEP) | |
+| `MODEL.MODELSOURCE` | Model source | `Undefined` |
 
 **Extruded vs model-backed:** a body with no model file (empty `MODEL.NAME`, not embedded) is a
-generic *extruded* body — `MODEL.MODELTYPE=0` plus `MODEL.EXTRUDED.MINZ/MAXZ` (the Z range Altium
-extrudes the outline between; without it the body has no volume and is discarded). A model-backed
-body uses `MODEL.MODELTYPE=1` plus `MODEL.MODELSOURCE=Undefined` instead. `ISSHAPEBASED` stays
-`FALSE` in both cases.
+generic *extruded* body, and its parameter string **ends at `TEXTUREROTATION` — no `MODEL.*`
+keys at all**, `MODELID` included: the golden's extruded bodies (`BODY3D`, `PRIMPROPS`) carry
+none, and the extrusion derives from `STANDOFFHEIGHT`/`OVERALLHEIGHT`. A model-backed body
+carries the whole `MODEL.*` group above with `MODEL.MODELTYPE=1`. `ISSHAPEBASED` stays `FALSE`
+in both cases.
 
 Unmodelled keys captured on read are re-emitted verbatim after the canonical set (with canonical
 duplicates dropped) so read-modify-write round-trips.

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1672,44 +1672,30 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     params.push("TEXTURESIZEY=0mil".to_string());
     params.push("TEXTUREROTATION= 0.00000000000000E+0000".to_string());
 
-    // Model reference. Extruded bodies have no model file but still need a model
-    // GUID, so synthesize one when the caller didn't supply it.
-    let model_id = if extruded && body.model_id.is_empty() {
-        format!("{{{}}}", uuid::Uuid::new_v4().to_string().to_uppercase())
-    } else {
-        body.model_id.clone()
-    };
-    params.push(format!("MODELID={model_id}"));
-    // Round-trip the stored checksum verbatim (default 0 keeps fresh output identical).
-    params.push(format!("MODEL.CHECKSUM={}", body.model_checksum));
-    params.push(format!(
-        "MODEL.EMBED={}",
-        if body.embedded { "TRUE" } else { "FALSE" }
-    ));
-    params.push(format!("MODEL.NAME={}", body.model_name));
-    params.push(format!("MODEL.2D.X={}", format_mil_coord(body.model_2d_x)));
-    params.push(format!("MODEL.2D.Y={}", format_mil_coord(body.model_2d_y)));
-    params.push(format!("MODEL.2D.ROTATION={:.3}", body.model_2d_rotation));
-    params.push(format!("MODEL.3D.ROTX={:.3}", body.rotation_x));
-    params.push(format!("MODEL.3D.ROTY={:.3}", body.rotation_y));
-    params.push(format!("MODEL.3D.ROTZ={:.3}", body.rotation_z));
-    params.push(format!("MODEL.3D.DZ={}", format_mil_coord(body.z_offset)));
-    // MODELTYPE 0 = Extruded (no model file); 1 = generic/STEP model.
-    let model_type = if extruded { "0" } else { "1" };
-    params.push(format!("MODEL.MODELTYPE={model_type}"));
-    if extruded {
-        // The extrusion itself: Z range from standoff (MINZ) to overall (MAXZ).
-        // This is what Altium actually extrudes the outline between; without it
-        // the body has no volume and is discarded on load.
+    // Model reference — only when there IS a model. The golden's extruded
+    // bodies (BODY3D, PRIMPROPS) end at TEXTUREROTATION with no MODEL keys at
+    // all — no MODELID, no MODEL.MODELTYPE, not even an EXTRUDED Z range: the
+    // extrusion derives from STANDOFFHEIGHT/OVERALLHEIGHT. We used to append
+    // the whole group anyway, inventing a fresh MODELID GUID per save, so an
+    // extruded body's record changed on every write and grew keys Altium never
+    // stores. Its STEP-backed EMBSTEP body carries exactly the group below.
+    if !extruded {
+        params.push(format!("MODELID={}", body.model_id));
+        // Round-trip the stored checksum verbatim.
+        params.push(format!("MODEL.CHECKSUM={}", body.model_checksum));
         params.push(format!(
-            "MODEL.EXTRUDED.MINZ={}",
-            format_mil_coord(body.standoff_height)
+            "MODEL.EMBED={}",
+            if body.embedded { "TRUE" } else { "FALSE" }
         ));
-        params.push(format!(
-            "MODEL.EXTRUDED.MAXZ={}",
-            format_mil_coord(body.overall_height)
-        ));
-    } else {
+        params.push(format!("MODEL.NAME={}", body.model_name));
+        params.push(format!("MODEL.2D.X={}", format_mil_coord(body.model_2d_x)));
+        params.push(format!("MODEL.2D.Y={}", format_mil_coord(body.model_2d_y)));
+        params.push(format!("MODEL.2D.ROTATION={:.3}", body.model_2d_rotation));
+        params.push(format!("MODEL.3D.ROTX={:.3}", body.rotation_x));
+        params.push(format!("MODEL.3D.ROTY={:.3}", body.rotation_y));
+        params.push(format!("MODEL.3D.ROTZ={:.3}", body.rotation_z));
+        params.push(format!("MODEL.3D.DZ={}", format_mil_coord(body.z_offset)));
+        params.push("MODEL.MODELTYPE=1".to_string());
         params.push("MODEL.MODELSOURCE=Undefined".to_string());
     }
 
@@ -3351,28 +3337,31 @@ mod tests {
 
     #[test]
     fn test_component_body_extruded_vs_model_params() {
-        // Generic extruded body: no model name, not embedded. Matches a real
-        // Altium-authored extruded body: ISSHAPEBASED=FALSE, MODELTYPE=0, a
-        // synthesized MODELID GUID, and the extrusion Z range via EXTRUDED.MIN/MAXZ.
+        // Generic extruded body: no model name, not embedded. The golden's own
+        // extruded bodies (BODY3D, PRIMPROPS) end at TEXTUREROTATION with NO
+        // MODEL keys at all — the extrusion derives from STANDOFFHEIGHT /
+        // OVERALLHEIGHT, and inventing a MODELID meant a fresh GUID per save.
         let mut extruded = ComponentBody::new("", "");
         extruded.embedded = false;
         extruded.overall_height = 1.0;
         extruded.standoff_height = 0.0;
         let s = build_component_body_params(&extruded);
         assert!(s.contains("ISSHAPEBASED=FALSE"), "got: {s}");
-        assert!(s.contains("MODEL.MODELTYPE=0"), "got: {s}");
-        assert!(s.contains("MODEL.EXTRUDED.MAXZ="), "got: {s}");
         assert!(
-            s.contains("MODELID={") && !s.contains("MODELID=|"),
+            s.ends_with("TEXTUREROTATION= 0.00000000000000E+0000"),
             "got: {s}"
         );
-        assert!(!s.contains("MODELSOURCE"), "got: {s}");
+        assert!(
+            !s.contains("MODEL"),
+            "no MODEL keys on an extruded body: {s}"
+        );
 
-        // Model-backed body (STEP) keeps the legacy shape/type, no extrusion range.
+        // Model-backed body (STEP): exactly the EMBSTEP golden's group.
         let mut model = ComponentBody::new("{GUID}", "part.step");
         model.embedded = true;
         let s = build_component_body_params(&model);
         assert!(s.contains("ISSHAPEBASED=FALSE"), "got: {s}");
+        assert!(s.contains("MODELID={GUID}"), "got: {s}");
         assert!(s.contains("MODEL.MODELTYPE=1"), "got: {s}");
         assert!(s.contains("MODEL.MODELSOURCE=Undefined"), "got: {s}");
         assert!(!s.contains("EXTRUDED"), "got: {s}");

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -277,6 +277,12 @@ fn encode_component_header(symbol: &Symbol) -> String {
         "Color=128".to_string(),          // Dark red outline
         format!("PartIDLocked={part_id_locked}"),
     ];
+    // Omitted at zero, like every zero-valued integer key: the golden's
+    // pinless symbols carry no AllPinCount key at all.
+    let parts: Vec<String> = parts
+        .into_iter()
+        .filter(|p| !(symbol.pins.is_empty() && p == "AllPinCount=0"))
+        .collect();
 
     // Leading pipe, NO trailing pipe (matches Altium's ParametersToString).
     format!("|{}", parts.join("|"))

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -261,6 +261,17 @@ fn block_divergences(golden: &[u8], ours: &[u8], label: &str) -> Vec<String> {
                 ));
             }
         }
+        // The other direction: a key we emit that Altium did not store is an
+        // invention, not fidelity — an extruded body used to grow a whole
+        // MODEL.* group (including a fresh MODELID GUID per save) that this
+        // loop never saw, because only golden-side keys were compared.
+        for (key, got) in &b[j] {
+            if !is_volatile_key(key) && !a[i].contains_key(key) {
+                out.push(format!(
+                    "{label}: {key} invented; ours={got:?}, golden omits it"
+                ));
+            }
+        }
     }
     for (i, used) in taken_g.iter().enumerate() {
         if !used {

--- a/tests/mcp_e2e.rs
+++ b/tests/mcp_e2e.rs
@@ -848,7 +848,7 @@ fn write_pcblib_component_body_fields_roundtrip() {
                 { "x": 1.0, "y": 1.0 }, { "x": -1.0, "y": 1.0 },
             ],
             "body_color_3d": 0xFF_0000, "body_opacity_3d": 0.5, "body_projection": 1,
-            "model_2d_rotation": 90.0, "is_shape_based": true, "kind": 2, "name": "BODY_A",
+            "is_shape_based": true, "kind": 2, "name": "BODY_A",
         }],
     });
     let write = h.call_tool(
@@ -873,7 +873,11 @@ fn write_pcblib_component_body_fields_roundtrip() {
     assert_eq!(i(bd, "body_color_3d"), 0xFF_0000, "body_color_3d");
     assert!(near(f(bd, "body_opacity_3d"), 0.5), "body_opacity_3d");
     assert_eq!(i(bd, "body_projection"), 1, "body_projection");
-    assert!(near(f(bd, "model_2d_rotation"), 90.0), "model_2d_rotation");
+    // model_2d_rotation is NOT asserted here: this body is extruded (outline,
+    // no model), and Altium stores the MODEL.* placement group only for
+    // model-backed bodies — the golden's extruded bodies carry no MODEL keys
+    // at all, so the field has nowhere to live in the file. It round-trips for
+    // STEP-backed bodies, where the group exists.
     assert!(b(bd, "is_shape_based"), "is_shape_based");
     assert_eq!(i(bd, "kind"), 2, "body kind");
     assert_eq!(s(bd, "name"), "BODY_A", "body name");


### PR DESCRIPTION
Closes the last entry in `COVERAGE_AUDIT.md` § Outstanding that was a writer defect (leaving only the ordinal-identity follow-up and the manual fixture rename).

## The defect

The golden's own extruded bodies (`BODY3D`, `PRIMPROPS`) end their parameter string at `TEXTUREROTATION`: **no `MODELID`, no `MODEL.MODELTYPE`, and no `MODEL.EXTRUDED` Z range** — the extrusion derives from `STANDOFFHEIGHT`/`OVERALLHEIGHT`. Our writer appended the whole `MODEL.*` group anyway, inventing a **fresh `MODELID` GUID on every save**, so an extruded body's record changed on every write and carried keys Altium never stores. The old comment claiming the `EXTRUDED` range was load-bearing ("without it the body has no volume and is discarded") is disproven by the golden. Model-backed bodies keep the full group — matching `EMBSTEP` key-for-key.

## Why the fidelity test never saw it — and what it caught once it could

`block_divergences` only walked **golden-side** keys, so any key *we* invent was structurally invisible. It now checks both directions: a key in our output that the golden omits is reported as `invented`. Run immediately, that surfaced a second invention on the SchLib side: **`AllPinCount=0` on every pinless symbol**, where Altium omits the key — now omitted at zero like every zero-valued integer key. Both goldens pass under the two-way comparison, so these two were the only inventions anywhere.

## One honest behaviour note

`model_2d_rotation` authored via MCP on an *extruded* body no longer round-trips — the format has nowhere to store placement for a modelless body. The e2e test that previously pinned our invention now documents this; the field still round-trips for STEP-backed bodies, where the `MODEL.*` group exists.

## Verification

- full suite green (12 suites), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean
- pyaltiumlib oracle: 13 passed, 0 regressions
- `PCBLIB_FORMAT.md` body table corrected (extruded bodies end at `TEXTUREROTATION`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)