### PR TITLE
docs: add a verified setup guide for every MCP client

### DIFF
--- a/.github/release-assets/README.md
+++ b/.github/release-assets/README.md
@@ -17,6 +17,7 @@ project, issue tracker and contribution guide live on GitHub:
 | `example-config.json` | Starting configuration — set `allowed_paths` to your library folders. |
 | `docs/CLAUDE_CODE_GUIDE.md` | Full Claude Code guide, including example workflows and prompts. |
 | `docs/ANTIGRAVITY_GUIDE.md` | Full Google Antigravity guide. |
+| `docs/CLIENT_SETUP.md` | Setup for every MCP client: Cursor, VS Code, Windsurf, Cline, Roo Code, Kiro, JetBrains, Zed, Gemini CLI, Codex CLI, Continue, Goose, OpenCode and more, plus troubleshooting. |
 | `docs/AGENT_GUIDE.md` | Invariants an AI assistant must follow (units, pin geometry, sandbox). |
 | `docs/TOOLS.md` | Reference for every MCP tool. |
 | `CHANGELOG.md` | Release history. |
@@ -84,13 +85,13 @@ Replace the paths with your own.
 ### Claude Code
 
 ```bash
-claude mcp add altium /usr/local/bin/altium-designer-mcp -- ~/.altium-designer-mcp/config.json
+claude mcp add altium -- /usr/local/bin/altium-designer-mcp ~/.altium-designer-mcp/config.json
 ```
 
 On Windows PowerShell:
 
 ```powershell
-claude mcp add altium "$env:LOCALAPPDATA\Programs\altium-designer-mcp\altium-designer-mcp.exe" -- "$env:USERPROFILE\.altium-designer-mcp\config.json"
+claude mcp add altium -- "$env:LOCALAPPDATA\Programs\altium-designer-mcp\altium-designer-mcp.exe" "$env:USERPROFILE\.altium-designer-mcp\config.json"
 ```
 
 Then run `claude`, and check it is loaded with `/mcp`. See `docs/CLAUDE_CODE_GUIDE.md` for worked
@@ -128,6 +129,11 @@ same `mcpServers` block as Claude Desktop.
 
 Create `.mcp.json` in the workspace, or use **MCP: Add Server** from the command palette. VS Code
 uses the same `command` / `args` fields, under a `servers` key rather than `mcpServers`.
+
+### Windsurf, Cline, Roo Code, Kiro, JetBrains, Zed, Gemini CLI, Codex CLI, Continue, Goose, OpenCode…
+
+`docs/CLIENT_SETUP.md` has a verified section for each — where its config file lives and the exact
+snippet — plus a troubleshooting table.
 
 ### Any other MCP client
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,7 @@ jobs:
                 cp LICENCE CHANGELOG.md dist/
                 cp config/example-config.json dist/
                 cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
-                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md dist/docs/
+                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md docs/CLIENT_SETUP.md dist/docs/
 
                 # A bundle-specific README rather than the repository's own:
                 # someone unpacking a binary wants install and verification
@@ -275,7 +275,7 @@ jobs:
 
                 for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
                          example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md \
-                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md; do
+                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md docs/CLIENT_SETUP.md; do
                     if [[ ! -e "verify/$f" ]]; then
                         echo "Error: $f missing from ${{ matrix.artifact }}"
                         exit 1
@@ -302,7 +302,7 @@ jobs:
                 cp LICENCE CHANGELOG.md dist/
                 cp config/example-config.json dist/
                 cp docs/AGENT_GUIDE.md docs/TOOLS.md dist/docs/
-                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md dist/docs/
+                cp docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md docs/CLIENT_SETUP.md dist/docs/
 
                 # A bundle-specific README rather than the repository's own:
                 # someone unpacking a binary wants install and verification
@@ -321,7 +321,7 @@ jobs:
 
                 for f in ${{ matrix.binary }} README.md LICENCE CHANGELOG.md \
                          example-config.json docs/AGENT_GUIDE.md docs/TOOLS.md \
-                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md; do
+                         docs/CLAUDE_CODE_GUIDE.md docs/ANTIGRAVITY_GUIDE.md docs/CLIENT_SETUP.md; do
                     if [[ ! -e "verify/$f" ]]; then
                         echo "Error: $f missing from ${{ matrix.artifact }}"
                         exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,6 +281,7 @@ remaining headroom sits in `mcp/server.rs` and `mcp/tools/library_ops.rs`.
 | `docs/AGENT_GUIDE.md` | Invariants for an agent driving the server (units, pin geometry, sandbox) |
 | `docs/CLAUDE_CODE_GUIDE.md` | Step-by-step Claude Code setup guide |
 | `docs/ANTIGRAVITY_GUIDE.md` | Google Antigravity setup guide |
