### PR TITLE
fix(mcp): compact output keeps a stacked pad's stack mode and per-layer data

### DIFF
--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -864,19 +864,15 @@ impl McpServer {
                             .iter()
                             .map(|pad| {
                                 let mut pad_json = serde_json::to_value(pad).unwrap();
-                                // Remove per-layer data if stack_mode is Simple OR all values are uniform
-                                let should_strip = pad.stack_mode == PadStackMode::Simple
-                                    || Self::pad_has_uniform_per_layer_data(pad);
-                                if should_strip {
+                                // Only a Simple pad's per-layer arrays are redundant; a
+                                // stacked pad keeps them and its stack_mode even when
+                                // every layer matches (see read_pcblib's compact mode).
+                                if pad.stack_mode == PadStackMode::Simple {
                                     if let Value::Object(ref mut obj) = pad_json {
                                         obj.remove("per_layer_sizes");
                                         obj.remove("per_layer_shapes");
                                         obj.remove("per_layer_corner_radii");
                                         obj.remove("per_layer_offsets");
-                                        // Downgrade stack_mode to simple if we stripped uniform data
-                                        if pad.stack_mode != PadStackMode::Simple {
-                                            obj.insert("stack_mode".to_string(), json!("simple"));
-                                        }
                                     }
                                 }
                                 pad_json
@@ -1895,6 +1891,27 @@ mod tests {
         }));
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("invalid base64"));
+
+        // A model entry without an id, or without data, is rejected by name.
+        for (entry, expected) in [
+            (json!({ "name": "x.step", "data": "AAEC" }), "has no 'id'"),
+            (json!({ "id": "{2}", "name": "x.step" }), "has no 'data'"),
+        ] {
+            let result = server.call_import_library(&json!({
+                "output_path": dir.path().join("Malformed.PcbLib").to_string_lossy(),
+                "json_data": {
+                    "file_type": "PcbLib",
+                    "footprints": [],
+                    "embedded_models": [entry],
+                },
+            }));
+            assert!(result.is_error, "{expected}");
+            assert!(
+                get_result_text(&result).contains(expected),
+                "{}",
+                get_result_text(&result)
+            );
+        }
     }
 
     /// Export → import is the backup/restore loop, so the footprint's kind-85
@@ -3245,13 +3262,12 @@ mod tests {
             assert!(!parsed["error"].as_str().unwrap().is_empty());
         }
 
-        // Compact export strips the per-layer arrays when every layer holds the
-        // same geometry — so it must also downgrade stack_mode to "simple".
-        // Left saying "full_stack", the payload describes a pad with
-        // independent per-layer geometry whose per-layer data is gone, and
-        // re-importing it loses the pad's real size.
+        // Compact export strips the per-layer arrays of a Simple pad only. A
+        // stacked pad keeps its arrays and its stack_mode even when every
+        // layer matches — so a re-import gets the pad back exactly, with the
+        // tapered stack's wider layer-0 land and the uniform stack's mode.
         #[test]
-        fn export_pcblib_compact_downgrades_uniform_full_stack_pads() {
+        fn export_pcblib_compact_keeps_stacked_pads_intact() {
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
 
@@ -3266,9 +3282,12 @@ mod tests {
             tapered_sizes[0] = (1.2, 0.5);
             tapered.per_layer_sizes = Some(tapered_sizes);
 
+            let simple = Pad::smd("3", 4.0, 0.0, 0.6, 0.5);
+
             let mut fp = Footprint::new("FULLSTACK");
             fp.add_pad(uniform);
             fp.add_pad(tapered);
+            fp.add_pad(simple);
             let mut lib = PcbLib::new();
             lib.add(fp);
             let path = dir.path().join("FullStack.PcbLib");
@@ -3279,49 +3298,30 @@ mod tests {
                 "format": "json",
                 "compact": true,
             })));
