### PR TITLE
docs(samples): record that an AD load+save damages committed goldens

### DIFF
--- a/scripts/samples/README.md
+++ b/scripts/samples/README.md
@@ -11,6 +11,22 @@ so CI can read them without Altium. Regenerate and re-commit whenever the author
 > Building these is iterative — generate, read back with the Rust tests, extend the
 > primitive set, regenerate. Coverage grows component by component.
 
+## NEVER open-and-save a committed golden in Altium
+
+An AD load+save cycle silently damages fixtures (measured 2026-08-16 by resaving
+`symbols.SchLib` through AD and diffing all 84 symbols with our reader):
+
+- the five known-damaged i18n symbols (`_JV`, `_BN`, `_CR`, `_IU`, `_SB`) degrade
+  *further* — AD's reader is the broken component, and each cycle compounds it;
+- `ꆈꌠ_YI` (Yi) is a sixth, slower victim: intact in the committed golden, but one
+  load+save turns its pin/label/parameter texts to mojibake;
+- `PARAMS` loses a parameter value outright: `100nF` comes back as `*` — not an
+  encoding issue, AD's own parameter handling.
+
+Regeneration via `Generate-Samples.ps1` is fine (it authors from scratch); opening a
+committed golden in the AD UI to "just fix one thing" and saving is not. Hand-fix work
+happens in a fresh library committed under `manual/` instead.
+
 ## `manual/` — hand-authored, do NOT regenerate
 
 `Generate-Samples.ps1` cannot produce everything: a few properties exist only in Altium's


### PR DESCRIPTION
Found during branch cleanup: this commit (2026-08-16) was pushed but never PR'd, and main already **references** its warning section — [scripts/samples/README.md line 43](https://github.com/embedded-society/altium-designer-mcp/blob/main/scripts/samples/README.md#L43) says "see the load+save warning above" pointing at a heading that only exists on this branch. Merging closes the dangling reference.

Content: the measured 2026-08-16 evidence that one AD load+save cycle damages committed goldens (the five i18n symbols degrade further, ꆈꌠ_YI turns to mojibake, PARAMS loses `100nF` → `*`), and the rule that hand-fixes happen in fresh `manual/` libraries, never by resaving a golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)