### PR TITLE
feat(pcblib): attach identities to primitives; prune TODO.md; pre-release plan

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,159 +1,60 @@
 # TODO — Working Notebook
 
-Durable task list for the post-reverse-engineering fix campaign and the on-site Altium tooling.
+Outstanding work only — shipped items are deleted, not struck through (git log is the
+record). The specialised worklists stay the single source of truth for their areas:
 
-> **Where the detail lives:** the full byte-level findings are preserved on the
-> `docs/format-re-findings` branch (and at `C:\tmp\re-out`); cross-session resume context is in the
-> `format-re-effort` memory. This file is the actionable to-do list, not the findings dump.
+| Area | Worklist |
+|------|----------|
+| Golden-fixture enrichment | `docs/FIXTURE_COVERAGE.md` |
+| Format parity + verified negatives | `docs/COVERAGE_AUDIT.md` § Outstanding |
+| Test-coverage climb + 99% gate | issue #302 (status comments, kept current in place) |
 
-## Status snapshot
+## A. Format / fidelity residue
 
-- Comprehensive byte-level RE complete: **48 PcbLib + 121 SchLib** verifier-confirmed discrepancies
-  and **~50 live-Altium gaps**. Answer key = AltiumSharp
-  (`git clone --depth 1 https://github.com/issus/AltiumSharp.git`).
-- Generated `.PcbLib` + `.SchLib` now **verified to open *and* render in real Altium 24** via the
-  on-site harness (PASS) — the ground truth, not just the proxy.
+- [ ] **Attach identities to primitives (`PcbLib`)** — `PrimitiveGuids` and unique ids are
+      keyed by the global ordinal, so they survive a read-modify-write but a *structural*
+      edit (delete a pad, insert a region) silently re-points every later identity. Fix:
+      `guid: Option<String>` on the eight primitive structs + rebuild the stream from
+      `write_sequence()`; replaces `Footprint::primitive_guids`. (The audit's last code item.)
+- [ ] **Footprint-model record fidelity (`SchLib` RECORD=45)** — three defects in
+      `encode_footprint_model`: `IsCurrent` is written as `index == 0` instead of the read
+      `model.is_current` (a symbol whose current footprint is the second model gets flipped);
+      `DatafileCount=1` is hardcoded (multi-datafile models unsupported); `UniqueID` is
+      regenerated every save instead of round-tripped.
+- [ ] **Audit `VOLATILE_KEYS` in `tests/golden_fidelity.rs`** — every entry excuses a value
+      from comparison; several may be identities Altium actually keeps stable across saves
+      (component `UniqueID`, `ITEMGUID`/`REVISIONGUID`) that we regenerate instead of
+      preserving. Settle each with a double-resave observation, then preserve the stable ones.
+- [ ] **Pad binary-block fidelity** — the golden fidelity diff compares parameter text, not
+      the pad's binary geometry blocks. Byte-diff the golden's pads against a rewrite to
+      settle the two old RE findings: oblong/oval SMD pads routing to the 651 size/shape
+      block, and the multi-entry full-stack tail (count > 1).
+- [ ] **`IDENTIFIER` codepoint list (`ComponentBody`)** — written empty; a non-empty value
+      (comma-separated codepoints) has no fixture. UI-only; candidate for the next
+      `manual/` authoring session.
 
----
+## B. Coverage (issue #302 owns the detail)
 
-## A. Format fix ladder (remaining RE findings)
-
-> Per-field detail is exhaustive in `{pcb,sch}_discrepancies.json` (on the `docs/format-re-findings`
-> branch). Below is **every record/area with outstanding work** so nothing is forgotten; severities:
-> 🔴 hard failure · 🟠 round-trip/data · ⚪ byte-cosmetic.
-
-### A1. PcbLib primitives (code bugs + missing features)
-
-- [ ] 🟠 **Pad** — remaining (golden / on-site / fidelity-gated): **multi-entry** full-stack
-      tail (count>1); oblong/oval SMD pads should route to the 651 size/shape block (golden
-      shows 651, we emit empty).
-
-### A2. PcbLib stream / container layer
-
-- [ ] ⚪ **PrimitiveGuids** sub-storage omitted; missing root streams (FileVersionInfo /
-      EmbeddedFonts / LayerKindMap) in the File-Structure tree.
-
-  *(SectionKeys + the non-empty WideStrings fidelity were triaged to §B — they need a real
-      golden `.PcbLib` to settle.)*
-
-### A3. SchLib records (code bugs + missing features)
-
-Outstanding SchLib field fidelity all needs an Altium-authored golden to settle — see §B.
-
----
-
-## B. Live-Altium gaps (~50) — now UNBLOCKED by the on-site harness
-
-- [ ] Use the committed `scripts/samples` goldens (`footprints.PcbLib` + `symbols.SchLib`, authored
-      on-site by `GenerateSamples.pas`) to settle the ~50 gaps the RE could not confirm: pad
-      cache/marker bytes, implementation datafile index base (0 vs 1), `OwnerIndex` on
-      RECORD=45/46/48, pin `FormalType` / SwapId aux-stream layouts, etc. (see
-      `{pcb,sch}_live_altium_gaps.json`).
-- [ ] 🔴 **SectionKeys** (long component names): format known (root stream, full-name→storage-key),
-      but the faithful fix is a coupled `Library/Data` full-name flip + reader-reorder lockstep with
-      an undecided `~NNN` collision rule — confirm the need against a real long-name `.PcbLib` first.
-- [ ] **WideStrings Tier 2**: text SubRecord-1 offset-115 `wideStringIndex`, the dot/empty-filtered
-      index base vs Altium's unfiltered, UTF-16-vs-Win1252 encoding, and the root-vs-per-component
-      reader path — needs a real multi-text footprint as the oracle.
-- [ ] **SchLib Component (RECORD=1) header fields**: remaining is the component `UniqueID`
-      (AltiumSharp carries it, but a fresh symbol would emit a brand-new random id — not
-      byte-identical; the golden headers also order it before `AreaColor` and omit `AllPinCount`
-      when 0) and the dropped header fields (`DesignItemId` / `ComponentKind` / `LibraryPath`
-      / `SheetPartFileName` / `IndexInSheet` / `OwnerPartId`) — need golden fixtures.
-- [ ] **SchLib Implementation structural**: `MapDefiner` (RECORD=47) pin→pad map, the 46/48 payload
-      bodies + cross-record `OwnerIndex` chain, honouring `IsCurrent` on write, `DataFileCount` > 1.
-- [ ] **PcbLib ComponentBody remaining**: `IDENTIFIER` (comma-separated codepoint list — would
-      misrender as a plain string), `MODEL.MODELTYPE`, `MODEL.SNAP*`, `TEXTURE`, and the non-default
-      unit-formatted values (`ARCRESOLUTION`/`CAVITYHEIGHT`/`MODEL.2D.X/Y`) — need a golden to
-      validate the formatting.
-- [ ] Feed confirmed answers back into the fix ladder (especially the pad, A3).
+- [ ] Land #379 (tool layer to ~98%+ on the production metric).
+- [ ] **Guard-then-read rework** (offered to ande2407): drop the redundant upfront length
+      guards in the `PcbLib` parsers so each read's `ok_or_else` arm becomes live, reachable
+      error handling — same behaviour, simpler, and the arms become testable.
+- [ ] Close the remainder to the 99% gate (production metric, `main.rs` excluded — see #381).
 
 ## C. On-site Altium tooling
 
-- [ ] *(Optional)* extend `Verify-Libraries.ps1` to assert primitive counts / specific properties,
-      not just "opened".
+- [ ] *(Optional)* extend `Verify-Libraries.ps1` to assert primitive counts / specific
+      properties, not just "opened".
 
 ## D. Release & distribution (no release exists yet)
 
-- [ ] Cut the **first tagged release** so non-Rust users get a prebuilt binary — everything is
-      release-ready (`CHANGELOG` carries the content under `[Unreleased]`; `release.yml` validates
-      the tag against `Cargo.toml`), but **the tag is deferred until the maintainer triggers it
-      personally**. Tag-day steps: stamp the changelog heading/date, `git tag v0.1.0`, push, watch
-      the Release workflow, verify artefacts.
+- [ ] Cut the **first tagged release** (v0.1.0) once the 99% gate is met — **maintainer
+      triggers it personally**. Tag-day steps: stamp the changelog heading/date,
+      `git tag v0.1.0`, push, watch the Release workflow, verify artefacts.
 - [ ] Consider a `.dxt` Claude Desktop extension for one-click install (pattern from
       coffeenmusic/altium-mcp).
 
-## F. Docs / AI workflow
+## E. Docs / AI workflow
 
-- [ ] Enrich `docs/AI_WORKFLOW.md` with symbol pin-placement guidance (idea from coffeenmusic's
-      `symbol_placement_rules.txt`).
-
----
-
-## G. Feature + fixture completeness audit (2026-07-08)
-
-**Goal:** *every* SchLib/PcbLib feature must be (1) implemented in the reader, (2) exercised by the
-`scripts/samples` goldens, (3) asserted by a `tests/samples_*` test. Close **ALL** gaps, not just
-high-value. Method: `cargo-llvm-cov` read-path coverage from the sample tests + primitive-set
-cross-reference against AltiumSharp DTOs (`C:\tmp\AltiumSharp`, the answer key).
-
-**Baseline read-path coverage from the sample tests** (`cargo llvm-cov test --test samples_schlib
---test samples_pcblib`): `schlib/reader.rs` 79.5% · `pcblib/reader/parsers.rs` 73.8% ·
-`pcblib/read_io.rs` 64.3% · `pcblib/reader/mod.rs` 49.3% · `schlib/pin_aux.rs` 43.4% ·
-`pcblib/reader/models.rs` **13.7%** · `pcblib/primitives/text.rs` **0%**. Every gap below is a
-concrete slice of those uncovered lines.
-
-### G1. SchLib — primitive set is COMPLETE ✓ (2026-07-11)
-
-Every record type that occurs in a real `.SchLib` is read, written, tool-exposed and
-golden-asserted (record IDs we handle: 1,2,3,4,5,6,7,8,9,10,11,12,13,14,28,30,34,41,44-48 +
-the `/Storage` embedded-image bytes). Scope check settled by enumerating record IDs across
-AltiumSharp's entire SchLib golden corpus — only `{1,4,6-14,28,34,41,44}` (+ binary pins)
-ever occur:
-
-- **OUT OF SCOPE (SchDoc-only, never occur in a symbol library — do NOT implement):**
-  `ParameterSet` (43), `Note` (209), `CompileMask` (211), `Hyperlink` (226) — verified absent
-  from every AltiumSharp SchLib golden and from `SchLibReader`'s expectations — plus Bus,
-  BusEntry, Wire, Junction, NetLabel, NoErc, Port, PowerObject, SheetEntry, SheetSymbol,
-  Template, Blanket, MapDefiner/List, Harness*, SignalHarness, Symbol(sheet).
-
-### G2. PcbLib — primitive set is COMPLETE ✓ (gaps are field-level, tracked in §A1)
-
-AltiumSharp `PcbLibReader` reads exactly: Arc, ComponentBody, Fill, Pad, Region, Text, Track, Via —
-which is precisely our set. **No missing PcbLib primitive.** Remaining PcbLib work is field-level
-(see §A1) plus the sample-coverage gaps in §G3.
-
-### G3. Sample-coverage gaps (feature implemented, golden never exercises it → low read coverage)
-
-Add each to `GenerateSamples.pas`, regenerate on-site, then assert exactly:
-
-- [ ] **3D STEP model** (`pcblib/reader/models.rs` 13.7%): `BODY3D` only has a plain *extruded* body.
-      Author a ComponentBody with an **embedded STEP model** (MODELID + model data stream) so the
-      Model/STEP read path (parse_component_body model block, `read_io` model-stream) is covered.
-- [ ] **Pad slot hole + tolerances** (`parsers.rs` ~1300/1370 uncovered): author a slot-hole pad
-      (`AddThPad` already has `eSlotHole`? verify it sets slot length @263 / hole rotation @267) and a
-      pad with drill tolerances.
-- [ ] **Pad thermal-relief / power-plane / mask** (batch-4 target): needs the `GetState_Cache`→
-      `SetState_Cache` pattern for mask expansion; corner-radius `CRPercentage[Layer]` crashes on a
-      fresh Simple pad — find the correct pad-stack init first (documented in `GenerateSamples.pas`).
-- [ ] **Via** net/power-plane/tenting + identity GUIDs — author a via carrying these.
-- [ ] **PcbLib Text** inverted-rect + barcode (`primitives/text.rs` 0%, `parsers.rs` ~1080-1105):
-      author an inverted (knockout) text and a barcode text.
-- [ ] **Region** cutout kinds beyond board-cutout; named region.
-- [ ] **Layer spread** (`reader/mod.rs` `layer_from_id` 379-484 mostly uncovered): the goldens place
-      primitives on only a few layers, so most `layer_from_id` arms never run — author primitives
-      across internal-plane / mechanical / drill / keepout layers (a single multi-layer footprint).
-- [ ] **SchLib** `IsNotAccesible=false` on Ellipse/Polyline; pin swap_id / part_and_sequence /
-      default_value at non-default values; multi-model Implementation (`DataFileCount>1`, `IsCurrent`).
-- [ ] **PcbLib primitive flags** (locked / keepout / tenting) at non-default on each 2D primitive.
-
-### G4. Execution plan
-
-1. **Close the remaining §G1 gap** (Pie, Image incl. embedded `/Storage` bytes, and TextFrame are
-   done): the in-scope verification of `ParameterSet`/`Hyperlink`/`Note`/`CompileMask`.
-2. **Enrich the generator** (§G3) with the un-exercised features — one on-site regenerate per batch
-   (kill `X2` between runs; a bad scripting name is a *compile* abort, a bad call can be a *runtime*
-   ScriptingSystem.DLL crash — see the `altium-delphiscript-api-names` memory).
-3. **Add exact `tests/samples_*` assertions** for every newly-exercised field; re-measure coverage
-   until the reader modules approach 100%.
-4. Fold in the §A1 field-level PcbLib gaps as their own format-EE PRs.
+- [ ] Enrich `docs/AI_WORKFLOW.md` with symbol pin-placement guidance (idea from
+      coffeenmusic's `symbol_placement_rules.txt`).

--- a/TODO.md
+++ b/TODO.md
@@ -11,11 +11,6 @@ record). The specialised worklists stay the single source of truth for their are
 
 ## A. Format / fidelity residue
 
-- [ ] **Attach identities to primitives (`PcbLib`)** — `PrimitiveGuids` and unique ids are
-      keyed by the global ordinal, so they survive a read-modify-write but a *structural*
-      edit (delete a pad, insert a region) silently re-points every later identity. Fix:
-      `guid: Option<String>` on the eight primitive structs + rebuild the stream from
-      `write_sequence()`; replaces `Footprint::primitive_guids`. (The audit's last code item.)
 - [ ] **Footprint-model record fidelity (`SchLib` RECORD=45)** — three defects in
       `encode_footprint_model`: `IsCurrent` is written as `index == 0` instead of the read
       `model.is_current` (a symbol whose current footprint is the second model gets flipped);
@@ -48,9 +43,10 @@ record). The specialised worklists stay the single source of truth for their are
 
 ## D. Release & distribution (no release exists yet)
 
-- [ ] Cut the **first tagged release** (v0.1.0) once the 99% gate is met — **maintainer
-      triggers it personally**. Tag-day steps: stamp the changelog heading/date,
-      `git tag v0.1.0`, push, watch the Release workflow, verify artefacts.
+- [ ] Cut **v0.1.0 as a pre-release** once §A above is complete (decision 2026-08-16) —
+      the 99% coverage climb continues calmly afterwards and stops gating the release.
+      **Maintainer triggers it personally.** Tag-day steps: stamp the changelog
+      heading/date, `git tag v0.1.0`, push, watch the Release workflow, verify artefacts.
 - [ ] Consider a `.dxt` Claude Desktop extension for one-click install (pattern from
       coffeenmusic/altium-mcp).
 

--- a/TODO.md
+++ b/TODO.md
@@ -44,9 +44,11 @@ record). The specialised worklists stay the single source of truth for their are
 ## D. Release & distribution (no release exists yet)
 
 - [ ] Cut **v0.1.0 as a pre-release** once §A above is complete (decision 2026-08-16) —
-      the 99% coverage climb continues calmly afterwards and stops gating the release.
-      **Maintainer triggers it personally.** Tag-day steps: stamp the changelog
+      **maintainer triggers it personally**. Tag-day steps: stamp the changelog
       heading/date, `git tag v0.1.0`, push, watch the Release workflow, verify artefacts.
+- [ ] **v1.0.0 is the real release**, gated on ALL features built and **99% test
+      coverage** (production metric, #381). The climb between the two happens calmly —
+      neither gate blocks the other's work.
 - [ ] Consider a `.dxt` Claude Desktop extension for one-click install (pattern from
       coffeenmusic/altium-mcp).
 

--- a/docs/COVERAGE_AUDIT.md
+++ b/docs/COVERAGE_AUDIT.md
@@ -26,14 +26,6 @@ keys are ANSI `?` husks; real names in raw-UTF-8 `%UTF8%` twins; pin names only 
 suffix (`FIXTURE_INCONSISTENT` in `tests/golden_fidelity.rs`); never open-and-save that
 golden in AD (see `scripts/samples/README.md`).
 
-**Identity streams are keyed by ordinal, not attached to the primitive (`PcbLib`).** A
-footprint's `PrimitiveGuids` records and its unique ids both name a primitive by its
-position among all the footprint's primitives. That position is preserved across a
-read-modify-write, so both survive one — but a *structural* edit (deleting a pad, inserting
-a region) renumbers everything after it and silently re-points every later identity.
-Attaching the GUID to the primitive it names would fix it, and touches eight primitive
-structs.
-
 ## How to re-verify before trusting this
 
 An earlier edition went badly stale — 103 of its 129 entries named fields that had since

--- a/scripts/altium/generate/requirements.txt
+++ b/scripts/altium/generate/requirements.txt
@@ -1,0 +1,1 @@
+TODO: fill out this

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -135,17 +135,13 @@ pub struct Footprint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_3d: Option<Model3D>,
 
-    /// Altium's per-primitive GUIDs, from the footprint's `PrimitiveGuids`
-    /// stream, preserved in read order.
-    ///
-    /// These are the stable identities Altium uses to recognise a primitive
-    /// across edits; dropping them makes every primitive look new. They are held
-    /// as read rather than attached to the primitives themselves, so a
-    /// read-modify-write that leaves the primitive collections alone reproduces
-    /// them exactly. Adding or removing a primitive shifts the ordinals, and the
-    /// writer drops any entry that no longer points at a primitive.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub primitive_guids: Vec<PrimitiveGuid>,
+    /// Altium's stable identity for the footprint record itself — the
+    /// `PrimitiveGuids` stream's kind-85 entry. Each primitive's own identity
+    /// rides on the primitive (`guid` on all eight primitive structs), so a
+    /// structural edit moves identities with their primitives; this field
+    /// carries the one identity that names no primitive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 
     /// The order the primitives are stored in, one entry per primitive.
     ///
@@ -201,6 +197,39 @@ impl PrimitiveKind {
         Self::ComponentBody,
     ];
 
+    /// Altium's numeric object id for this kind, as a `PrimitiveGuids`
+    /// record stores it.
+    #[must_use]
+    pub const fn altium_object_id(self) -> u32 {
+        match self {
+            Self::Arc => 1,
+            Self::Pad => 2,
+            Self::Via => 3,
+            Self::Track => 4,
+            Self::Text => 5,
+            Self::Fill => 6,
+            Self::Region => 89,
+            Self::ComponentBody => 90,
+        }
+    }
+
+    /// The kind for one of Altium's numeric object ids, or `None` for an id
+    /// that names no library primitive (85 is the footprint record itself).
+    #[must_use]
+    pub const fn from_altium_object_id(id: u32) -> Option<Self> {
+        match id {
+            1 => Some(Self::Arc),
+            2 => Some(Self::Pad),
+            3 => Some(Self::Via),
+            4 => Some(Self::Track),
+            5 => Some(Self::Text),
+            6 => Some(Self::Fill),
+            89 => Some(Self::Region),
+            90 => Some(Self::ComponentBody),
+            _ => None,
+        }
+    }
+
     /// The `PRIMITIVEOBJECTID` token Altium writes for this kind in a
     /// `UniqueIDPrimitiveInformation` record.
     #[must_use]
@@ -218,7 +247,11 @@ impl PrimitiveKind {
     }
 }
 
-/// One `PrimitiveGuids` record: which primitive it names, and its GUID.
+/// One `PrimitiveGuids` record as it sits in the stream.
+///
+/// Which primitive it names, and its GUID. Parse/emit carrier only — the
+/// identities themselves live on the primitives (`guid`) and on
+/// [`Footprint::guid`].
 ///
 /// The stream is a `u32` count followed by that many 24-byte records of
 /// `[object_kind: u32][ordinal: u32][guid: 16 bytes, little-endian]`.
@@ -337,7 +370,7 @@ impl Footprint {
             fills: Vec::new(),
             component_bodies: Vec::new(),
             model_3d: None,
-            primitive_guids: Vec::new(),
+            guid: None,
             primitive_order: Vec::new(),
         }
     }
