### PR TITLE
fix(mcp): write_pcblib no longer adds a designator to a replayed footprint

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -123,11 +123,12 @@ Use this to learn from existing libraries and create consistent new components.
 
 Write footprints to an Altium .PcbLib file (set 'append': true to add to an existing library instead of replacing it). Each footprint is defined by its primitives: pads
 (with position, size, shape, layer), tracks, vias, fills, arcs, regions, text and component_bodies. The AI is responsible for calculating correct positions and sizes
-based on IPC-7351B or other standards. All coordinates and dimensions must be in millimetres (mm). A footprint given no '.Designator' text receives one on the Top Overlay
-automatically, just above its topmost pad, so every placed part shows its reference designator; supply your own to control its placement. The response 'bodies' array
-echoes each footprint's 3D body height and source; a footprint with no STEP model and no component body reports source 'none'. Set 'auto_3d_body': true to have an
-extruded placeholder body (default height 1.0 mm, flagged 'assumed_height': true) added to such footprints, then confirm or override it by supplying 'component_bodies'
-explicitly. The response also includes a 'warnings' array flagging silkscreen (overlay) tracks that overlap a pad (silk-on-pad) so you can move them clear.
+based on IPC-7351B or other standards. All coordinates and dimensions must be in millimetres (mm). A footprint authored without a '.Designator' text receives one on the
+Top Overlay automatically, just above its topmost pad, so every placed part shows its reference designator: supply your own to control its placement, or set
+'auto_designator': false to omit it; a footprint echoed back from a read (carrying primitive_order) is never touched. The response 'bodies' array echoes each footprint's
+3D body height and source; a footprint with no STEP model and no component body reports source 'none'. Set 'auto_3d_body': true to have an extruded placeholder body
+(default height 1.0 mm, flagged 'assumed_height': true) added to such footprints, then confirm or override it by supplying 'component_bodies' explicitly. The response
+also includes a 'warnings' array flagging silkscreen (overlay) tracks that overlap a pad (silk-on-pad) so you can move them clear.
 
 **Example**
 
