### PR TITLE
fix(mcp): a panicking tool answers with an error instead of killing the server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,10 @@ proptest = "1.6"
 opt-level = 3
 lto = true
 strip = true
-panic = "abort"
+# Unwinding (the default) is deliberate: the tool dispatcher catches a panic
+# and answers the call with an error result, so one failing tool cannot take
+# the server — and the assistant's whole session — down. `panic = "abort"`
+# would make that safety net impossible.
 codegen-units = 1
 
 [lints.rust]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -45,6 +45,7 @@ The following are within scope and have concrete controls behind them.
 | Internal-path disclosure in error messages | Denial message is generic; file errors render only the final path component | generic denial `src/mcp/server.rs`; `sanitise_path_for_client` `src/altium/error.rs` |
 | Runaway-write / backup-thrash DoS (e.g. an AI loop) | Token-bucket rate limiter gates **mutating** tools only | gate `src/mcp/server.rs`; `is_mutating_tool` `src/mcp/server.rs` |
 | Malformed / truncated / hostile `.PcbLib` / `.SchLib` input | Parsers return `Err`, never panic, on arbitrary bytes — proven by property tests | `tests/property_tests.rs` |
+| A panic anywhere below a tool (a parser assertion, a third-party crate's debug check) taking the server — and the assistant's session — down | The dispatcher runs every tool call under `catch_unwind` and answers a panic with an ordinary `isError` result; the payload is logged server-side only. The release profile keeps unwinding on purpose | `guard_panics` `src/mcp/server.rs`; `[profile.release]` `Cargo.toml` |
 | Decompression bombs / oversized embedded 3D models | Each embedded model is decompressed through a bounded reader; output beyond `MAX_DECOMPRESSED_MODEL_BYTES` (256 MiB) is rejected and the model skipped, so a high-ratio zlib stream cannot exhaust memory | `decompress_model_data` / `decompress_capped` `src/altium/pcblib/reader/models.rs` |
 
 A note on the parser guarantee: the no-panic property is not merely asserted, it is

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -742,6 +742,32 @@ impl McpServer {
         Ok(JsonRpcResponse::success(req.id.clone(), result))
     }
 
+    /// Runs one tool call with a panic safety net.
+    ///
+    /// A panic anywhere below a tool — a parser assertion, an index past the
+    /// end, a third-party crate's debug check — must not take the server down
+    /// mid-conversation: the client loses every later call until someone
+    /// restarts the process. Caught here, it becomes an `isError` result like
+    /// any other failure, and the session continues. The panic payload is
+    /// logged server-side only; the client message carries no detail, because
+    /// a payload may quote a path or file content.
+    fn guard_panics(tool: &str, call: impl FnOnce() -> ToolCallResult) -> ToolCallResult {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(call)) {
+            Ok(result) => result,
+            Err(payload) => {
+                let detail = payload
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| payload.downcast_ref::<&str>().copied())
+                    .unwrap_or("non-string panic payload");
+                tracing::error!(tool = %tool, panic = %detail, "tool call panicked; server kept running");
+                ToolCallResult::error(format!(
+                    "Internal error while running '{tool}'. The server is still running; please report this with the arguments used."
+                ))
+            }
+        }
+    }
+
     /// Handles the tools/call request.
     fn handle_tools_call(&self, req: &JsonRpcRequest) -> Result<JsonRpcResponse, JsonRpcError> {
         self.require_running(&req.id)?;
@@ -775,7 +801,7 @@ impl McpServer {
                  Please slow down and retry.",
             )
         } else {
-            match params.name.as_str() {
+            Self::guard_panics(&params.name, || match params.name.as_str() {
                 // Library I/O tools
                 "read_pcblib" => self.call_read_pcblib(&params.arguments),
                 "write_pcblib" => self.call_write_pcblib(&params.arguments),
@@ -816,7 +842,7 @@ impl McpServer {
                 "update_primitive" => self.call_update_primitive(&params.arguments),
                 // Unknown tool
                 _ => ToolCallResult::error(format!("Unknown tool: {}", params.name)),
-            }
+            })
         };
 
         // Audit destructive operations at the dispatch chokepoint (best-effort;
@@ -2886,6 +2912,45 @@ mod tests {
 
     mod dispatch_and_lifecycle {
         use super::*;
+
+        /// A tool that panics answers its call with an error result and the
+        /// server keeps running; the panic's own text stays in the log, never
+        /// in the client-facing message. A tool that returns normally is
+        /// passed through untouched.
+        #[test]
+        fn guard_panics_turns_a_panic_into_an_error_result() {
+            // Silence the default hook's stderr noise for this one test.
+            let previous = std::panic::take_hook();
+            std::panic::set_hook(Box::new(|_| {}));
+            let result = McpServer::guard_panics("boom_tool", || {
+                panic!("secret detail: C:/Users/someone/Library.PcbLib");
+            });
+            let payload_result = McpServer::guard_panics("boom_tool", || {
+                std::panic::panic_any(42_u8);
+            });
+            std::panic::set_hook(previous);
+
+            assert!(result.is_error);
+            let text = match &result.content[0] {
+                ToolContent::Text { text } => text.clone(),
+            };
+            assert!(
+                text.contains("Internal error while running 'boom_tool'"),
+                "{text}"
+            );
+            assert!(text.contains("still running"), "{text}");
+            assert!(
+                !text.contains("secret detail"),
+                "panic text must not reach the client: {text}"
+            );
+            assert!(
+                payload_result.is_error,
+                "non-string payloads are guarded too"
+            );
+
+            let ok = McpServer::guard_panics("fine_tool", || ToolCallResult::text("fine"));
+            assert!(!ok.is_error);
+        }
 
         fn req(method: &str, params: Option<Value>) -> JsonRpcRequest {
             JsonRpcRequest {


### PR DESCRIPTION
Structural follow-up to #417. That PR closed one route to a panic (a colon in a component name asserting inside `cfb`); this one closes the **consequence** for all of them.

## The gap

The release profile set `panic = "abort"`, so any panic below a tool call — a parser assertion, an index past the end, a third-party crate's debug check — terminated the server instantly, and the assistant's session with it: every later call fails until someone restarts the process.

## The fix

- `McpServer::guard_panics`: the dispatcher runs each tool call under `catch_unwind` and answers a panic with an ordinary `isError` result that names the tool and says the server is still running. The panic payload is **logged server-side only** — it may quote a path or file content, so the client message carries no detail (tested: a panic whose message contains a path yields a client message without it).
- `[profile.release]` keeps the default unwinding, with the reason documented beside it — abort would make the net impossible. Release build verified (`cargo build --release --locked` clean).
- `docs/SECURITY.md` threat model gains the row.

Gates: fmt ✅ clippy ✅ 1378 tests ✅ coverage **99.08%** (397/43,340).

🤖 Generated with [Claude Code](https://claude.com/claude-code)