+| `docs/CLIENT_SETUP.md` | Setup for every other MCP client (Cursor, VS Code, Windsurf, Cline, Zed, JetBrains, Gemini CLI, Codex CLI, …) + troubleshooting |
 | `docs/SECURITY.md` | Security threat model and design rationale |
 | `docs/RELEASING.md` | Release runbook: dry run, tag-day steps, draft review, rollback |
 | `docs/errors.md` | Error reference catalogue |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Let an AI build your Altium libraries — it does the engineering, this tool writes the files.**
 
-An MCP server that gives AI assistants (Claude Code, Claude Desktop, Google Antigravity, VSCode Copilot) file I/O
+An MCP server that gives AI assistants (Claude Code, Claude Desktop, Cursor, Antigravity, VS Code Copilot — any MCP client) file I/O
 and primitive-placement tools for Altium Designer `.PcbLib` (footprint) and `.SchLib` (symbol)
 libraries — so the AI can create and maintain *any* component, not just pre-programmed packages.
 
@@ -54,7 +54,7 @@ read and write the actual `.PcbLib` / `.SchLib` files.
 
 | If you… | Then… |
 |---------|-------|
-| Use Claude Code, Claude Desktop, Google Antigravity, or VSCode + Copilot and design in Altium | ✅ This is for you |
+| Use Claude Code, Claude Desktop, Cursor, Antigravity, VS Code + Copilot — [any MCP client](docs/CLIENT_SETUP.md) — and design in Altium | ✅ This is for you |
 | Want pre-baked generators for a fixed set of packages | ❌ Not this — the point is *any* component |
 | Don't use Altium | ❌ Not applicable |
 
@@ -71,6 +71,14 @@ read and write the actual `.PcbLib` / `.SchLib` files.
 
 > **[Google Antigravity Setup Guide](docs/ANTIGRAVITY_GUIDE.md)** — Step-by-step instructions
 > for using this MCP server with Google Antigravity (IDE and CLI) on **Windows**, **Linux**, and **macOS**.
+
+---
+
+## Quick Start with any other AI client
+
+> **[Client Setup](docs/CLIENT_SETUP.md)** — verified configuration for Claude Desktop, Cursor,
+> VS Code, GitHub Copilot CLI, Windsurf, Cline, Roo Code, Kiro, JetBrains, Zed, Gemini CLI,
+> Codex CLI, Continue, Goose, OpenCode and any other stdio MCP client, plus troubleshooting.
 
 ---
 
@@ -97,7 +105,7 @@ read and write the actual `.PcbLib` / `.SchLib` files.
 │    │                         │  write_schlib(symbol)        │ .SchLib files │
 │    │                         ├─────────────────────────────►│               │
 │    │                         │◄─────────────────────────────┤               │
-│    │                         │  { success: true }           │               │
+│    │                         │  { status: "success" }       │               │
 │    │                         │                              │               │
 │    │  "Done! Footprint       │                              │               │
 │    │   and symbol created"   │                              │               │

