### PR TITLE
docs: verify Antigravity against its current docs; SECURITY touch-ups

### DIFF
--- a/docs/ANTIGRAVITY_GUIDE.md
+++ b/docs/ANTIGRAVITY_GUIDE.md
@@ -55,11 +55,12 @@ Antigravity reads MCP servers from:
 ~/.gemini/config/mcp_config.json
 ```
 
-(Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`)
+(Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`) — or, for one project only,
+from `.agents/mcp_config.json` in the workspace root.
 
 It uses the standard `mcpServers` schema (`command` / `args` / `env`, plus an optional
 `disabled` flag), so the server entry mirrors any other MCP client. The Antigravity IDE and
-CLI share this same file.
+CLI share these same files.
 
 ### Option A — Edit the raw config (recommended)
 

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -63,7 +63,7 @@ it rather than pasting a second object.
 |--------|------------------------|-------|
 | [Claude Code](#claude-code) | `claude mcp add`, or `.mcp.json` in the project | standard block |
 | [Claude Desktop](#claude-desktop) | `claude_desktop_config.json` (Settings → Developer → Edit Config) | standard block |
-| [Google Antigravity](#google-antigravity) | `~/.gemini/config/mcp_config.json` | standard block |
+| [Google Antigravity](#google-antigravity) | `~/.gemini/config/mcp_config.json` or `.agents/mcp_config.json` | standard block |
 | [Cursor](#cursor) | `~/.cursor/mcp.json` or `.cursor/mcp.json` | standard block |
 | [VS Code (Copilot)](#vs-code-github-copilot) | `.vscode/mcp.json` or user `mcp.json` | `servers` key |
 | [GitHub Copilot CLI](#github-copilot-cli) | `~/.copilot/mcp-config.json` or `/mcp add` | standard block + `type: local` |
@@ -122,13 +122,14 @@ stderr, and `mcp.log` beside them the connection attempts.
 
 ## Google Antigravity
 
-Settings → **Customizations** → **Add MCP**, or edit the file directly:
+Settings (bottom left) → **Customizations** → **Add MCP**, or edit the file directly:
 
 - Linux / macOS: `~/.gemini/config/mcp_config.json`
 - Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`
+- One project only: `.agents/mcp_config.json` in the workspace root
 
-Paste the standard block. The file is strict JSON (no comments). Full walkthrough in
-[`ANTIGRAVITY_GUIDE.md`](ANTIGRAVITY_GUIDE.md).
+Paste the standard block (`"disabled": true` parks an entry without deleting it). The file
+is strict JSON (no comments). Full walkthrough in [`ANTIGRAVITY_GUIDE.md`](ANTIGRAVITY_GUIDE.md).
 
 ## Cursor
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -85,9 +85,10 @@ intermediate failure messages likewise surface only the sanitised file name.
 
 ### Backups with bounded retention (`create_backup` / `MAX_BACKUPS`)
 
-Before a destructive operation, `create_backup` (`src/mcp/server.rs`) copies the
-existing file to a timestamped `filepath.YYYYMMDD_HHMMSS.bak`. New-file creation is a
-no-op. Retention is bounded: `MAX_BACKUPS = 5` (`src/mcp/server.rs`) and
+Before a destructive operation — including `restore_backup`, which snapshots the
+current file before the chosen backup replaces it — `create_backup` (`src/mcp/server.rs`)
+copies the existing file to a timestamped `filepath.YYYYMMDD_HHMMSS.bak`. New-file
+creation is a no-op. Retention is bounded: `MAX_BACKUPS = 5` (`src/mcp/server.rs`) and
 `cleanup_old_backups` (`src/mcp/server.rs`) prunes the oldest backups so the safety
 net cannot itself become an unbounded-disk-usage DoS.
 
@@ -111,7 +112,7 @@ component (falling back to `<file>`). This is deliberately important for writes:
 atomic-write temporary path (for example `…/MyLib.pcblib.tmp`) is never surfaced to the
 client. The full path is retained in the structured error field for `tracing` at debug
 level only. Regression tests assert that neither read nor write errors leak their
-directory (`src/altium/error.rs`, `src/altium/error.rs`).
+directory (`src/altium/error.rs`).
 
 **Central sanitiser choke-point.** Beyond the per-variant `Display` sanitisation above,
 every client-facing error funnels through one egress point: `ToolCallResult::error` and


### PR DESCRIPTION
Docs crusade, remaining items:

- **Antigravity re-verified** against its current official docs (they had timed out during the client-setup research). Our global path (`~/.gemini/config/mcp_config.json`) and the `disabled` flag were right; it also supports a **workspace-local `.agents/mcp_config.json`**, now in both `ANTIGRAVITY_GUIDE.md` and `CLIENT_SETUP.md` along with the bottom-left Settings entry point.
- **`docs/SECURITY.md`**: the backups paragraph names `restore_backup`'s new pre-restore snapshot (#409); a duplicated source reference collapsed.
- **`docs/errors.md`**: cold-read and re-verified claim by claim (error variants, path-validation messages, config validation rules) — needed nothing.

markdownlint clean; offline link check 197 OK / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)