@@ -210,6 +211,7 @@ explicitly. The response also includes a 'warnings' array flagging silkscreen (o
 | --- | --- | --- | --- |
 | `append` | boolean | no | If true, append to existing file; if false, create new file |
 | `auto_3d_body` | boolean | no | If true, footprints with pads but no STEP model and no component body get a placeholder extruded 3D body (1.0 mm tall, flagged assumed_height). Default false: nothing is added unless you ask, since many footprints (fiducials, test points, mounting holes) legitimately have no body. Prefer supplying real heights via component_bodies. |
+| `auto_designator` | boolean | no | If true (default), a footprint authored without a '.Designator' text gets one on the Top Overlay just above its topmost pad, so the placed part shows its reference designator. Never applied to a footprint echoed back from read_pcblib/get_component (one carrying primitive_order): Altium's own library footprints carry no designator text, and a read-modify-write must not add primitives. Set false to author a footprint without one. |
 | `filepath` | string | yes | Path to the .PcbLib file to create/modify |
 | `footprints` | array<object> | yes | Array of footprint definitions |
 

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -187,9 +187,11 @@ impl McpServer {
                      fills, arcs, regions, text and component_bodies. The AI is responsible for \
                      calculating correct positions and sizes based on IPC-7351B or other standards. \
                      All coordinates and dimensions must be in millimetres (mm). A footprint \
-                     given no '.Designator' text receives one on the Top Overlay automatically, \
-                     just above its topmost pad, so every placed part shows its reference \
-                     designator; supply your own to control its placement. \
+                     authored without a '.Designator' text receives one on the Top Overlay \
+                     automatically, just above its topmost pad, so every placed part shows its \
+                     reference designator: supply your own to control its placement, or set \
+                     'auto_designator': false to omit it; a footprint echoed back from a read \
+                     (carrying primitive_order) is never touched. \
                      The response 'bodies' array echoes each footprint's 3D body height and source; \
                      a footprint with no STEP model and no component body reports source 'none'. \
                      Set 'auto_3d_body': true to have an extruded placeholder body (default height \
@@ -569,6 +571,10 @@ impl McpServer {
                         "auto_3d_body": {
                             "type": "boolean",
                             "description": "If true, footprints with pads but no STEP model and no component body get a placeholder extruded 3D body (1.0 mm tall, flagged assumed_height). Default false: nothing is added unless you ask, since many footprints (fiducials, test points, mounting holes) legitimately have no body. Prefer supplying real heights via component_bodies."
+                        },
+                        "auto_designator": {
+                            "type": "boolean",
+                            "description": "If true (default), a footprint authored without a '.Designator' text gets one on the Top Overlay just above its topmost pad, so the placed part shows its reference designator. Never applied to a footprint echoed back from read_pcblib/get_component (one carrying primitive_order): Altium's own library footprints carry no designator text, and a read-modify-write must not add primitives. Set false to author a footprint without one."
                         }
                     },
                     "required": ["filepath", "footprints"]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -501,6 +501,10 @@ impl McpServer {
             .get("auto_3d_body")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let auto_designator = arguments
+            .get("auto_designator")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
 
         // If append mode and file exists, read existing library; otherwise create new
         let mut library = if append && std::path::Path::new(filepath).exists() {
@@ -889,11 +893,17 @@ impl McpServer {
             // caller did not provide one, so every placed footprint renders its
             // reference designator. Placed just above the topmost pad (or at the
             // origin when there are no pads); the user can reposition in Altium.
+            // Never for a footprint echoed back from a read: Altium's own
+            // library footprints carry no designator text (none of the 22
+            // golden ones does), so adding one there would change every real
+            // footprint on a read-modify-write. A read echo always carries
+            // `primitive_order`; from-scratch JSON never does.
+            let is_read_echo = fp_json.get("primitive_order").is_some();
             let has_designator = footprint
                 .text
                 .iter()
                 .any(|t| t.text.trim().eq_ignore_ascii_case(".designator"));
-            if !has_designator {
+            if auto_designator && !is_read_echo && !has_designator {
                 use crate::altium::pcblib::{Layer, PcbFlags, Text, TextJustification, TextKind};
                 let top = footprint
                     .pads
@@ -2790,6 +2800,84 @@ mod tests {
                 footprints_before, footprints_after,
                 "read → write → read is lossless"
             );
+        }
+
+        /// An Altium-authored footprint carries no `.Designator` text (none of
+        /// the golden's 22 does), so a read → write through the tool layer must
+        /// not add one: the echo's `primitive_order` marks it as a replay and
+        /// the primitive count comes back unchanged.
+        #[test]
+        fn write_pcblib_does_not_add_a_designator_to_a_read_echo() {
+            let dir = test_temp_dir();
+            let samples = std::path::Path::new("scripts/samples")
+                .canonicalize()
+                .unwrap();
+            let server =
+                crate::mcp::server::McpServer::new(vec![dir.path().to_path_buf(), samples.clone()]);
+
+            let read = server.call_read_pcblib(&json!({
+                "filepath": samples.join("footprints.PcbLib").to_string_lossy(),
+                "component_name": "PAD_SHAPES",
+            }));
+            assert!(!read.is_error, "{}", get_result_text(&read));
+            let footprints = parse_result_json(&read)["footprints"].clone();
+            let texts_before = footprints[0]["text"].as_array().map_or(0, Vec::len);
+            let has_designator = footprints[0]["text"].as_array().is_some_and(|texts| {
+                texts.iter().any(|t| {
+                    t["text"]
+                        .as_str()
+                        .is_some_and(|s| s.eq_ignore_ascii_case(".designator"))
+                })
+            });
+            assert!(
+                !has_designator,
+                "the golden footprint has no designator text to begin with"
+            );
+
+            let out = dir.path().join("Echo.PcbLib");
+            let written = server.call_write_pcblib(&json!({
+                "filepath": out.to_string_lossy(),
+                "footprints": footprints,
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+            let back = server.call_read_pcblib(&json!({ "filepath": out.to_string_lossy() }));
+            let texts_after = parse_result_json(&back)["footprints"][0]["text"]
+                .as_array()
+                .map_or(0, Vec::len);
+            assert_eq!(
+                texts_after, texts_before,
+                "no primitive was added to a replayed footprint"
+            );
+        }
+
+        /// From scratch the designator is still added by default, and
+        /// `auto_designator: false` switches it off.
+        #[test]
+        fn write_pcblib_auto_designator_is_opt_out_for_new_footprints() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let pads =
+                json!([{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }]);
+            for (i, (auto, expected_texts)) in [(None, 1), (Some(true), 1), (Some(false), 0)]
+                .into_iter()
+                .enumerate()
+            {
+                let path = dir.path().join(format!("Auto{i}.PcbLib"));
+                let mut args = json!({
+                    "filepath": path.to_string_lossy(),
+                    "footprints": [{ "name": "FP", "pads": pads }],
+                });
+                if let Some(flag) = auto {
+                    args["auto_designator"] = json!(flag);
+                }
+                let written = server.call_write_pcblib(&args);
+                assert!(!written.is_error, "{}", get_result_text(&written));
+                let back = server.call_read_pcblib(&json!({ "filepath": path.to_string_lossy() }));
+                let texts = parse_result_json(&back)["footprints"][0]["text"]
+                    .as_array()
+                    .map_or(0, Vec::len);
+                assert_eq!(texts, expected_texts, "auto_designator={auto:?}");
+            }
         }
 
         /// `read_schlib` → `write_schlib` replays a symbol's interleaved


### PR DESCRIPTION
Tenth bug of the sweep — the design question flagged days ago, now settled by data.

## The bug

`write_pcblib` injected a `.Designator` overlay text into every footprint lacking one. Reasonable for authoring from scratch — but **none of the 22 Altium-authored golden footprints carries such a text**; Altium's own library footprints simply don't. So a read → write through the tool layer added a primitive to *every real footprint it touched*. The byte-fidelity suite never saw it (it drives the library API), and the tool-layer replay test had dodged it by authoring a designator of its own.

## The fix

- A footprint echoed back from `read_pcblib`/`get_component` always carries `primitive_order`, and from-scratch JSON never does — so that marks a replay and the injection skips it. No heuristics on content.
- For new footprints the behaviour is unchanged and now **explicit**: `auto_designator` (default `true`) switches it off, mirroring `auto_3d_body`. Schema + tool description updated; TOOLS.md regenerated.

Tests: the golden `PAD_SHAPES` footprint replayed through the tool layer keeps its primitive count; from scratch the default still adds one and `auto_designator: false` does not.

Gates: fmt ✅ clippy ✅ 1383 tests ✅ coverage **99.06%** (411/43,529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)