--- a/TODO.md
+++ b/TODO.md
@@ -18,8 +18,12 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **v1.0.0 is the real release**, gated on ALL features built (the 99% coverage
       gate — production metric, #381 — is already met). The climb happens calmly;
       [`docs/RELEASING.md`](docs/RELEASING.md) is the proven runbook.
-- [ ] Consider a `.dxt` Claude Desktop extension for one-click install (pattern from
-      coffeenmusic/altium-mcp).
+- [ ] **Streamable HTTP transport** alongside stdio, so web-only assistants (claude.ai in
+      the browser, ChatGPT) can connect as a remote server — today they cannot
+      (`docs/CLIENT_SETUP.md` § Web-only assistants).
+- [ ] **`.mcpb` Claude Desktop extension** for one-click install — the format that
+      superseded `.dxt`; Claude Desktop now steers users to extensions over hand-edited
+      JSON (pattern from coffeenmusic/altium-mcp).
 
 ## C. Docs / AI workflow
 

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -117,13 +117,13 @@ You can also add the MCP server globally using the Claude Code CLI:
 **Windows (PowerShell):**
 
 ```powershell
-claude mcp add altium C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe -- $env:USERPROFILE\.altium-designer-mcp\config.json
+claude mcp add altium -- C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe $env:USERPROFILE\.altium-designer-mcp\config.json
 ```
 
 **Linux / macOS:**
 
 ```bash
-claude mcp add altium /path/to/altium-designer-mcp/target/release/altium-designer-mcp -- ~/.altium-designer-mcp/config.json
+claude mcp add altium -- /path/to/altium-designer-mcp/target/release/altium-designer-mcp ~/.altium-designer-mcp/config.json
 ```
 
 To verify it was added:

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -1,0 +1,348 @@
+# Connecting an AI client
+
+How to wire `altium-designer-mcp` into every MCP-capable assistant we know of. Every
+client below needs the same two facts — **where the binary is** and **where your config
+file is** — and differs only in where that pair is written down.
+
+<!-- markdownlint-disable MD013 -->
+
+## Before you start
+
+1. **Install the binary** somewhere permanent and note its absolute path. The release
+   bundle's `README.md` covers this; from source it is `target/release/altium-designer-mcp`
+   (`.exe` on Windows).
+2. **Write a config file** listing the folders holding your libraries (start from the
+   bundled `example-config.json`):
+
+   ```json
+   {
+       "allowed_paths": ["C:\\Users\\you\\Documents\\Altium\\Libraries"]
+   }
+   ```
+
+   The server refuses to touch anything outside `allowed_paths`.
+3. **Check the binary runs** before involving any client:
+
+   ```bash
+   altium-designer-mcp --version
+   ```
+
+The server speaks MCP over **stdio** and takes the config path as its **single argument**.
+Throughout this page:
+
+| Placeholder | Linux / macOS example | Windows example (as written in JSON) |
+|-------------|-----------------------|--------------------------------------|
+| `<binary>` | `/usr/local/bin/altium-designer-mcp` | `C:\\Users\\you\\AppData\\Local\\Programs\\altium-designer-mcp\\altium-designer-mcp.exe` |
+| `<config>` | `/home/you/.altium-designer-mcp/config.json` | `C:\\Users\\you\\.altium-designer-mcp\\config.json` |
+
+Always use **absolute paths**. In JSON on Windows, every backslash is doubled (`\\`);
+in YAML and TOML a backslash inside double quotes also needs doubling, or use forward
+slashes (`C:/Users/you/...`), which Windows accepts everywhere.
+
+### The standard block
+
+Most clients read the same `mcpServers` shape. This is the block referred to below:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "<binary>",
+            "args": ["<config>"]
+        }
+    }
+}
+```
+
+If the client's file already has an `mcpServers` object, add the `"altium"` entry inside
+it rather than pasting a second object.
+
+## Quick reference
+
+| Client | Where the config lives | Shape |
+|--------|------------------------|-------|
+| [Claude Code](#claude-code) | `claude mcp add`, or `.mcp.json` in the project | standard block |
+| [Claude Desktop](#claude-desktop) | `claude_desktop_config.json` (Settings → Developer → Edit Config) | standard block |
+| [Google Antigravity](#google-antigravity) | `~/.gemini/config/mcp_config.json` | standard block |
+| [Cursor](#cursor) | `~/.cursor/mcp.json` or `.cursor/mcp.json` | standard block |
+| [VS Code (Copilot)](#vs-code-github-copilot) | `.vscode/mcp.json` or user `mcp.json` | `servers` key |
+| [GitHub Copilot CLI](#github-copilot-cli) | `~/.copilot/mcp-config.json` or `/mcp add` | standard block + `type: local` |
+| [Windsurf](#windsurf) | `~/.codeium/windsurf/mcp_config.json` | standard block |
+| [Cline](#cline) | MCP Servers panel → Configure, or `~/.cline/mcp.json` (CLI) | standard block |
+| [Roo Code](#roo-code) | `mcp_settings.json` (global) or `.roo/mcp.json` | standard block |
+| [Kiro](#kiro) | `~/.kiro/settings/mcp.json` or `.kiro/settings/mcp.json` | standard block |
+| [JetBrains AI Assistant](#jetbrains-ai-assistant) | Settings → Tools → AI Assistant → MCP, "As JSON" | standard block |
+| [Zed](#zed) | `settings.json` → `context_servers` | own key |
+| [Gemini CLI](#gemini-cli) | `gemini mcp add`, or `~/.gemini/settings.json` | standard block |
+| [OpenAI Codex CLI](#openai-codex-cli) | `codex mcp add`, or `~/.codex/config.toml` | TOML |
+| [Continue](#continue) | `~/.continue/config.yaml` or `.continue/mcpServers/*.yaml` | YAML |
+| [Goose](#goose) | `~/.config/goose/config.yaml` | YAML (`extensions`) |
+| [OpenCode](#opencode) | `opencode.json` | `mcp` key, command as array |
+| [Anything else](#any-other-mcp-client) | its stdio server settings | `command` + `args` |
+
+## Claude Code
+
+The CLI does the editing for you. Everything after `--` is the command that starts the
+server:
+
+```bash
+claude mcp add altium -- /usr/local/bin/altium-designer-mcp /home/you/.altium-designer-mcp/config.json
+```
+
+Windows (PowerShell):
+
+```powershell
+claude mcp add altium -- "$env:LOCALAPPDATA\Programs\altium-designer-mcp\altium-designer-mcp.exe" "$env:USERPROFILE\.altium-designer-mcp\config.json"
+```
+
+Add `--scope user` before the name to make it available in every project (the default,
+*local*, is this project only on this machine). To share with a team instead, commit the
+standard block as `.mcp.json` at the project root — Claude Code asks each person to
+approve it on first use.
+
+Check: `claude mcp list` shows `altium` with `✔ Connected`; inside a session, `/mcp` lists
+its 34 tools. See [`CLAUDE_CODE_GUIDE.md`](CLAUDE_CODE_GUIDE.md) for worked examples.
+
+## Claude Desktop
+
+macOS and Windows only (there is no Linux build of Claude Desktop).
+
+1. Claude menu → **Settings…** → **Developer** → **Edit Config**. This opens (or creates)
+   - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+2. Paste the standard block (Windows paths with doubled backslashes).
+3. Quit Claude Desktop completely and start it again.
+
+Check: the **+** ("Add files, connectors, and more") button below the message box →
+**Connectors** lists `altium`.
+
+If it does not appear, the logs say why: `~/Library/Logs/Claude/mcp-server-altium.log`
+(macOS) or `%APPDATA%\Claude\logs\mcp-server-altium.log` (Windows) carry the server's
+stderr, and `mcp.log` beside them the connection attempts.
+
+## Google Antigravity
+
+Settings → **Customizations** → **Add MCP**, or edit the file directly:
+
+- Linux / macOS: `~/.gemini/config/mcp_config.json`
+- Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`
+
+Paste the standard block. The file is strict JSON (no comments). Full walkthrough in
+[`ANTIGRAVITY_GUIDE.md`](ANTIGRAVITY_GUIDE.md).
+
+## Cursor
+
+Global: `~/.cursor/mcp.json` (every project). Project: `.cursor/mcp.json` in the project
+root. Both take the standard block; `"type": "stdio"` is the default for a `command`
+entry.
+
+Check: Cursor Settings → **MCP** shows `altium` with a green dot and its tool list.
+
+## VS Code (GitHub Copilot)
+
+Workspace: `.vscode/mcp.json`. User-wide: run **MCP: Open User Configuration** from the
+Command Palette. VS Code uses a `servers` key rather than `mcpServers`:
+
+```json
+{
+    "servers": {
+        "altium": {
+            "type": "stdio",
+            "command": "<binary>",
+            "args": ["<config>"]
+        }
+    }
+}
+```
+
+**MCP: Add Server** in the Command Palette walks through the same fields. The tools
+appear in Copilot Chat's **Agent** mode under the tools picker.
+
+## GitHub Copilot CLI
+
+Start `copilot`, enter `/mcp add`, and fill in the form: name `altium`, type
+**Local/STDIO**, the command *including its argument* (`<binary> <config>`), no
+environment variables, tools `*`. Or edit `~/.copilot/mcp-config.json`:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "type": "local",
+            "command": "<binary>",
+            "args": ["<config>"],
+            "env": {},
+            "tools": ["*"]
+        }
+    }
+}
+```
+
+A `.mcp.json` or `.github/mcp.json` in the repository is also read, after you confirm
+folder trust on first launch.
+
+## Windsurf
+
+Cascade panel → **MCPs** icon, or Settings → Cascade → **MCP Servers**; the file is
+`~/.codeium/windsurf/mcp_config.json` and takes the standard block. Cascade caps the
+total at 100 tools across all servers — this server's 34 fit comfortably.
+
+## Cline
+
+In the IDE extension: **MCP Servers** icon in the toolbar → **Configure** tab →
+**Configure MCP Servers**, which opens the settings JSON. Cline's CLI reads
+`~/.cline/mcp.json`. Either way, the standard block, optionally with Cline's extras:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "command": "<binary>",
+            "args": ["<config>"],
+            "disabled": false,
+            "autoApprove": []
+        }
+    }
+}
+```
+
+## Roo Code
+
+Settings icon in the Roo Code pane → **Edit Global MCP** (`mcp_settings.json`) or
+**Edit Project MCP** (`.roo/mcp.json`). Standard block; Roo's `alwaysAllow` array lists
+tools that skip the approval prompt — leave it empty for a file-writing server until you
+trust the workflow. A project entry overrides a global one of the same name.
+
+## Kiro
+
+User level `~/.kiro/settings/mcp.json`, workspace level `.kiro/settings/mcp.json`
+(Command Palette → **Kiro: Open workspace MCP config (JSON)**); workspace wins. Standard
+block, with Kiro's optional `disabled` / `autoApprove` fields. Kiro CLI (formerly Amazon
+Q Developer CLI — migrated automatically in November 2025) reads the same files.
+
+## JetBrains AI Assistant
+
+**Settings → Tools → AI Assistant → Model Context Protocol (MCP)** → **+** → choose
+**As JSON** and paste the standard block. Pick *Global* or *Project* level. (IntelliJ,
+PyCharm, CLion, Rider and the rest share this dialog.)
+
+## Zed
+
+Settings → AI → **MCP Servers** → **Add Server** → **Add Local Server**, or run
+`zed: open settings file` and add:
+
+```json
+{
+    "context_servers": {
+        "altium": {
+            "command": "<binary>",
+            "args": ["<config>"],
+            "env": {}
+        }
+    }
+}
+```
+
+## Gemini CLI
+
+```bash
+gemini mcp add --scope user altium /usr/local/bin/altium-designer-mcp /home/you/.altium-designer-mcp/config.json
+```
+
+(omit `--scope user` for a project-only entry). Or add the standard block to
+`~/.gemini/settings.json` (user) or `.gemini/settings.json` (project). `gemini mcp list`
+confirms the connection.
+
+## OpenAI Codex CLI
+
+```bash
+codex mcp add altium -- /usr/local/bin/altium-designer-mcp /home/you/.altium-designer-mcp/config.json
+```
+
+Or in `~/.codex/config.toml` (or a trusted project's `.codex/config.toml`):
+
+```toml
+[mcp_servers.altium]
+command = "/usr/local/bin/altium-designer-mcp"
+args = ["/home/you/.altium-designer-mcp/config.json"]
+```
+
+On Windows, write the paths with forward slashes or doubled backslashes inside the
+quotes. `codex mcp list` shows the result.
+
+## Continue
+
+Continue's configuration is YAML. Either in `~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: altium
+    type: stdio
+    command: /usr/local/bin/altium-designer-mcp
+    args:
+      - /home/you/.altium-designer-mcp/config.json
+```
+
+or as its own file under `.continue/mcpServers/` in the workspace — that folder also
+accepts a copied `mcpServers` JSON block from another client.
+
+## Goose
+
+`~/.config/goose/config.yaml` (Linux / macOS) or `%APPDATA%\Block\goose\config\config.yaml`
+(Windows), under `extensions`:
+
+```yaml
+extensions:
+  altium:
+    type: stdio
+    name: altium
+    enabled: true
+    cmd: /usr/local/bin/altium-designer-mcp
+    args: ["/home/you/.altium-designer-mcp/config.json"]
+    envs: {}
+    env_keys: []
+    timeout: 300
+```
+
+Restart Goose after editing; `goose configure` offers the same through a menu.
+
+## OpenCode
+
+`opencode.json` in the workspace. The command is a **single array** holding the binary
+and its argument:
+
+```json
+{
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+        "altium": {
+            "type": "local",
+            "command": ["<binary>", "<config>"],
+            "enabled": true
+        }
+    }
+}
+```
+
+## Any other MCP client
+
+If it supports **local (stdio) servers**, it will ask for a command and arguments:
+command `<binary>`, one argument `<config>`, no environment variables. The standard block
+is the de-facto interchange format — many clients import it directly.
+
+### Web-only assistants
+
+claude.ai in the browser and ChatGPT connect only to *remote* MCP servers over HTTP.
+This server currently speaks stdio, so it pairs with the desktop, CLI and IDE clients
+above; an HTTP transport is on the roadmap for v1.0.0.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| Server missing from the client's list | The config file is valid JSON/YAML/TOML (a trailing comma is the usual culprit); paths are absolute; the client was fully restarted. |
+| "Failed to connect" / spawn error | Run `<binary> <config>` in a terminal: it should sit silently waiting for input (press Ctrl+C to stop). If it prints an error, fix that first — a typo in `allowed_paths`, or a missing config file. |
+| Windows: path errors | Every `\` in JSON must be `\\`; or use forward slashes. `%APPDATA%`-style variables are not expanded inside JSON — write the real path. |
+| Windows SmartScreen / macOS Gatekeeper blocks the first run | The binaries are not code-signed. Windows: **More info → Run anyway**. macOS: right-click → **Open** once, or `xattr -d com.apple.quarantine <binary>`. The release's signed provenance attestation is the stronger check — see the release notes. |
+| Tools are listed but every call fails with a path error | The library file is outside `allowed_paths`. Add its folder to the config and restart the client. |
+| Claude Desktop shows nothing | Read `mcp-server-altium.log` (locations above) — it holds the server's own error output. |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,7 +24,7 @@ The final publish is a manual click. Nothing in CI makes a release public.
 ### What ships in an archive
 
 The binary, `example-config.json`, `LICENCE`, `CHANGELOG.md`, and `docs/`
-(`CLAUDE_CODE_GUIDE`, `ANTIGRAVITY_GUIDE`, `AGENT_GUIDE`, `TOOLS`) — plus a
+(`CLIENT_SETUP`, `CLAUDE_CODE_GUIDE`, `ANTIGRAVITY_GUIDE`, `AGENT_GUIDE`, `TOOLS`) — plus a
 **bundle-specific `README.md` generated from
 [`.github/release-assets/README.md`](../.github/release-assets/README.md)**, with
 `@VERSION@` substituted for the tag. That file is what someone sees first after


### PR DESCRIPTION
First workstream of the docs-to-perfection chapter: **usage instructions for as many AI clients as possible**, in the repo and in the release bundle.

## `docs/CLIENT_SETUP.md` — 17 clients, every snippet verified against the client's *current* official docs

Claude Code · Claude Desktop · Google Antigravity · Cursor · VS Code (Copilot) · GitHub Copilot CLI · Windsurf · Cline · Roo Code · Kiro · JetBrains AI Assistant · Zed · Gemini CLI · OpenAI Codex CLI · Continue · Goose · OpenCode — plus a generic "any stdio client" section, the web-only-assistant caveat (claude.ai / ChatGPT need a remote server), and a troubleshooting table (invalid JSON, Windows backslashes, SmartScreen/Gatekeeper, `allowed_paths`, Claude Desktop's per-server logs).

Writing from memory would have shipped wrong instructions. Verification caught, among others:

| Client | Drift caught |
|--------|--------------|
| **Claude Code** | the documented form is `claude mcp add altium -- <binary> <config>` (whole command after `--`) — our bundle README and CLAUDE_CODE_GUIDE had the binary *before* `--`; both corrected |
| **Amazon Q Developer CLI** | no longer exists — became Kiro CLI (Nov 2025, product sunsetting); the guide documents Kiro |
| **Zed** | flattened its format (`command` is now a plain string) |
| **Continue** | config is YAML now |
| **OpenCode** | `command` is an array |
| **Windsurf** | docs moved under Devin/Cognition; 100-tool cap noted (our 34 fit) |
| **Claude Desktop** | macOS + Windows only — stated explicitly |

## Wiring

- Ships in the release bundle: `release.yml` copies and verifies it on all three platforms; listed in the bundle README, `RELEASING.md` § What ships, `CONTRIBUTING.md`'s doc table.
- README: new "Quick Start with any other AI client" entry; who-is-this-for row; the "How It Works" diagram no longer shows a `{ success: true }` response the server never sends.
- TODO § B gains two roadmap items the research surfaced: **Streamable HTTP transport** (web-only assistants cannot reach a stdio server) and an **`.mcpb` Claude Desktop extension** — the format that superseded `.dxt`, which Claude Desktop now steers users toward over hand-edited JSON.

markdownlint clean across all touched files; `release.yml` parses and the four copy/verify sites are updated symmetrically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