@@ -1102,6 +1135,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
         original.add_text(Text {
             barcode_full_width: None,
@@ -1139,6 +1173,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encoding should succeed");
@@ -1204,6 +1239,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encode");
@@ -1257,6 +1293,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encode");
@@ -1311,6 +1348,7 @@ mod tests {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 unique_id: None,
+                guid: None,
             },
             None,
         );
@@ -1383,6 +1421,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encode");
@@ -1444,6 +1483,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
         original.add_text(text.clone());
         text.text = ".Comment".to_string();
@@ -1584,6 +1624,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encode");
@@ -1652,6 +1693,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encoding should succeed");
@@ -1712,6 +1754,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
 
         let mut fp = Footprint::new("LONG_TEXT");
@@ -1893,6 +1936,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: 4,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encoding should succeed");
@@ -2003,6 +2047,7 @@ mod tests {
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,
+            guid: None,
         });
 
         let data = writer::encode_data_stream(&original).expect("encoding should succeed");
@@ -2078,6 +2123,7 @@ mod tests {
             layer: Layer::Top3DBody,
             outline: vec![(-2.0, 1.0), (-2.0, -1.0), (2.0, -1.0), (2.0, 1.0)],
             unique_id: None,
+            guid: None,
             model_checksum: 7_654_321,
             name: " ".to_string(),
             kind: 0,
@@ -2150,6 +2196,7 @@ mod tests {
                 layer: Layer::Top3DBody,
                 outline: Vec::new(), // exercise the synthesised-bbox fallback
                 unique_id: None,
+                guid: None,
                 model_checksum: 0,
                 name: " ".to_string(),
                 kind: 0,

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -134,6 +134,14 @@ pub struct ComponentBody {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 
     /// Model integrity checksum (Altium `MODEL.CHECKSUM`). Round-tripped verbatim —
     /// never recomputed, because the checksum is over the raw (uncompressed) model
@@ -268,6 +276,7 @@ impl ComponentBody {
             layer: Layer::Top3DBody,
             outline: Vec::new(),
             unique_id: None,
+            guid: None,
             model_checksum: 0,
             name: default_body_name(),
             kind: 0,

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -255,6 +255,14 @@ pub struct Pad {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 
     /// Per-pad identity GUID — extended-tail bytes @126-141 ("GUID-A"), read
     /// back verbatim as a braced uppercase GUID string (Windows little-endian
@@ -376,6 +384,7 @@ impl Pad {
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),
             unique_id: None,
+            guid: None,
             identity_guid: None,
             identity_guid_b: None,
         }
@@ -430,6 +439,7 @@ impl Pad {
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),
             unique_id: None,
+            guid: None,
             identity_guid: None,
             identity_guid_b: None,
         }
@@ -796,6 +806,14 @@ pub struct Via {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 }
 
 /// Default thermal relief gap (10 mils = 0.254mm).
@@ -863,6 +881,7 @@ impl Via {
             solder_mask_expansion_from_hole_edge: false,
             drill_layer_pair_type: DrillLayerPairType::Through,
             unique_id: None,
+            guid: None,
         }
     }
 
@@ -904,6 +923,7 @@ impl Via {
             solder_mask_expansion_from_hole_edge: false,
             drill_layer_pair_type: DrillLayerPairType::Through,
             unique_id: None,
+            guid: None,
         }
     }
 }

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -78,6 +78,14 @@ pub struct Track {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
     /// Solder mask expansion in mm. `None` (the default) writes 0; preserved
     /// when reading an Altium-authored track (round-trip fidelity, #113).
     #[serde(
@@ -107,6 +115,7 @@ impl Track {
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),
             unique_id: None,
+            guid: None,
             solder_mask_expansion: None,
             keepout_restrictions: None,
         }
