### PR TITLE
ci: measure coverage on production code, excluding only main.rs

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -222,10 +222,18 @@ jobs:
                     rust-coverage-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-
 
             - name: Generate coverage report (lcov)
-              run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+              # main.rs is excluded from the metric, not from testing: the whole
+              # mcp_e2e suite drives the shipped binary through it, but
+              # instrumentation cannot see across the process boundary, so its
+              # lines read as uncovered no matter how tested they are. Everything
+              # else counts, including in-file #[cfg(test)] modules (their only
+              # uncovered lines are assertion-failure branches — noise that biases
+              # the number DOWN, which is the safe direction). Integration files
+              # under tests/ were never part of the report.
+              run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --ignore-filename-regex '(^|[/\\])main\.rs$'
 
             - name: Generate coverage summary
-              run: cargo llvm-cov report --summary-only
+              run: cargo llvm-cov report --summary-only --ignore-filename-regex '(^|[/\\])main\.rs$'
 
             - name: Save Rust cache
               if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -195,10 +195,18 @@ jobs:
                     rust-coverage-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-
 
             - name: Generate coverage report (lcov)
-              run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+              # main.rs is excluded from the metric, not from testing: the whole
+              # mcp_e2e suite drives the shipped binary through it, but
+              # instrumentation cannot see across the process boundary, so its
+              # lines read as uncovered no matter how tested they are. Everything
+              # else counts, including in-file #[cfg(test)] modules (their only
+              # uncovered lines are assertion-failure branches — noise that biases
+              # the number DOWN, which is the safe direction). Integration files
+              # under tests/ were never part of the report.
+              run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --ignore-filename-regex '(^|[/\\])main\.rs$'
 
             - name: Generate coverage summary
-              run: cargo llvm-cov report --summary-only
+              run: cargo llvm-cov report --summary-only --ignore-filename-regex '(^|[/\\])main\.rs$'
 
             # The token is mandatory (see ci_main.yml). Dependabot cannot read
             # secrets, so its PRs would fail the upload — skip them instead.


### PR DESCRIPTION
Implements the gate decision from #379's two findings, agreed with @MatejGomboc.

## What the measurement showed

- **`tests/` was never in the report** — llvm-cov only lists `src/` files, so the proposed test-file exclusion is a no-op and the moving-denominator effect is confined to in-file `#[cfg(test)]` modules.
- **In-file test modules stay counted**: their only uncovered lines are assertion-failure branches — noise that biases the number *down*, the safe direction to be wrong in. Excluding them would require a mass test-relocation refactor or nightly attributes; not worth it.
- **`main.rs` is the one real distortion**: 58/96 lines read uncovered even though the entire `mcp_e2e` suite drives the shipped binary through them — instrumentation can't see across the process boundary. Excluded from the *metric*, not from testing (anchored regex, both workflows, lcov + summary so Codecov and the console agree).

## The number and the path

Production metric on current `main`: **95.81% lines** (1,534 / 36,628). The 99% gate stays, measured this way. Remaining path: #379 (≈ +2.5 points), then the guard-then-read parser rework — dropping the redundant upfront length guards so each read's `ok_or_else` arm becomes live, reachable error handling instead of dead insurance (same behaviour, simpler code, and the arms become testable). That follow-up is open for @ande2407, who offered exactly this split.

Issue #302's status comment updated in place to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)