### PR TITLE
fix(mcp): replay all fidelity fields through the tool-layer JSON boundary

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -49,6 +49,7 @@ pub use primitives::{
     Arc, ComponentBody, DrillLayerPairType, EmbeddedModel, Fill, HoleShape, Layer,
     MaskExpansionMode, Model3D, Pad, PadShape, PadStackMode, PcbFlags, PowerPlaneConnectStyle,
     Region, RegionKind, StrokeFont, Text, TextJustification, TextKind, Track, Vertex, Via,
+    ViaStackMode,
 };
 
 use crate::altium::error::{AltiumError, AltiumResult};

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -889,7 +889,7 @@ impl McpServer {
                             .collect()
                     };
 
-                    json!({
+                    let mut fp_json = json!({
                         "name": fp.name,
                         "description": fp.description,
                         "pads": pads,
@@ -901,7 +901,18 @@ impl McpServer {
                         "text": fp.text,
                         "model_3d": fp.model_3d,
                         "component_bodies": fp.component_bodies,
-                    })
+                    });
+                    // Footprint-level fidelity fields, mirroring the struct's
+                    // serde shape (present only when carried) — export→import
+                    // is the backup/restore loop, so the kind-85 identity and
+                    // the interleaved stream order must survive it.
+                    if let Some(guid) = &fp.guid {
+                        fp_json["guid"] = json!(guid);
+                    }
+                    if !fp.primitive_order.is_empty() {
+                        fp_json["primitive_order"] = json!(fp.primitive_order);
+                    }
+                    fp_json
                 })
                 .collect();
 