@@ -148,6 +157,7 @@ impl Track {
 ///     polygon_index: 0xFFFF,
 ///     component_index: -1,
 ///     unique_id: None,
+///     guid: None,
 ///     solder_mask_expansion: None,
 ///     keepout_restrictions: None,
 /// };
@@ -192,6 +202,14 @@ pub struct Arc {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
     /// Solder mask expansion in mm. `None` (the default) writes 0; preserved
     /// when reading an Altium-authored arc (round-trip fidelity, #113).
     #[serde(
@@ -222,6 +240,7 @@ impl Arc {
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),
             unique_id: None,
+            guid: None,
             solder_mask_expansion: None,
             keepout_restrictions: None,
         }
@@ -335,6 +354,14 @@ pub struct Region {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
     /// The `V7_LAYER` token exactly as Altium wrote it, kept only when it names
     /// a different layer than [`Self::layer`].
     ///
@@ -416,6 +443,7 @@ impl Default for Region {
             union_index: 0,
             is_shape_based: false,
             unique_id: None,
+            guid: None,
             additional_parameters: Vec::new(),
         }
     }

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -272,6 +272,14 @@ pub struct Text {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 }
 
 /// A filled rectangle on a layer.
@@ -323,6 +331,14 @@ pub struct Fill {
     /// Unique ID assigned by Altium (8-character alphanumeric string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// Altium's stable identity for this primitive, from the footprint's
+    /// `PrimitiveGuids` stream (`{XXXXXXXX-…}`), or `None` for a primitive
+    /// with no recorded identity (anything built from scratch). Riding on the
+    /// primitive itself, the identity follows it through structural edits —
+    /// deleting a neighbour cannot re-point it, which the old footprint-level
+    /// ordinal list could not guarantee.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<String>,
 }
 
 impl Fill {
@@ -343,6 +359,7 @@ impl Fill {
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,
+            guid: None,
         }
     }
 
@@ -365,6 +382,7 @@ impl Fill {
             solder_mask_expansion: None,
             keepout_restrictions: None,
             unique_id: None,
+            guid: None,
         }
     }
 }

