### PR TITLE
docs(ai-workflow): add symbol pin-placement guidance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,8 +24,3 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **`.mcpb` Claude Desktop extension** for one-click install — the format that
       superseded `.dxt`; Claude Desktop now steers users to extensions over hand-edited
       JSON (pattern from coffeenmusic/altium-mcp).
-
-## C. Docs / AI workflow
-
-- [ ] Enrich `docs/AI_WORKFLOW.md` with symbol pin-placement guidance (idea from
-      coffeenmusic's `symbol_placement_rules.txt`).

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -198,6 +198,47 @@ For multi-unit parts (dual / quad op-amps, gate arrays): set `part_count` on the
 and tag each pin with `owner_part_id` (the 1-based part it belongs to). The `DUALPART`
 sample demonstrates a two-part symbol with pins split across parts 1 and 2.
 
+### Pin placement
+
+A symbol reads well when pins sit where an engineer expects them. These rules (adapted from
+[coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp)'s
+`symbol_placement_rules.txt`, MIT) give a consistent layout for ICs, regulators and
+connectors; apply them unless the datasheet's reference schematic or an existing library
+style says otherwise.
+
+**Sides.** Use the **left and right** sides only — a pin on the top or bottom edge breaks the
+signal-flow reading and makes wiring awkward. Never overlap or merge pins.
+
+**Where each kind goes**, from most to least important:
+
+| Pins | Position |
+|------|----------|
+| Ground — analogue, digital, power, exposed pad | bottom **left** |
+| No-connect (`NC`, `DNC`) | bottom **right** |
+| Power rails (`VCC`, `VDD`, `AVDD`, `VREF`…) | upper **right** |
+| Inputs | **left** |
+| Outputs | **right** |
+| Switching regulator `VIN` | **left** (input-to-output flow) |
+
+Everything else is grouped by function — one block for SPI, one for I²C, one for RGMII, the
+GPIO bank together — each block's pins in the datasheet's order.
+
+**Spacing.** Pins stay on the 10-unit grid (one 100 mil step). Separate groups with a **gap
+of one grid step**; if the body has room to spare, distribute the groups at equal spacing
+instead of stacking them at one end. Leave the body tall enough that the longer side's groups
+fit without crowding — stretching the rectangle is free, a cramped symbol is not.
+
+**Coordinates.** Lower `x` is left, lower `y` is bottom. In this server a pin's `(x, y)` is
+its body-attach end and `orientation` is the direction it points *outward* (see
+[AGENT_GUIDE.md § Pin geometry](AGENT_GUIDE.md#pin-geometry-the-counter-intuitive-one)), so a
+left-side pin at the body's left edge uses `"orientation": "left"` and its tip extends
+further left. The `write_schlib` response echoes each pin's computed `body_end`/`tip`, which is
+the cheapest way to check a layout before opening Altium.
+
+**Explain first.** Before emitting the symbol, list each pin (or group) with the position
+chosen for it and why — a reviewer can correct a plan in one line; a finished symbol costs a
+regeneration.
+
 ## Working with Large Libraries
 
 For libraries with many components, use pagination to avoid output limits:


### PR DESCRIPTION
The last open docs item from TODO: **where pins go on a symbol** so it reads the way an engineer expects. Adapted with attribution from [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp)'s `symbol_placement_rules.txt` (MIT) and translated into this server's conventions:

- left/right sides only, no overlaps;
- the priority table — grounds bottom-left, no-connects bottom-right, power rails upper-right, inputs left, outputs right, regulator `VIN` left;
- functional grouping (SPI / I²C / RGMII / GPIO banks) with one-grid-step gaps, or equal spacing when there's room;
- the coordinate model tied to AGENT_GUIDE's body-attach/outward-orientation rule, with the `write_schlib` `body_end`/`tip` echo as the cheapest pre-Altium check;
- "explain the plan before emitting the symbol".

The shipped item leaves `TODO.md` (it was § C's only entry, so the section goes with it). markdownlint clean; offline link check 175 OK / 0 errors including the new cross-anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)