### PR TITLE
fix: a component name can no longer crash or fail the save

### DIFF
--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -243,14 +243,31 @@ pub fn fold_ansi_widened(text: &str) -> Option<String> {
 /// # Returns
 ///
 /// A safe OLE name (≤31 units) that doesn't collide with existing names.
+/// Characters an OLE/CFB storage name cannot contain. `generate_ole_name`
+/// maps each to `_`; a library refuses to save a component whose name is
+/// empty, since there is no storage name to derive from nothing.
+pub const OLE_NAME_FORBIDDEN: &[char] = &['/', '\\', ':', '!'];
+
 #[must_use]
 pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String, S>) -> String {
-    // OLE/CFB storage names cannot contain the path separator '/'; a component
-    // named e.g. "A/B" would otherwise make the storage-creation call fail.
-    // Altium sanitises it to '_' before creating the component storage, so a
-    // component whose name carries a slash still saves. Apply it up front so
-    // both the short-name and truncated paths use the sanitised form.
-    let sanitized = name.replace('/', "_");
+    // OLE/CFB storage names cannot contain `/`, `\`, `:` or `!`: the `cfb`
+    // crate reads `/` and `\` as path separators (the storage-creation call
+    // fails) and asserts on `:` (the whole save would panic). Altium sanitises
+    // a slash to `_` before creating the component storage, so a component
+    // whose name carries one still saves; the other three get the same
+    // treatment. Apply it up front so both the short-name and truncated paths
+    // use the sanitised form; `SectionKeys` still maps the storage name back
+    // to the real one.
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if OLE_NAME_FORBIDDEN.contains(&c) {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect();
     let name = sanitized.as_str();
 
     // The OLE/CFB limit is 31 UTF-16 code units — not bytes or chars. Measure

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -19,6 +19,16 @@ impl PcbLib {
         &mut self,
         writer: impl std::io::Read + std::io::Write + std::io::Seek,
     ) -> AltiumResult<()> {
+        // An empty name has no storage name to derive — the root storage
+        // would be "created" twice and the save fail half-way — so refuse it
+        // before touching the file.
+        if let Some(i) = self.footprints.iter().position(|f| f.name.is_empty()) {
+            return Err(AltiumError::InvalidParameter {
+                name: "name".to_string(),
+                message: format!("footprint {i} has an empty name"),
+            });
+        }
+
         // Convert model_3d references to ComponentBody + EmbeddedModel before writing
         self.prepare_3d_models_for_writing()?;
 

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -25,6 +25,12 @@ impl SchLib {
         // is ASCII to match `text_field`: the golden stores `Résistance` this
         // way despite `é` having a single-byte form, so the storage name and
         // the record's `LibReference` stay the same bytes.
+        if let Some(i) = symbols.iter().position(|s| s.name.is_empty()) {
+            return Err(AltiumError::InvalidParameter {
+                name: "name".to_string(),
+                message: format!("symbol {i} has an empty name"),
+            });
+        }
         let storage_names: Vec<String> = symbols
             .iter()
             .map(|s| {

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -475,26 +475,6 @@ impl McpServer {
 
         Layer::parse(spaced)
     }
-
-    /// Validates a component name.
-    ///
-    /// Note: OLE storage names are limited to 31 characters, but the library layer
-    /// handles this by truncating storage names while preserving full names in
-    /// the PATTERN/LIBREFERENCE fields.
-    pub(crate) fn validate_ole_name(name: &str) -> Result<(), String> {
-        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
-
-        if name.is_empty() {
-            return Err("Component name cannot be empty".to_string());
-        }
-        if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
-            return Err(format!(
-                "Component name '{name}' contains invalid character '{c}'. \
-                 Names cannot contain: / \\ : * ? \" < > |",
-            ));
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1307,6 +1307,9 @@ impl McpServer {
                 .and_then(Value::as_str)
                 .unwrap_or("Unnamed");
 
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(format!("Footprint {idx}: {e}"));
+            }
             // Check for duplicate
             if library.get(name).is_some() {
                 return ToolCallResult::error(format!(
@@ -1512,6 +1515,9 @@ impl McpServer {
                 .and_then(Value::as_str)
                 .unwrap_or("Unnamed");
 
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(format!("Symbol {idx}: {e}"));
+            }
             // Check for duplicate
             if library.get(name).is_some() {
                 return ToolCallResult::error(format!(
@@ -2152,6 +2158,47 @@ mod tests {
             symbol.primitive_order,
             vec![SchPrimitiveKind::Line, SchPrimitiveKind::Pin]
         );
+    }
+
+    /// Import data names components too: an empty or storage-hostile name is
+    /// refused by position, on both formats, before anything is written.
+    #[test]
+    fn import_library_refuses_names_no_storage_can_carry() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        for (file_type, key, name, expect) in [
+            (
+                "PcbLib",
+                "footprints",
+                "A:B",
+                "Footprint 0: Component name 'A:B' contains invalid character ':'",
+            ),
+            (
+                "PcbLib",
+                "footprints",
+                "",
+                "Footprint 0: Component name cannot be empty",
+            ),
+            (
+                "SchLib",
+                "symbols",
+                "A/B",
+                "Symbol 0: Component name 'A/B' contains invalid character '/'",
+            ),
+        ] {
+            let out = dir.path().join(format!("Import{file_type}.{file_type}"));
+            let result = server.call_import_library(&json!({
+                "output_path": out.to_string_lossy(),
+                "json_data": { "file_type": file_type, key: [{ "name": name }] },
+            }));
+            assert!(result.is_error, "{file_type} {name:?}");
+            assert!(
+                get_result_text(&result).contains(expect),
+                "{}",
+                get_result_text(&result)
+            );
+            assert!(!out.exists(), "nothing written");
+        }
     }
 
     #[test]
@@ -3813,6 +3860,7 @@ mod tests {
 
     mod degenerate_libraries {
         use crate::altium::pcblib::{Arc, Footprint, Layer, Pad, PcbLib, Track};
+        use crate::altium::schlib::{SchLib, Symbol};
         use crate::mcp::tools::test_support::{
             create_test_server, parse_result_json, test_temp_dir,
         };
@@ -3855,10 +3903,10 @@ mod tests {
             // The validator carries "component has empty name" checks in four
             // places (validate_pcblib, validate_schlib and both post-write
             // passes), but none of them can fire on a library read from disk:
-            // the component name IS the OLE storage name, so an empty one
-            // collides with the root and the save is refused before a file
-            // exists to validate. Pinning that here so the checks are
-            // understood as unreachable-by-construction rather than untested.
+            // the component name IS the OLE storage name, so a writer refuses
+            // an empty one up front and no file exists to validate. Pinning
+            // that here so the checks are understood as
+            // unreachable-by-construction rather than untested.
             let dir = test_temp_dir();
 
             let mut fp = Footprint::new("");
@@ -3868,7 +3916,37 @@ mod tests {
             let err = lib
                 .save(dir.path().join("Nameless.PcbLib"))
                 .expect_err("a nameless footprint has no storage name");
-            assert!(err.to_string().contains("storage"), "{err}");
+            assert!(err.to_string().contains("empty name"), "{err}");
+
+            let mut lib = SchLib::new();
+            lib.add(Symbol::new(""));
+            let err = lib
+                .save(dir.path().join("Nameless.SchLib"))
+                .expect_err("a nameless symbol has no storage name");
+            assert!(err.to_string().contains("empty name"), "{err}");
+        }
+
+        /// Names carrying characters an OLE storage name cannot hold (`/ \ : !`)
+        /// save anyway: the storage name is sanitised the way Altium sanitises a
+        /// slash, `SectionKeys` maps it back, and the real name survives the
+        /// round trip. A colon used to reach the cfb crate and panic.
+        #[test]
+        fn ole_forbidden_characters_in_a_name_are_sanitised_not_fatal() {
+            let dir = test_temp_dir();
+            for (i, name) in ["A:B", r"A\B", "A!B", "A/B"].iter().enumerate() {
+                let mut fp = Footprint::new(*name);
+                fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+                let mut lib = PcbLib::new();
+                lib.add(fp);
+                let path = dir.path().join(format!("Forbidden{i}.PcbLib"));
+                lib.save(&path).unwrap_or_else(|e| panic!("{name}: {e}"));
+                let back = PcbLib::open(&path).unwrap();
+                assert_eq!(
+                    back.names(),
+                    vec![(*name).to_string()],
+                    "{name} round-trips"
+                );
+            }
         }
 
         #[test]

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -168,6 +168,12 @@ impl McpServer {
         let mut new_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for (old_name, new_name) in &renames {
+            // A regex replacement can produce anything, including an empty
+            // string or a name no storage can carry.
+            if let Err(e) = Self::validate_ole_name(new_name) {
+                errors.push(format!("Cannot rename '{old_name}': {e}"));
+                continue;
+            }
             // Check if new name conflicts with an existing name that's not being renamed
             if existing_names.contains(new_name.as_str()) {
                 let is_being_renamed = renames.iter().any(|(o, _)| o == new_name);
@@ -269,6 +275,12 @@ impl McpServer {
         let mut new_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for (old_name, new_name) in &renames {
+            // A regex replacement can produce anything, including an empty
+            // string or a name no storage can carry.
+            if let Err(e) = Self::validate_ole_name(new_name) {
+                errors.push(format!("Cannot rename '{old_name}': {e}"));
+                continue;
+            }
             if existing_names.contains(new_name.as_str()) {
                 let is_being_renamed = renames.iter().any(|(o, _)| o == new_name);
                 if !is_being_renamed {
@@ -1349,6 +1361,42 @@ mod tests {
         assert!(lib.get("RES_0402").is_some());
         assert!(lib.get("RES_0603").is_some());
         assert!(lib.get("CHIP_0402").is_none());
+    }
+
+    /// A replacement can produce a name no storage (or file) can carry, or
+    /// nothing at all; both are refused by name, on both formats, and the
+    /// library is left untouched.
+    #[test]
+    fn bulk_rename_refuses_names_no_storage_can_carry() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let pcb = dir.path().join("BulkBad.PcbLib");
+        create_test_pcblib(&pcb);
+        let sch = dir.path().join("BulkBad.SchLib");
+        create_test_schlib(&sch);
+
+        for (path, pattern, replacement, expect) in [
+            (&pcb, "^CHIP_(.*)$", "CHIP:$1", "invalid character ':'"),
+            (&pcb, "^CHIP_0402$", "", "cannot be empty"),
+            (&sch, "^RESISTOR$", "RES/1", "invalid character '/'"),
+        ] {
+            let result = server.call_bulk_rename(&json!({
+                "filepath": path.to_string_lossy(),
+                "pattern": pattern,
+                "replacement": replacement,
+            }));
+            assert!(result.is_error, "{pattern} -> {replacement:?}");
+            let text = get_result_text(&result);
+            assert!(text.contains(expect), "{text}");
+        }
+        assert!(
+            PcbLib::open(&pcb).unwrap().get("CHIP_0402").is_some(),
+            "untouched"
+        );
+        assert!(
+            SchLib::open(&sch).unwrap().get("RESISTOR").is_some(),
+            "untouched"
+        );
     }
 
     #[test]

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -196,10 +196,15 @@ impl McpServer {
         // A replacement may carry a new name, which makes this a rename too —
         // and a rename onto a name another footprint already holds would leave
         // two components answering to it. Refuse, as rename_component does.
-        if name != component_name && library.get(name).is_some() {
-            return ToolCallResult::error(format!(
-                "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
-            ));
+        if name != component_name {
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(e);
+            }
+            if library.get(name).is_some() {
+                return ToolCallResult::error(format!(
+                    "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
+                ));
+            }
         }
 
         // Get the old component for comparison
@@ -592,10 +597,15 @@ impl McpServer {
         // A replacement may carry a new name, which makes this a rename too —
         // and a rename onto a name another symbol already holds would leave
         // two components answering to it. Refuse, as rename_component does.
-        if name != component_name && library.get(name).is_some() {
-            return ToolCallResult::error(format!(
-                "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
-            ));
+        if name != component_name {
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(e);
+            }
+            if library.get(name).is_some() {
+                return ToolCallResult::error(format!(
+                    "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
+                ));
+            }
         }
 
         // Get the old component for comparison
@@ -1581,6 +1591,58 @@ mod tests {
         assert!(get_result_text(&result).contains("already exists"));
         let lib = SchLib::open(&sch).unwrap();
         assert_eq!(lib.len(), 2, "nothing changed");
+
+        // A rename onto a name no storage can carry is refused too, on both formats.
+        for (path, key, body) in [
+            (
+                &pcb,
+                "footprint",
+                json!({ "name": "BAD:NAME", "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }] }),
+            ),
+            (&sch, "symbol", json!({ "name": "BAD/NAME", "pins": [] })),
+        ] {
+            let result = server.call_update_component(&json!({
+                "filepath": path.to_string_lossy(),
+                "component_name": if key == "footprint" { "CHIP_0603" } else { "RESISTOR" },
+                key: body,
+            }));
+            assert!(result.is_error, "{key}");
+            assert!(
+                get_result_text(&result).contains("invalid character"),
+                "{}",
+                get_result_text(&result)
+            );
+        }
+    }
+
+    /// A malformed `primitive_order` in a replacement is ignored with the
+    /// default grouped order rather than failing the update, on both formats —
+    /// the same advisory treatment the create path gives it.
+    #[test]
+    fn update_component_ignores_a_malformed_primitive_order() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        let pcb = dir.path().join("Order.PcbLib");
+        create_test_pcblib(&pcb);
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "footprint": {
+                "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+                "primitive_order": ["not_a_kind"],
+            },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+
+        let sch = dir.path().join("Order.SchLib");
+        create_test_schlib(&sch);
+        let result = server.call_update_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "component_name": "RESISTOR",
+            "symbol": { "pins": [], "primitive_order": 42 },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -479,20 +479,12 @@ impl McpServer {
             }
         }
 
-        // Validate footprint names
-        // Note: OLE storage names are limited to 31 characters, but the library layer
-        // handles this by truncating storage names while preserving full names in PATTERN.
-        #[allow(clippy::items_after_statements)]
-        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+        // Validate footprint names (OLE storage names are limited to 31 units,
+        // but the library layer handles that by truncating the storage name
+        // while PATTERN keeps the full one).
         for name in &new_names {
-            if name.is_empty() {
-                return ToolCallResult::error("Footprint name cannot be empty");
-            }
-            if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
-                return ToolCallResult::error(format!(
-                    "Footprint name '{name}' contains invalid character '{c}'. \
-                     Names cannot contain: / \\ : * ? \" < > |",
-                ));
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(e);
             }
         }
 
@@ -1238,20 +1230,12 @@ impl McpServer {
             }
         }
 
-        // Validate symbol names
-        // Note: OLE storage names are limited to 31 characters, but the library layer
-        // handles this by truncating storage names while preserving full names in LIBREFERENCE.
-        #[allow(clippy::items_after_statements)]
-        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+        // Validate symbol names (OLE storage names are limited to 31 units,
+        // but the library layer handles that by truncating the storage name
+        // while LIBREFERENCE keeps the full one).
         for name in &new_names {
-            if name.is_empty() {
-                return ToolCallResult::error("Symbol name cannot be empty");
-            }
-            if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
-                return ToolCallResult::error(format!(
-                    "Symbol name '{name}' contains invalid character '{c}'. \
-                     Names cannot contain: / \\ : * ? \" < > |",
-                ));
+            if let Err(e) = Self::validate_ole_name(name) {
+                return ToolCallResult::error(e);
             }
         }
 

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -26,6 +26,30 @@ impl McpServer {
         Ok(())
     }
 
+    /// Validates a component name for every tool that creates one (write,
+    /// copy, rename, bulk rename, update, import): non-empty and free of the
+    /// characters neither an OLE storage name nor a Windows file name may
+    /// carry. The library layer sanitises the OLE-forbidden subset as a
+    /// safety net, but the tools refuse up front so a caller learns why.
+    ///
+    /// Note: OLE storage names are limited to 31 characters, but the library layer
+    /// handles this by truncating storage names while preserving full names in
+    /// the PATTERN/LIBREFERENCE fields.
+    pub(crate) fn validate_ole_name(name: &str) -> Result<(), String> {
+        const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+
+        if name.is_empty() {
+            return Err("Component name cannot be empty".to_string());
+        }
+        if let Some(c) = name.chars().find(|c| INVALID_CHARS.contains(c)) {
+            return Err(format!(
+                "Component name '{name}' contains invalid character '{c}'. \
+                 Names cannot contain: / \\ : * ? \" < > |",
+            ));
+        }
+        Ok(())
+    }
+
     /// Validates all coordinates in a footprint before writing.
     pub(crate) fn validate_footprint_coordinates(
         footprint: &crate::altium::pcblib::Footprint,


### PR DESCRIPTION
Ninth bug of the sweep, and the most serious so far — class: *validation parity*, with a **process crash** at the bottom of it.

## The bug

`rename_component`/`copy_component` validate a new name (non-empty, none of `/ \ : * ? \" < > |`); `bulk_rename`, `update_component`'s rename and `import_library` never did. Probing what the library layer then does with such names:

| Name | Before |
|------|--------|
| `A:B` | **panic inside the `cfb` crate** during save — a panic takes the whole MCP server down |
| `A\B` | save fails (`\` read as a path separator) |
| `""` | save fails half-way with a root-storage collision |
| `A/B` | fine — the only character the OLE-name generator sanitised |

## The fix — two layers

1. **The library layer cannot panic on a name.** `generate_ole_name` now sanitises every character a CFB storage name cannot carry (`/ \ : !`) the way Altium sanitises a slash, with `SectionKeys` mapping the storage name back — so such names round-trip (tested for all four). Both writers refuse an **empty** name up front with an `InvalidParameter` instead of failing mid-file.
2. **Every name-creating tool validates** with the one shared rule (`validate_ole_name`, moved from `batch.rs` to `validation.rs`; the two writers drop their private duplicate): `bulk_rename` per computed name (reported beside its conflicts, library untouched), `update_component`'s rename, `import_library` per footprint/symbol by position.

Tests: library-layer sanitisation round trip (`A:B` explicitly — the former panic), empty-name refusal on both formats, and tool-level refusals on all three tools; plus `update_component`'s malformed-`primitive_order` arms, which were the only lines of that logic still untested.

Gates: fmt ✅ clippy ✅ 1381 tests ✅ coverage **99.07%** (406/43,457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)