--- a/src/altium/pcblib/read_io.rs
+++ b/src/altium/pcblib/read_io.rs
@@ -457,11 +457,19 @@ impl PcbLib {
             Self::parse_primitives(&mut footprint, &data, &wide_strings);
         }
 
-        // PrimitiveGuids holds Altium's stable per-primitive identity. Losing it
-        // makes every primitive look new to Altium after a rewrite.
+        // PrimitiveGuids holds Altium's stable per-primitive identity, keyed
+        // by the primitive's ordinal among ALL the footprint's primitives in
+        // Data-stream order — which right after parsing is exactly the
+        // sequence `write_sequence()` yields. Each identity is attached to the
+        // primitive it names (with the record's kind cross-checked, so a
+        // foreign file with a shifted ordinal base mis-attaches nothing);
+        // kind 85 is the footprint record's own identity.
         let guid_path = storage_path.join("PrimitiveGuids/Data");
         if let Some(guid_data) = crate::altium::read_stream_opt(cfb, &guid_path) {
-            footprint.primitive_guids = reader::parse_primitive_guids(&guid_data);
+            reader::apply_primitive_guids(
+                &mut footprint,
+                &reader::parse_primitive_guids(&guid_data),
+            );
         }
 
         // Read UniqueIDPrimitiveInformation stream if present (contains unique IDs for primitives)

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -267,6 +267,49 @@ pub fn parse_primitive_guids(data: &[u8]) -> Vec<crate::altium::pcblib::Primitiv
         .collect()
 }
 
