### PR TITLE
docs: bring the Claude Code and Antigravity guides up to the release

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,8 +21,9 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **Streamable HTTP transport** alongside stdio, so web-only assistants (claude.ai in
       the browser, ChatGPT) can connect as a remote server — today they cannot
       (`docs/CLIENT_SETUP.md` § Web-only assistants).
-- [ ] **`.mcpb` Claude Desktop extension** for one-click install — the format that
-      superseded `.dxt`; Claude Desktop now steers users to extensions over hand-edited
+- [ ] **Claude Desktop extension** for one-click install, published as **both `.mcpb` and
+      `.dxt`** — the same bundle format under its new and old names, so older Claude Desktop
+      builds install it too. Claude Desktop now steers users to extensions over hand-edited
       JSON (pattern from coffeenmusic/altium-mcp).
 
 ## C. Docs / AI workflow

--- a/docs/ANTIGRAVITY_GUIDE.md
+++ b/docs/ANTIGRAVITY_GUIDE.md
@@ -25,16 +25,18 @@ to generate library files that you then open in Altium Designer on Windows.
 
 ### Prerequisites
 
-- [Rust 1.75+](https://rustup.rs/) (to build from source)
 - [Google Antigravity](https://antigravity.google) installed
+- [Rust 1.75+](https://rustup.rs/) only if you build from source
 
-### Step 1: Build the server
+### Step 1: Get the server binary
 
-See [CONTRIBUTING.md § Development Setup](../CONTRIBUTING.md#development-setup) for build
-instructions. After building, the binary is at:
+**Download** the archive for your platform from the
+[Releases page](https://github.com/embedded-society/altium-designer-mcp/releases), unpack it,
+and move the binary somewhere permanent — the bundled `README.md` walks through it. Or
+**build from source** per [CONTRIBUTING.md § Development Setup](../CONTRIBUTING.md#development-setup);
+the binary then lands at `target/release/altium-designer-mcp` (`.exe` on Windows).
 
-- **Windows:** `target\release\altium-designer-mcp.exe`
-- **Linux/macOS:** `target/release/altium-designer-mcp`
+Note the binary's absolute path — Step 3 needs it.
 
 ### Step 2: Create the server config file
 
@@ -71,7 +73,7 @@ binary and the server `config.json` (replace the example paths with yours):
 {
     "mcpServers": {
         "altium": {
-            "command": "C:\\path\\to\\altium-designer-mcp\\target\\release\\altium-designer-mcp.exe",
+            "command": "C:\\Users\\you\\AppData\\Local\\Programs\\altium-designer-mcp\\altium-designer-mcp.exe",
             "args": ["C:\\Users\\you\\.altium-designer-mcp\\config.json"]
         }
     }
@@ -84,7 +86,7 @@ binary and the server `config.json` (replace the example paths with yours):
 {
     "mcpServers": {
         "altium": {
-            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "command": "/usr/local/bin/altium-designer-mcp",
             "args": ["/home/you/.altium-designer-mcp/config.json"]
         }
     }
@@ -97,7 +99,7 @@ binary and the server `config.json` (replace the example paths with yours):
 {
     "mcpServers": {
         "altium": {
-            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "command": "/usr/local/bin/altium-designer-mcp",
             "args": ["/Users/you/.altium-designer-mcp/config.json"]
         }
     }
@@ -153,7 +155,11 @@ What silkscreen style does it use?
   file is valid JSON (no trailing commas, no comments).
 - Use absolute paths; on Windows the `.exe` extension is required and backslashes must be
   escaped (`\\`).
+- Run the binary by hand once (`altium-designer-mcp --version`): on the very first run
+  Windows SmartScreen or macOS Gatekeeper may block an unsigned binary — **More info → Run
+  anyway** on Windows, right-click → **Open** on macOS.
 - Reload Antigravity after editing the file.
+- [CLIENT_SETUP.md § Troubleshooting](CLIENT_SETUP.md#troubleshooting) has the full checklist.
 
 ### "Access denied" error
 
@@ -162,8 +168,10 @@ The target path is outside the server's `allowed_paths`. Add the directory to yo
 
 ### Library won't open in Altium
 
-Use Altium Designer 19+ and open via **File → Open**. The file format is binary-compatible
-across platforms, so libraries generated on Linux/macOS open on Windows.
+The files are verified against Altium Designer 24 (the project's golden fixtures are
+AD24-authored); older versions that read the same library format should work but are
+untested. The format is binary-compatible across platforms, so libraries generated on
+Linux/macOS open on Windows. Ask the agent to run `validate_library` on a file that misbehaves.
 
 For anything not covered here, the behaviour is identical to other MCP clients — see the
 [Claude Code guide](CLAUDE_CODE_GUIDE.md#troubleshooting).
@@ -173,6 +181,8 @@ For anything not covered here, the behaviour is identical to other MCP clients �
 ## Next Steps
 
 - [docs/TOOLS.md](TOOLS.md) — full tool reference
-- [AI_WORKFLOW.md](AI_WORKFLOW.md) — IPC-7351B reference
+- [AGENT_GUIDE.md](AGENT_GUIDE.md) — the unit and pin-geometry conventions; worth pasting into a project brief
+- [AI_WORKFLOW.md](AI_WORKFLOW.md) — IPC-7351B workflow and symbol conventions
+- [CLIENT_SETUP.md](CLIENT_SETUP.md) — every other MCP client
 - [ARCHITECTURE.md](ARCHITECTURE.md) — technical details
 - [Antigravity MCP docs](https://antigravity.google/docs/mcp) — authoritative, version-current setup

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -24,17 +24,18 @@ platform to generate library files that can then be opened in Altium Designer on
 
 ### Prerequisites
 
-- [Rust 1.75+](https://rustup.rs/) (for building from source)
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
+- [Claude Code](https://code.claude.com/docs) CLI installed
+- [Rust 1.75+](https://rustup.rs/) only if you build from source
 
-### Step 1: Clone and Build
+### Step 1: Get the Binary
 
-See [CONTRIBUTING.md § Development Setup](../CONTRIBUTING.md#development-setup) for build instructions.
+**Download** the archive for your platform from the
+[Releases page](https://github.com/embedded-society/altium-designer-mcp/releases), unpack it,
+and move the binary somewhere permanent — the bundled `README.md` walks through it. Or
+**build from source** per [CONTRIBUTING.md § Development Setup](../CONTRIBUTING.md#development-setup);
+the binary then lands at `target/release/altium-designer-mcp` (`.exe` on Windows).
 
-**Binary location after build:**
-
-- **Windows:** `target\release\altium-designer-mcp.exe`
-- **Linux/macOS:** `target/release/altium-designer-mcp`
+Either way, note the binary's absolute path — every configuration step below needs it.
 
 ### Step 2: Create Configuration File
 
@@ -65,7 +66,9 @@ Claude Code uses a `.mcp.json` file in your project root to configure MCP server
 
 #### Option A: Project-Level Configuration (Recommended)
 
-Create a `.mcp.json` file in your Altium project's root directory:
+Create a `.mcp.json` file in your Altium project's root directory. It can be committed, so a
+team shares one setup; Claude Code asks each person to approve the server the first time it
+loads the file.
 
 #### Windows
 
@@ -73,16 +76,15 @@ Create a `.mcp.json` file in your Altium project's root directory:
 {
     "mcpServers": {
         "altium": {
-            "command": "C:\\path\\to\\altium-designer-mcp\\target\\release\\altium-designer-mcp.exe",
-            "args": ["%USERPROFILE%\\.altium-designer-mcp\\config.json"]
+            "command": "C:\\Users\\yourname\\AppData\\Local\\Programs\\altium-designer-mcp\\altium-designer-mcp.exe",
+            "args": ["C:\\Users\\yourname\\.altium-designer-mcp\\config.json"]
         }
     }
 }
 ```
 
-> **Note:** the JSON `args` are passed to the server verbatim — they are **not** shell-expanded,
-> so `%USERPROFILE%` only works if the client expands it for you. An absolute path
-> (for example `C:\\Users\\yourname\\.altium-designer-mcp\\config.json`) is safest.
+> Use **absolute paths** with every backslash doubled. JSON `args` reach the server verbatim —
+> nothing expands `%USERPROFILE%` or `~` for you.
 
 #### Linux
 
@@ -90,7 +92,7 @@ Create a `.mcp.json` file in your Altium project's root directory:
 {
     "mcpServers": {
         "altium": {
-            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "command": "/usr/local/bin/altium-designer-mcp",
             "args": ["/home/yourname/.altium-designer-mcp/config.json"]
         }
     }
@@ -103,34 +105,38 @@ Create a `.mcp.json` file in your Altium project's root directory:
 {
     "mcpServers": {
         "altium": {
-            "command": "/path/to/altium-designer-mcp/target/release/altium-designer-mcp",
+            "command": "/usr/local/bin/altium-designer-mcp",
             "args": ["/Users/yourname/.altium-designer-mcp/config.json"]
         }
     }
 }
 ```
 
-#### Option B: Global Configuration via CLI
+#### Option B: Configuration via CLI
 
-You can also add the MCP server globally using the Claude Code CLI:
+`claude mcp add` writes the entry for you. Everything after `--` is the command that starts
+the server. With `--scope user` it is available in every project on this machine; without it,
+only in the current project (local scope).
 
 **Windows (PowerShell):**
 
 ```powershell
-claude mcp add altium -- C:\path\to\altium-designer-mcp\target\release\altium-designer-mcp.exe $env:USERPROFILE\.altium-designer-mcp\config.json
+claude mcp add --scope user altium -- "$env:LOCALAPPDATA\Programs\altium-designer-mcp\altium-designer-mcp.exe" "$env:USERPROFILE\.altium-designer-mcp\config.json"
 ```
 
 **Linux / macOS:**
 
 ```bash
-claude mcp add altium -- /path/to/altium-designer-mcp/target/release/altium-designer-mcp ~/.altium-designer-mcp/config.json
+claude mcp add --scope user altium -- /usr/local/bin/altium-designer-mcp ~/.altium-designer-mcp/config.json
 ```
 
-To verify it was added:
+To verify it was added and connects:
 
 ```bash
 claude mcp list
 ```
+
+`altium` should show `✔ Connected`.
 
 ---
 
@@ -333,18 +339,22 @@ Add an 0402 resistor footprint to the existing ./Passives.PcbLib (append mode)
 The file path is outside `allowed_paths`. Update your config.json to include the
 directory where you want to create libraries.
 
-### MCP Server Not Found
+### MCP Server Not Found / Failed to Connect
 
-Verify the path in your Claude Code configuration points to the correct binary:
-
-- Windows: `.exe` extension required
-- Check the path exists and is executable
+- The configured path must point at the binary itself (`.exe` on Windows) and be absolute.
+- Run it by hand first: `altium-designer-mcp --version`. On the very first run Windows
+  SmartScreen or macOS Gatekeeper may block an unsigned binary — **More info → Run anyway**
+  on Windows, right-click → **Open** on macOS.
+- `claude mcp list` shows the connection state;
+  [CLIENT_SETUP.md § Troubleshooting](CLIENT_SETUP.md#troubleshooting) has the full checklist.
 
 ### Library Won't Open in Altium
 
-- Ensure you're using a recent version of Altium Designer (19+)
-- Check that the file was created successfully (non-zero file size)
-- Try opening with File > Open rather than drag-and-drop
+- The files are verified against Altium Designer 24 (the project's golden fixtures are
+  AD24-authored). Older versions that read the same library format should work but are
+  untested.
+- Check that the file was created successfully (non-zero file size), and ask Claude Code to
+  run `validate_library` on it.
 
 ### Style Extraction Shows Unexpected Values
 
@@ -369,7 +379,6 @@ Generate libraries on Linux and transfer to Windows for use in Altium:
 
 - Use a shared folder, cloud sync, or version control
 - File format is binary-compatible across platforms
-- Consider using Wine with Altium Designer (community-supported)
 
 ### macOS
 
@@ -393,6 +402,10 @@ to allow library operations.
 
 ## Next Steps
 
-- Read [AI_WORKFLOW.md](AI_WORKFLOW.md) for detailed IPC-7351B reference
-- See [ARCHITECTURE.md](ARCHITECTURE.md) for technical details
-- Check sample files in `scripts/` folder for examples
+- Read [AI_WORKFLOW.md](AI_WORKFLOW.md) for the IPC-7351B workflow and symbol conventions
+- Paste [AGENT_GUIDE.md](AGENT_GUIDE.md) into a project brief so Claude knows the unit and
+  pin-geometry conventions
+- Using a different assistant as well? [CLIENT_SETUP.md](CLIENT_SETUP.md) covers every other
+  MCP client
+- See [ARCHITECTURE.md](ARCHITECTURE.md) for technical details and `scripts/samples/` for
+  Altium-authored example libraries


### PR DESCRIPTION
Docs-crusade workstream 3 — the two bundled setup guides, reread cold after the release.

## What was stale

Both guides still read as if building from source were the only route (Rust as a prerequisite, "Step 1: Clone and Build", `target/release` example paths). They now lead with the Releases download, source build second, and use the same installed-binary paths as the bundle README and `CLIENT_SETUP.md` — one consistent setup story across every document.

## Corrections

| Guide | Was | Now |
|-------|-----|-----|
| Claude Code | "Option B: **Global** Configuration via CLI" — but `claude mcp add` defaults to *local* scope | `--scope user` shown and scopes explained |
| Claude Code | Windows `.mcp.json` example used `%USERPROFILE%` plus a caveat that it won't expand | real absolute path, one-line rule |
| Both | "Altium Designer 19+" — never verified | verified against AD24 (the golden fixtures' author); older untested |
| Claude Code | drag-and-drop folklore, "consider Wine" | removed |
| Both | — | SmartScreen/Gatekeeper first-run guidance; link to CLIENT_SETUP troubleshooting |
| Both | next steps | cross-link AGENT_GUIDE + CLIENT_SETUP; samples pointer names `scripts/samples/` |

TODO § B's extension item now reads **both `.mcpb` and `.dxt`** per the maintainer's call (same bundle format, new and old names).

markdownlint clean; offline link check 180 OK / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)