@@ -975,10 +986,13 @@ impl McpServer {
             let symbols: Vec<Value> = library
                 .iter()
                 .map(|symbol| {
-                    json!({
+                    let mut sym_json = json!({
                         "name": symbol.name,
                         "description": symbol.description,
                         "designator": symbol.designator,
+                        "designator_x": symbol.designator_x,
+                        "designator_y": symbol.designator_y,
+                        "designator_unique_id": symbol.designator_unique_id,
                         "part_count": symbol.part_count,
                         "display_mode_count": symbol.display_mode_count,
                         "current_part_id": symbol.current_part_id,
@@ -1002,7 +1016,13 @@ impl McpServer {
                         "text": symbol.text,
                         "parameters": symbol.parameters,
                         "footprints": symbol.footprints,
-                    })
+                    });
+                    // The interleaved record order, mirroring the struct's
+                    // serde shape — export→import must not regroup records.
+                    if !symbol.primitive_order.is_empty() {
+                        sym_json["primitive_order"] = json!(symbol.primitive_order);
+                    }
+                    sym_json
                 })
                 .collect();
 
@@ -1692,6 +1712,115 @@ mod tests {
     }
 
     // ==================== import_library ====================
+
+    /// Export → import is the backup/restore loop, so the footprint's kind-85
+    /// identity and interleaved stream order must survive it — pinned here
+    /// end-to-end against the reopened imported file.
+    #[test]
+    fn export_import_round_trips_pcblib_fidelity_fields() {
+        use crate::altium::pcblib::{Layer, Pad, PrimitiveKind, Track};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        // Track before pad: a non-canonical order no grouped rewrite keeps.
+        let mut fp = Footprint::new("FID");
+        fp.guid = Some("{11111111-2222-3333-4444-555555555555}".to_string());
+        fp.add_track(Track::new(-1.0, -1.0, 1.0, -1.0, 0.2, Layer::TopOverlay));
+        fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+        let mut lib = PcbLib::new();
+        lib.add(fp);
+        let src = dir.path().join("FidSrc.PcbLib");
+        lib.save(&src).unwrap();
+
+        let exported = parse_result_json(&server.call_export_library(&json!({
+            "filepath": src.to_string_lossy(),
+            "format": "json",
+        })));
+        assert_eq!(
+            exported["footprints"][0]["primitive_order"],
+            json!(["track", "pad"]),
+            "export carries the interleaved order"
+        );
+        assert!(
+            exported["footprints"][0]["guid"].is_string(),
+            "export carries the footprint guid"
+        );
+
+        let out = dir.path().join("FidDst.PcbLib");
+        let result = server.call_import_library(&json!({
+            "output_path": out.to_string_lossy(),
+            "json_data": {
+                "file_type": "PcbLib",
+                "footprints": exported["footprints"],
+            },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+
+        let reopened = PcbLib::open(&out).unwrap();
+        let fp = reopened.iter().next().unwrap();
+        assert_eq!(
+            fp.guid.as_deref(),
+            Some("{11111111-2222-3333-4444-555555555555}")
+        );
+        assert_eq!(
+            fp.primitive_order,
+            vec![PrimitiveKind::Track, PrimitiveKind::Pad]
+        );
+    }
+
+    /// The `SchLib` flavour: designator position/identity and the interleaved
+    /// record order survive export → import.
+    #[test]
+    fn export_import_round_trips_schlib_designator_and_order() {
+        use crate::altium::schlib::{Line, SchPrimitiveKind};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        // The designator position rides inside the designator record, which
+        // is only written when the designator text is non-empty — as in any
+        // real symbol.
+        let mut symbol = Symbol::new("FID");
+        symbol.designator = "U?".to_string();
+        symbol.designator_x = 5.5;
+        symbol.designator_y = -3.5;
+        symbol.add_line(Line::new(0.0, 0.0, 10.0, 10.0));
+        symbol.add_pin(Pin::new("IN", "1", 0, 0, 10, PinOrientation::Left));
+        let mut lib = SchLib::new();
+        lib.add(symbol);
+        let src = dir.path().join("FidSrc.SchLib");
+        lib.save(&src).unwrap();
+
+        let exported = parse_result_json(&server.call_export_library(&json!({
+            "filepath": src.to_string_lossy(),
+            "format": "json",
+        })));
+        assert_eq!(
+            exported["symbols"][0]["primitive_order"],
+            json!(["line", "pin"]),
+            "export carries the interleaved order"
+        );
+
+        let out = dir.path().join("FidDst.SchLib");
+        let result = server.call_import_library(&json!({
+            "output_path": out.to_string_lossy(),
+            "json_data": {
+                "file_type": "SchLib",
+                "symbols": exported["symbols"],
+            },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+
+        let reopened = SchLib::open(&out).unwrap();
+        let symbol = reopened.iter().next().unwrap();
+        assert!((symbol.designator_x - 5.5).abs() < 1e-9);
+        assert!((symbol.designator_y - (-3.5)).abs() < 1e-9);
+        assert_eq!(
+            symbol.primitive_order,
+            vec![SchPrimitiveKind::Line, SchPrimitiveKind::Pin]
+        );
+    }
 
     #[test]
     fn import_library_pcblib_round_trips_an_export() {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -129,6 +129,26 @@ fn json_guid(json: &Value) -> Option<String> {
     json.get("guid").and_then(Value::as_str).map(str::to_string)
 }
 
+/// Reads a base64-encoded byte field: the raw replay bases `read_pcblib`
+/// emits (a pad's `raw_tail`, a via's `raw_block`, a text's `raw_geometry`)
+/// and embedded image bytes. Passing one back through the tool layer keeps
+/// the write byte-identical to the source block. Invalid base64 is treated
+/// as absent (this parser is lenient Option-style throughout) with a debug
+/// log for diagnosis; the writer then falls back to its captured template,
+/// so the write still succeeds semantically.
+fn json_base64(json: &Value, key: &str) -> Option<Vec<u8>> {
+    json.get(key).and_then(Value::as_str).and_then(|s| {
+        use base64::Engine as _;
+        match base64::engine::general_purpose::STANDARD.decode(s.as_bytes()) {
+            Ok(bytes) => Some(bytes),
+            Err(e) => {
+                tracing::debug!(error = %e, key, "invalid base64; ignoring");
+                None
+            }
+        }
+    })
+}
+
 /// Reads an optional verbatim string field from a primitive's JSON.
 fn json_guidless_opt(json: &Value, key: &str) -> Option<String> {
     json.get(key).and_then(Value::as_str).map(str::to_string)
@@ -461,7 +481,7 @@ impl McpServer {
             flags: json_flags(json),
             unique_id: json_unique_id(json),
             guid: json_guid(json),
-            raw_tail: None,
+            raw_tail: json_base64(json, "raw_tail"),
             identity_guid,
             identity_guid_b,
         })
@@ -513,6 +533,7 @@ impl McpServer {
         track.solder_mask_expansion = json_f64(json, "solder_mask_expansion");
         track.keepout_restrictions = json_keepout(json);
         track.unique_id = json_unique_id(json);
+        track.guid = json_guid(json);
         Ok(track)
     }
 
@@ -844,7 +865,7 @@ impl McpServer {
             component_index: json_component_index(json),
             unique_id: json_unique_id(json),
             guid: json_guid(json),
-            raw_geometry: None,
+            raw_geometry: json_base64(json, "raw_geometry"),
             barcode_full_width: json_f64(json, "barcode_full_width"),
             barcode_full_height: json_f64(json, "barcode_full_height"),
             barcode_x_margin: json_f64(json, "barcode_x_margin"),
@@ -1166,6 +1187,8 @@ impl McpServer {
 
         via.flags = json_flags(json);
         via.unique_id = json_unique_id(json);
+        via.guid = json_guid(json);
+        via.raw_block = json_base64(json, "raw_block");
 
         Ok(via)
     }
@@ -1219,6 +1242,7 @@ impl McpServer {
         fill.solder_mask_expansion = json.get("solder_mask_expansion").and_then(Value::as_f64);
         fill.keepout_restrictions = json_keepout(json);
         fill.unique_id = json_unique_id(json);
+        fill.guid = json_guid(json);
 
         Ok(fill)
     }
@@ -1920,21 +1944,8 @@ impl McpServer {
             .unwrap_or_default()
             .to_string();
         // Base64-encoded raw image bytes destined for the library /Storage
-        // stream. Invalid base64 is treated as absent (this parser is lenient
-        // Option-style throughout), with a debug log for diagnosis.
-        let image_data = json
-            .get("image_data")
-            .and_then(Value::as_str)
-            .and_then(|s| {
-                use base64::Engine as _;
-                match base64::engine::general_purpose::STANDARD.decode(s.as_bytes()) {
-                    Ok(bytes) => Some(bytes),
-                    Err(e) => {
-                        tracing::debug!(error = %e, "invalid base64 in image_data; ignoring");
-                        None
-                    }
-                }
-            });
+        // stream.
+        let image_data = json_base64(json, "image_data");
         let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Image {
@@ -2894,6 +2905,71 @@ mod tests {
         }))
         .expect("via should parse");
         assert_eq!(via.unique_id, None);
+    }
+
+    #[test]
+    fn json_base64_decodes_and_ignores_invalid() {
+        // "AAEC" is [0, 1, 2]; invalid base64 and absent keys both read None,
+        // so the writer falls back to its template instead of erroring.
+        assert_eq!(
+            super::json_base64(&json!({ "raw": "AAEC" }), "raw"),
+            Some(vec![0u8, 1, 2])
+        );
+        assert_eq!(super::json_base64(&json!({ "raw": "!!!" }), "raw"), None);
+        assert_eq!(super::json_base64(&json!({}), "raw"), None);
+    }
+
+    #[test]
+    fn parse_pad_preserves_raw_tail() {
+        let pad = McpServer::parse_pad(&json!({
+            "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5,
+            "raw_tail": "AAECAwQ=",
+        }))
+        .expect("pad should parse");
+        assert_eq!(pad.raw_tail.as_deref(), Some(&[0u8, 1, 2, 3, 4][..]));
+    }
+
+    #[test]
+    fn parse_via_preserves_guid_and_raw_block() {
+        let via = McpServer::parse_via(&json!({
+            "x": 0.0, "y": 0.0, "diameter": 0.6, "hole_size": 0.3,
+            "guid": "{01234567-89AB-CDEF-0123-456789ABCDEF}",
+            "raw_block": "BQYH",
+        }))
+        .expect("via should parse");
+        assert_eq!(
+            via.guid.as_deref(),
+            Some("{01234567-89AB-CDEF-0123-456789ABCDEF}")
+        );
+        assert_eq!(via.raw_block.as_deref(), Some(&[5u8, 6, 7][..]));
+    }
+
+    #[test]
+    fn parse_text_preserves_raw_geometry() {
+        let text = McpServer::parse_text(&json!({
+            "text": "REF", "x": 0.0, "y": 0.0, "height": 1.0, "layer": "Top Overlay",
+            "raw_geometry": "CAkK",
+        }))
+        .expect("text should parse");
+        assert_eq!(text.raw_geometry.as_deref(), Some(&[8u8, 9, 10][..]));
+    }
+
+    #[test]
+    fn parse_track_and_fill_preserve_guid() {
+        let guid = "{FEDCBA98-7654-3210-FEDC-BA9876543210}";
+        let track = McpServer::parse_track(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.2,
+            "layer": "Top Overlay", "guid": guid,
+        }))
+        .expect("track should parse");
+        assert_eq!(track.guid.as_deref(), Some(guid));
+
+        let fill = McpServer::parse_fill(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0,
+            "layer": "Top Layer", "guid": guid,
+        }))
+        .expect("fill should parse");
+        assert_eq!(fill.guid.as_deref(), Some(guid));
     }
 
     #[test]

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -1035,7 +1035,7 @@ impl McpServer {
     #[allow(clippy::too_many_lines)] // Via has many optional fields requiring individual parsing
     pub(crate) fn parse_via(json: &Value) -> Result<crate::altium::pcblib::Via, String> {
         use crate::altium::pcblib::{
-            DrillLayerPairType, Layer, MaskExpansionMode, PowerPlaneConnectStyle, Via,
+            DrillLayerPairType, Layer, MaskExpansionMode, PowerPlaneConnectStyle, Via, ViaStackMode,
         };
 
         let x = json
@@ -1183,6 +1183,26 @@ impl McpServer {
         }
         if let Some(v) = json.get("hole_negative_tolerance").and_then(Value::as_f64) {
             via.hole_negative_tolerance = Some(v);
+        }
+
+        if let Some(v) = json
+            .get("solder_mask_expansion_back")
+            .and_then(Value::as_f64)
+        {
+            via.solder_mask_expansion_back = Some(v);
+        }
+        via.diameter_stack_mode = match json
+            .get("diameter_stack_mode")
+            .and_then(Value::as_str)
+            .map(str::to_lowercase)
+            .as_deref()
+        {
+            Some("top_middle_bottom") => ViaStackMode::TopMiddleBottom,
+            Some("full_stack") => ViaStackMode::FullStack,
+            _ => ViaStackMode::Simple,
+        };
+        if let Some(diameters) = json.get("per_layer_diameters").and_then(Value::as_array) {
+            via.per_layer_diameters = Some(diameters.iter().filter_map(Value::as_f64).collect());
         }
 
         via.flags = json_flags(json);
@@ -2927,6 +2947,33 @@ mod tests {
         }))
         .expect("pad should parse");
         assert_eq!(pad.raw_tail.as_deref(), Some(&[0u8, 1, 2, 3, 4][..]));
+    }
+
+    #[test]
+    fn parse_via_reads_diameter_stack_and_back_mask() {
+        use crate::altium::pcblib::ViaStackMode;
+        let via = McpServer::parse_via(&json!({
+            "x": 0.0, "y": 0.0, "diameter": 0.6, "hole_size": 0.3,
+            "diameter_stack_mode": "full_stack",
+            "per_layer_diameters": [0.6, 0.7, 0.8],
+            "solder_mask_expansion_back": 0.05,
+        }))
+        .expect("via should parse");
+        assert_eq!(via.diameter_stack_mode, ViaStackMode::FullStack);
+        assert_eq!(
+            via.per_layer_diameters.as_deref(),
+            Some(&[0.6, 0.7, 0.8][..])
+        );
+        assert_eq!(via.solder_mask_expansion_back, Some(0.05));
+
+        // Absent -> struct defaults, so a from-scratch via is unchanged.
+        let plain = McpServer::parse_via(&json!({
+            "x": 0.0, "y": 0.0, "diameter": 0.6, "hole_size": 0.3,
+        }))
+        .expect("via should parse");
+        assert_eq!(plain.diameter_stack_mode, ViaStackMode::Simple);
+        assert_eq!(plain.per_layer_diameters, None);
+        assert_eq!(plain.solder_mask_expansion_back, None);
     }
 
     #[test]

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -170,6 +170,21 @@ impl McpServer {
             }
         }
 
+        // Footprint-level replay fields, mirroring the create path: the
+        // kind-85 identity and the interleaved stream order a
+        // get_component → update_component loop echoes back.
+        if let Some(g) = fp_json.get("guid").and_then(Value::as_str) {
+            footprint.guid = Some(g.to_string());
+        }
+        if let Some(order) = fp_json.get("primitive_order") {
+            match serde_json::from_value(order.clone()) {
+                Ok(kinds) => footprint.primitive_order = kinds,
+                Err(e) => {
+                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                }
+            }
+        }
+
         // Reject out-of-range / non-finite geometry before it can saturate in
         // from_mm() on save. The create path validates here; this path skipped
         // it (parallels the #102 update_pad/update_primitive bug). Runs in
@@ -386,6 +401,27 @@ impl McpServer {
         }
         if let Some(v) = sym_json.get("target_file_name").and_then(Value::as_str) {
             symbol.target_file_name = v.to_string();
+        }
+        // Designator position/identity and the interleaved record order,
+        // mirroring the create path: a get_component → update_component loop
+        // echoes them back, and dropping any of them moved the designator or
+        // regrouped the records.
+        if let Some(x) = sym_json.get("designator_x").and_then(Value::as_f64) {
+            symbol.designator_x = x;
+        }
+        if let Some(y) = sym_json.get("designator_y").and_then(Value::as_f64) {
+            symbol.designator_y = y;
+        }
+        if let Some(uid) = sym_json.get("designator_unique_id").and_then(Value::as_str) {
+            symbol.designator_unique_id = Some(uid.to_string());
+        }
+        if let Some(order) = sym_json.get("primitive_order") {
+            match serde_json::from_value(order.clone()) {
+                Ok(kinds) => symbol.primitive_order = kinds,
+                Err(e) => {
+                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                }
+            }
         }
 
         // Parse pins
@@ -1379,6 +1415,98 @@ mod tests {
         assert_eq!(fp.description, "reworked 0402");
         assert_eq!(fp.pads.len(), 3);
         assert_eq!(fp.tracks.len(), 1);
+    }
+
+    /// The natural edit loop — `get_component` → `update_component` with the
+    /// echoed JSON — keeps the footprint's kind-85 identity and interleaved
+    /// stream order, mirroring the create path's replay.
+    #[test]
+    fn update_component_replays_footprint_fidelity_fields() {
+        use crate::altium::pcblib::{Footprint, Layer, Pad, PcbLib, PrimitiveKind, Track};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        // Track before pad: an interleaving the grouped default would lose.
+        let mut fp = Footprint::new("FID");
+        fp.guid = Some("{11111111-2222-3333-4444-555555555555}".to_string());
+        fp.add_track(Track::new(-1.0, -1.0, 1.0, -1.0, 0.2, Layer::TopOverlay));
+        fp.add_pad(Pad::smd("1", -0.5, 0.0, 0.6, 0.5));
+        let mut lib = PcbLib::new();
+        lib.add(fp);
+        let path = dir.path().join("FidUpdate.PcbLib");
+        lib.save(&path).unwrap();
+
+        let fetched = parse_result_json(&server.call_get_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "FID",
+        })));
+        assert_eq!(
+            fetched["component"]["primitive_order"],
+            json!(["track", "pad"]),
+            "get_component echoes the interleaved order"
+        );
+
+        let result = server.call_update_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "FID",
+            "footprint": fetched["component"],
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+
+        let reopened = PcbLib::open(&path).unwrap();
+        let fp = reopened.get("FID").unwrap();
+        assert_eq!(
+            fp.guid.as_deref(),
+            Some("{11111111-2222-3333-4444-555555555555}")
+        );
+        assert_eq!(
+            fp.primitive_order,
+            vec![PrimitiveKind::Track, PrimitiveKind::Pad]
+        );
+    }
+
+    /// The `SchLib` flavour: designator position/identity and the interleaved
+    /// record order survive the get → update loop.
+    #[test]
+    fn update_component_replays_symbol_fidelity_fields() {
+        use crate::altium::schlib::{Line, Pin, PinOrientation, SchLib, SchPrimitiveKind, Symbol};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        let mut symbol = Symbol::new("FID");
+        symbol.designator = "U?".to_string();
+        symbol.designator_x = 5.5;
+        symbol.designator_y = -3.5;
+        symbol.add_line(Line::new(0.0, 0.0, 10.0, 10.0));
+        symbol.add_pin(Pin::new("IN", "1", 0, 0, 10, PinOrientation::Left));
+        let mut lib = SchLib::new();
+        lib.add(symbol);
+        let path = dir.path().join("FidUpdate.SchLib");
+        lib.save(&path).unwrap();
+
+        let fetched = parse_result_json(&server.call_get_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "FID",
+        })));
+
+        let result = server.call_update_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "FID",
+            "symbol": fetched["component"],
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+
+        let reopened = SchLib::open(&path).unwrap();
+        let symbol = reopened.get("FID").unwrap();
+        assert!((symbol.designator_x - 5.5).abs() < 1e-9);
+        assert!((symbol.designator_y - (-3.5)).abs() < 1e-9);
+        assert!(symbol.designator_unique_id.is_some());
+        assert_eq!(
+            symbol.primitive_order,
+            vec![SchPrimitiveKind::Line, SchPrimitiveKind::Pin]
+        );
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1130,6 +1130,11 @@ impl McpServer {
                             "designator_y": symbol.designator_y,
                             "designator_unique_id": symbol.designator_unique_id,
                             "part_count": symbol.part_count,
+                            "display_mode_count": symbol.display_mode_count,
+                            "current_part_id": symbol.current_part_id,
+                            "part_id_locked": symbol.part_id_locked,
+                            "source_library_name": symbol.source_library_name,
+                            "target_file_name": symbol.target_file_name,
                             "pins": symbol.pins,
                             "rectangles": symbol.rectangles,
                             "round_rects": symbol.round_rects,
@@ -2811,8 +2816,13 @@ mod tests {
             let server = create_test_server(dir.path());
 
             // Line between the pin and the rectangle: a non-canonical
-            // interleaving no grouped rewrite would reproduce.
+            // interleaving no grouped rewrite would reproduce. The part/mode
+            // scalars carry non-defaults so their emission is observable too.
             let mut symbol = crate::altium::schlib::Symbol::new("REPLAY");
+            symbol.part_count = 2;
+            symbol.display_mode_count = 2;
+            symbol.current_part_id = 2;
+            symbol.part_id_locked = true;
             symbol.add_pin(Pin::new("IN", "1", 0, 0, 10, PinOrientation::Left));
             symbol.add_line(Line::new(0.0, 0.0, 10.0, 10.0));
             symbol.add_rectangle(Rectangle::new(0.0, 0.0, 20.0, 20.0));
@@ -2844,11 +2854,17 @@ mod tests {
                 "filepath": dst.to_string_lossy(),
             }));
             assert!(!second_read.is_error, "{}", get_result_text(&second_read));
