### PR TITLE
fix(mcp): moving a region drops its replayed V7_LAYER token

### DIFF
--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -381,6 +381,9 @@ impl McpServer {
                 if region.layer == from_layer {
                     if !dry_run {
                         region.layer = to_layer;
+                        // The replayed V7_LAYER token named the old layer; let
+                        // the writer derive it from the new one.
+                        region.v7_layer = None;
                     }
                     fp_changes["regions"] = json!(fp_changes["regions"].as_u64().unwrap_or(0) + 1);
                     fp_total += 1;
@@ -956,6 +959,46 @@ mod tests {
             .filter(|t| t.layer == Layer::TopOverlay)
             .count();
         assert_eq!(on_top, 0, "all Top Overlay tracks were moved");
+    }
+
+    /// A region read with a `V7_LAYER` token that disagreed with its layer byte
+    /// carries the token as an override; moving the region drops it, so the
+    /// saved token names the new layer rather than the old one.
+    #[test]
+    fn batch_rename_layer_drops_a_region_stale_v7_token() {
+        use crate::altium::pcblib::{Footprint, Region};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let mut region = Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopOverlay);
+        region.v7_layer = Some("MECHANICAL4".to_string()); // disagrees with Top Overlay
+        let mut fp = Footprint::new("RGN");
+        fp.add_pad(Pad::smd("1", 0.0, 0.0, 0.6, 0.5));
+        fp.add_region(region);
+        let mut lib = PcbLib::new();
+        lib.add(fp);
+        let path = dir.path().join("RegionToken.PcbLib");
+        lib.save(&path).unwrap();
+        // The override round-trips as long as nothing moves the region.
+        let before = PcbLib::open(&path).unwrap();
+        assert_eq!(
+            before.get("RGN").unwrap().regions[0].v7_layer.as_deref(),
+            Some("MECHANICAL4")
+        );
+
+        let r = server.call_batch_update(&json!({
+            "filepath": path.to_string_lossy(),
+            "operation": "rename_layer",
+            "parameters": { "from_layer": "Top Overlay", "to_layer": "Bottom Overlay" },
+        }));
+        assert!(!r.is_error, "{}", get_result_text(&r));
+
+        let after = PcbLib::open(&path).unwrap();
+        let moved = &after.get("RGN").unwrap().regions[0];
+        assert_eq!(moved.layer, Layer::BottomOverlay);
+        // The reader keeps a token only when it disagrees with the byte, so
+        // `None` here means the saved token is Bottom Overlay's own.
+        assert_eq!(moved.v7_layer, None, "stale token not replayed");
     }
 
     #[test]

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -1053,6 +1053,10 @@ impl McpServer {
                     if let Some(layer) = parse_layer(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", region.layer), "new": layer_str}));
                         region.layer = layer;
+                        // A replayed V7_LAYER token names the layer the region
+                        // was read on; moving it makes that stale, so the
+                        // writer derives the token from the new layer instead.
+                        region.v7_layer = None;
                     } else {
                         return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                     }
@@ -2202,6 +2206,40 @@ mod tests {
                 lib.get("RICH").unwrap().regions[0].layer,
                 Layer::BottomLayer
             );
+        }
+
+        /// A region carrying a replayed `V7_LAYER` override loses it when its
+        /// layer changes, so the saved token names the new layer — `None` on
+        /// re-read means the token agrees with the byte.
+        #[test]
+        fn update_primitive_region_layer_change_drops_stale_v7_token() {
+            use crate::altium::pcblib::{Footprint, Pad, Region};
+
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let mut region = Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopOverlay);
+            region.v7_layer = Some("MECHANICAL4".to_string());
+            let mut fp = Footprint::new("RGN");
+            fp.add_pad(Pad::smd("1", 0.0, 0.0, 0.6, 0.5));
+            fp.add_region(region);
+            let mut lib = PcbLib::new();
+            lib.add(fp);
+            let path = dir.path().join("RegionToken.PcbLib");
+            lib.save(&path).unwrap();
+
+            let result = server.call_update_primitive(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": "RGN",
+                "primitive_type": "region",
+                "index": 0,
+                "updates": { "layer": "Bottom Overlay" },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+
+            let lib = PcbLib::open(&path).unwrap();
+            let moved = &lib.get("RGN").unwrap().regions[0];
+            assert_eq!(moved.layer, Layer::BottomOverlay);
+            assert_eq!(moved.v7_layer, None, "stale token not replayed");
         }
 
         #[test]


### PR DESCRIPTION
Eighth bug of the sweep — the region sibling of #407's class (*typed edit leaves replayed sibling data stale*).

A region read with a `V7_LAYER` token that disagreed with its layer byte (a board cutout keeps its *drawn* layer there) carries the token as an override the writer replays verbatim. `update_primitive` and `batch_update`'s `rename_layer` changed `region.layer` but left the override in place, so the saved token still named the **old** layer. Both tools now clear the override on a layer change; the writer derives the token from the new layer.

Tests on both paths: a region saved with a disagreeing override round-trips it untouched, then after the move re-reads with `v7_layer == None` — which, given the reader keeps a token only when it disagrees with the byte, proves the saved token is the new layer's own.

Gates: fmt ✅ clippy ✅ 1375 tests ✅ coverage **99.07%** (401/43,187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)