### PR TITLE
chore(release): stamp the changelog for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Everything below ships in the first tagged release (the version heading and date are
-stamped when the tag is cut). An MCP server that gives AI assistants file I/O and
-primitive-placement tools for Altium Designer `.PcbLib` (footprint) and `.SchLib`
-(symbol) libraries.
+## [0.1.0] - 2026-08-18
+
+An MCP server that gives AI assistants file I/O and primitive-placement tools
+for Altium Designer `.PcbLib` (footprint) and `.SchLib` (symbol) libraries.
 
 ### Added
 


### PR DESCRIPTION
Step 2 of [docs/RELEASING.md § Cutting the release](https://github.com/embedded-society/altium-designer-mcp/blob/main/docs/RELEASING.md#cutting-the-release), executed with the maintainer's explicit delegation:

- `## [Unreleased]` → `## [0.1.0] - 2026-08-18`
- The stamp-time meta-sentence ("Everything below ships in the first tagged release…") is deleted — it described the stamping act itself and would have published verbatim into the GitHub release notes.
- A fresh empty `## [Unreleased]` opens the next cycle.

The dry run on this content's parent (`54176d2`, [run #2](https://github.com/embedded-society/altium-designer-mcp/actions/runs/32058308917)) was fully green: three platforms built `--locked`, archives self-verified, and the Windows artefact was additionally downloaded and smoke-tested locally — all nine files present, binary serves the full MCP protocol (34 tools).

After this merges: the by-the-book second dry run on the stamped commit, then the signed `v0.1.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)