+            let symbol_after = parse_result_json(&second_read)["symbols"][0].clone();
             assert_eq!(
-                parse_result_json(&second_read)["symbols"][0]["primitive_order"],
+                symbol_after["primitive_order"],
                 json!(["pin", "line", "rectangle"]),
                 "record order survives the tool-layer round trip"
             );
+            // The part/mode scalars ride the same read → write → read loop.
+            assert_eq!(symbol_after["part_count"], 2);
+            assert_eq!(symbol_after["display_mode_count"], 2);
+            assert_eq!(symbol_after["current_part_id"], 2);
+            assert_eq!(symbol_after["part_id_locked"], true);
         }
 
         /// A malformed `primitive_order` is ignored with the default grouped

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -379,7 +379,7 @@ impl McpServer {
                                 .collect()
                         };
 
-                        json!({
+                        let mut fp_json = json!({
                             "name": fp.name,
                             "description": fp.description,
                             "pads": pads,
@@ -391,7 +391,20 @@ impl McpServer {
                             "text": fp.text,
                             "model_3d": fp.model_3d,
                             "component_bodies": fp.component_bodies,
-                        })
+                        });
+                        // Footprint-level fidelity fields, mirroring the
+                        // struct's own serde shape (get_component serialises
+                        // the whole struct): present only when carried, and
+                        // replayed by write_pcblib so a read-modify-write
+                        // keeps the kind-85 identity and the interleaved
+                        // stream order.
+                        if let Some(guid) = &fp.guid {
+                            fp_json["guid"] = json!(guid);
+                        }
+                        if !fp.primitive_order.is_empty() {
+                            fp_json["primitive_order"] = json!(fp.primitive_order);
+                        }
+                        fp_json
                     })
                     .collect();
 
