### PR TITLE
fix(mcp): refuse renames onto existing names and self-targeted copies

### DIFF
--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -410,6 +410,16 @@ impl McpServer {
 
     // ==================== Cross-Library Copy ====================
 
+    /// Whether two paths name the same file. Resolved through the filesystem
+    /// so `./Lib.PcbLib` and an absolute spelling compare equal; a path that
+    /// cannot be resolved (it does not exist yet) is compared textually.
+    fn same_file(a: &str, b: &str) -> bool {
+        match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => a == b,
+        }
+    }
+
     /// Copies a component from one Altium library to another.
     pub(crate) fn call_copy_component_cross_library(&self, arguments: &Value) -> ToolCallResult {
         let Some(source_filepath) = arguments.get("source_filepath").and_then(Value::as_str) else {
@@ -441,6 +451,15 @@ impl McpServer {
         }
         if let Err(e) = self.validate_path(target_filepath) {
             return ToolCallResult::error(e);
+        }
+        // Source and target being one file makes this a copy within a library,
+        // which copy_component handles — and gives the copy fresh identities,
+        // which the cross-library path (the same component in another file)
+        // deliberately does not.
+        if Self::same_file(source_filepath, target_filepath) {
+            return ToolCallResult::error(
+                "source_filepath and target_filepath are the same file; use copy_component to duplicate a component within a library",
+            );
         }
 
         // Validate new name if provided
@@ -791,6 +810,17 @@ impl McpServer {
         }
         if let Err(e) = self.validate_path(target_filepath) {
             return ToolCallResult::error(e);
+        }
+        // Merging a library into itself duplicates every component — with
+        // on_duplicate=rename, as identity-sharing twins. Nothing sensible
+        // comes of it, so refuse.
+        if let Some(path) = source_paths
+            .iter()
+            .find(|p| Self::same_file(p, target_filepath))
+        {
+            return ToolCallResult::error(format!(
+                "Source library '{path}' is the target library; a library cannot be merged into itself"
+            ));
         }
 
         // Determine file types from extensions
@@ -1784,6 +1814,38 @@ mod tests {
         assert_ne!(copy.rectangles[0].unique_id, orig.rectangles[0].unique_id);
         assert_ne!(copy.designator_unique_id, orig.designator_unique_id);
         assert_eq!(copy.pins.len(), 1, "geometry copied");
+    }
+
+    /// A cross-library copy or merge whose source IS the target is refused —
+    /// it would duplicate components as identity-sharing twins — and the check
+    /// sees through a differently spelled path to the same file.
+    #[test]
+    fn cross_library_tools_refuse_a_source_that_is_the_target() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Self.PcbLib");
+        create_test_pcblib(&path);
+        // A differently spelled path to the same file.
+        let spelled = dir.path().join(".").join("Self.PcbLib");
+
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": path.to_string_lossy(),
+            "target_filepath": spelled.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "new_name": "CHIP_0402_COPY",
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("use copy_component"));
+
+        let result = server.call_merge_libraries(&json!({
+            "source_filepaths": [spelled.to_string_lossy()],
+            "target_filepath": path.to_string_lossy(),
+            "on_duplicate": "rename",
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("cannot be merged into itself"));
+
+        assert_eq!(PcbLib::open(&path).unwrap().len(), 2, "nothing changed");
     }
 
     #[test]

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -193,6 +193,15 @@ impl McpServer {
             return ToolCallResult::error(e);
         }
 
+        // A replacement may carry a new name, which makes this a rename too —
+        // and a rename onto a name another footprint already holds would leave
+        // two components answering to it. Refuse, as rename_component does.
+        if name != component_name && library.get(name).is_some() {
+            return ToolCallResult::error(format!(
+                "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
+            ));
+        }
+
         // Get the old component for comparison
         let old = library.get(component_name).cloned();
 
@@ -578,6 +587,15 @@ impl McpServer {
         // here; this path skipped it entirely). Runs in dry-run too.
         if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
             return ToolCallResult::error(e);
+        }
+
+        // A replacement may carry a new name, which makes this a rename too —
+        // and a rename onto a name another symbol already holds would leave
+        // two components answering to it. Refuse, as rename_component does.
+        if name != component_name && library.get(name).is_some() {
+            return ToolCallResult::error(format!(
+                "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
+            ));
         }
 
         // Get the old component for comparison
@@ -1507,6 +1525,62 @@ mod tests {
             symbol.primitive_order,
             vec![SchPrimitiveKind::Line, SchPrimitiveKind::Pin]
         );
+    }
+
+    /// A replacement carrying another component's name is a collision, not a
+    /// rename — refused on both formats, in dry-run too, while renaming onto a
+    /// free name still works.
+    #[test]
+    fn update_component_refuses_to_rename_onto_an_existing_name() {
+        use crate::altium::{PcbLib, SchLib};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        let pcb = dir.path().join("Collide.PcbLib");
+        create_test_pcblib(&pcb); // CHIP_0402 + CHIP_0603
+        for dry_run in [true, false] {
+            let result = server.call_update_component(&json!({
+                "filepath": pcb.to_string_lossy(),
+                "component_name": "CHIP_0402",
+                "dry_run": dry_run,
+                "footprint": {
+                    "name": "CHIP_0603",
+                    "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+                },
+            }));
+            assert!(result.is_error, "dry_run={dry_run}");
+            assert!(get_result_text(&result).contains("already exists"));
+        }
+        let lib = PcbLib::open(&pcb).unwrap();
+        assert_eq!(lib.len(), 2, "nothing changed");
+        assert!(lib.get("CHIP_0402").is_some() && lib.get("CHIP_0603").is_some());
+
+        // Renaming onto a free name is still a rename.
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "footprint": {
+                "name": "CHIP_0402_V2",
+                "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+            },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["renamed"], true);
+        let lib = PcbLib::open(&pcb).unwrap();
+        assert!(lib.get("CHIP_0402").is_none() && lib.get("CHIP_0402_V2").is_some());
+
+        let sch = dir.path().join("Collide.SchLib");
+        create_test_schlib(&sch); // RESISTOR + CAPACITOR
+        let result = server.call_update_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "component_name": "RESISTOR",
+            "symbol": { "name": "CAPACITOR", "pins": [] },
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("already exists"));
+        let lib = SchLib::open(&sch).unwrap();
+        assert_eq!(lib.len(), 2, "nothing changed");
     }
 
     #[test]


### PR DESCRIPTION
Seventh bug of the sweep — class: *name collisions and self-reference*. Three ways to end up with two components answering to one name, or two sharing one identity:

| Tool | Problem | Now |
|------|---------|-----|
| `update_component` | a replacement whose `name` ≠ `component_name` is a rename, and it replaced the slot **without checking whether another component already held the new name** — two footprints/symbols with one name | refused on both formats and in dry run (rename_component's wording); renaming onto a free name still works |
| `copy_component_cross_library` | source and target naming the *same file* is a within-library copy, which this path performs **without** the fresh identities #408 gave clones | refused, pointing at `copy_component` |
| `merge_libraries` | a source that *is* the target duplicates every component as an identity-sharing twin under `on_duplicate=rename` | refused |

The same-file check resolves both paths through the filesystem, so `./Lib.PcbLib` and an absolute spelling compare equal (tested with a differently spelled path).

Gates: fmt ✅ clippy ✅ 1375 tests ✅ coverage **99.07%** (402/43,216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)