-            let exported = &parsed["footprints"][0]["pads"][0];
-            assert_eq!(
-                exported["stack_mode"], "simple",
-                "a stripped pad must not still claim a full stack: {exported}"
-            );
-            for stripped in [
-                "per_layer_sizes",
-                "per_layer_shapes",
-                "per_layer_corner_radii",
-                "per_layer_offsets",
-            ] {
-                assert!(
-                    exported.get(stripped).is_none(),
-                    "uniform {stripped} must be stripped: {exported}"
+            let pads = &parsed["footprints"][0]["pads"];
+            for (i, label) in [(0, "uniform"), (1, "tapered")] {
+                assert_eq!(
+                    pads[i]["stack_mode"], "full_stack",
+                    "{label} stack keeps its mode: {}",
+                    pads[i]
+                );
+                assert_eq!(
+                    pads[i]["per_layer_sizes"].as_array().map(Vec::len),
+                    Some(32),
+                    "{label} stack keeps its per-layer sizes: {}",
+                    pads[i]
                 );
             }
-            // The pad's real geometry has to survive the strip, or the compact
-            // form describes a pad of unknown size.
-            let width = exported["width"].as_f64().unwrap();
-            assert!((width - 0.6).abs() < 1e-3, "width lost: {exported}");
-
-            // The tapered pad's per-layer sizes are not redundant: stripping
-            // them would export a plain 0.6 mm pad and silently lose the wider
-            // layer-0 land the part actually needs.
-            let tapered = &parsed["footprints"][0]["pads"][1];
-            assert_eq!(
-                tapered["stack_mode"], "full_stack",
-                "a non-uniform stack must keep its mode: {tapered}"
-            );
-            let sizes = tapered["per_layer_sizes"]
-                .as_array()
-                .unwrap_or_else(|| panic!("per-layer sizes must be kept: {tapered}"));
+            let layer0 = &pads[1]["per_layer_sizes"][0];
+            assert!((layer0[0].as_f64().unwrap() - 1.2).abs() < 1e-3, "{layer0}");
+            assert_eq!(pads[2]["stack_mode"], "simple");
             assert!(
-                (sizes[0][0].as_f64().unwrap() - 1.2).abs() < 1e-3,
-                "the wider layer-0 size must survive: {tapered}"
+                pads[2].get("per_layer_sizes").is_none(),
+                "a Simple pad's arrays are stripped: {}",
+                pads[2]
             );
         }
 
-        // ---------- import_library ----------
-
-        // Import writes a file. Without the sandbox check it would be an
-        // arbitrary-file writer, which is the one thing the server must never
-        // become.
         #[test]
         fn import_library_rejects_path_outside_allowed_roots() {
             let allowed = test_temp_dir();
@@ -3683,7 +3683,7 @@ mod tests {
     mod degenerate_libraries {
         use crate::altium::pcblib::{Arc, Footprint, Layer, Pad, PcbLib, Track};
         use crate::mcp::tools::test_support::{
-            create_test_server, get_result_text, parse_result_json, test_temp_dir,
+            create_test_server, parse_result_json, test_temp_dir,
         };
         use serde_json::json;
 
@@ -3764,45 +3764,6 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n");
             assert!(issues.contains("no pads"), "{issues}");
-        }
-
-        #[test]
-        fn export_strips_a_uniform_stack_the_same_way_read_does() {
-            // export_library carries its own copy of the compact-pad logic, so
-            // a FullStack pad whose 32 layers all match reports as simple here
-            // too rather than dragging the redundant arrays into the JSON.
-            let dir = test_temp_dir();
-            let server = create_test_server(dir.path());
-            let path = dir.path().join("Stack.PcbLib");
-            let uniform: Vec<serde_json::Value> = (0..32)
-                .map(|_| json!({ "width": 1.0, "height": 1.0 }))
-                .collect();
-
-            let written = server.call_write_pcblib(&json!({
-                "filepath": path.to_string_lossy(),
-                "footprints": [{
-                    "name": "FP",
-                    "pads": [{
-                        "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
-                        "stack_mode": "full_stack", "per_layer_sizes": uniform,
-                    }],
-                }],
-            }));
-            assert!(!written.is_error, "{}", get_result_text(&written));
-
-            let exported = server.call_export_library(&json!({
-                "filepath": path.to_string_lossy(),
-                "format": "json",
-                "compact": true,
-            }));
-            assert!(!exported.is_error, "{}", get_result_text(&exported));
-
-            let text = get_result_text(&exported);
-            assert!(text.contains("\"simple\""), "stack not downgraded: {text}");
-            assert!(
-                !text.contains("per_layer_sizes"),
-                "redundant stack arrays survived the export: {text}"
-            );
         }
     }
 }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -351,22 +351,19 @@ impl McpServer {
                                 .iter()
                                 .map(|pad| {
                                     let mut pad_json = serde_json::to_value(pad).unwrap();
-                                    // Remove per-layer data if stack_mode is Simple OR all values are uniform
-                                    let should_strip = pad.stack_mode == PadStackMode::Simple
-                                        || Self::pad_has_uniform_per_layer_data(pad);
-                                    if should_strip {
+                                    // A Simple pad's per-layer arrays carry nothing the
+                                    // main size/shape do not, so they go. A stacked pad
+                                    // keeps them — and its stack_mode — even when every
+                                    // layer happens to match: the mode is a stored
+                                    // property Altium shows, and rewriting it to
+                                    // "simple" here silently changed the pad on the next
+                                    // write.
+                                    if pad.stack_mode == PadStackMode::Simple {
                                         if let Value::Object(ref mut obj) = pad_json {
                                             obj.remove("per_layer_sizes");
                                             obj.remove("per_layer_shapes");
                                             obj.remove("per_layer_corner_radii");
                                             obj.remove("per_layer_offsets");
-                                            // Downgrade stack_mode to simple if we stripped uniform data
-                                            if pad.stack_mode != PadStackMode::Simple {
-                                                obj.insert(
-                                                    "stack_mode".to_string(),
-                                                    json!("simple"),
-                                                );
-                                            }
                                         }
                                     }
                                     pad_json
@@ -3909,12 +3906,12 @@ mod tests {
         // ---- read_pcblib / read_schlib ---------------------------------------
 
         #[test]
-        fn read_pcblib_compact_downgrades_a_uniform_full_stack_pad() {
-            // A FullStack pad whose per-layer values all match the primary pair
-            // carries no information: compact mode strips the arrays and
-            // reports the pad as simple. The reader always materialises all 32
-            // layers, so every one of them has to match or the pad is genuinely
-            // non-uniform and must keep its stack.
+        fn read_pcblib_compact_keeps_a_stacked_pad_intact() {
+            // Compact mode strips the per-layer arrays of a Simple pad only.
+            // A FullStack pad keeps its arrays and its stack_mode even when
+            // every layer matches the primary pair: the mode is a stored
+            // property Altium shows, and reporting it as "simple" turned the
+            // pad into a simple one on the next write.
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
             let path = dir.path().join("Stack.PcbLib");
@@ -3925,11 +3922,14 @@ mod tests {
                 "filepath": path.to_string_lossy(),
                 "footprints": [{
                     "name": "FP",
-                    "pads": [{
-                        "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
-                        "stack_mode": "full_stack",
-                        "per_layer_sizes": uniform,
-                    }],
+                    "pads": [
+                        {
+                            "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
+                            "stack_mode": "full_stack",
+                            "per_layer_sizes": uniform,
+                        },
+                        { "designator": "2", "x": 2.0, "y": 0.0, "width": 1.0, "height": 1.0 }
+                    ],
                 }],
             }));
             assert!(!written.is_error, "{}", get_result_text(&written));
@@ -3937,9 +3937,37 @@ mod tests {
             let r = server.call_read_pcblib(&json!({
                 "filepath": path.to_string_lossy(), "compact": true,
             }));
-            let pad_json = &parse_result_json(&r)["footprints"][0]["pads"][0];
-            assert_eq!(pad_json["stack_mode"], "simple");
-            assert!(pad_json.get("per_layer_sizes").is_none());
+            let pads = &parse_result_json(&r)["footprints"][0]["pads"];
+            assert_eq!(
+                pads[0]["stack_mode"], "full_stack",
+                "mode kept: {}",
+                pads[0]
+            );
+            assert_eq!(
+                pads[0]["per_layer_sizes"].as_array().map(Vec::len),
+                Some(32),
+                "arrays kept for a stacked pad: {}",
+                pads[0]
+            );
+            assert_eq!(pads[1]["stack_mode"], "simple");
+            assert!(
+                pads[1].get("per_layer_sizes").is_none(),
+                "a Simple pad's arrays are stripped: {}",
+                pads[1]
+            );
+
+            // And the compact output writes back to the same stack mode.
+            let back = dir.path().join("StackBack.PcbLib");
+            let rewritten = server.call_write_pcblib(&json!({
+                "filepath": back.to_string_lossy(),
+                "footprints": parse_result_json(&r)["footprints"],
+            }));
+            assert!(!rewritten.is_error, "{}", get_result_text(&rewritten));
+            let again = server.call_read_pcblib(&json!({ "filepath": back.to_string_lossy() }));
+            assert_eq!(
+                parse_result_json(&again)["footprints"][0]["pads"][0]["stack_mode"],
+                "full_stack"
+            );
         }
 
         #[test]

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -26,41 +26,6 @@ impl McpServer {
         Ok(())
     }
 
-    /// Checks if a pad's per-layer data is uniform (all layers have same values).
-    ///
-    /// When all per-layer values are identical, the data is redundant and can be
-    /// omitted in compact mode, even if the pad was stored with `FullStack` mode.
-    pub(crate) fn pad_has_uniform_per_layer_data(pad: &crate::altium::pcblib::Pad) -> bool {
-        // Check per_layer_sizes - all should match primary width/height
-        let sizes_uniform = pad.per_layer_sizes.as_ref().map_or(true, |sizes| {
-            sizes
-                .iter()
-                .all(|&(w, h)| (w - pad.width).abs() < 0.001 && (h - pad.height).abs() < 0.001)
-        });
-
-        // Check per_layer_shapes - all should match primary shape
-        let shapes_uniform = pad
-            .per_layer_shapes
-            .as_ref()
-            .map_or(true, |shapes| shapes.iter().all(|s| *s == pad.shape));
-
-        // Check per_layer_corner_radii - all should match primary corner_radius_percent
-        let primary_radius = pad.corner_radius_percent.unwrap_or(0);
-        let radii_uniform = pad
-            .per_layer_corner_radii
-            .as_ref()
-            .map_or(true, |radii| radii.iter().all(|&r| r == primary_radius));
-
-        // Check per_layer_offsets - all should be zero (no offset)
-        let offsets_uniform = pad.per_layer_offsets.as_ref().map_or(true, |offsets| {
-            offsets
-                .iter()
-                .all(|&(x, y)| x.abs() < 0.001 && y.abs() < 0.001)
-        });
-
-        sizes_uniform && shapes_uniform && radii_uniform && offsets_uniform
-    }
-
     /// Validates all coordinates in a footprint before writing.
     pub(crate) fn validate_footprint_coordinates(
         footprint: &crate::altium::pcblib::Footprint,
@@ -344,7 +309,7 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use crate::altium::pcblib::{Arc, Footprint, Layer, Pad, PadShape, Region, Track};
+    use crate::altium::pcblib::{Arc, Footprint, Layer, Pad, Region, Track};
     use crate::altium::schlib::{Ellipse, Line, Pin, PinOrientation, Rectangle, RoundRect, Symbol};
     use crate::mcp::server::McpServer;
 
@@ -637,36 +602,6 @@ mod tests {
         assert!(McpServer::validate_coordinate(6000.0, "x")
             .unwrap_err()
             .contains("exceeds"));
-    }
-
-    // ---- pad_has_uniform_per_layer_data ------------------------------------
-
-    #[test]
-    fn pad_uniform_when_no_per_layer_data() {
-        let pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
-        assert!(McpServer::pad_has_uniform_per_layer_data(&pad));
-    }
-
-    #[test]
-    fn pad_non_uniform_sizes_shapes_radii_offsets() {
-        let base = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
-
-        let mut sizes = base.clone();
-        sizes.per_layer_sizes = Some(vec![(2.0, 1.0)]); // width differs from 1.0
-        assert!(!McpServer::pad_has_uniform_per_layer_data(&sizes));
-
-        let mut shapes = base.clone();
-        shapes.per_layer_shapes = Some(vec![PadShape::Round]); // differs from primary
-        assert!(!McpServer::pad_has_uniform_per_layer_data(&shapes));
-
-        let mut radii = base.clone();
-        radii.corner_radius_percent = Some(0);
-        radii.per_layer_corner_radii = Some(vec![50]); // differs from 0
-        assert!(!McpServer::pad_has_uniform_per_layer_data(&radii));
-
-        let mut offsets = base;
-        offsets.per_layer_offsets = Some(vec![(0.5, 0.0)]); // non-zero offset
-        assert!(!McpServer::pad_has_uniform_per_layer_data(&offsets));
     }
 
     // ---- validate_footprint_coordinates ------------------------------------


### PR DESCRIPTION
Third bug of the sweep, and the subtlest: **the default read changed pads.**

## The bug

`read_pcblib` and `export_library` default to `compact=true`. Compact mode did more than its description (*"omit per-layer pad data when stack_mode is Simple"*): it also stripped a `full_stack` / `top_middle_bottom` pad whose 32 layers all matched **and rewrote its `stack_mode` to `"simple"`**. Fed back through `write_pcblib` — or `import_library`, the backup loop — a deliberately stacked pad became a simple one. That's a stored property Altium shows in the pad dialog, silently changed by a read.

The history had moved once already: an earlier fix chose the downgrade over leaving a payload that claimed a full stack with no data. Both lose something; the faithful answer is to strip nothing from a stacked pad.

## The fix

Compact mode now strips only a Simple pad's arrays — exactly what both schema descriptions always said. The uniform-detection helper (`pad_has_uniform_per_layer_data`) and its tests go with the behaviour. The three tests pinning the downgrade are replaced by ones pinning the intact stack, including a compact read → write → read loop that keeps `full_stack`, and a Simple pad still stripped.

## About the red patch check on #405

That ❌ was codecov's **patch** coverage (98.61%, 2 lines), not the project total — CI's production metric on main is 99.06% and codecov 99.21%. The two lines were `import_embedded_models`' "no `id`" / "no `data`" error arms; this PR covers them.

Gates: fmt ✅ clippy ✅ 1367 tests ✅ coverage **99.07%** (398/42,612).

🤖 Generated with [Claude Code](https://claude.com/claude-code)