+/// Attaches parsed `PrimitiveGuids` records to the primitives they name.
+///
+/// A record's `index` is the primitive's ordinal among all the footprint's
+/// primitives in Data-stream order; called right after parsing, that order is
+/// exactly what [`Footprint::write_sequence`] yields. The record's kind must
+/// agree with the primitive found at the ordinal or the record is skipped —
+/// a foreign file whose ordinal base does not line up mis-attaches nothing.
+/// Kind 85 names the footprint record itself.
+pub fn apply_primitive_guids(
+    footprint: &mut Footprint,
+    records: &[crate::altium::pcblib::PrimitiveGuid],
+) {
+    use crate::altium::pcblib::PrimitiveKind;
+
+    let sequence = footprint.write_sequence();
+    for record in records {
+        if record.object_kind == 85 {
+            footprint.guid = Some(record.guid.clone());
+            continue;
+        }
+        let Some(kind) = PrimitiveKind::from_altium_object_id(record.object_kind) else {
+            continue;
+        };
+        let Some(&(seq_kind, index)) = sequence.get(record.index as usize) else {
+            continue;
+        };
+        if seq_kind != kind {
+            continue;
+        }
+        let guid = Some(record.guid.clone());
+        match kind {
+            PrimitiveKind::Arc => footprint.arcs[index].guid = guid,
+            PrimitiveKind::Pad => footprint.pads[index].guid = guid,
+            PrimitiveKind::Via => footprint.vias[index].guid = guid,
+            PrimitiveKind::Track => footprint.tracks[index].guid = guid,
+            PrimitiveKind::Text => footprint.text[index].guid = guid,
+            PrimitiveKind::Region => footprint.regions[index].guid = guid,
+            PrimitiveKind::Fill => footprint.fills[index].guid = guid,
+            PrimitiveKind::ComponentBody => footprint.component_bodies[index].guid = guid,
+        }
+    }
+}
+
 /// Formats 16 GUID bytes as `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`.
 ///
 /// The first three fields are little-endian, the last two are byte order as

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -341,6 +341,7 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         component_index,
         flags,
         unique_id: None,
+        guid: None,
         identity_guid,
         identity_guid_b,
     };
@@ -609,6 +610,7 @@ pub(super) fn parse_via(data: &[u8], offset: usize) -> ParseResult<Via> {
         per_layer_diameters,
         flags,
         unique_id: None,
+        guid: None,
     };
 
     Ok((via, next))
@@ -687,6 +689,7 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
         polygon_index,
         component_index,
         unique_id: None,
+        guid: None,
         solder_mask_expansion,
         keepout_restrictions,
     };
@@ -761,6 +764,7 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
         polygon_index,
         component_index,
         unique_id: None,
+        guid: None,
         solder_mask_expansion,
         keepout_restrictions,
     };
@@ -1005,6 +1009,7 @@ pub(super) fn parse_text(
         polygon_index,
         component_index,
         unique_id: None,
+        guid: None,
         barcode_full_width,
         barcode_full_height,
         barcode_x_margin: barcode_margin_x,
@@ -1331,6 +1336,7 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
         union_index,
         is_shape_based,
         unique_id: None,
+        guid: None,
         additional_parameters,
     };
 
@@ -1438,6 +1444,7 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
         solder_mask_expansion,
         keepout_restrictions,
         unique_id: None,
+        guid: None,
     };
 
     Ok((fill, current))
@@ -1449,6 +1456,14 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
 /// A `ComponentBody` is a single size-prefixed block (matching `AltiumSharp` and
 /// the `BODY_3D` golden libraries): the layer/flags header, a C-string
 /// parameter block, then the 2D outline polygon — all within the one block.
