### PR TITLE
fix(pcblib): give ComponentBody a one-byte replay base for unmapped layers

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -2207,6 +2207,8 @@ mod tests {
 
         // Add a ComponentBody with typical values and an explicit outline.
         let body = ComponentBody {
+            raw_layer_id: None,
+            v7_layer: None,
             model_id: "{TEST-GUID-1234-5678-ABCDEFGH}".to_string(),
             identifier: String::new(),
             texture_center_x: None,
@@ -2285,6 +2287,8 @@ mod tests {
         fp.add_pad(Pad::smd("2", 1.0, 0.0, 0.6, 0.5));
         for i in 0..2 {
             fp.add_component_body(ComponentBody {
+                raw_layer_id: None,
+                v7_layer: None,
                 model_id: format!("{{GUID-{i}}}"),
                 identifier: String::new(),
                 texture_center_x: None,

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -221,6 +221,26 @@ pub struct ComponentBody {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub texture_size_y: Option<String>,
 
+    /// The header layer byte exactly as read, kept only when `layer_from_id`
+    /// hit its `MultiLayer` catch-all on an id it does not map — the byte
+    /// cannot be re-derived from [`Self::layer`] then, and without this the
+    /// writer rewrote it to the canonical `MultiLayer` id (#391). Replayed
+    /// (together with [`Self::v7_layer`]) only while the body still sits on
+    /// that catch-all layer; retargeting the body to a real layer discards
+    /// both and emits the canonical pair.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
+
+    /// The `V7_LAYER` token verbatim, kept only when it disagrees with the
+    /// canonical token for [`Self::layer`] — the text half of the same
+    /// unmapped-byte pair as [`Self::raw_layer_id`]. Unlike `Region::v7_layer`
+    /// (where a mapped layer can legitimately carry a disagreeing token, so
+    /// replay is unconditional), a body's disagreement only arises from an
+    /// unmapped byte, so byte and token replay under the same condition and
+    /// can never re-emit as a mismatched pair.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v7_layer: Option<String>,
+
     /// Net index into the board's net list — common-header u16 @3. `0xFFFF`
     /// (65535) means "no net", the from-scratch default (round-trip fidelity).
     #[serde(default = "default_net_index")]
@@ -318,6 +338,8 @@ impl ComponentBody {
             texture_center_y: None,
             texture_size_x: None,
             texture_size_y: None,
+            raw_layer_id: None,
+            v7_layer: None,
             net_index: default_net_index(),
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1578,6 +1578,20 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         .first()
         .map_or(Layer::Top3DBody, |&id| layer_from_id(id));
 
+    // #391's one-byte replay base: when the byte is an id `layer_from_id`
+    // does not map, the decode above collapses it to the `MultiLayer`
+    // catch-all and re-deriving the byte from `layer` would rewrite it. Keep
+    // the byte (and, below, its `V7_LAYER` token) verbatim so the pair
+    // round-trips; a genuine `MultiLayer` body (the canonical id itself)
+    // keeps `None`.
+    let raw_layer_id = block0.first().copied().filter(|&id| {
+        layer == Layer::MultiLayer && id != crate::altium::pcblib::writer::layer_to_id(layer)
+    });
+    let v7_layer = params
+        .get("V7_LAYER")
+        .filter(|token| **token != crate::altium::pcblib::writer::v7_layer_token(layer))
+        .cloned();
+
     // Common-header connectivity indices @3-8 (net/polygon/component). The body's
     // block starts with the layer byte @0, the 0x0C/0x00 record-type marker @1-2,
     // then the net/polygon/component words @3-8 (0xFF padding for a free body).
@@ -1655,6 +1669,8 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         model_2d_rotation,
         model_2d_x,
         model_2d_y,
+        raw_layer_id,
+        v7_layer,
         net_index,
         polygon_index,
         component_index,

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -166,6 +166,8 @@ impl PcbLib {
                 texture_center_y: None,
                 texture_size_x: None,
                 texture_size_y: None,
+                raw_layer_id: None,
+                v7_layer: None,
                 model_name: filename,
                 embedded: true,
                 rotation_x: 0.0,

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -86,7 +86,7 @@ fn write_string_block(
 /// - Top 3D Body: 62 (Mech 6)
 /// - Bottom 3D Body: 63 (Mech 7)
 #[allow(clippy::too_many_lines)] // Layer-to-ID lookup for all layer types
-const fn layer_to_id(layer: Layer) -> u8 {
+pub(super) const fn layer_to_id(layer: Layer) -> u8 {
     match layer {
         Layer::TopLayer => 1,
         // Mid layers (IDs 2-31)
@@ -1659,8 +1659,15 @@ fn encode_component_body(data: &mut Vec<u8>, body: &ComponentBody, outline: &[(f
 fn encode_component_body_block(body: &ComponentBody, outline: &[(f64, f64)]) -> Vec<u8> {
     let mut block = Vec::with_capacity(128);
 
-    // Layer ID (1 byte)
-    block.push(layer_to_id(body.layer));
+    // Layer ID (1 byte). An unmapped byte the reader could not decode is
+    // replayed verbatim while the body still sits on the `MultiLayer`
+    // catch-all its decode produced (#391); a retargeted body gets the
+    // canonical id for its new layer.
+    let layer_id = match body.raw_layer_id {
+        Some(id) if body.layer == Layer::MultiLayer => id,
+        _ => layer_to_id(body.layer),
+    };
+    block.push(layer_id);
 
     // Record type marker (2 bytes): 0x0C 0x00
     block.push(0x0C);
@@ -1767,7 +1774,14 @@ fn build_component_body_params(body: &ComponentBody) -> String {
     // MECHANICAL{n} token for any mechanical layer (Top3DBody=MECHANICAL6,
     // Mechanical1=MECHANICAL1, etc.) instead of hardcoding one — a mismatch
     // between the param string and the layer byte makes Altium drop the body.
-    params.push(format!("V7_LAYER={}", v7_layer_token(body.layer)));
+    // A captured token replays under the same condition as the raw layer
+    // byte it pairs with (#391), so byte and token can never re-emit
+    // mismatched against each other.
+    let v7_token = match &body.v7_layer {
+        Some(token) if body.layer == Layer::MultiLayer => token.clone(),
+        _ => v7_layer_token(body.layer),
+    };
+    params.push(format!("V7_LAYER={v7_token}"));
 
     // Standard parameters. Each field's default reproduces the prior hard-coded
     // literal exactly, so a template-default body stays byte-identical (the oracle
@@ -3630,6 +3644,61 @@ mod tests {
         assert!((b.model_2d_rotation - 90.0).abs() < 1e-9);
         assert_eq!(b.name, "BODY_A");
         assert_eq!(b.layer, Layer::Mechanical13, "body layer round-trips");
+    }
+
+    /// #391: a header layer byte `layer_from_id` does not map decodes to the
+    /// `MultiLayer` catch-all but must round-trip verbatim, together with its
+    /// `V7_LAYER` token — the pair is the body's one-byte replay base.
+    #[test]
+    fn component_body_unmapped_layer_byte_roundtrips_verbatim() {
+        use super::super::reader;
+
+        let mut original = Footprint::new("RT_BODY_RAWLAYER");
+        let mut body = ComponentBody::new("{G-1234}", "p.step");
+        body.layer = Layer::MultiLayer;
+        body.raw_layer_id = Some(150); // unmapped: 86-185 has no Layer variant
+        body.v7_layer = Some("MECHANICAL22".to_string());
+        original.add_component_body(body);
+
+        let data = encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("RT_BODY_RAWLAYER");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        let b = &decoded.component_bodies[0];
+        assert_eq!(b.layer, Layer::MultiLayer, "catch-all decode is unchanged");
+        assert_eq!(b.raw_layer_id, Some(150), "the authored byte survives");
+        assert_eq!(
+            b.v7_layer.as_deref(),
+            Some("MECHANICAL22"),
+            "the authored token survives"
+        );
+
+        // And the second write re-emits the identical pair.
+        let data2 = encode_data_stream(&decoded).expect("re-encode");
+        assert_eq!(data, data2, "unmapped-layer body is byte-stable");
+    }
+
+    /// Retargeting such a body to a real layer discards the stale pair and
+    /// emits the canonical byte + token for the new layer.
+    #[test]
+    fn component_body_retarget_discards_stale_raw_layer_pair() {
+        use super::super::reader;
+
+        let mut original = Footprint::new("RT_BODY_RETARGET");
+        let mut body = ComponentBody::new("{G-1234}", "p.step");
+        body.layer = Layer::Mechanical13; // retargeted away from the catch-all
+        body.raw_layer_id = Some(150); // stale echo from a previous read
+        body.v7_layer = Some("MECHANICAL22".to_string());
+        original.add_component_body(body);
+
+        let data = encode_data_stream(&original).expect("encode");
+        let mut decoded = Footprint::new("RT_BODY_RETARGET");
+        reader::parse_data_stream(&mut decoded, &data, None);
+
+        let b = &decoded.component_bodies[0];
+        assert_eq!(b.layer, Layer::Mechanical13, "typed layer wins");
+        assert_eq!(b.raw_layer_id, None, "stale byte was not written");
+        assert_eq!(b.v7_layer, None, "canonical token was written");
     }
 
     #[test]

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -2332,6 +2332,8 @@ mod tests {
         /// A placeholder extruded body, so the component-body count can differ.
         fn body() -> ComponentBody {
             ComponentBody {
+                raw_layer_id: None,
+                v7_layer: None,
                 model_id: String::new(),
                 identifier: String::new(),
                 texture_center_x: None,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -940,6 +940,11 @@ impl McpServer {
             texture_center_y: json_guidless_opt(body_json, "texture_center_y"),
             texture_size_x: json_guidless_opt(body_json, "texture_size_x"),
             texture_size_y: json_guidless_opt(body_json, "texture_size_y"),
+            raw_layer_id: body_json
+                .get("raw_layer_id")
+                .and_then(Value::as_u64)
+                .and_then(|v| u8::try_from(v).ok()),
+            v7_layer: json_guidless_opt(body_json, "v7_layer"),
             model_id: str_or("model_id", ""),
             model_name: str_or("model_name", ""),
             embedded: body_json
@@ -2925,6 +2930,28 @@ mod tests {
         }))
         .expect("via should parse");
         assert_eq!(via.unique_id, None);
+    }
+
+    #[test]
+    fn parse_component_body_reads_raw_layer_pair() {
+        // #391: the unmapped-byte pair read_pcblib echoes must survive the
+        // tool-layer JSON boundary like every other replay field.
+        let body = McpServer::parse_component_body_json(&json!({
+            "model_id": "{G-1}",
+            "layer": "Multi-Layer",
+            "raw_layer_id": 150,
+            "v7_layer": "MECHANICAL22",
+        }));
+        assert_eq!(body.raw_layer_id, Some(150));
+        assert_eq!(body.v7_layer.as_deref(), Some("MECHANICAL22"));
+
+        // Absent -> None, out-of-range -> None (lenient Option-style).
+        let plain = McpServer::parse_component_body_json(&json!({
+            "model_id": "{G-1}",
+            "raw_layer_id": 300,
+        }));
+        assert_eq!(plain.raw_layer_id, None);
+        assert_eq!(plain.v7_layer, None);
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -796,6 +796,8 @@ impl McpServer {
                             texture_center_y: None,
                             texture_size_x: None,
                             texture_size_y: None,
+                            raw_layer_id: None,
+                            v7_layer: None,
                             model_name: model_path.to_string(), // Preserve full path
                             embedded: false,
                             rotation_x: 0.0,
@@ -976,6 +978,8 @@ impl McpServer {
                     texture_center_y: None,
                     texture_size_x: None,
                     texture_size_y: None,
+                    raw_layer_id: None,
+                    v7_layer: None,
                     model_name: String::new(),
                     embedded: false,
                     rotation_x: 0.0,
@@ -2549,6 +2553,8 @@ mod tests {
     fn body_3d_summary_reports_source_and_height() {
         use crate::altium::pcblib::{ComponentBody, Footprint, Layer};
         let body = |h: f64, name: &str| ComponentBody {
+            raw_layer_id: None,
+            v7_layer: None,
             model_id: String::new(),
             identifier: String::new(),
             texture_center_x: None,

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -863,6 +863,8 @@ fn test_component_body_roundtrip() {
 
     // Add a ComponentBody with typical 3D model properties
     let body = ComponentBody {
+        raw_layer_id: None,
+        v7_layer: None,
         model_id: "TEST-MODEL-GUID".to_string(),
         identifier: String::new(),
         texture_center_x: None,
@@ -931,6 +933,8 @@ fn test_component_body_with_rotation() {
 
     // 3D model with rotation
     let body = ComponentBody {
+        raw_layer_id: None,
+        v7_layer: None,
         model_id: "ROTATED-GUID".to_string(),
         identifier: String::new(),
         texture_center_x: None,
@@ -2769,6 +2773,8 @@ fn test_component_body_external_model_reference() {
 
     // Add ComponentBody with external reference
     let body = ComponentBody {
+        raw_layer_id: None,
+        v7_layer: None,
         model_id: "{EXTERNAL-GUID-1234}".to_string(),
         identifier: String::new(),
         texture_center_x: None,


### PR DESCRIPTION
Closes #391 — @ande2407's analysis was correct on every point: `ComponentBody` was the one primitive without a replay base, so a body whose header layer byte is unmapped (`0`, `86–185`, `202–255`) decoded to the `MultiLayer` catch-all **and** had its byte rewritten to the canonical `74` on save.

## Maintainer decision (of the issue's options)

- **C — implemented, but byte-sized rather than whole-block.** `golden_fidelity` already proves body blocks reconstruct byte-identically for every mapped body, so the only lossy spot was the unmapped byte and its `V7_LAYER` token. Those two now survive as a pair: `raw_layer_id: Option<u8>` + `v7_layer: Option<String>` (token captured only when it disagrees with the canonical token, mirroring `Region::v7_layer`'s capture condition).
- **Replay is gated on the body still sitting on the catch-all layer.** Retargeting the body to a real layer discards the stale pair and emits canonical byte + token — so unlike an unconditional replay, byte and token can never re-emit mismatched against each other (the failure mode the writer comment warns makes Altium drop the body). This is documented as a deliberate divergence from `Region::v7_layer`'s unconditional replay, whose capture condition is different in kind.
- **B — deferred pending a fixture**, exactly as proposed: it changes read semantics on a case no fixture proves reachable, and `golden_fidelity` could not catch a regression in it. If an AD-authored library with an unmapped body byte ever surfaces, it becomes a golden and B becomes decidable.

## Tests

- `component_body_unmapped_layer_byte_roundtrips_verbatim` — byte 150 + `MECHANICAL22` survive encode → decode, and a second encode is byte-identical to the first.
- `component_body_retarget_discards_stale_raw_layer_pair` — retargeted body emits canonical values, stale echo ignored.
- `parse_component_body_reads_raw_layer_pair` — the pair crosses the tool-layer JSON boundary like every other replay field (out-of-range byte → lenient `None`).

Gates: fmt ✅, `clippy --locked -D warnings` ✅, full suite ✅ (1366), coverage **99.07%** (395/42,433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