@@ -1000,6 +1013,23 @@ impl McpServer {
             };
             bodies_echo.push(body_3d_summary(&footprint, assumed_height));
 
+            // Footprint-level replay fields `read_pcblib` emits. The guid is
+            // the kind-85 identity record; the interleaved Data-stream order
+            // replaces the grouped order the add_* calls accumulated, so a
+            // read-modify-write keeps the source's stream order
+            // (`write_sequence` is advisory-safe against a stale list).
+            if let Some(g) = fp_json.get("guid").and_then(Value::as_str) {
+                footprint.guid = Some(g.to_string());
+            }
+            if let Some(order) = fp_json.get("primitive_order") {
+                match serde_json::from_value(order.clone()) {
+                    Ok(kinds) => footprint.primitive_order = kinds,
+                    Err(e) => {
+                        tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                    }
+                }
+            }
+
             // Validate coordinates before adding
             if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
                 return ToolCallResult::error(e);
@@ -1092,7 +1122,7 @@ impl McpServer {
                     .skip(offset)
                     .take(limit.unwrap_or(usize::MAX))
                     .map(|symbol| {
-                        json!({
+                        let mut sym_json = json!({
                             "name": symbol.name,
                             "description": symbol.description,
                             "designator": symbol.designator,
@@ -1117,7 +1147,15 @@ impl McpServer {
                             "text": symbol.text,
                             "parameters": symbol.parameters,
                             "footprints": symbol.footprints,
-                        })
+                        });
+                        // The interleaved record order, mirroring the struct's
+                        // serde shape (present only when carried) and replayed
+                        // by write_schlib so a read-modify-write keeps the
+                        // source's record order.
+                        if !symbol.primitive_order.is_empty() {
+                            sym_json["primitive_order"] = json!(symbol.primitive_order);
+                        }
+                        sym_json
                     })
                     .collect();
 
@@ -1890,6 +1928,18 @@ impl McpServer {
                 }
             }
 
+            // The interleaved record order `read_schlib` reported; replaying it
+            // replaces the grouped order the add_* calls accumulated, so a
+            // read-modify-write keeps the source's record order.
+            if let Some(order) = sym_json.get("primitive_order") {
+                match serde_json::from_value(order.clone()) {
+                    Ok(kinds) => symbol.primitive_order = kinds,
+                    Err(e) => {
+                        tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                    }
+                }
+            }
+
             // Validate coordinates before adding
             if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
                 return ToolCallResult::error(e);
@@ -2611,6 +2661,227 @@ mod tests {
     fn ieee_map_unknown_falls_back_to_u() {
         assert_eq!(ieee_designator_prefix("flux_capacitor"), "U");
         assert_eq!(ieee_designator_prefix(""), "U");
+    }
+
+    // ==================== fidelity replay ====================
+
+    mod fidelity_replay {
+        use crate::altium::pcblib::{
+            Fill, Footprint, Layer, Pad, PcbFlags, PcbLib, Text, TextJustification, TextKind,
+            Track, Via,
+        };
+        use crate::mcp::tools::test_support::{
+            create_test_server, get_result_text, parse_result_json, test_temp_dir,
+        };
+        use serde_json::json;
+
+        /// A footprint whose fidelity fields all carry values, in a
+        /// deliberately non-canonical primitive order (text before pads) so
+        /// order replay is observable rather than coincidental. The text is
+        /// the `.Designator` special string a real footprint carries — also
+        /// what keeps `write_pcblib`'s auto-injection of one from adding a
+        /// primitive the source never had.
+        fn replay_footprint() -> Footprint {
+            let mut fp = Footprint::new("REPLAY");
+            fp.guid = Some("{11111111-2222-3333-4444-555555555555}".to_string());
+            fp.add_text(Text {
+                barcode_full_width: None,
+                barcode_full_height: None,
+                barcode_x_margin: None,
+                barcode_y_margin: None,
+                barcode_kind: 0,
+                barcode_font_name: String::new(),
+                barcode_inverted: false,
+                barcode_show_text: false,
+                x: 0.0,
+                y: -2.0,
+                text: ".Designator".to_string(),
+                height: 1.0,
+                layer: Layer::TopOverlay,
+                kind: TextKind::Stroke,
+                rotation: 0.0,
+                stroke_font: None,
+                stroke_width: None,
+                italic: false,
+                bold: false,
+                mirror: false,
+                is_comment: false,
+                is_designator: false,
+                font_name: "Arial".to_string(),
+                justification: TextJustification::default(),
+                is_inverted: false,
+                inverted_border: None,
+                use_inverted_rectangle: false,
+                inverted_rect_width: None,
+                inverted_rect_height: None,
+                inverted_rect_text_offset: None,
+                flags: PcbFlags::default(),
+                net_index: 0xFFFF,
+                polygon_index: 0xFFFF,
+                component_index: -1,
+                unique_id: None,
+                guid: Some("{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}".to_string()),
+                raw_geometry: None,
+            });
+            let mut via = Via::new(1.5, 0.0, 0.6, 0.3);
+            via.guid = Some("{22222222-3333-4444-5555-666666666666}".to_string());
+            fp.add_via(via);
+            let mut track = Track::new(-1.0, -1.0, 1.0, -1.0, 0.2, Layer::TopOverlay);
+            track.guid = Some("{33333333-4444-5555-6666-777777777777}".to_string());
+            fp.add_track(track);
+            let mut pad = Pad::smd("1", -0.5, 0.0, 0.6, 0.5);
+            pad.guid = Some("{44444444-5555-6666-7777-888888888888}".to_string());
+            fp.add_pad(pad);
+            let mut fill = Fill::new(-0.5, 0.8, 0.5, 1.2, Layer::TopLayer);
+            fill.guid = Some("{55555555-6666-7777-8888-999999999999}".to_string());
+            fp.add_fill(fill);
+            fp
+        }
+
+        /// `read_pcblib` → `write_pcblib` replays every fidelity field the
+        /// reader emits — pad `raw_tail`, via `raw_block`, text
+        /// `raw_geometry`, per-primitive and footprint `guid`s, and the
+        /// interleaved `primitive_order` — so a read-modify-write through the
+        /// tool layer preserves them exactly as the library API does. The
+        /// assertion is total: the second read's footprint JSON must equal
+        /// the first, field for field (raw fields included, so the written
+        /// binary blocks were byte-identical to the source's).
+        #[test]
+        fn write_pcblib_replays_fidelity_fields_read_pcblib_emits() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = PcbLib::new();
+            lib.add(replay_footprint());
+            let src = dir.path().join("Src.PcbLib");
+            lib.save(&src).unwrap();
+
+            let first_read = server.call_read_pcblib(&json!({
+                "filepath": src.to_string_lossy(),
+            }));
+            assert!(!first_read.is_error, "{}", get_result_text(&first_read));
+            let footprints_before = parse_result_json(&first_read)["footprints"].clone();
+
+            // The first read must actually carry the replay fields, or the
+            // equality below passes vacuously.
+            let fp = &footprints_before[0];
+            assert_eq!(
+                fp["primitive_order"],
+                json!(["text", "via", "track", "pad", "fill"]),
+                "authored (non-canonical) order survives the first read"
+            );
+            assert!(fp["pads"][0]["raw_tail"].is_string(), "pad raw_tail read");
+            assert!(fp["vias"][0]["raw_block"].is_string(), "via raw_block read");
+            assert!(
+                fp["text"][0]["raw_geometry"].is_string(),
+                "text raw_geometry read"
+            );
+            for list in ["pads", "vias", "tracks", "fills", "text"] {
+                assert!(fp[list][0]["guid"].is_string(), "{list} guid read");
+            }
+            assert!(fp["guid"].is_string(), "footprint guid read");
+
+            let dst = dir.path().join("Dst.PcbLib");
+            let write = server.call_write_pcblib(&json!({
+                "filepath": dst.to_string_lossy(),
+                "footprints": footprints_before,
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+
+            let second_read = server.call_read_pcblib(&json!({
+                "filepath": dst.to_string_lossy(),
+            }));
+            assert!(!second_read.is_error, "{}", get_result_text(&second_read));
+            let footprints_after = parse_result_json(&second_read)["footprints"].clone();
+
+            assert_eq!(
+                footprints_before, footprints_after,
+                "read → write → read is lossless"
+            );
+        }
+
+        /// `read_schlib` → `write_schlib` replays a symbol's interleaved
+        /// `primitive_order`, so a read-modify-write keeps the source's
+        /// record order instead of regrouping records by kind.
+        #[test]
+        fn write_schlib_replays_the_symbol_primitive_order() {
+            use crate::altium::schlib::{Line, Pin, PinOrientation, Rectangle, SchLib};
+
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            // Line between the pin and the rectangle: a non-canonical
+            // interleaving no grouped rewrite would reproduce.
+            let mut symbol = crate::altium::schlib::Symbol::new("REPLAY");
+            symbol.add_pin(Pin::new("IN", "1", 0, 0, 10, PinOrientation::Left));
+            symbol.add_line(Line::new(0.0, 0.0, 10.0, 10.0));
+            symbol.add_rectangle(Rectangle::new(0.0, 0.0, 20.0, 20.0));
+
+            let mut lib = SchLib::new();
+            lib.add(symbol);
+            let src = dir.path().join("Src.SchLib");
+            lib.save(&src).unwrap();
+
+            let first_read = server.call_read_schlib(&json!({
+                "filepath": src.to_string_lossy(),
+            }));
+            assert!(!first_read.is_error, "{}", get_result_text(&first_read));
+            let symbols = parse_result_json(&first_read)["symbols"].clone();
+            assert_eq!(
+                symbols[0]["primitive_order"],
+                json!(["pin", "line", "rectangle"]),
+                "authored interleaving survives the first read"
+            );
+
+            let dst = dir.path().join("Dst.SchLib");
+            let write = server.call_write_schlib(&json!({
+                "filepath": dst.to_string_lossy(),
+                "symbols": symbols,
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+
+            let second_read = server.call_read_schlib(&json!({
+                "filepath": dst.to_string_lossy(),
+            }));
+            assert!(!second_read.is_error, "{}", get_result_text(&second_read));
+            assert_eq!(
+                parse_result_json(&second_read)["symbols"][0]["primitive_order"],
+                json!(["pin", "line", "rectangle"]),
+                "record order survives the tool-layer round trip"
+            );
+        }
+
+        /// A malformed `primitive_order` is ignored with the default grouped
+        /// order rather than failing the write — it is advisory, exactly as
+        /// on the struct.
+        #[test]
+        fn invalid_primitive_order_is_ignored_not_fatal() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let pcb = dir.path().join("Bad.PcbLib");
+            let write = server.call_write_pcblib(&json!({
+                "filepath": pcb.to_string_lossy(),
+                "footprints": [{
+                    "name": "FP",
+                    "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+                    "primitive_order": ["not_a_kind"],
+                }],
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+
+            let sch = dir.path().join("Bad.SchLib");
+            let write = server.call_write_schlib(&json!({
+                "filepath": sch.to_string_lossy(),
+                "symbols": [{
+                    "name": "SYM",
+                    "pins": [{ "designator": "1", "name": "IN", "x": 0, "y": 0,
+                               "orientation": "left" }],
+                    "primitive_order": 42,
+                }],
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+        }
     }
 
     // ==================== extract_style ====================


### PR DESCRIPTION
Found during the pre-release review: the MCP tool layer silently dropped most of the byte-fidelity fields the readers emit, so an external MCP client doing read → write could not get the byte-identical output the library API guarantees. Regions already replayed theirs (`v7_layer`, `param_key_order`, `guid`) — which makes the rest an inconsistency inside one feature, not a design line.

## What was dropped

| Path | Field(s) | Symptom |
|------|----------|---------|
| `parse_pad` | `raw_tail` | pad extended tail rebuilt from template instead of replayed |
| `parse_via` | `raw_block`, `guid` | via block rebuilt; identity lost |
| `parse_text` | `raw_geometry` | allow-listed, then discarded |
| `parse_track` / `parse_fill` | `guid` | identity lost |
| `write_pcblib` | footprint `guid`, `primitive_order` | allow-listed, never read — kind-85 identity lost, primitives regrouped by kind |
| `write_schlib` | symbol `primitive_order` | same regrouping on the SchLib side |
| `read_pcblib` / `read_schlib` | footprint/symbol `guid` + `primitive_order` | never emitted at all (`get_component`, which serialises the whole struct, already emitted them — that is what the write allow-lists were extended for) |

## The fix

- Shared lenient `json_base64` helper (invalid base64 → absent + debug log, writer falls back to its template — the same Option-style leniency as the rest of the parser), also replacing the equivalent inline `image_data` decode.
- The five parser gaps wired through; both write tools now replay the footprint/symbol-level fields; both read tools emit them, mirroring the structs' serde shape (present only when carried).
- A malformed `primitive_order` is ignored, not fatal — it is advisory on the struct, and `write_sequence` is defensive against stale lists (pinned by test).

## Proof

`write_pcblib_replays_fidelity_fields_read_pcblib_emits` asserts **total JSON equality** across read → write → read with every fidelity field carried and a deliberately non-canonical primitive order (text, via, track, pad, fill). Because the equality includes the base64 `raw_tail`/`raw_block`/`raw_geometry` *re-read from the written file*, it proves the written binary blocks are byte-identical to the source's through the JSON boundary. The vacuity guard asserts the first read actually carries every replay field before comparing.

(That test also flushed out `write_pcblib`'s `.Designator` auto-injection — intentional and separately tested, so the fixture carries its own `.Designator` text as real footprints do. Whether that auto-add should become opt-in like the auto-3D-body after #182 is left as a separate decision.)

Gates: `cargo fmt` ✅, `clippy -D warnings` ✅, full suite ✅ (runs inside the instrumented coverage run), coverage on the production metric **99.01%** (416/42,074 uncovered — gate still met with the new lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
