### PR TITLE
fix(pcblib): encode WideStrings as UTF-16 units; one footprint parser for both tools

### DIFF
--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -133,8 +133,10 @@ Standard `WriteCStringParameterBlock` encoding. Altium-authored libraries also c
 ```
 
 One `|ENCODEDTEXT{n}=` entry per text primitive with real (non-special, non-empty) content, in
-primitive order — a leading pipe per entry, NO trailing pipe. The value is the comma-separated
-byte values of the text.
+primitive order — a leading pipe per entry, NO trailing pipe. The value is the text as
+comma-separated **UTF-16 code units** in decimal (`10µF` → `49,48,181,70`, `Ω` → `937`), which is
+how the stream carries text the Windows-1252 `Data` block cannot; a text with an entry here is
+read from it in preference to the `Data` block.
 
 When empty (no text content): `[block_len:4][\x00]` (`block_len` = 1 — just the null terminator,
 no pipe).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -173,14 +173,16 @@ The structured document inside `text` always carries these keys:
 
 ### Unknown-Field Rejection
 
-`write_pcblib` and `write_schlib` refuse any JSON object key they do not know —
+`write_pcblib`, `write_schlib` and `update_component` refuse any JSON object key they do not know —
 `Unknown field 'widht'. Allowed fields are: [...]` — rather than ignoring it, because an
 ignored typo is a pad of the wrong shape or a track on the wrong layer, found only in Altium.
 Every object is checked: footprints and symbols, each primitive kind, 3D-model and
 component-body objects, footprint links. The accepted keys are the fields the read tools
 emit for that object plus its authoring-only spellings (`step_model`, `vertices`, `hidden`,
 `designator_prefix`, …), so anything a read returned can be passed straight back
-(`src/mcp/tools/allowed_keys.rs`).
+(`src/mcp/tools/allowed_keys.rs`). A footprint is parsed by one routine whichever tool
+receives it (`parse_footprint_json`, `src/mcp/tools/parsing.rs`), so `update_component`
+accepts exactly what `write_pcblib` does and reports a malformed primitive the same way.
 
 ---
 

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -110,8 +110,7 @@ pub fn parse_wide_strings(data: &[u8]) -> WideStrings {
         if let Some(rest) = pair.strip_prefix("ENCODEDTEXT") {
             if let Some((index_str, encoded)) = rest.split_once('=') {
                 if let Ok(index) = index_str.parse::<usize>() {
-                    // Decode comma-separated ASCII codes
-                    let decoded = decode_ascii_codes(encoded);
+                    let decoded = decode_wide_string(encoded);
                     if !decoded.is_empty() {
                         tracing::trace!(index, text = %decoded, "Decoded WideStrings entry");
                         strings.insert(index, decoded);
@@ -125,26 +124,19 @@ pub fn parse_wide_strings(data: &[u8]) -> WideStrings {
     strings
 }
 
-/// Decodes comma-separated ASCII codes to a string.
+/// Decodes an `ENCODEDTEXT` value — comma-separated UTF-16 code units in
+/// decimal — to a string: `"84,69,83,84"` → `"TEST"`, `"49,48,181,70"` →
+/// `"10µF"`, `"937"` → `"Ω"`.
 ///
-/// # Example
-///
-/// `"84,69,83,84"` → `"TEST"`
-///
-/// # Non-ASCII Handling
-///
-/// Values 0-127 are valid ASCII and converted directly.
-/// Values 128-255 are replaced with the Unicode replacement character (U+FFFD)
-/// since Altium's ENCODEDTEXT format should only contain ASCII.
-fn decode_ascii_codes(encoded: &str) -> String {
-    // The values are Windows-1252 bytes despite the ENCODEDTEXT name — Altium
-    // writes `10µF` as `49,48,181,70` — so the whole set goes through the
-    // shared decoder rather than being treated as ASCII.
-    let bytes: Vec<u8> = encoded
+/// The units are what `WideStrings` exists to carry: text the Windows-1252
+/// `Data` stream cannot hold. A unit that does not parse is skipped; an
+/// unpaired surrogate becomes U+FFFD.
+fn decode_wide_string(encoded: &str) -> String {
+    let units: Vec<u16> = encoded
         .split(',')
-        .filter_map(|s| s.trim().parse::<u8>().ok())
+        .filter_map(|s| s.trim().parse::<u16>().ok())
         .collect();
-    crate::altium::decode_windows1252(&bytes)
+    String::from_utf16_lossy(&units)
 }
 
 /// Parses the `UniqueIDPrimitiveInformation/Data` stream content.
@@ -1175,26 +1167,31 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_ascii_codes() {
-        assert_eq!(decode_ascii_codes("84,69,83,84"), "TEST");
-        assert_eq!(decode_ascii_codes("72,69,76,76,79"), "HELLO");
-        assert_eq!(decode_ascii_codes("65"), "A");
-        assert_eq!(decode_ascii_codes(""), "");
+    fn decode_wide_string_reads_ascii() {
+        assert_eq!(decode_wide_string("84,69,83,84"), "TEST");
+        assert_eq!(decode_wide_string("72,69,76,76,79"), "HELLO");
+        assert_eq!(decode_wide_string("65"), "A");
+        assert_eq!(decode_wide_string(""), "");
     }
 
+    /// The values are UTF-16 code units, not bytes: Altium writes `10µF` as
+    /// `49,48,181,70` (the golden `TEXT_WIN1252`), and a character beyond
+    /// Latin-1 is one unit above 255 — which is the whole point of the stream.
     #[test]
-    fn test_decode_ascii_codes_high_bytes_are_windows_1252() {
-        // The values are Windows-1252 bytes, despite the ENCODEDTEXT name:
-        // Altium writes `10µF` as `49,48,181,70`. Anything above 127 must
-        // decode through the code page, not be treated as non-ASCII and lost.
-        assert_eq!(decode_ascii_codes("49,48,181,70"), "10\u{B5}F");
-        assert_eq!(decode_ascii_codes("177,53,37"), "\u{B1}5%");
-        assert_eq!(decode_ascii_codes("65,200,66"), "A\u{C8}B");
-        assert_eq!(decode_ascii_codes("255"), "\u{FF}");
-        // 0x7F is a control character and maps to itself; 0x80 is the Euro
-        // sign in Windows-1252, not an invalid byte.
-        assert_eq!(decode_ascii_codes("127"), "\x7F");
-        assert_eq!(decode_ascii_codes("128"), "\u{20AC}");
+    fn decode_wide_string_reads_utf16_code_units() {
+        assert_eq!(decode_wide_string("49,48,181,70"), "10\u{B5}F");
+        assert_eq!(decode_wide_string("177,53,37"), "\u{B1}5%");
+        assert_eq!(decode_wide_string("937"), "\u{3A9}");
+        assert_eq!(decode_wide_string("8364"), "\u{20AC}");
+        assert_eq!(decode_wide_string("26085,26412"), "日本");
+        // A surrogate pair is two units; a lone one is replaced, not dropped.
+        assert_eq!(decode_wide_string("55357,56832"), "\u{1F600}");
+        assert_eq!(decode_wide_string("55357"), "\u{FFFD}");
+        // Unit 128 is U+0080 (a control), not the Windows-1252 Euro: the
+        // Euro is 8364 here.
+        assert_eq!(decode_wide_string("128"), "\u{80}");
+        // A value that is not a unit is skipped rather than failing the text.
+        assert_eq!(decode_wide_string("65,x,66,70000"), "AB");
     }
 
     // =============================================================================

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -2253,11 +2253,14 @@ pub fn encode_component_wide_strings(footprint: &Footprint) -> Vec<u8> {
     // pipe per entry and NO trailing pipe (matching AltiumSharp). With no entries the
     // string is empty, so the stream is just `[01 00 00 00][00]` — AltiumSharp's empty
     // form — rather than the spurious `[02 00 00 00][7C 00]` (leading-pipe) we emitted.
+    // Each value is the text's UTF-16 code units in decimal — `10µF` is
+    // `49,48,181,70`, `Ω` is `937` — which is what lets the stream carry text
+    // the Windows-1252 `Data` block cannot.
     let mut content = String::new();
     for (index, text) in texts.iter().enumerate() {
         let encoded: String = text
-            .bytes()
-            .map(|b| b.to_string())
+            .encode_utf16()
+            .map(|unit| unit.to_string())
             .collect::<Vec<_>>()
             .join(",");
         let _ = write!(content, "|ENCODEDTEXT{index}={encoded}");

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -5,7 +5,8 @@
 
 use serde_json::Value;
 
-use crate::mcp::server::McpServer;
+use crate::altium::pcblib::Footprint;
+use crate::mcp::server::{ErrorContext, McpServer, ToolCallResult};
 
 /// Reads a JSON integer field as `i32`, returning `None` if it is missing, not
 /// an integer, or outside `i32` range — so an out-of-range value is rejected
@@ -180,6 +181,339 @@ impl McpServer {
     }
 
     // ==================== Primitive Parsing Helpers ====================
+
+    /// Refuses a JSON object carrying a key outside `keys` (see
+    /// [`check_unknown_fields`](Self::check_unknown_fields)).
+    fn refuse_unknown(json: &Value, keys: &[&str]) -> Result<(), ToolCallResult> {
+        Self::check_unknown_fields(json, keys).map_err(ToolCallResult::error)
+    }
+
+    /// Parses one footprint object — the `footprints[]` element of
+    /// `write_pcblib` and the `footprint` of `update_component` — into a
+    /// [`Footprint`], refusing unknown keys on every object and validating the
+    /// geometry. Both tools go through here so neither can fall behind the
+    /// other on a primitive kind, a 3D-model spelling or a replay field.
+    ///
+    /// `operation` names the calling tool in error context; `default_name` is
+    /// the footprint name when the object carries none.
+    #[allow(clippy::too_many_lines)] // one straight-line pass over every footprint field
+    pub(crate) fn parse_footprint_json(
+        &self,
+        fp_json: &Value,
+        keys: &crate::mcp::tools::allowed_keys::PcbLibKeys,
+        operation: &str,
+        filepath: &str,
+        default_name: &str,
+    ) -> Result<Footprint, ToolCallResult> {
+        use crate::altium::pcblib::Model3D;
+
+        Self::refuse_unknown(fp_json, &keys.footprint)?;
+        let name = fp_json
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or(default_name);
+        let mut footprint = Footprint::new(name);
+
+        if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
+            footprint.description = desc.to_string();
+        }
+
+        // Parse pads
+        if let Some(pads) = fp_json.get("pads").and_then(Value::as_array) {
+            for (i, pad_json) in pads.iter().enumerate() {
+                Self::refuse_unknown(pad_json, &keys.pad)?;
+                match Self::parse_pad(pad_json) {
+                    Ok(pad) => footprint.add_pad(pad),
+                    Err(e) => {
+                        return Err(ToolCallResult::error_with_context(
+                            ErrorContext::new(operation, e)
+                                .with_filepath(filepath)
+                                .with_component(name)
+                                .with_details(format!("Failed to parse pad at index {i}")),
+                        ))
+                    }
+                }
+            }
+        }
+
+        // Parse tracks
+        if let Some(tracks) = fp_json.get("tracks").and_then(Value::as_array) {
+            for (i, track_json) in tracks.iter().enumerate() {
+                Self::refuse_unknown(track_json, &keys.track)?;
+                match Self::parse_track(track_json) {
+                    Ok(track) => footprint.add_track(track),
+                    Err(e) => {
+                        return Err(ToolCallResult::error_with_context(
+                            ErrorContext::new(operation, e)
+                                .with_filepath(filepath)
+                                .with_component(name)
+                                .with_details(format!("Failed to parse track at index {i}")),
+                        ))
+                    }
+                }
+            }
+        }
+
+        // Parse vias
+        if let Some(vias) = fp_json.get("vias").and_then(Value::as_array) {
+            for (i, via_json) in vias.iter().enumerate() {
+                Self::refuse_unknown(via_json, &keys.via)?;
+                match Self::parse_via(via_json) {
+                    Ok(via) => footprint.add_via(via),
+                    Err(e) => {
+                        return Err(ToolCallResult::error_with_context(
+                            ErrorContext::new(operation, e)
+                                .with_filepath(filepath)
+                                .with_component(name)
+                                .with_details(format!("Failed to parse via at index {i}")),
+                        ))
+                    }
+                }
+            }
+        }
+
+        // Parse fills
+        if let Some(fills) = fp_json.get("fills").and_then(Value::as_array) {
+            for (i, fill_json) in fills.iter().enumerate() {
+                Self::refuse_unknown(fill_json, &keys.fill)?;
+                match Self::parse_fill(fill_json) {
+                    Ok(fill) => footprint.add_fill(fill),
+                    Err(e) => {
+                        return Err(ToolCallResult::error_with_context(
+                            ErrorContext::new(operation, e)
+                                .with_filepath(filepath)
+                                .with_component(name)
+                                .with_details(format!("Failed to parse fill at index {i}")),
+                        ))
+                    }
+                }
+            }
+        }
+
+        // Parse arcs
+        if let Some(arcs) = fp_json.get("arcs").and_then(Value::as_array) {
+            for (i, arc_json) in arcs.iter().enumerate() {
+                Self::refuse_unknown(arc_json, &keys.arc)?;
+                match Self::parse_arc(arc_json) {
+                    Ok(arc) => footprint.add_arc(arc),
+                    Err(e) => {
+                        return Err(ToolCallResult::error_with_context(
+                            ErrorContext::new(operation, e)
+                                .with_filepath(filepath)
+                                .with_component(name)
+                                .with_details(format!("Failed to parse arc at index {i}")),
+                        ))
+                    }
+                }
+            }
+        }
+
+        // Parse regions
+        if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
+            for region_json in regions {
+                Self::refuse_unknown(region_json, &keys.region)?;
+                if let Some(region) = Self::parse_region(region_json) {
+                    footprint.add_region(region);
+                }
+            }
+        }
+
+        // Parse text
+        if let Some(texts) = fp_json.get("text").and_then(Value::as_array) {
+            for text_json in texts {
+                Self::refuse_unknown(text_json, &keys.text)?;
+                if let Some(text) = Self::parse_text(text_json) {
+                    footprint.add_text(text);
+                }
+            }
+        }
+
+        // Parse 3D model
+        if let Some(model_json) = fp_json.get("step_model") {
+            Self::refuse_unknown(model_json, &keys.model)?;
+            if let Some(model_path) = model_json.get("filepath").and_then(Value::as_str) {
+                let embed = model_json
+                    .get("embed")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true);
+
+                if embed {
+                    // The embed source is read from disk at save time
+                    // (prepare_3d_models_for_writing -> std::fs::read), far from
+                    // this handler. Validate it against the allow-list now so a
+                    // caller cannot embed an arbitrary file (e.g. "../../etc/passwd")
+                    // into the library. External references (embed=false) are only
+                    // stored as a string and never read, so they are not gated here.
+                    if let Err(e) = self.validate_path(model_path) {
+                        return Err(ToolCallResult::error(e));
+                    }
+
+                    // Embedded model - use Model3D which will read the file on save
+                    footprint.model_3d = Some(Model3D {
+                        filepath: model_path.to_string(),
+                        x_offset: model_json
+                            .get("x_offset")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                        y_offset: model_json
+                            .get("y_offset")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                        z_offset: model_json
+                            .get("z_offset")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                        rotation: model_json
+                            .get("rotation")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                    });
+                } else {
+                    // External reference only: a model-backed body whose file
+                    // stays outside the library. The writer emits the MODEL.*
+                    // group — MODEL.EMBED=FALSE and MODEL.NAME carrying the
+                    // full path, so organised subfolders resolve — only for a
+                    // body with a MODELID, so the reference gets a fresh one
+                    // here or the path would not reach the file at all. No
+                    // golden carries a non-embedded model; the form follows
+                    // the group Altium writes for embedded ones.
+                    use crate::altium::pcblib::{ComponentBody, Layer};
+                    let model_id =
+                        format!("{{{}}}", uuid::Uuid::new_v4().to_string().to_uppercase());
+                    footprint.add_component_body(ComponentBody {
+                        model_id,
+                        identifier: String::new(),
+                        texture_center_x: None,
+                        texture_center_y: None,
+                        texture_size_x: None,
+                        texture_size_y: None,
+                        raw_layer_id: None,
+                        v7_layer: None,
+                        model_name: model_path.to_string(), // Preserve full path
+                        embedded: false,
+                        rotation_x: 0.0,
+                        rotation_y: 0.0,
+                        rotation_z: model_json
+                            .get("rotation")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                        z_offset: model_json
+                            .get("z_offset")
+                            .and_then(Value::as_f64)
+                            .unwrap_or(0.0),
+                        overall_height: 0.0,
+                        standoff_height: 0.0,
+                        cavity_height: 0.0,
+                        layer: Layer::Top3DBody,
+                        outline: Vec::new(),
+                        unique_id: None,
+                        guid: None,
+                        model_checksum: 0, // External reference: no embedded model.
+                        name: " ".to_string(),
+                        kind: 0,
+                        sub_poly_index: -1,
+                        union_index: 0,
+                        is_shape_based: false,
+                        body_projection: 0,
+                        body_color_3d: 8_421_504,
+                        body_opacity_3d: 1.0,
+                        model_2d_rotation: 0.0,
+                        model_2d_x: 0.0,
+                        model_2d_y: 0.0,
+                        // External reference: no board association (free primitive).
+                        net_index: 0xFFFF,
+                        polygon_index: 0xFFFF,
+                        component_index: -1,
+                        additional_parameters: Vec::new(),
+                    });
+                }
+            }
+        }
+
+        // Parse "model_3d" — read_pcblib's spelling of the same model
+        // reference (it emits the key for every footprint, null when there
+        // is no model), accepted so a read result replays into
+        // write_pcblib unchanged. `step_model` wins when both are given
+        // (it is the authoring-time spelling, incl. the embed switch);
+        // null is ignored. The fields mirror the Model3D serde shape
+        // (filepath + offsets/rotation).
+        if fp_json.get("step_model").is_none() {
+            if let Some(model_json) = fp_json.get("model_3d").filter(|v| !v.is_null()) {
+                Self::refuse_unknown(model_json, &keys.model)?;
+                let model_path = model_json
+                    .get("filepath")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                // The save path embeds the file (std::fs::read) when the
+                // path resolves to an existing file, so gate exactly that
+                // case against the allow-list — the same arbitrary-file-
+                // read defence as step_model. Bare model names replayed
+                // from read_pcblib output don't exist on disk and are kept
+                // as inert references, so they are not gated.
+                if std::path::Path::new(model_path).is_file() {
+                    if let Err(e) = self.validate_path(model_path) {
+                        return Err(ToolCallResult::error(e));
+                    }
+                }
+                footprint.model_3d = Some(Model3D {
+                    filepath: model_path.to_string(),
+                    x_offset: model_json
+                        .get("x_offset")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0),
+                    y_offset: model_json
+                        .get("y_offset")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0),
+                    z_offset: model_json
+                        .get("z_offset")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0),
+                    rotation: model_json
+                        .get("rotation")
+                        .and_then(Value::as_f64)
+                        .unwrap_or(0.0),
+                });
+            }
+        }
+
+        // Parse generic extruded 3D bodies (no STEP model). Each body is
+        // defined by an optional 2D outline (auto-bounding-box from pads when
+        // omitted) plus standoff/overall heights, on the Top/Bottom 3D Body
+        // layer. model_id/model_name stay empty so the writer marks them as
+        // shape-based extruded bodies.
+        if let Some(bodies) = fp_json.get("component_bodies").and_then(Value::as_array) {
+            for body_json in bodies {
+                Self::refuse_unknown(body_json, &keys.component_body)?;
+                footprint.add_component_body(Self::parse_component_body_json(body_json));
+            }
+        }
+
+        // Footprint-level replay fields `read_pcblib` emits. The guid is
+        // the kind-85 identity record; the interleaved Data-stream order
+        // replaces the grouped order the add_* calls accumulated, so a
+        // read-modify-write keeps the source's stream order
+        // (`write_sequence` is advisory-safe against a stale list).
+        if let Some(g) = fp_json.get("guid").and_then(Value::as_str) {
+            footprint.guid = Some(g.to_string());
+        }
+        if let Some(order) = fp_json.get("primitive_order") {
+            match serde_json::from_value(order.clone()) {
+                Ok(kinds) => footprint.primitive_order = kinds,
+                Err(e) => {
+                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                }
+            }
+        }
+
+        // Out-of-range or non-finite geometry would saturate in from_mm() on
+        // save; refused here so both tools report it the same way.
+        if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
+            return Err(ToolCallResult::error(e));
+        }
+
+        Ok(footprint)
+    }
 
     pub(crate) fn check_unknown_fields(
         json: &serde_json::Value,

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -39,7 +39,7 @@ impl McpServer {
                         "Missing required parameter: footprint (required for .PcbLib files)",
                     );
                 };
-                Self::update_pcblib_component(filepath, component_name, fp_json, dry_run)
+                self.update_pcblib_component(filepath, component_name, fp_json, dry_run)
             }
             Some("schlib") => {
                 let Some(sym_json) = arguments.get("symbol") else {
@@ -56,12 +56,13 @@ impl McpServer {
     /// Updates a footprint in-place within a `PcbLib` file.
     #[allow(clippy::too_many_lines)] // Includes parsing and dry_run logic
     pub(crate) fn update_pcblib_component(
+        &self,
         filepath: &str,
         component_name: &str,
         fp_json: &Value,
         dry_run: bool,
     ) -> ToolCallResult {
-        use crate::altium::pcblib::{Footprint, PcbLib};
+        use crate::altium::pcblib::PcbLib;
 
         // Read the library
         let mut library = match PcbLib::open(filepath) {
@@ -79,119 +80,21 @@ impl McpServer {
             ));
         }
 
-        // Parse the replacement footprint
-        let name = fp_json
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or(component_name);
-        let mut footprint = Footprint::new(name);
-
-        if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
-            footprint.description = desc.to_string();
-        }
-
-        // Parse pads
-        if let Some(pads) = fp_json.get("pads").and_then(Value::as_array) {
-            for (i, pad_json) in pads.iter().enumerate() {
-                match Self::parse_pad(pad_json) {
-                    Ok(pad) => footprint.add_pad(pad),
-                    Err(e) => return ToolCallResult::error(format!("Pad {i}: {e}")),
-                }
-            }
-        }
-
-        // Parse tracks
-        if let Some(tracks) = fp_json.get("tracks").and_then(Value::as_array) {
-            for (i, track_json) in tracks.iter().enumerate() {
-                match Self::parse_track(track_json) {
-                    Ok(track) => footprint.add_track(track),
-                    Err(e) => return ToolCallResult::error(format!("Track {i}: {e}")),
-                }
-            }
-        }
-
-        // Parse arcs
-        if let Some(arcs) = fp_json.get("arcs").and_then(Value::as_array) {
-            for (i, arc_json) in arcs.iter().enumerate() {
-                match Self::parse_arc(arc_json) {
-                    Ok(arc) => footprint.add_arc(arc),
-                    Err(e) => return ToolCallResult::error(format!("Arc {i}: {e}")),
-                }
-            }
-        }
-
-        // Parse regions
-        if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
-            for region_json in regions {
-                if let Some(region) = Self::parse_region(region_json) {
-                    footprint.add_region(region);
-                }
-            }
-        }
-
-        // Parse vias, fills and component bodies. The create path (call_write_pcblib)
-        // handles these, and this update path must mirror it exactly: omitting
-        // them makes a read-modify-write of a footprint carrying any via / fill
-        // / 3D body silently drop it.
-        if let Some(vias) = fp_json.get("vias").and_then(Value::as_array) {
-            for (i, via_json) in vias.iter().enumerate() {
-                match Self::parse_via(via_json) {
-                    Ok(via) => footprint.add_via(via),
-                    Err(e) => return ToolCallResult::error(format!("Via {i}: {e}")),
-                }
-            }
-        }
-        if let Some(fills) = fp_json.get("fills").and_then(Value::as_array) {
-            for (i, fill_json) in fills.iter().enumerate() {
-                match Self::parse_fill(fill_json) {
-                    Ok(fill) => footprint.add_fill(fill),
-                    Err(e) => return ToolCallResult::error(format!("Fill {i}: {e}")),
-                }
-            }
-        }
-        if let Some(bodies) = fp_json.get("component_bodies").and_then(Value::as_array) {
-            for body_json in bodies {
-                footprint.add_component_body(Self::parse_component_body_json(body_json));
-            }
-        }
-
-        // Parse text. Accept both "text" (the create-path key) and the legacy
-        // "texts", so reusing the create schema for an update does not silently
-        // drops text primitives.
-        if let Some(texts) = fp_json
-            .get("text")
-            .or_else(|| fp_json.get("texts"))
-            .and_then(Value::as_array)
-        {
-            for text_json in texts {
-                if let Some(text) = Self::parse_text(text_json) {
-                    footprint.add_text(text);
-                }
-            }
-        }
-
-        // Footprint-level replay fields, mirroring the create path: the
-        // kind-85 identity and the interleaved stream order a
-        // get_component → update_component loop echoes back.
-        if let Some(g) = fp_json.get("guid").and_then(Value::as_str) {
-            footprint.guid = Some(g.to_string());
-        }
-        if let Some(order) = fp_json.get("primitive_order") {
-            match serde_json::from_value(order.clone()) {
-                Ok(kinds) => footprint.primitive_order = kinds,
-                Err(e) => {
-                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
-                }
-            }
-        }
-
-        // Reject out-of-range / non-finite geometry before it can saturate in
-        // from_mm() on save. The create path validates here; this path skipped
-        // it (parallels the #102 update_pad/update_primitive bug). Runs in
-        // dry-run too so previews report the error.
-        if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
-            return ToolCallResult::error(e);
-        }
+        // Parse the replacement footprint — the same parser as write_pcblib,
+        // so an update accepts exactly what a write does.
+        let keys = crate::mcp::tools::allowed_keys::PcbLibKeys::new();
+        let footprint = match self.parse_footprint_json(
+            fp_json,
+            &keys,
+            "update_component",
+            filepath,
+            component_name,
+        ) {
+            Ok(footprint) => footprint,
+            Err(result) => return result,
+        };
+        let name = footprint.name.clone();
+        let name = name.as_str();
 
         // A replacement may carry a new name, which makes this a rename too —
         // and a rename onto a name another footprint already holds would leave
@@ -2324,33 +2227,34 @@ mod tests {
             let fx = Fixtures::new();
             let server = create_test_server(fx.dir.path());
 
-            // The update path mirrors the create path's parsing, so a malformed
-            // primitive is named and indexed the same way rather than dropped.
+            // The update path IS the create path's parser, so a malformed
+            // primitive is named and indexed the same way rather than dropped,
+            // under the updating tool's name.
             let cases: [(&str, serde_json::Value, &str); 5] = [
                 (
                     "pads",
                     json!([{ "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 }]),
-                    "Pad 0",
+                    "Failed to parse pad at index 0",
                 ),
                 (
                     "tracks",
                     json!([{ "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.2 }]),
-                    "Track 0",
+                    "Failed to parse track at index 0",
                 ),
                 (
                     "arcs",
                     json!([{ "x": 0.0, "y": 0.0, "radius": 1.0, "start_angle": 0.0, "end_angle": 90.0 }]),
-                    "Arc 0",
+                    "Failed to parse arc at index 0",
                 ),
                 (
                     "vias",
                     json!([{ "x": 0.0, "y": 0.0, "diameter": 0.0, "hole_size": 0.3 }]),
-                    "Via 0",
+                    "Failed to parse via at index 0",
                 ),
                 (
                     "fills",
                     json!([{ "y1": 0.0, "x2": 1.0, "y2": 1.0 }]),
-                    "Fill 0",
+                    "Failed to parse fill at index 0",
                 ),
             ];
 
@@ -2363,6 +2267,7 @@ mod tests {
                     "footprint": footprint,
                 }));
                 assert_error_mentions(&r, expected);
+                assert_error_mentions(&r, "update_component");
             }
         }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -441,7 +441,7 @@ impl McpServer {
     /// Writes footprints to a `PcbLib` file.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn call_write_pcblib(&self, arguments: &Value) -> ToolCallResult {
-        use crate::altium::pcblib::{Footprint, Model3D, PcbLib};
+        use crate::altium::pcblib::PcbLib;
 
         let Some(filepath) = arguments.get("filepath").and_then(Value::as_str) else {
             return ToolCallResult::error("Missing required parameter: filepath");
@@ -551,279 +551,16 @@ impl McpServer {
 
         let keys = allowed_keys::PcbLibKeys::new();
         for fp_json in footprints_json {
-            check_keys!(fp_json, &keys.footprint);
-            let name = fp_json
-                .get("name")
-                .and_then(Value::as_str)
-                .unwrap_or("Unnamed");
-            let mut footprint = Footprint::new(name);
-
-            if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
-                footprint.description = desc.to_string();
-            }
-
-            // Parse pads
-            if let Some(pads) = fp_json.get("pads").and_then(Value::as_array) {
-                for (i, pad_json) in pads.iter().enumerate() {
-                    check_keys!(pad_json, &keys.pad);
-                    match Self::parse_pad(pad_json) {
-                        Ok(pad) => footprint.add_pad(pad),
-                        Err(e) => {
-                            return ToolCallResult::error_with_context(
-                                ErrorContext::new("write_pcblib", e)
-                                    .with_filepath(filepath)
-                                    .with_component(name)
-                                    .with_details(format!("Failed to parse pad at index {i}")),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Parse tracks
-            if let Some(tracks) = fp_json.get("tracks").and_then(Value::as_array) {
-                for (i, track_json) in tracks.iter().enumerate() {
-                    check_keys!(track_json, &keys.track);
-                    match Self::parse_track(track_json) {
-                        Ok(track) => footprint.add_track(track),
-                        Err(e) => {
-                            return ToolCallResult::error_with_context(
-                                ErrorContext::new("write_pcblib", e)
-                                    .with_filepath(filepath)
-                                    .with_component(name)
-                                    .with_details(format!("Failed to parse track at index {i}")),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Parse vias
-            if let Some(vias) = fp_json.get("vias").and_then(Value::as_array) {
-                for (i, via_json) in vias.iter().enumerate() {
-                    check_keys!(via_json, &keys.via);
-                    match Self::parse_via(via_json) {
-                        Ok(via) => footprint.add_via(via),
-                        Err(e) => {
-                            return ToolCallResult::error_with_context(
-                                ErrorContext::new("write_pcblib", e)
-                                    .with_filepath(filepath)
-                                    .with_component(name)
-                                    .with_details(format!("Failed to parse via at index {i}")),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Parse fills
-            if let Some(fills) = fp_json.get("fills").and_then(Value::as_array) {
-                for (i, fill_json) in fills.iter().enumerate() {
-                    check_keys!(fill_json, &keys.fill);
-                    match Self::parse_fill(fill_json) {
-                        Ok(fill) => footprint.add_fill(fill),
-                        Err(e) => {
-                            return ToolCallResult::error_with_context(
-                                ErrorContext::new("write_pcblib", e)
-                                    .with_filepath(filepath)
-                                    .with_component(name)
-                                    .with_details(format!("Failed to parse fill at index {i}")),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Parse arcs
-            if let Some(arcs) = fp_json.get("arcs").and_then(Value::as_array) {
-                for (i, arc_json) in arcs.iter().enumerate() {
-                    check_keys!(arc_json, &keys.arc);
-                    match Self::parse_arc(arc_json) {
-                        Ok(arc) => footprint.add_arc(arc),
-                        Err(e) => {
-                            return ToolCallResult::error_with_context(
-                                ErrorContext::new("write_pcblib", e)
-                                    .with_filepath(filepath)
-                                    .with_component(name)
-                                    .with_details(format!("Failed to parse arc at index {i}")),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Parse regions
-            if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
-                for region_json in regions {
-                    check_keys!(region_json, &keys.region);
-                    if let Some(region) = Self::parse_region(region_json) {
-                        footprint.add_region(region);
-                    }
-                }
-            }
-
-            // Parse text
-            if let Some(texts) = fp_json.get("text").and_then(Value::as_array) {
-                for text_json in texts {
-                    check_keys!(text_json, &keys.text);
-                    if let Some(text) = Self::parse_text(text_json) {
-                        footprint.add_text(text);
-                    }
-                }
-            }
-
-            // Parse 3D model
-            if let Some(model_json) = fp_json.get("step_model") {
-                check_keys!(model_json, &keys.model);
-                if let Some(model_path) = model_json.get("filepath").and_then(Value::as_str) {
-                    let embed = model_json
-                        .get("embed")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(true);
-
-                    if embed {
-                        // The embed source is read from disk at save time
-                        // (prepare_3d_models_for_writing -> std::fs::read), far from
-                        // this handler. Validate it against the allow-list now so a
-                        // caller cannot embed an arbitrary file (e.g. "../../etc/passwd")
-                        // into the library. External references (embed=false) are only
-                        // stored as a string and never read, so they are not gated here.
-                        if let Err(e) = self.validate_path(model_path) {
-                            return ToolCallResult::error(e);
-                        }
-
-                        // Embedded model - use Model3D which will read the file on save
-                        footprint.model_3d = Some(Model3D {
-                            filepath: model_path.to_string(),
-                            x_offset: model_json
-                                .get("x_offset")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                            y_offset: model_json
-                                .get("y_offset")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                            z_offset: model_json
-                                .get("z_offset")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                            rotation: model_json
-                                .get("rotation")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                        });
-                    } else {
-                        // External reference only - create ComponentBody directly
-                        // Preserve the full path for external references so organized subfolders work
-                        use crate::altium::pcblib::{ComponentBody, Layer};
-                        footprint.add_component_body(ComponentBody {
-                            model_id: String::new(), // No GUID for external reference
-                            identifier: String::new(),
-                            texture_center_x: None,
-                            texture_center_y: None,
-                            texture_size_x: None,
-                            texture_size_y: None,
-                            raw_layer_id: None,
-                            v7_layer: None,
-                            model_name: model_path.to_string(), // Preserve full path
-                            embedded: false,
-                            rotation_x: 0.0,
-                            rotation_y: 0.0,
-                            rotation_z: model_json
-                                .get("rotation")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                            z_offset: model_json
-                                .get("z_offset")
-                                .and_then(Value::as_f64)
-                                .unwrap_or(0.0),
-                            overall_height: 0.0,
-                            standoff_height: 0.0,
-                            cavity_height: 0.0,
-                            layer: Layer::Top3DBody,
-                            outline: Vec::new(),
-                            unique_id: None,
-                            guid: None,
-                            model_checksum: 0, // External reference: no embedded model.
-                            name: " ".to_string(),
-                            kind: 0,
-                            sub_poly_index: -1,
-                            union_index: 0,
-                            is_shape_based: false,
-                            body_projection: 0,
-                            body_color_3d: 8_421_504,
-                            body_opacity_3d: 1.0,
-                            model_2d_rotation: 0.0,
-                            model_2d_x: 0.0,
-                            model_2d_y: 0.0,
-                            // External reference: no board association (free primitive).
-                            net_index: 0xFFFF,
-                            polygon_index: 0xFFFF,
-                            component_index: -1,
-                            additional_parameters: Vec::new(),
-                        });
-                    }
-                }
-            }
-
-            // Parse "model_3d" — read_pcblib's spelling of the same model
-            // reference (it emits the key for every footprint, null when there
-            // is no model), accepted so a read result replays into
-            // write_pcblib unchanged. `step_model` wins when both are given
-            // (it is the authoring-time spelling, incl. the embed switch);
-            // null is ignored. The fields mirror the Model3D serde shape
-            // (filepath + offsets/rotation).
-            if fp_json.get("step_model").is_none() {
-                if let Some(model_json) = fp_json.get("model_3d").filter(|v| !v.is_null()) {
-                    check_keys!(model_json, &keys.model);
-                    let model_path = model_json
-                        .get("filepath")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default();
-                    // The save path embeds the file (std::fs::read) when the
-                    // path resolves to an existing file, so gate exactly that
-                    // case against the allow-list — the same arbitrary-file-
-                    // read defence as step_model. Bare model names replayed
-                    // from read_pcblib output don't exist on disk and are kept
-                    // as inert references, so they are not gated.
-                    if std::path::Path::new(model_path).is_file() {
-                        if let Err(e) = self.validate_path(model_path) {
-                            return ToolCallResult::error(e);
-                        }
-                    }
-                    footprint.model_3d = Some(Model3D {
-                        filepath: model_path.to_string(),
-                        x_offset: model_json
-                            .get("x_offset")
-                            .and_then(Value::as_f64)
-                            .unwrap_or(0.0),
-                        y_offset: model_json
-                            .get("y_offset")
-                            .and_then(Value::as_f64)
-                            .unwrap_or(0.0),
-                        z_offset: model_json
-                            .get("z_offset")
-                            .and_then(Value::as_f64)
-                            .unwrap_or(0.0),
-                        rotation: model_json
-                            .get("rotation")
-                            .and_then(Value::as_f64)
-                            .unwrap_or(0.0),
-                    });
-                }
-            }
-
-            // Parse generic extruded 3D bodies (no STEP model). Each body is
-            // defined by an optional 2D outline (auto-bounding-box from pads when
-            // omitted) plus standoff/overall heights, on the Top/Bottom 3D Body
-            // layer. model_id/model_name stay empty so the writer marks them as
-            // shape-based extruded bodies.
-            if let Some(bodies) = fp_json.get("component_bodies").and_then(Value::as_array) {
-                for body_json in bodies {
-                    check_keys!(body_json, &keys.component_body);
-                    footprint.add_component_body(Self::parse_component_body_json(body_json));
-                }
-            }
+            let mut footprint = match self.parse_footprint_json(
+                fp_json,
+                &keys,
+                "write_pcblib",
+                filepath,
+                "Unnamed",
+            ) {
+                Ok(footprint) => footprint,
+                Err(result) => return result,
+            };
 
             // Auto-inject the `.Designator` special string on the Top Overlay if the
             // caller did not provide one, so every placed footprint renders its
@@ -951,28 +688,6 @@ impl McpServer {
                 false
             };
             bodies_echo.push(body_3d_summary(&footprint, assumed_height));
-
-            // Footprint-level replay fields `read_pcblib` emits. The guid is
-            // the kind-85 identity record; the interleaved Data-stream order
-            // replaces the grouped order the add_* calls accumulated, so a
-            // read-modify-write keeps the source's stream order
-            // (`write_sequence` is advisory-safe against a stale list).
-            if let Some(g) = fp_json.get("guid").and_then(Value::as_str) {
-                footprint.guid = Some(g.to_string());
-            }
-            if let Some(order) = fp_json.get("primitive_order") {
-                match serde_json::from_value(order.clone()) {
-                    Ok(kinds) => footprint.primitive_order = kinds,
-                    Err(e) => {
-                        tracing::debug!(error = %e, "invalid primitive_order; using default order");
-                    }
-                }
-            }
-
-            // Validate coordinates before adding
-            if let Err(e) = Self::validate_footprint_coordinates(&footprint) {
-                return ToolCallResult::error(e);
-            }
 
             silk_warnings.extend(silk_over_pad_warnings(&footprint));
             silk_warnings.extend(pad_copper_overlap_warnings(&footprint));
@@ -2540,7 +2255,7 @@ mod tests {
 
             for (g_name, o_name) in pairs {
                 let (g, o) = (&golden[g_name], &ours[o_name]);
-                for stream in ["Data", "UniqueIDPrimitiveInformation/Data"] {
+                for stream in ["Data", "WideStrings", "UniqueIDPrimitiveInformation/Data"] {
                     assert_same_stream(&format!("{g_name}/{stream}"), g.get(stream), o.get(stream));
                 }
                 // Altium scrambles the PrimitiveGuids record order while the
@@ -2878,6 +2593,179 @@ mod tests {
             assert_eq!(link["unique_id"], "ABCDEFGH", "{link}");
             assert_eq!(link["is_current"], true, "{link}");
             assert_eq!(link["library_path"], "Lib.PcbLib", "{link}");
+        }
+
+        /// The in-place twin: every golden footprint read through
+        /// `read_pcblib` and handed back to `update_component` as its own
+        /// replacement leaves the library byte-for-byte as the library-level
+        /// save has it — the update path parses with its own hands, so it is
+        /// held to the same bar as `write_pcblib`.
+        #[test]
+        fn update_component_replays_every_golden_footprint_byte_for_byte() {
+            use crate::altium::PcbLib;
+
+            let dir = test_temp_dir();
+            let samples = std::path::Path::new("scripts/samples")
+                .canonicalize()
+                .unwrap();
+            let server =
+                crate::mcp::server::McpServer::new(vec![dir.path().to_path_buf(), samples.clone()]);
+            let src = samples.join("footprints.PcbLib");
+
+            let baseline = dir.path().join("Baseline.PcbLib");
+            PcbLib::open(&src).unwrap().save(&baseline).unwrap();
+            let work = dir.path().join("Work.PcbLib");
+            std::fs::copy(&src, &work).unwrap();
+
+            let read = server.call_read_pcblib(&json!({ "filepath": src.to_string_lossy() }));
+            assert!(!read.is_error, "{}", get_result_text(&read));
+            let footprints = parse_result_json(&read)["footprints"].clone();
+            for fp in footprints.as_array().unwrap() {
+                let updated = server.call_update_component(&json!({
+                    "filepath": work.to_string_lossy(),
+                    "component_name": fp["name"],
+                    "footprint": fp,
+                }));
+                assert!(
+                    !updated.is_error,
+                    "{}: {}",
+                    fp["name"],
+                    get_result_text(&updated)
+                );
+            }
+
+            let (expected, ours) = (component_streams(&baseline), component_streams(&work));
+            assert_eq!(
+                expected.keys().collect::<Vec<_>>(),
+                ours.keys().collect::<Vec<_>>(),
+                "footprint storages differ"
+            );
+            for (name, e) in &expected {
+                let o = &ours[name];
+                for stream in ["Data", "WideStrings", "UniqueIDPrimitiveInformation/Data"] {
+                    assert_same_stream(&format!("{name}/{stream}"), e.get(stream), o.get(stream));
+                }
+            }
+        }
+
+        /// `update_component` parses with `write_pcblib`'s parser: a typo on
+        /// any object is refused, and the 3D-model spellings are honoured.
+        #[test]
+        fn update_component_parses_exactly_what_write_pcblib_does() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let lib = dir.path().join("Upd.PcbLib");
+            let pad = json!({ "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 });
+            let written = server.call_write_pcblib(&json!({
+                "filepath": lib.to_string_lossy(),
+                "footprints": [{ "name": "U", "pads": [pad] }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+
+            for (kind, footprint) in [
+                (
+                    "footprint",
+                    json!({ "name": "U", "pads": [pad], "descripton": "x" }),
+                ),
+                (
+                    "pad",
+                    json!({ "name": "U", "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0, "shpae": "round" }] }),
+                ),
+                (
+                    "track",
+                    json!({ "name": "U", "pads": [pad], "tracks": [{ "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0, "width": 0.2, "layr": "Top Overlay" }] }),
+                ),
+                (
+                    "body",
+                    json!({ "name": "U", "pads": [pad], "component_bodies": [{ "overal_height": 1.0 }] }),
+                ),
+                (
+                    "step_model",
+                    json!({ "name": "U", "pads": [pad], "step_model": { "filepath": "x.step", "embed": false, "rotaton": 0.0 } }),
+                ),
+            ] {
+                let result = server.call_update_component(&json!({
+                    "filepath": lib.to_string_lossy(),
+                    "component_name": "U",
+                    "footprint": footprint,
+                }));
+                let text = get_result_text(&result);
+                assert!(result.is_error, "{kind}: a typo was accepted: {text}");
+                assert!(text.contains("Unknown field"), "{kind}: {text}");
+            }
+
+            // An external STEP reference lands as a component body, as it
+            // does on a write.
+            let result = server.call_update_component(&json!({
+                "filepath": lib.to_string_lossy(),
+                "component_name": "U",
+                "footprint": { "name": "U", "pads": [pad], "step_model": { "filepath": "models/U.step", "embed": false, "rotation": 90.0 } },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let back = server.call_read_pcblib(&json!({ "filepath": lib.to_string_lossy() }));
+            let fp = parse_result_json(&back)["footprints"][0].clone();
+            assert_eq!(
+                fp["component_bodies"][0]["model_name"], "models/U.step",
+                "{fp}"
+            );
+            assert_eq!(fp["component_bodies"][0]["embedded"], false, "{fp}");
+        }
+
+        /// Text beyond ASCII survives a write, a read and — the case that
+        /// corrupted it a character per save — every further open/save.
+        #[test]
+        fn write_pcblib_keeps_non_ascii_text_through_repeated_saves() {
+            use crate::altium::PcbLib;
+
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let lib = dir.path().join("Wide.PcbLib");
+            let texts = ["10µF", "Ω ±5%", "日本語", "€ 1,50"];
+            let written = server.call_write_pcblib(&json!({
+                "filepath": lib.to_string_lossy(),
+                "footprints": [{
+                    "name": "W",
+                    "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 }],
+                    "text": texts.iter().enumerate().map(|(i, t)| json!({
+                        "x": 0.0, "y": f64::from(u8::try_from(i).unwrap()) * 2.0, "text": t, "height": 1.0,
+                    })).collect::<Vec<_>>(),
+                }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+
+            let read_texts = |path: &std::path::Path| -> Vec<String> {
+                let back = server.call_read_pcblib(&json!({ "filepath": path.to_string_lossy() }));
+                parse_result_json(&back)["footprints"][0]["text"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .filter(|t| !t["text"].as_str().unwrap().starts_with('.'))
+                    .map(|t| t["text"].as_str().unwrap().to_string())
+                    .collect()
+            };
+            assert_eq!(read_texts(&lib), texts);
+
+            let first = std::fs::read(&lib).unwrap();
+            for _ in 0..3 {
+                let mut opened = PcbLib::open(&lib).unwrap();
+                opened.save(&lib).unwrap();
+            }
+            assert_eq!(read_texts(&lib), texts);
+            let streams_after = component_streams(&lib);
+            assert_eq!(
+                component_streams(&dir.path().join("Wide.PcbLib"))["W"]["WideStrings"],
+                streams_after["W"]["WideStrings"]
+            );
+            let wide = String::from_utf8_lossy(&streams_after["W"]["WideStrings"]).into_owned();
+            assert!(wide.contains("|ENCODEDTEXT0=49,48,181,70|"), "{wide}");
+            assert!(wide.contains("|ENCODEDTEXT1=937,32,177,53,37|"), "{wide}");
+            assert!(wide.contains("|ENCODEDTEXT2=26085,26412,35486|"), "{wide}");
+            assert!(wide.contains("|ENCODEDTEXT3=8364,32,49,44,53,48"), "{wide}");
+            assert_eq!(
+                std::fs::read(&lib).unwrap().len(),
+                first.len(),
+                "a save must not grow the file"
+            );
         }
 
         /// From scratch the designator is still added by default, and

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -421,6 +421,33 @@ fn pcblib_golden_survives_a_round_trip() {
         }
     }
 
+    // 6. Every footprint's WideStrings stream byte-identical: it carries the
+    //    text the Windows-1252 Data block cannot (as UTF-16 code units), and
+    //    the reader prefers it, so a wrong encoding here corrupts every
+    //    non-ASCII text a character further on each save while the Data
+    //    stream above stays byte-identical.
+    for (canonical, g_path) in &before {
+        let Some(name) = canonical
+            .strip_suffix("/widestrings")
+            .filter(|n| !n.contains('/'))
+        else {
+            continue;
+        };
+        if is_known(canonical) {
+            continue;
+        }
+        let g = stream_bytes(&src, g_path).expect("walked stream exists");
+        match after.get(canonical).and_then(|p| stream_bytes(&out, p)) {
+            Some(o) if o == g => {}
+            Some(o) => failures.push(format!(
+                "{name}: WideStrings not byte-identical: golden {:?}, ours {:?}",
+                String::from_utf8_lossy(&g),
+                String::from_utf8_lossy(&o)
+            )),
+            None => failures.push(format!("{name}: WideStrings not written back")),
+        }
+    }
+
     assert!(
         failures.is_empty(),
         "the golden does not survive a read/write cycle intact ({} divergence(s)).\n\


### PR DESCRIPTION
**Stacked on #421** (base branch `fix/unknown-field-allow-lists`; I will retarget to `main` once #421 lands). Bugs #12–#14 of the sweep, found by the *in-place* twin of the byte-fidelity suite: every golden footprint read through `read_pcblib` and handed back to `update_component` as its own replacement — 22 saves in a row.

## 1. WideStrings corrupted every non-ASCII text, a byte per save 🔥

`ENCODEDTEXT` values are the text's **UTF-16 code units** in decimal — AltiumSharp's reader *and* writer agree, and the golden's `10µF` is `49,48,181,70`. Our writer emitted **UTF-8 bytes**; our reader parsed each value as a **Windows-1252 byte** (anything above U+00FF silently dropped). The reader prefers WideStrings over the Data block, so after one save `µ` read back as `Âµ`, and every further open/save — *any* mutating tool — re-encoded its own mojibake: `µ` → `Âµ` → `Ã‚Âµ` → … The Data stream stayed byte-identical throughout and no suite compared WideStrings, which is how it hid.

Fix: both sides speak UTF-16 units; `tests/golden_fidelity.rs` gains a WideStrings byte-identity pass and both tool-layer twins compare it too.

## 2. `update_component` had drifted from `write_pcblib` (again)

It parsed a footprint by hand: no unknown-field check on any object (typos silently ignored), `step_model`/`model_3d` silently ignored, a different error shape. Both tools now go through **one `parse_footprint_json`** — the structural fix, since this path had already drifted once before on vias/fills/bodies.

## 3. External STEP references never reached the file

`embed: false` created a body with no `MODELID`, and the writer emits the `MODEL.*` group (`MODEL.NAME`, `MODEL.EMBED=FALSE`) only for a body that has one — so the path was dropped while the response said `"step-external"`. The reference now carries a fresh `MODELID` and its path survives a read. (No golden carries a non-embedded model — fixture gap noted.)

## Tests

Update twin (22 footprints byte-identical incl. WideStrings), non-ASCII text through write → read → 3 further saves (file length + WideStrings stable; units asserted for µ, Ω, CJK, €), typo refusal on the update path, external-reference read-back, UTF-16 decoder incl. surrogate pairs.

Gates: fmt ✅ clippy ✅ 1405 tests ✅ coverage **99.08%** (406/43,926).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