+/// The `MODEL.CHECKSUM` value, round-tripped verbatim (0 when absent).
+fn parse_model_checksum(params: &std::collections::HashMap<String, String>) -> i64 {
+    params
+        .get("MODEL.CHECKSUM")
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(0)
+}
+
 pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<ComponentBody> {
     // The single block holds the header, parameters and outline.
     let (block0, current) = read_block(data, offset).ok_or_else(|| {
@@ -1502,10 +1517,7 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
 
     // MODEL.CHECKSUM is a plain integer. Round-trip it verbatim
     // (0 = default/valid) — it is not recomputed from the model bytes here.
-    let model_checksum = params
-        .get("MODEL.CHECKSUM")
-        .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or(0);
+    let model_checksum = parse_model_checksum(&params);
 
     // The body's layer is the CommonPrimitiveData layer byte at block offset 0 — the
     // authoritative source, exactly as AltiumSharp does (`result.Layer = layer`,
@@ -1580,6 +1592,7 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         layer,
         outline,
         unique_id: None,
+        guid: None,
         model_checksum,
         name,
         kind,

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -182,6 +182,7 @@ impl PcbLib {
                 layer: Layer::Top3DBody,
                 outline: Vec::new(), // Synthesised from the footprint extent on write
                 unique_id: None,
+                guid: None,
                 model_checksum: 0, // Fresh embed; Altium computes the real checksum on save.
                 name: " ".to_string(),
                 kind: 0,
@@ -627,7 +628,9 @@ impl PcbLib {
         if let Some(guid_data) = writer::encode_primitive_guids(footprint) {
             let guid_storage = format!("{storage_path}/PrimitiveGuids");
             crate::altium::create_storage(cfb, &guid_storage)?;
-            let count = u32::try_from(footprint.primitive_guids.len()).unwrap_or(u32::MAX);
+            // Header = record count; the data is fixed 24-byte records, so the
+            // count is exactly what was emitted.
+            let count = u32::try_from(guid_data.len() / 24).unwrap_or(u32::MAX);
             crate::altium::write_stream(
                 cfb,
                 &format!("{guid_storage}/Header"),

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -1918,20 +1918,43 @@ fn encode_unique_id_record(
 /// first three fields little-endian. A malformed GUID string is skipped rather
 /// than written as zeroes, which would claim an identity Altium never issued.
 ///
+/// Rebuilt from the primitives themselves: each carries its own `guid`, and
+/// its ordinal is its position in [`Footprint::write_sequence`] — so a
+/// structural edit (delete a pad, insert a region) moves every identity WITH
+/// its primitive instead of re-pointing the survivors. The footprint record's
+/// own identity (kind 85) leads, then the primitives in ordinal order; Altium
+/// scrambles its record order, but the records are keyed, not positional.
+///
 /// Nothing is emitted for a from-scratch footprint: it has no identities to
 /// preserve, and inventing them would make every save produce different bytes.
 pub fn encode_primitive_guids(footprint: &Footprint) -> Option<Vec<u8>> {
-    if footprint.primitive_guids.is_empty() {
-        return None;
+    let mut out = Vec::new();
+    let mut push = |kind: u32, ordinal: usize, guid: &str| {
+        if let Some(bytes) = parse_guid(guid) {
+            out.extend_from_slice(&kind.to_le_bytes());
+            #[allow(clippy::cast_possible_truncation)] // primitive counts are small
+            out.extend_from_slice(&(ordinal as u32).to_le_bytes());
+            out.extend_from_slice(&bytes);
+        }
+    };
+
+    if let Some(guid) = &footprint.guid {
+        push(85, 0, guid);
     }
-    let mut out = Vec::with_capacity(footprint.primitive_guids.len() * 24);
-    for entry in &footprint.primitive_guids {
-        let Some(bytes) = parse_guid(&entry.guid) else {
-            continue;
+    for (ordinal, (kind, index)) in footprint.write_sequence().into_iter().enumerate() {
+        let guid = match kind {
+            PrimitiveKind::Arc => &footprint.arcs[index].guid,
+            PrimitiveKind::Pad => &footprint.pads[index].guid,
+            PrimitiveKind::Via => &footprint.vias[index].guid,
+            PrimitiveKind::Track => &footprint.tracks[index].guid,
+            PrimitiveKind::Text => &footprint.text[index].guid,
+            PrimitiveKind::Region => &footprint.regions[index].guid,
+            PrimitiveKind::Fill => &footprint.fills[index].guid,
+            PrimitiveKind::ComponentBody => &footprint.component_bodies[index].guid,
         };
-        out.extend_from_slice(&entry.object_kind.to_le_bytes());
-        out.extend_from_slice(&entry.index.to_le_bytes());
-        out.extend_from_slice(&bytes);
+        if let Some(guid) = guid {
+            push(kind.altium_object_id(), ordinal, guid);
+        }
     }
     (!out.is_empty()).then_some(out)
 }
@@ -2210,6 +2233,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
         let geom = encode_text_geometry(&text, None);
         assert_eq!(geom[40], 0x01, "IsComment @40");
@@ -2301,6 +2325,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
         let geom = encode_text_geometry(&text, None);
         assert_eq!(
@@ -2373,6 +2398,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
         let geom = encode_text_geometry(&text, None);
         assert_eq!(geom[110], 0x01, "IsInverted @110");
@@ -3628,6 +3654,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         };
         let mut fp = Footprint::new("WS");
         fp.add_text(mk("AB")); // bytes 65, 66

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -1579,6 +1579,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             unique_id: None,
+            guid: None,
         }
     }
 
@@ -2343,6 +2344,7 @@ mod tests {
                 layer: Layer::Top3DBody,
                 outline: Vec::new(),
                 unique_id: None,
+                guid: None,
                 model_checksum: 0,
                 name: " ".to_string(),
                 kind: 0,

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -618,6 +618,7 @@ mod tests {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 unique_id: None,
+                guid: None,
             }
         }
 

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -1760,6 +1760,7 @@ mod tests {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 unique_id: None,
+                guid: None,
             });
             lib.add(fp);
             lib.save(path).expect("Failed to create rich PcbLib");

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -123,6 +123,12 @@ fn json_unique_id(json: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Reads a primitive's Altium identity GUID from its JSON, so a
+/// read-modify-write that passes through the tool layer keeps it.
+fn json_guid(json: &Value) -> Option<String> {
+    json.get("guid").and_then(Value::as_str).map(str::to_string)
+}
+
 /// Accepted pad-shape spellings, quoted in every shape error so the two tools
 /// give identical guidance.
 pub const PAD_SHAPE_HELP: &str = "Valid shapes are: rectangle, round (or circle), \
@@ -449,6 +455,7 @@ impl McpServer {
             component_index: json_component_index(json),
             flags: json_flags(json),
             unique_id: json_unique_id(json),
+            guid: json_guid(json),
             identity_guid,
             identity_guid_b,
         })
@@ -556,6 +563,7 @@ impl McpServer {
             polygon_index: json_polygon_index(json),
             component_index: json_component_index(json),
             unique_id: json_unique_id(json),
+            guid: json_guid(json),
             // Optional EE tail (mirrors the modelled optionals; absent keys keep
             // the default `None` so a from-scratch arc is byte-identical).
             solder_mask_expansion: json_f64(json, "solder_mask_expansion"),
@@ -682,6 +690,7 @@ impl McpServer {
             union_index,
             is_shape_based,
             unique_id: text_field("unique_id"),
+            guid: text_field("guid"),
             additional_parameters,
         })
     }
@@ -812,6 +821,7 @@ impl McpServer {
             polygon_index: json_polygon_index(json),
             component_index: json_component_index(json),
             unique_id: json_unique_id(json),
+            guid: json_guid(json),
             barcode_full_width: json_f64(json, "barcode_full_width"),
             barcode_full_height: json_f64(json, "barcode_full_height"),
             barcode_x_margin: json_f64(json, "barcode_x_margin"),
@@ -900,6 +910,7 @@ impl McpServer {
                 .get("unique_id")
                 .and_then(Value::as_str)
                 .map(str::to_string),
+            guid: json_guid(body_json),
             model_checksum: body_json
                 .get("model_checksum")
                 .and_then(Value::as_i64)

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -789,6 +789,7 @@ impl McpServer {
                             layer: Layer::Top3DBody,
                             outline: Vec::new(),
                             unique_id: None,
+                            guid: None,
                             model_checksum: 0, // External reference: no embedded model.
                             name: " ".to_string(),
                             kind: 0,
@@ -927,6 +928,7 @@ impl McpServer {
                     polygon_index: 0xFFFF,
                     component_index: -1,
                     unique_id: None,
+                    guid: None,
                 });
             }
 
@@ -955,6 +957,7 @@ impl McpServer {
                     layer: Layer::Top3DBody,
                     outline: Vec::new(),
                     unique_id: None,
+                    guid: None,
                     model_checksum: 0,
                     name: " ".to_string(),
                     kind: 0,
@@ -2485,6 +2488,7 @@ mod tests {
             layer: Layer::Top3DBody,
             outline: Vec::new(),
             unique_id: None,
+            guid: None,
             model_checksum: 0,
             name: " ".to_string(),
             kind: 0,

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -181,6 +181,7 @@ fn pcblib_file_roundtrip_all_primitives() {
         polygon_index: 0xFFFF,
         component_index: -1,
         unique_id: None,
+        guid: None,
     };
     fp.add_text(text);
 
@@ -923,6 +924,7 @@ fn pcblib_roundtrip_preserves_numeric_silkscreen_text() {
         polygon_index: 0xFFFF,
         component_index: -1,
         unique_id: None,
+        guid: None,
     };
 
     let mut lib = PcbLib::new();

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -344,30 +344,43 @@ fn pcblib_golden_survives_a_round_trip() {
         );
     }
 
-    // 4. The identity streams, byte for byte. Both key a primitive by its
-    //    ordinal among all of the footprint's primitives, and a block-level
-    //    diff cannot see a reordering. `PrimitiveGuids` is replayed as read, so
-    //    equality there means the replay is intact; the unique-id records are
-    //    rebuilt from the write sequence, so equality there means the order the
-    //    ordinals refer to survived.
+    // 4. The identity streams. Both key a primitive by its ordinal among all
+    //    of the footprint's primitives, and a block-level diff cannot see a
+    //    reordering. The unique-id records are rebuilt in ordinal order, which
+    //    is also the order Altium stores them — compared byte for byte.
+    //    PrimitiveGuids records are keyed (kind, ordinal, guid) but Altium
+    //    scrambles their order in the stream while our writer emits them
+    //    canonically, so they are compared as record SETS: same identities on
+    //    the same primitives, which is the property that matters.
     for (canonical, g_path) in &before {
-        if !canonical.ends_with("primitiveguids/data")
-            && !canonical.ends_with("uniqueidprimitiveinformation/data")
-        {
-            continue;
-        }
         if is_known(canonical) {
             continue;
         }
-        let g = stream_bytes(&src, g_path).expect("walked stream exists");
-        match after.get(canonical).and_then(|p| stream_bytes(&out, p)) {
-            Some(o) if o == g => {}
-            Some(o) => failures.push(format!(
-                "{canonical} differs: {} bytes golden, {} ours",
-                g.len(),
-                o.len()
-            )),
-            None => failures.push(format!("{canonical} was not written back")),
+        if canonical.ends_with("uniqueidprimitiveinformation/data") {
+            let g = stream_bytes(&src, g_path).expect("walked stream exists");
+            match after.get(canonical).and_then(|p| stream_bytes(&out, p)) {
+                Some(o) if o == g => {}
+                Some(o) => failures.push(format!(
+                    "{canonical} differs: {} bytes golden, {} ours",
+                    g.len(),
+                    o.len()
+                )),
+                None => failures.push(format!("{canonical} was not written back")),
+            }
+        } else if canonical.ends_with("primitiveguids/data") {
+            let records = |bytes: &[u8]| -> std::collections::BTreeSet<Vec<u8>> {
+                bytes.chunks_exact(24).map(<[u8]>::to_vec).collect()
+            };
+            let g = stream_bytes(&src, g_path).expect("walked stream exists");
+            match after.get(canonical).and_then(|p| stream_bytes(&out, p)) {
+                Some(o) if records(&o) == records(&g) => {}
+                Some(o) => failures.push(format!(
+                    "{canonical} records differ: {} golden, {} ours",
+                    g.len() / 24,
+                    o.len() / 24
+                )),
+                None => failures.push(format!("{canonical} was not written back")),
+            }
         }
     }
 

--- a/tests/samples_pcblib.rs
+++ b/tests/samples_pcblib.rs
@@ -1006,46 +1006,36 @@ fn samples_pcblib_text_stroke_fonts() {
     assert_eq!(serif.stroke_font, Some(StrokeFont::Serif), "FontID 3");
 }
 
+/// A borrowed list of per-primitive identity GUIDs, one entry per primitive.
+type GuidList<'a> = Vec<&'a Option<String>>;
+
 #[test]
 fn samples_pcblib_primitive_guids_survive_a_rewrite() {
     let src = sample("footprints.PcbLib");
     let mut lib = PcbLib::open(&src).expect("failed to open footprints.PcbLib");
 
-    // Altium gives every primitive a stable GUID in the footprint's
-    // PrimitiveGuids stream and uses it to recognise that primitive across
-    // edits. We used to read none of it and write none of it, so a
-    // read-modify-write handed Altium a library in which everything looked new.
+    // Identities ride on the primitives themselves, so a structural edit moves
+    // them with their primitive instead of re-pointing the survivors. ARCS: two
+    // arcs, each with its own GUID, plus the footprint record's own (kind 85).
     let arcs = lib.get("ARCS").expect("ARCS footprint not found");
-    assert!(
-        !arcs.primitive_guids.is_empty(),
-        "ARCS carries per-primitive GUIDs"
+    let (a, b) = (
+        arcs.arcs[0].guid.as_deref().expect("arc 0 carries a GUID"),
+        arcs.arcs[1].guid.as_deref().expect("arc 1 carries a GUID"),
     );
-    // Object kind 1 is an arc and 85 is the footprint record itself; the index
-    // counts within the kind, so two arcs give indices 0 and 1.
-    let arc_ids: Vec<u32> = arcs
-        .primitive_guids
-        .iter()
-        .filter(|g| g.object_kind == 1)
-        .map(|g| g.index)
-        .collect();
-    assert_eq!(
-        arc_ids,
-        vec![0, 1],
-        "one GUID per arc, indexed within the kind"
-    );
-    assert!(
-        arcs.primitive_guids.iter().any(|g| g.object_kind == 85),
-        "the footprint record has a GUID of its own"
-    );
-    for guid in &arcs.primitive_guids {
+    assert_ne!(a, b, "each arc has its own identity");
+    for guid in [a, b] {
         assert!(
-            guid.guid.starts_with('{') && guid.guid.ends_with('}') && guid.guid.len() == 38,
-            "GUID is brace-wrapped and 36 characters wide, got {:?}",
-            guid.guid
+            guid.starts_with('{') && guid.ends_with('}') && guid.len() == 38,
+            "GUID is brace-wrapped and 36 characters wide, got {guid:?}"
         );
     }
+    assert!(
+        arcs.guid.is_some(),
+        "the footprint record has a GUID of its own"
+    );
 
-    // The point of reading them is writing them back unchanged.
+    // The point of reading them is writing them back unchanged — on every
+    // primitive of every footprint.
     let dir = tempfile::tempdir().expect("tempdir");
     let out = dir.path().join("rewritten.PcbLib");
     lib.save(&out).expect("write the library back");
@@ -1056,10 +1046,59 @@ fn samples_pcblib_primitive_guids_survive_a_rewrite() {
             .get(&footprint.name)
             .unwrap_or_else(|| panic!("{} missing after rewrite", footprint.name));
         assert_eq!(
-            after.primitive_guids, footprint.primitive_guids,
-            "{}: primitive GUIDs changed across a rewrite",
+            after.guid, footprint.guid,
+            "{}: footprint GUID",
             footprint.name
         );
+        let pairs: [(&str, GuidList, GuidList); 8] = [
+            (
+                "arcs",
+                footprint.arcs.iter().map(|p| &p.guid).collect(),
+                after.arcs.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "pads",
+                footprint.pads.iter().map(|p| &p.guid).collect(),
+                after.pads.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "vias",
+                footprint.vias.iter().map(|p| &p.guid).collect(),
+                after.vias.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "tracks",
+                footprint.tracks.iter().map(|p| &p.guid).collect(),
+                after.tracks.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "text",
+                footprint.text.iter().map(|p| &p.guid).collect(),
+                after.text.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "regions",
+                footprint.regions.iter().map(|p| &p.guid).collect(),
+                after.regions.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "fills",
+                footprint.fills.iter().map(|p| &p.guid).collect(),
+                after.fills.iter().map(|p| &p.guid).collect(),
+            ),
+            (
+                "bodies",
+                footprint.component_bodies.iter().map(|p| &p.guid).collect(),
+                after.component_bodies.iter().map(|p| &p.guid).collect(),
+            ),
+        ];
+        for (kind, before_guids, after_guids) in pairs {
+            assert_eq!(
+                after_guids, before_guids,
+                "{}: {kind} GUIDs changed across a rewrite",
+                footprint.name
+            );
+        }
     }
 }
 
@@ -1480,83 +1519,71 @@ fn samples_pcblib_golden_survives_a_read_modify_write() {
 }
 
 #[test]
-fn samples_pcblib_read_order_matches_the_guid_ordinals() {
-    // Altium's object ids, as they appear in a PrimitiveGuids record.
-    fn kind_of(object_kind: u32) -> Option<PrimitiveKind> {
-        match object_kind {
-            1 => Some(PrimitiveKind::Arc),
-            2 => Some(PrimitiveKind::Pad),
-            3 => Some(PrimitiveKind::Via),
-            4 => Some(PrimitiveKind::Track),
-            5 => Some(PrimitiveKind::Text),
-            6 => Some(PrimitiveKind::Fill),
-            89 => Some(PrimitiveKind::Region),
-            90 => Some(PrimitiveKind::ComponentBody),
-            // 85 is the footprint record itself, which is not a primitive and
-            // sits outside the ordinal space (always index 0).
-            _ => None,
-        }
-    }
+fn samples_pcblib_every_guid_record_attaches_to_its_primitive() {
+    use std::io::Read as _;
 
-    // PrimitiveGuids keys each GUID by the primitive's ordinal among ALL of the
-    // footprint's primitives — not among its own kind. Checking our read order
-    // against that ordinal space is a cross-check between two independent
-    // streams of the same file: if they disagreed, every GUID we write back
-    // would name a different primitive than Altium meant.
-    let lib = PcbLib::open(sample("footprints.PcbLib")).expect("failed to open footprints.PcbLib");
+    // The stream keys each GUID by the primitive's ordinal among ALL of the
+    // footprint's primitives. The reader attaches each record to the primitive
+    // at that ordinal (kind cross-checked), so for the golden — whose ordinal
+    // space is known-good — every non-85 record must land: the multiset of
+    // attached GUIDs equals the multiset in the raw stream.
+    let path = sample("footprints.PcbLib");
+    let lib = PcbLib::open(&path).expect("failed to open footprints.PcbLib");
+    let file = std::fs::File::open(&path).expect("open");
+    let mut cfb = cfb::CompoundFile::open(file).expect("parse OLE");
 
     let mut checked = 0;
-    let mut interleaved = 0;
     for footprint in lib.iter() {
-        if footprint.primitive_guids.is_empty() {
+        let stream = format!("/{}/PrimitiveGuids/Data", footprint.name);
+        let Ok(mut s) = cfb.open_stream(&stream) else {
             continue;
-        }
-        let mut by_ordinal: Vec<(u32, PrimitiveKind)> = footprint
-            .primitive_guids
-            .iter()
-            .filter_map(|g| kind_of(g.object_kind).map(|k| (g.index, k)))
+        };
+        let mut raw = Vec::new();
+        s.read_to_end(&mut raw).expect("read stream");
+
+        // Raw records: [kind: u32][ordinal: u32][guid: 16 bytes].
+        let mut stream_guids: Vec<(u32, [u8; 16])> = raw
+            .chunks_exact(24)
+            .map(|r| {
+                let kind = u32::from_le_bytes([r[0], r[1], r[2], r[3]]);
+                let mut g = [0u8; 16];
+                g.copy_from_slice(&r[8..24]);
+                (kind, g)
+            })
             .collect();
-        by_ordinal.sort_unstable_by_key(|&(ordinal, _)| ordinal);
+        stream_guids.retain(|&(kind, _)| kind != 85);
 
-        let ordinals: Vec<u32> = by_ordinal.iter().map(|&(o, _)| o).collect();
+        let mut attached: Vec<&str> = footprint
+            .arcs
+            .iter()
+            .map(|p| p.guid.as_deref())
+            .chain(footprint.pads.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.vias.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.tracks.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.text.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.regions.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.fills.iter().map(|p| p.guid.as_deref()))
+            .chain(footprint.component_bodies.iter().map(|p| p.guid.as_deref()))
+            .flatten()
+            .collect();
+        attached.sort_unstable();
+
         assert_eq!(
-            ordinals,
-            (0..u32::try_from(by_ordinal.len()).expect("footprint fits u32")).collect::<Vec<_>>(),
-            "{}: PrimitiveGuids ordinals are a permutation of 0..n-1",
+            attached.len(),
+            stream_guids.len(),
+            "{}: every non-85 record must attach to exactly one primitive",
             footprint.name
         );
-
-        let from_guids: Vec<PrimitiveKind> = by_ordinal.into_iter().map(|(_, k)| k).collect();
-        assert_eq!(
-            footprint.primitive_order, from_guids,
-            "{}: the order we read the primitives in must be the order the \
-             GUID ordinals describe",
+        assert!(
+            footprint.guid.is_some(),
+            "{}: the kind-85 record becomes the footprint's own GUID",
             footprint.name
         );
-
-        // A footprint whose kinds come out in blocks would pass the check above
-        // even if we grouped by type, so at least one has to actually interleave
-        // for this to be worth anything.
-        let mut seen: Vec<PrimitiveKind> = Vec::new();
-        if from_guids.windows(2).any(|w| w[0] != w[1]) {
-            for kind in &from_guids {
-                if seen.last() != Some(kind) {
-                    if seen.contains(kind) {
-                        interleaved += 1;
-                        break;
-                    }
-                    seen.push(*kind);
-                }
-            }
-        }
         checked += 1;
     }
-
-    assert!(checked >= 20, "only {checked} footprints carried GUIDs");
     assert!(
-        interleaved > 0,
-        "no golden footprint interleaves its primitive kinds, so this test \
-         cannot tell a preserved order from a type-grouped one"
+        checked >= 20,
+        "only {checked} footprints carried GUID streams"
     );
 }
 

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -576,6 +576,7 @@ fn test_text_special_strings() {
         polygon_index: 0xFFFF,
         component_index: -1,
         unique_id: None,
+        guid: None,
     };
     fp.add_text(text1);
 
@@ -616,6 +617,7 @@ fn test_text_special_strings() {
         polygon_index: 0xFFFF,
         component_index: -1,
         unique_id: None,
+        guid: None,
     };
     fp.add_text(text2);
 
@@ -872,6 +874,7 @@ fn test_component_body_roundtrip() {
         layer: Layer::TopLayer,
         outline: Vec::new(),
         unique_id: None,
+        guid: None,
         model_checksum: 0,
         name: " ".to_string(),
         kind: 0,
@@ -934,6 +937,7 @@ fn test_component_body_with_rotation() {
         layer: Layer::TopLayer,
         outline: Vec::new(),
         unique_id: None,
+        guid: None,
         model_checksum: 0,
         name: " ".to_string(),
         kind: 0,
@@ -2766,6 +2770,7 @@ fn test_component_body_external_model_reference() {
         layer: Layer::Top3DBody,
         outline: Vec::new(),
         unique_id: None,
+        guid: None,
         model_checksum: 0,
         name: " ".to_string(),
         kind: 0,


### PR DESCRIPTION
Two commits: the TODO.md prune, and the last §A-blocking code item.

## Identities ride on their primitives now

`PrimitiveGuids` records were an opaque footprint-level list keyed by `(kind, ordinal)` — fine across a read-modify-write, silently re-pointed by any *structural* edit (delete a pad and every later identity names the wrong primitive). Now:

- each of the eight primitive structs carries `guid: Option<String>`; the footprint keeps only the kind-85 record's GUID (`Footprint::guid`);
- the reader attaches each record to the primitive at its ordinal, kind cross-checked (a foreign file with a shifted base mis-attaches nothing);
- the writer rebuilds the stream from the primitives via `write_sequence()` — so identities move **with** their primitives through any edit;
- the MCP JSON path passes `guid` through like `unique_id`, so tool-level RMW keeps identities too.

Altium scrambles its record order while we emit canonically, so `golden_fidelity` compares `PrimitiveGuids` as keyed-record **sets** (same identities on the same primitives — the property that matters); `UniqueIDPrimitiveInformation` stays byte-compared. Samples tests now assert per-primitive across all eight kinds, plus: every non-85 record in the golden's raw streams attaches to exactly one primitive.

## TODO.md pruned

Outstanding work only; the shipped RE/fixture/fidelity campaigns deleted. Two kept items were live-verified first — `encode_footprint_model` really does write `IsCurrent` as `index == 0` (next §A item), and the pad binary blocks have never been byte-diffed against the golden.

## Release plan (per @MatejGomboc, 2026-08-16)

**v0.1.0 ships as a pre-release once TODO.md §A completes** — remaining: footprint-model record fidelity, `VOLATILE_KEYS` audit, pad binary-block byte-diff, `IDENTIFIER` (manual-fixture candidate). The 99% coverage climb continues calmly afterwards and no longer gates the release. §D carries the tag-day steps.

`scripts/altium/generate/requirements.txt` is Matej's, pairing the new `.venv` convention with the generate scripts.

## Verification

Full suite green (12 suites incl. #379's 1,013 lib tests), clippy `-D warnings`, fmt, `cargo doc`, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)