### PR TITLE
fix(mcp): one symbol parser for both tools; refuse a malformed record instead of dropping it

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,12 +8,32 @@ record). The specialised worklists stay the single source of truth for their are
 | Golden-fixture enrichment | `docs/FIXTURE_COVERAGE.md` |
 | Format parity + verified negatives | `docs/COVERAGE_AUDIT.md` § Outstanding |
 
-## A. On-site Altium tooling
+## A. Findings deferred from the bug sweep
+
+Found while fixing something else; each needs its own verification or a fixture first.
+
+- [ ] **SchLib header `UniqueID` (RECORD=1) is dropped on write** — Altium stores one per
+      component (`|RECORD=1|...|UniqueID=PMHDDPDX`); `Symbol` has no field for it, so the
+      writer omits it and Altium presumably re-generates it. Excused today via
+      `VOLATILE_KEYS` in `tests/golden_fidelity.rs`. Carry it like `designator_unique_id`.
+- [ ] **Shapes the golden stores without a `UniqueID` (pies) get a fresh random one per
+      save** — `encode_pie` always emits `UniqueID=`, so two saves of the same library
+      differ. Either Altium accepts an absent key (omit when `None`, matching the golden)
+      or the fixture is an outlier; settle against Altium, then make saves deterministic.
+- [ ] **`EllipticalArc` and `Text` (RECORD=11 / RECORD=3) carry no display flags**
+      (`graphically_locked`, `disabled`, `dimmed`, `owner_part_display_mode`) in the model,
+      while the other 13 graphics do — almost certainly a gap, but no golden record exists
+      to verify the keys AD24 emits. Blocked on the fixture (see `docs/FIXTURE_COVERAGE.md`).
+- [ ] **Non-embedded STEP reference form is unverified** — `step_model.embed: false` now
+      writes `MODELID` + `MODEL.EMBED=FALSE` + `MODEL.NAME=<path>`; whether Altium also
+      expects an entry in `/Library/ModelsNoEmbed` is unknown. Blocked on the fixture.
+
+## B. On-site Altium tooling
 
 - [ ] *(Optional)* extend `Verify-Libraries.ps1` to assert primitive counts / specific
       properties, not just "opened".
 
-## B. Release & distribution
+## C. Release & distribution
 
 - [ ] **v1.0.0 is the real release**, gated on ALL features built (the 99% coverage
       gate — production metric, #381 — is already met). The climb happens calmly;

--- a/docs/FIXTURE_COVERAGE.md
+++ b/docs/FIXTURE_COVERAGE.md
@@ -124,8 +124,20 @@ not say which name was at fault.
 
 **SchLib, not yet attempted:** `*_Frac` coordinates on the shapes that still lack
 them. (Parameter "area colour" appeared here in error — `parse_parameter` reads no
-such key, and no authored parameter record carries one.)
+such key, and no authored parameter record carries one.) **Record kinds the golden
+does not contain at all** — the tool-layer replay tests can only hold these to the
+structs, not to Altium: an elliptical arc (RECORD=11; also the reason `EllipticalArc`
+carries no display flags in the model — nothing to verify them against), a text
+annotation (RECORD=3; same for `Text`), and a footprint model link (RECORD=45, with
+its `ImplementationList`/`MapDefiner` children) — the `FootprintModel` replay of
+`unique_id`/`is_current` is unit-tested only.
 
-**PcbLib:** region net and the cavity/subpoly params, raw-outline precision for ComponentBody. Pad thermal-relief / power-plane is
+**PcbLib:** region net and the cavity/subpoly params, raw-outline precision for ComponentBody.
+A **non-embedded STEP reference** (`MODEL.EMBED=FALSE` + `MODEL.NAME`, and whatever
+`/Library/ModelsNoEmbed` holds for it) — `write_pcblib`'s `step_model.embed: false`
+now writes the MODEL group with a fresh MODELID, but the form is unverified against
+Altium. A **text beyond U+00FF** (Ω, CJK) so a golden pins `WideStrings` as UTF-16
+code units (today only AltiumSharp and the Latin-1 `10µF` of `TEXT_WIN1252` do).
+Pad thermal-relief / power-plane is
 🚫 **FINAL** on the scripting side (native crash on a fresh library pad in every sequence
 tried — see the Pad row); a golden would need a non-scripted authoring route.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -180,9 +180,14 @@ Every object is checked: footprints and symbols, each primitive kind, 3D-model a
 component-body objects, footprint links. The accepted keys are the fields the read tools
 emit for that object plus its authoring-only spellings (`step_model`, `vertices`, `hidden`,
 `designator_prefix`, …), so anything a read returned can be passed straight back
-(`src/mcp/tools/allowed_keys.rs`). A footprint is parsed by one routine whichever tool
-receives it (`parse_footprint_json`, `src/mcp/tools/parsing.rs`), so `update_component`
-accepts exactly what `write_pcblib` does and reports a malformed primitive the same way.
+(`src/mcp/tools/allowed_keys.rs`). A footprint or symbol is parsed by one routine whichever
+tool receives it (`parse_footprint_json` / `parse_symbol_json`, `src/mcp/tools/parsing.rs`),
+so `update_component` accepts exactly what `write_pcblib` / `write_schlib` do.
+
+A record the parser cannot build — a required field missing or of the wrong type — is
+likewise refused, never silently left out: the error names the kind and index
+(`Failed to parse region at index 2`, `Failed to parse footprint link at index 0`) in the
+structured context above, and nothing is written.
 
 ---
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1370,7 +1370,8 @@ mod tests {
         let mut sym_json = serde_json::to_value(&symbol).expect("serialise symbol");
         sym_json["description"] = json!("after");
 
-        let result = McpServer::update_schlib_component(
+        let server = McpServer::new(vec![temp.path().to_path_buf()]);
+        let result = server.update_schlib_component(
             &lib_path.to_string_lossy(),
             "FAMILIES",
             &sym_json,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -6,7 +6,54 @@
 use serde_json::Value;
 
 use crate::altium::pcblib::Footprint;
+use crate::altium::schlib::Symbol;
 use crate::mcp::server::{ErrorContext, McpServer, ToolCallResult};
+use crate::mcp::tools::allowed_keys;
+
+/// Maps a free-text component type to its reference-designator class letter,
+/// following the conventions of IEEE 315 / ASME Y14.44 (commercial usage).
+///
+/// Used as the fallback when a symbol is written without an explicit
+/// `designator_prefix`. Unknown or unspecified types resolve to `"U"`
+/// (integrated circuit / inseparable assembly), the most common case.
+// The explicit IC/regulator arm shares the `"U"` body with the wildcard
+// fallback; it is kept to document the recognised IC synonyms rather than
+// silently folding them into `_`.
+#[allow(clippy::match_same_arms)]
+pub fn ieee_designator_prefix(component_type: &str) -> &'static str {
+    match component_type.trim().to_ascii_lowercase().as_str() {
+        "resistor" | "res" | "potentiometer" | "pot" | "trimmer" | "rheostat" => "R",
+        "resistor_network" | "resistor_array" | "network" => "RN",
+        "thermistor" | "ntc" | "ptc" => "RT",
+        "varistor" | "mov" => "RV",
+        "capacitor" | "cap" => "C",
+        "inductor" | "coil" | "choke" | "ferrite" | "ferrite_bead" | "bead" => "L",
+        "diode" | "rectifier" | "schottky" | "zener" | "tvs" | "led" => "D",
+        "display" | "lamp" | "indicator" | "lightbulb" => "DS",
+        "transistor" | "mosfet" | "fet" | "bjt" | "igbt" | "jfet" => "Q",
+        "ic" | "integrated_circuit" | "microcircuit" | "opamp" | "mcu" | "regulator"
+        | "voltage_regulator" => "U",
+        "connector" | "header" | "jack" | "receptacle" => "J",
+        "plug" => "P",
+        "socket" => "X",
+        "crystal" | "oscillator" | "resonator" | "xtal" => "Y",
+        "switch" | "button" | "pushbutton" | "dip_switch" | "dipswitch" => "S",
+        "relay" | "contactor" => "K",
+        "transformer" => "T",
+        "fuse" => "F",
+        "filter" => "FL",
+        "battery" | "cell" => "BT",
+        "test_point" | "testpoint" => "TP",
+        "terminal_block" | "terminal" => "TB",
+        "speaker" | "loudspeaker" | "buzzer" => "LS",
+        "microphone" => "MK",
+        "motor" | "fan" | "blower" => "B",
+        "module" | "assembly" | "subassembly" => "A",
+        "mechanical" | "standoff" | "screw" | "mounting" => "MP",
+        "jumper" | "wire" | "cable" => "W",
+        _ => "U",
+    }
+}
 
 /// Reads a JSON integer field as `i32`, returning `None` if it is missing, not
 /// an integer, or outside `i32` range — so an out-of-range value is rejected
@@ -182,10 +229,346 @@ impl McpServer {
 
     // ==================== Primitive Parsing Helpers ====================
 
+    /// Parses one symbol object — the `symbols[]` element of `write_schlib`
+    /// and the `symbol` of `update_component` — into a [`Symbol`], refusing
+    /// unknown keys on every object and validating the geometry. Both tools
+    /// go through here so neither can fall behind the other on a record kind
+    /// or a replay field. The designator is always assigned: explicit
+    /// `designator`, else `designator_prefix`, else `component_type` via the
+    /// IEEE 315 / ASME Y14.44 table, else `U`.
+    ///
+    /// `operation` names the calling tool; `default_name` is the symbol name
+    /// when the object carries none.
+    #[allow(clippy::too_many_lines)] // one straight-line pass over every symbol field
+    #[allow(clippy::unused_self)] // kept as a method beside parse_footprint_json
+    pub(crate) fn parse_symbol_json(
+        &self,
+        sym_json: &Value,
+        keys: &allowed_keys::SchLibKeys,
+        operation: &str,
+        filepath: &str,
+        default_name: &str,
+    ) -> Result<Symbol, ToolCallResult> {
+        use crate::altium::schlib::FootprintModel;
+
+        Self::refuse_unknown(sym_json, &keys.symbol)?;
+        let name = sym_json
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or(default_name);
+        let mut symbol = Symbol::new(name);
+
+        if let Some(desc) = sym_json.get("description").and_then(Value::as_str) {
+            symbol.description = desc.to_string();
+        }
+
+        // Always assign a reference designator. Precedence:
+        //   1. explicit `designator`
+        //   2. explicit `designator_prefix`
+        //   3. `component_type` mapped via IEEE 315 / ASME Y14.44 table
+        //   4. fallback "U" (integrated circuit)
+        // so every symbol carries a `<prefix>?` designator in the SchLib.
+        let designator = sym_json
+            .get("designator")
+            .and_then(Value::as_str)
+            .map_or_else(
+                || {
+                    let prefix = sym_json
+                        .get("designator_prefix")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                        .or_else(|| {
+                            sym_json
+                                .get("component_type")
+                                .and_then(Value::as_str)
+                                .map(|t| ieee_designator_prefix(t).to_string())
+                        })
+                        .unwrap_or_else(|| "U".to_string());
+                    format!("{prefix}?")
+                },
+                str::to_string,
+            );
+        symbol.designator = designator;
+
+        // Designator text position (RECORD=34 Location.X/Y) and identity.
+        // Defaults -5/5 per the AD24 golden; the unique id is reused when
+        // supplied (e.g. a read-modify-write) so the record is deterministic.
+        if let Some(x) = sym_json.get("designator_x").and_then(Value::as_f64) {
+            symbol.designator_x = x;
+        }
+        if let Some(y) = sym_json.get("designator_y").and_then(Value::as_f64) {
+            symbol.designator_y = y;
+        }
+        if let Some(uid) = sym_json.get("designator_unique_id").and_then(Value::as_str) {
+            symbol.designator_unique_id = Some(uid.to_string());
+        }
+
+        // Parse part_count for multi-part symbols (e.g., dual op-amp)
+        if let Some(part_count) = sym_json.get("part_count").and_then(Value::as_u64) {
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                symbol.part_count = part_count.clamp(1, 255) as u32;
+            }
+        }
+
+        // Parse the remaining symbol header fields (mirrors
+        // update_schlib_component): export_schlib emits them, so an
+        // export -> write_schlib round-trip must not reset them to
+        // defaults (e.g. collapsing a two-display-mode symbol to one).
+        if let Some(v) = sym_json.get("display_mode_count").and_then(Value::as_u64) {
+            symbol.display_mode_count = u32::try_from(v).unwrap_or(symbol.display_mode_count);
+        }
+        if let Some(v) = sym_json.get("current_part_id").and_then(Value::as_u64) {
+            symbol.current_part_id = u32::try_from(v).unwrap_or(symbol.current_part_id);
+        }
+        if let Some(v) = sym_json.get("part_id_locked").and_then(Value::as_bool) {
+            symbol.part_id_locked = v;
+        }
+        if let Some(v) = sym_json.get("source_library_name").and_then(Value::as_str) {
+            symbol.source_library_name = v.to_string();
+        }
+        if let Some(v) = sym_json.get("target_file_name").and_then(Value::as_str) {
+            symbol.target_file_name = v.to_string();
+        }
+
+        // Parse pins
+        if let Some(pins) = sym_json.get("pins").and_then(Value::as_array) {
+            for (i, pin_json) in pins.iter().enumerate() {
+                Self::refuse_unknown(pin_json, &keys.pin)?;
+                let pin = Self::parse_schlib_pin(pin_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "pin", i))?;
+                symbol.add_pin(pin);
+            }
+        }
+
+        // Parse rectangles
+        if let Some(rects) = sym_json.get("rectangles").and_then(Value::as_array) {
+            for (i, rect_json) in rects.iter().enumerate() {
+                Self::refuse_unknown(rect_json, allowed_keys::RECTANGLE)?;
+                let rect = Self::parse_schlib_rectangle(rect_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "rectangle", i))?;
+                symbol.add_rectangle(rect);
+            }
+        }
+
+        // Parse rounded rectangles
+        if let Some(round_rects) = sym_json.get("round_rects").and_then(Value::as_array) {
+            for (i, round_rect_json) in round_rects.iter().enumerate() {
+                Self::refuse_unknown(round_rect_json, allowed_keys::ROUND_RECT)?;
+                let round_rect = Self::parse_schlib_round_rect(round_rect_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "round_rect", i))?;
+                symbol.add_round_rect(round_rect);
+            }
+        }
+
+        // Parse lines
+        if let Some(lines) = sym_json.get("lines").and_then(Value::as_array) {
+            for (i, line_json) in lines.iter().enumerate() {
+                Self::refuse_unknown(line_json, allowed_keys::LINE)?;
+                let line = Self::parse_schlib_line(line_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "line", i))?;
+                symbol.add_line(line);
+            }
+        }
+
+        // Parse polylines
+        if let Some(polylines) = sym_json.get("polylines").and_then(Value::as_array) {
+            for (i, polyline_json) in polylines.iter().enumerate() {
+                Self::refuse_unknown(polyline_json, allowed_keys::POLYLINE)?;
+                let polyline = Self::parse_schlib_polyline(polyline_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "polyline", i))?;
+                symbol.add_polyline(polyline);
+            }
+        }
+
+        // Parse polygons
+        if let Some(polygons) = sym_json.get("polygons").and_then(Value::as_array) {
+            for (i, polygon_json) in polygons.iter().enumerate() {
+                Self::refuse_unknown(polygon_json, allowed_keys::POLYGON)?;
+                let polygon = Self::parse_schlib_polygon(polygon_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "polygon", i))?;
+                symbol.add_polygon(polygon);
+            }
+        }
+
+        // Parse arcs
+        if let Some(arcs) = sym_json.get("arcs").and_then(Value::as_array) {
+            for (i, arc_json) in arcs.iter().enumerate() {
+                // SchLib arcs are centre/radius/angle based, NOT layer-based like PcbLib arcs; the
+                // allow-list must match the documented fields in tool_definitions or every arc is
+                // rejected as an "unknown field" (was erroneously copied from the PcbLib arc as ["layer"]).
+                Self::refuse_unknown(arc_json, allowed_keys::ARC)?;
+                let arc = Self::parse_schlib_arc(arc_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "arc", i))?;
+                symbol.add_arc(arc);
+            }
+        }
+
+        if let Some(pies) = sym_json.get("pies").and_then(Value::as_array) {
+            for (i, pie_json) in pies.iter().enumerate() {
+                Self::refuse_unknown(pie_json, allowed_keys::PIE)?;
+                let pie = Self::parse_schlib_pie(pie_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "pie", i))?;
+                symbol.add_pie(pie);
+            }
+        }
+
+        if let Some(images) = sym_json.get("images").and_then(Value::as_array) {
+            for (i, image_json) in images.iter().enumerate() {
+                Self::refuse_unknown(image_json, allowed_keys::IMAGE)?;
+                let image = Self::parse_schlib_image(image_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "image", i))?;
+                symbol.add_image(image);
+            }
+        }
+
+        if let Some(text_frames) = sym_json.get("text_frames").and_then(Value::as_array) {
+            for (i, frame_json) in text_frames.iter().enumerate() {
+                Self::refuse_unknown(frame_json, allowed_keys::TEXT_FRAME)?;
+                let text_frame = Self::parse_schlib_text_frame(frame_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "text_frame", i))?;
+                symbol.add_text_frame(text_frame);
+            }
+        }
+
+        if let Some(beziers) = sym_json.get("beziers").and_then(Value::as_array) {
+            for (i, bezier_json) in beziers.iter().enumerate() {
+                Self::refuse_unknown(bezier_json, allowed_keys::BEZIER)?;
+                let bezier = Self::parse_schlib_bezier(bezier_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "bezier", i))?;
+                symbol.add_bezier(bezier);
+            }
+        }
+
+        if let Some(ell_arcs) = sym_json.get("elliptical_arcs").and_then(Value::as_array) {
+            for (i, ell_arc_json) in ell_arcs.iter().enumerate() {
+                Self::refuse_unknown(ell_arc_json, allowed_keys::ELLIPTICAL_ARC)?;
+                let ell_arc = Self::parse_schlib_elliptical_arc(ell_arc_json).ok_or_else(|| {
+                    Self::malformed(operation, filepath, name, "elliptical_arc", i)
+                })?;
+                symbol.add_elliptical_arc(ell_arc);
+            }
+        }
+
+        // Parse ellipses
+        if let Some(ellipses) = sym_json.get("ellipses").and_then(Value::as_array) {
+            for (i, ellipse_json) in ellipses.iter().enumerate() {
+                Self::refuse_unknown(ellipse_json, allowed_keys::ELLIPSE)?;
+                let ellipse = Self::parse_schlib_ellipse(ellipse_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "ellipse", i))?;
+                symbol.add_ellipse(ellipse);
+            }
+        }
+
+        // Parse labels
+        if let Some(labels) = sym_json.get("labels").and_then(Value::as_array) {
+            for (i, label_json) in labels.iter().enumerate() {
+                Self::refuse_unknown(label_json, allowed_keys::LABEL)?;
+                let label = Self::parse_schlib_label(label_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "label", i))?;
+                symbol.add_label(label);
+            }
+        }
+
+        // Parse text annotations
+        if let Some(texts) = sym_json.get("text").and_then(Value::as_array) {
+            for (i, text_json) in texts.iter().enumerate() {
+                Self::refuse_unknown(text_json, allowed_keys::TEXT)?;
+                let text = Self::parse_schlib_text(text_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "text", i))?;
+                symbol.add_text(text);
+            }
+        }
+
+        // Parse parameters
+        if let Some(params) = sym_json.get("parameters").and_then(Value::as_array) {
+            for (i, param_json) in params.iter().enumerate() {
+                Self::refuse_unknown(param_json, allowed_keys::PARAMETER)?;
+                let param = Self::parse_schlib_parameter(param_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "parameter", i))?;
+                symbol.add_parameter(param);
+            }
+        }
+
+        // Parse footprint references
+        if let Some(footprints) = sym_json.get("footprints").and_then(Value::as_array) {
+            for (i, fp_json) in footprints.iter().enumerate() {
+                // A footprint reference is a model link, not an embedded
+                // footprint: name, description, library_path, and the
+                // read-preserved identity a replay carries back.
+                Self::refuse_unknown(fp_json, &keys.footprint)?;
+                let fp_name = fp_json.get("name").and_then(Value::as_str).ok_or_else(|| {
+                    Self::malformed(operation, filepath, name, "footprint link", i)
+                })?;
+                {
+                    let mut fp = FootprintModel::new(fp_name);
+                    if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
+                        fp.description = desc.to_string();
+                    }
+                    // Optional PcbLib path -> ModelDatafile0, so Altium can
+                    // resolve the footprint instead of reporting "not found".
+                    if let Some(lib_path) = fp_json.get("library_path").and_then(Value::as_str) {
+                        fp.library_path = Some(lib_path.to_string());
+                    }
+                    fp.is_current = fp_json
+                        .get("is_current")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    fp.unique_id = fp_json
+                        .get("unique_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    symbol.add_footprint(fp);
+                }
+            }
+        }
+
+        // The interleaved record order `read_schlib` reported; replaying it
+        // replaces the grouped order the add_* calls accumulated, so a
+        // read-modify-write keeps the source's record order.
+        if let Some(order) = sym_json.get("primitive_order") {
+            match serde_json::from_value(order.clone()) {
+                Ok(kinds) => symbol.primitive_order = kinds,
+                Err(e) => {
+                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                }
+            }
+        }
+
+        // Out-of-range or non-finite geometry is refused here so both tools
+        // report it the same way.
+        if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
+            return Err(ToolCallResult::error(e));
+        }
+
+        Ok(symbol)
+    }
+
     /// Refuses a JSON object carrying a key outside `keys` (see
     /// [`check_unknown_fields`](Self::check_unknown_fields)).
     fn refuse_unknown(json: &Value, keys: &[&str]) -> Result<(), ToolCallResult> {
         Self::check_unknown_fields(json, keys).map_err(ToolCallResult::error)
+    }
+
+    /// The error for an object its parser could not build: a required field
+    /// missing or of the wrong type. Named and indexed like a malformed pad,
+    /// so a bad record is refused rather than silently left out of the file.
+    fn malformed(
+        operation: &str,
+        filepath: &str,
+        component: &str,
+        kind: &str,
+        index: usize,
+    ) -> ToolCallResult {
+        ToolCallResult::error_with_context(
+            ErrorContext::new(
+                operation,
+                format!("Malformed {kind}: a required field is missing or invalid"),
+            )
+            .with_filepath(filepath)
+            .with_component(component)
+            .with_details(format!("Failed to parse {kind} at index {index}")),
+        )
     }
 
     /// Parses one footprint object — the `footprints[]` element of
@@ -200,7 +583,7 @@ impl McpServer {
     pub(crate) fn parse_footprint_json(
         &self,
         fp_json: &Value,
-        keys: &crate::mcp::tools::allowed_keys::PcbLibKeys,
+        keys: &allowed_keys::PcbLibKeys,
         operation: &str,
         filepath: &str,
         default_name: &str,
@@ -310,21 +693,21 @@ impl McpServer {
 
         // Parse regions
         if let Some(regions) = fp_json.get("regions").and_then(Value::as_array) {
-            for region_json in regions {
+            for (i, region_json) in regions.iter().enumerate() {
                 Self::refuse_unknown(region_json, &keys.region)?;
-                if let Some(region) = Self::parse_region(region_json) {
-                    footprint.add_region(region);
-                }
+                let region = Self::parse_region(region_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "region", i))?;
+                footprint.add_region(region);
             }
         }
 
         // Parse text
         if let Some(texts) = fp_json.get("text").and_then(Value::as_array) {
-            for text_json in texts {
+            for (i, text_json) in texts.iter().enumerate() {
                 Self::refuse_unknown(text_json, &keys.text)?;
-                if let Some(text) = Self::parse_text(text_json) {
-                    footprint.add_text(text);
-                }
+                let text = Self::parse_text(text_json)
+                    .ok_or_else(|| Self::malformed(operation, filepath, name, "text", i))?;
+                footprint.add_text(text);
             }
         }
 

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -47,7 +47,7 @@ impl McpServer {
                         "Missing required parameter: symbol (required for .SchLib files)",
                     );
                 };
-                Self::update_schlib_component(filepath, component_name, sym_json, dry_run)
+                self.update_schlib_component(filepath, component_name, sym_json, dry_run)
             }
             _ => ToolCallResult::error("Unknown file type. Expected .PcbLib or .SchLib extension."),
         }
@@ -256,12 +256,13 @@ impl McpServer {
     /// Updates a symbol in-place within a `SchLib` file.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn update_schlib_component(
+        &self,
         filepath: &str,
         component_name: &str,
         sym_json: &Value,
         dry_run: bool,
     ) -> ToolCallResult {
-        use crate::altium::schlib::{SchLib, Symbol};
+        use crate::altium::schlib::SchLib;
 
         // Read the library
         let mut library = match SchLib::open(filepath) {
@@ -279,223 +280,21 @@ impl McpServer {
             ));
         }
 
-        // Parse the replacement symbol
-        let name = sym_json
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or(component_name);
-        let mut symbol = Symbol::new(name);
-
-        if let Some(desc) = sym_json.get("description").and_then(Value::as_str) {
-            symbol.description = desc.to_string();
-        }
-
-        if let Some(designator) = sym_json.get("designator").and_then(Value::as_str) {
-            symbol.designator = designator.to_string();
-        }
-
-        // Parse part_count and the other symbol header fields (mirrors the
-        // create path for part_count; the rest are returned by get_component,
-        // so a read-modify-write must not reset them to defaults — omitting
-        // part_count here silently collapsed a multi-part symbol to one part).
-        if let Some(part_count) = sym_json.get("part_count").and_then(Value::as_u64) {
-            #[allow(clippy::cast_possible_truncation)]
-            {
-                symbol.part_count = part_count.clamp(1, 255) as u32;
-            }
-        }
-        if let Some(v) = sym_json.get("display_mode_count").and_then(Value::as_u64) {
-            symbol.display_mode_count = u32::try_from(v).unwrap_or(symbol.display_mode_count);
-        }
-        if let Some(v) = sym_json.get("current_part_id").and_then(Value::as_u64) {
-            symbol.current_part_id = u32::try_from(v).unwrap_or(symbol.current_part_id);
-        }
-        if let Some(v) = sym_json.get("part_id_locked").and_then(Value::as_bool) {
-            symbol.part_id_locked = v;
-        }
-        if let Some(v) = sym_json.get("source_library_name").and_then(Value::as_str) {
-            symbol.source_library_name = v.to_string();
-        }
-        if let Some(v) = sym_json.get("target_file_name").and_then(Value::as_str) {
-            symbol.target_file_name = v.to_string();
-        }
-        // Designator position/identity and the interleaved record order,
-        // mirroring the create path: a get_component → update_component loop
-        // echoes them back, and dropping any of them moved the designator or
-        // regrouped the records.
-        if let Some(x) = sym_json.get("designator_x").and_then(Value::as_f64) {
-            symbol.designator_x = x;
-        }
-        if let Some(y) = sym_json.get("designator_y").and_then(Value::as_f64) {
-            symbol.designator_y = y;
-        }
-        if let Some(uid) = sym_json.get("designator_unique_id").and_then(Value::as_str) {
-            symbol.designator_unique_id = Some(uid.to_string());
-        }
-        if let Some(order) = sym_json.get("primitive_order") {
-            match serde_json::from_value(order.clone()) {
-                Ok(kinds) => symbol.primitive_order = kinds,
-                Err(e) => {
-                    tracing::debug!(error = %e, "invalid primitive_order; using default order");
-                }
-            }
-        }
-
-        // Parse pins
-        if let Some(pins) = sym_json.get("pins").and_then(Value::as_array) {
-            for pin_json in pins {
-                if let Some(pin) = Self::parse_schlib_pin(pin_json) {
-                    symbol.pins.push(pin);
-                }
-            }
-        }
-
-        // Parse rectangles
-        if let Some(rects) = sym_json.get("rectangles").and_then(Value::as_array) {
-            for rect_json in rects {
-                if let Some(rect) = Self::parse_schlib_rectangle(rect_json) {
-                    symbol.rectangles.push(rect);
-                }
-            }
-        }
-
-        // Parse lines
-        if let Some(lines) = sym_json.get("lines").and_then(Value::as_array) {
-            for line_json in lines {
-                if let Some(line) = Self::parse_schlib_line(line_json) {
-                    symbol.lines.push(line);
-                }
-            }
-        }
-
-        // Parse polylines
-        if let Some(polylines) = sym_json.get("polylines").and_then(Value::as_array) {
-            for polyline_json in polylines {
-                if let Some(polyline) = Self::parse_schlib_polyline(polyline_json) {
-                    symbol.polylines.push(polyline);
-                }
-            }
-        }
-
-        // Parse arcs
-        if let Some(arcs) = sym_json.get("arcs").and_then(Value::as_array) {
-            for arc_json in arcs {
-                if let Some(arc) = Self::parse_schlib_arc(arc_json) {
-                    symbol.arcs.push(arc);
-                }
-            }
-        }
-
-        // Parse ellipses
-        if let Some(ellipses) = sym_json.get("ellipses").and_then(Value::as_array) {
-            for ellipse_json in ellipses {
-                if let Some(ellipse) = Self::parse_schlib_ellipse(ellipse_json) {
-                    symbol.ellipses.push(ellipse);
-                }
-            }
-        }
-
-        // Parse parameters
-        if let Some(params) = sym_json.get("parameters").and_then(Value::as_array) {
-            for param_json in params {
-                if let Some(param) = Self::parse_schlib_parameter(param_json) {
-                    symbol.parameters.push(param);
-                }
-            }
-        }
-
-        // Parse round_rects, polygons, labels and text. The create path
-        // (call_write_schlib) handles all of these; this update path omitted them,
-        // so a read-modify-write of a symbol carrying any of them silently DROPPED
-        // it. Mirror the create path.
-        if let Some(round_rects) = sym_json.get("round_rects").and_then(Value::as_array) {
-            for rr_json in round_rects {
-                if let Some(rr) = Self::parse_schlib_round_rect(rr_json) {
-                    symbol.round_rects.push(rr);
-                }
-            }
-        }
-        if let Some(polygons) = sym_json.get("polygons").and_then(Value::as_array) {
-            for polygon_json in polygons {
-                if let Some(polygon) = Self::parse_schlib_polygon(polygon_json) {
-                    symbol.polygons.push(polygon);
-                }
-            }
-        }
-        if let Some(labels) = sym_json.get("labels").and_then(Value::as_array) {
-            for label_json in labels {
-                if let Some(label) = Self::parse_schlib_label(label_json) {
-                    symbol.labels.push(label);
-                }
-            }
-        }
-        if let Some(texts) = sym_json.get("text").and_then(Value::as_array) {
-            for text_json in texts {
-                if let Some(text) = Self::parse_schlib_text(text_json) {
-                    symbol.text.push(text);
-                }
-            }
-        }
-
-        // Parse pies and images (mirror the create path — both were added to
-        // call_write_schlib without this path, recreating exactly the
-        // dropped-primitive bug documented above).
-        if let Some(pies) = sym_json.get("pies").and_then(Value::as_array) {
-            for pie_json in pies {
-                if let Some(pie) = Self::parse_schlib_pie(pie_json) {
-                    symbol.pies.push(pie);
-                }
-            }
-        }
-        if let Some(images) = sym_json.get("images").and_then(Value::as_array) {
-            for image_json in images {
-                if let Some(image) = Self::parse_schlib_image(image_json) {
-                    symbol.images.push(image);
-                }
-            }
-        }
-        if let Some(text_frames) = sym_json.get("text_frames").and_then(Value::as_array) {
-            for frame_json in text_frames {
-                if let Some(text_frame) = Self::parse_schlib_text_frame(frame_json) {
-                    symbol.text_frames.push(text_frame);
-                }
-            }
-        }
-
-        // Beziers and elliptical arcs (mirror the create path, which authors
-        // them through the same parse helpers — the JSON keys equal the serde
-        // field names, so a get_component echo parses identically).
-        if let Some(beziers) = sym_json.get("beziers").and_then(Value::as_array) {
-            for bezier_json in beziers {
-                if let Some(bezier) = Self::parse_schlib_bezier(bezier_json) {
-                    symbol.beziers.push(bezier);
-                }
-            }
-        }
-        if let Some(ell_arcs) = sym_json.get("elliptical_arcs").and_then(Value::as_array) {
-            for ell_arc_json in ell_arcs {
-                if let Some(ell_arc) = Self::parse_schlib_elliptical_arc(ell_arc_json) {
-                    symbol.elliptical_arcs.push(ell_arc);
-                }
-            }
-        }
-
-        // Parse footprint references. serde shape (get_component echo) and the
-        // create-path shape ({name, description, library_path}) both
-        // deserialise, since every other FootprintModel field has a default.
-        if let Some(footprints) = sym_json.get("footprints").and_then(Value::as_array) {
-            for fp_json in footprints {
-                if let Ok(fp) = serde_json::from_value(fp_json.clone()) {
-                    symbol.footprints.push(fp);
-                }
-            }
-        }
-
-        // Reject out-of-range geometry before save (the create path validates
-        // here; this path skipped it entirely). Runs in dry-run too.
-        if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
-            return ToolCallResult::error(e);
-        }
+        // Parse the replacement symbol — the same parser as write_schlib, so
+        // an update accepts exactly what a write does.
+        let keys = crate::mcp::tools::allowed_keys::SchLibKeys::new();
+        let symbol = match self.parse_symbol_json(
+            sym_json,
+            &keys,
+            "update_component",
+            filepath,
+            component_name,
+        ) {
+            Ok(symbol) => symbol,
+            Err(result) => return result,
+        };
+        let name = symbol.name.clone();
+        let name = name.as_str();
 
         // A replacement may carry a new name, which makes this a rename too —
         // and a rename onto a name another symbol already holds would leave

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -5,51 +5,6 @@ use serde_json::{json, Value};
 use crate::mcp::server::{ErrorContext, McpServer, ToolCallResult};
 use crate::mcp::tools::allowed_keys;
 
-/// Maps a free-text component type to its reference-designator class letter,
-/// following the conventions of IEEE 315 / ASME Y14.44 (commercial usage).
-///
-/// Used as the fallback when a symbol is written without an explicit
-/// `designator_prefix`. Unknown or unspecified types resolve to `"U"`
-/// (integrated circuit / inseparable assembly), the most common case.
-// The explicit IC/regulator arm shares the `"U"` body with the wildcard
-// fallback; it is kept to document the recognised IC synonyms rather than
-// silently folding them into `_`.
-#[allow(clippy::match_same_arms)]
-fn ieee_designator_prefix(component_type: &str) -> &'static str {
-    match component_type.trim().to_ascii_lowercase().as_str() {
-        "resistor" | "res" | "potentiometer" | "pot" | "trimmer" | "rheostat" => "R",
-        "resistor_network" | "resistor_array" | "network" => "RN",
-        "thermistor" | "ntc" | "ptc" => "RT",
-        "varistor" | "mov" => "RV",
-        "capacitor" | "cap" => "C",
-        "inductor" | "coil" | "choke" | "ferrite" | "ferrite_bead" | "bead" => "L",
-        "diode" | "rectifier" | "schottky" | "zener" | "tvs" | "led" => "D",
-        "display" | "lamp" | "indicator" | "lightbulb" => "DS",
-        "transistor" | "mosfet" | "fet" | "bjt" | "igbt" | "jfet" => "Q",
-        "ic" | "integrated_circuit" | "microcircuit" | "opamp" | "mcu" | "regulator"
-        | "voltage_regulator" => "U",
-        "connector" | "header" | "jack" | "receptacle" => "J",
-        "plug" => "P",
-        "socket" => "X",
-        "crystal" | "oscillator" | "resonator" | "xtal" => "Y",
-        "switch" | "button" | "pushbutton" | "dip_switch" | "dipswitch" => "S",
-        "relay" | "contactor" => "K",
-        "transformer" => "T",
-        "fuse" => "F",
-        "filter" => "FL",
-        "battery" | "cell" => "BT",
-        "test_point" | "testpoint" => "TP",
-        "terminal_block" | "terminal" => "TB",
-        "speaker" | "loudspeaker" | "buzzer" => "LS",
-        "microphone" => "MK",
-        "motor" | "fan" | "blower" => "B",
-        "module" | "assembly" | "subassembly" => "A",
-        "mechanical" | "standoff" | "screw" | "mounting" => "MP",
-        "jumper" | "wire" | "cable" => "W",
-        _ => "U",
-    }
-}
-
 /// Computes a pin's connection-tip coordinate from its body-attach end `(x,y)`,
 /// `length`, and `orientation`, mirroring how the pin is drawn: the tip is
 /// `length` units from `(x,y)` in the `orientation` direction.
@@ -285,14 +240,6 @@ fn body_3d_summary(fp: &crate::altium::pcblib::Footprint, assumed_height: bool) 
         "note": "No 3D body written. Set component_bodies[].overall_height to the real \
                  part height, or pass auto_3d_body:true for a flagged 1.0 mm placeholder.",
     })
-}
-
-macro_rules! check_keys {
-    ($json:expr, $keys:expr) => {
-        if let Err(e) = McpServer::check_unknown_fields($json, $keys) {
-            return crate::mcp::server::ToolCallResult::error(e);
-        }
-    };
 }
 
 impl McpServer {
@@ -852,7 +799,7 @@ impl McpServer {
     /// Writes symbols to a `SchLib` file.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn call_write_schlib(&self, arguments: &Value) -> ToolCallResult {
-        use crate::altium::schlib::{FootprintModel, SchLib, Symbol};
+        use crate::altium::schlib::SchLib;
 
         let Some(filepath) = arguments.get("filepath").and_then(Value::as_str) else {
             return ToolCallResult::error("Missing required parameter: filepath");
@@ -945,291 +892,16 @@ impl McpServer {
 
         let keys = allowed_keys::SchLibKeys::new();
         for sym_json in symbols_json {
-            check_keys!(sym_json, &keys.symbol);
-            let name = sym_json
-                .get("name")
-                .and_then(Value::as_str)
-                .unwrap_or("Unnamed");
-            let mut symbol = Symbol::new(name);
-
-            if let Some(desc) = sym_json.get("description").and_then(Value::as_str) {
-                symbol.description = desc.to_string();
-            }
-
-            // Always assign a reference designator. Precedence:
-            //   1. explicit `designator`
-            //   2. explicit `designator_prefix`
-            //   3. `component_type` mapped via IEEE 315 / ASME Y14.44 table
-            //   4. fallback "U" (integrated circuit)
-            // so every symbol carries a `<prefix>?` designator in the SchLib.
-            let designator = sym_json
-                .get("designator")
-                .and_then(Value::as_str)
-                .map_or_else(
-                    || {
-                        let prefix = sym_json
-                            .get("designator_prefix")
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                            .or_else(|| {
-                                sym_json
-                                    .get("component_type")
-                                    .and_then(Value::as_str)
-                                    .map(|t| ieee_designator_prefix(t).to_string())
-                            })
-                            .unwrap_or_else(|| "U".to_string());
-                        format!("{prefix}?")
-                    },
-                    str::to_string,
-                );
-            symbol.designator = designator;
-
-            // Designator text position (RECORD=34 Location.X/Y) and identity.
-            // Defaults -5/5 per the AD24 golden; the unique id is reused when
-            // supplied (e.g. a read-modify-write) so the record is deterministic.
-            if let Some(x) = sym_json.get("designator_x").and_then(Value::as_f64) {
-                symbol.designator_x = x;
-            }
-            if let Some(y) = sym_json.get("designator_y").and_then(Value::as_f64) {
-                symbol.designator_y = y;
-            }
-            if let Some(uid) = sym_json.get("designator_unique_id").and_then(Value::as_str) {
-                symbol.designator_unique_id = Some(uid.to_string());
-            }
-
-            // Parse part_count for multi-part symbols (e.g., dual op-amp)
-            if let Some(part_count) = sym_json.get("part_count").and_then(Value::as_u64) {
-                #[allow(clippy::cast_possible_truncation)]
-                {
-                    symbol.part_count = part_count.clamp(1, 255) as u32;
-                }
-            }
-
-            // Parse the remaining symbol header fields (mirrors
-            // update_schlib_component): export_schlib emits them, so an
-            // export -> write_schlib round-trip must not reset them to
-            // defaults (e.g. collapsing a two-display-mode symbol to one).
-            if let Some(v) = sym_json.get("display_mode_count").and_then(Value::as_u64) {
-                symbol.display_mode_count = u32::try_from(v).unwrap_or(symbol.display_mode_count);
-            }
-            if let Some(v) = sym_json.get("current_part_id").and_then(Value::as_u64) {
-                symbol.current_part_id = u32::try_from(v).unwrap_or(symbol.current_part_id);
-            }
-            if let Some(v) = sym_json.get("part_id_locked").and_then(Value::as_bool) {
-                symbol.part_id_locked = v;
-            }
-            if let Some(v) = sym_json.get("source_library_name").and_then(Value::as_str) {
-                symbol.source_library_name = v.to_string();
-            }
-            if let Some(v) = sym_json.get("target_file_name").and_then(Value::as_str) {
-                symbol.target_file_name = v.to_string();
-            }
-
-            // Parse pins
-            if let Some(pins) = sym_json.get("pins").and_then(Value::as_array) {
-                for pin_json in pins {
-                    check_keys!(pin_json, &keys.pin);
-                    if let Some(pin) = Self::parse_schlib_pin(pin_json) {
-                        symbol.add_pin(pin);
-                    }
-                }
-            }
-
-            // Parse rectangles
-            if let Some(rects) = sym_json.get("rectangles").and_then(Value::as_array) {
-                for rect_json in rects {
-                    check_keys!(rect_json, allowed_keys::RECTANGLE);
-                    if let Some(rect) = Self::parse_schlib_rectangle(rect_json) {
-                        symbol.add_rectangle(rect);
-                    }
-                }
-            }
-
-            // Parse rounded rectangles
-            if let Some(round_rects) = sym_json.get("round_rects").and_then(Value::as_array) {
-                for round_rect_json in round_rects {
-                    check_keys!(round_rect_json, allowed_keys::ROUND_RECT);
-                    if let Some(round_rect) = Self::parse_schlib_round_rect(round_rect_json) {
-                        symbol.add_round_rect(round_rect);
-                    }
-                }
-            }
-
-            // Parse lines
-            if let Some(lines) = sym_json.get("lines").and_then(Value::as_array) {
-                for line_json in lines {
-                    check_keys!(line_json, allowed_keys::LINE);
-                    if let Some(line) = Self::parse_schlib_line(line_json) {
-                        symbol.add_line(line);
-                    }
-                }
-            }
-
-            // Parse polylines
-            if let Some(polylines) = sym_json.get("polylines").and_then(Value::as_array) {
-                for polyline_json in polylines {
-                    check_keys!(polyline_json, allowed_keys::POLYLINE);
-                    if let Some(polyline) = Self::parse_schlib_polyline(polyline_json) {
-                        symbol.add_polyline(polyline);
-                    }
-                }
-            }
-
-            // Parse polygons
-            if let Some(polygons) = sym_json.get("polygons").and_then(Value::as_array) {
-                for polygon_json in polygons {
-                    check_keys!(polygon_json, allowed_keys::POLYGON);
-                    if let Some(polygon) = Self::parse_schlib_polygon(polygon_json) {
-                        symbol.add_polygon(polygon);
-                    }
-                }
-            }
-
-            // Parse arcs
-            if let Some(arcs) = sym_json.get("arcs").and_then(Value::as_array) {
-                for arc_json in arcs {
-                    // SchLib arcs are centre/radius/angle based, NOT layer-based like PcbLib arcs; the
-                    // allow-list must match the documented fields in tool_definitions or every arc is
-                    // rejected as an "unknown field" (was erroneously copied from the PcbLib arc as ["layer"]).
-                    check_keys!(arc_json, allowed_keys::ARC);
-                    if let Some(arc) = Self::parse_schlib_arc(arc_json) {
-                        symbol.add_arc(arc);
-                    }
-                }
-            }
-
-            if let Some(pies) = sym_json.get("pies").and_then(Value::as_array) {
-                for pie_json in pies {
-                    check_keys!(pie_json, allowed_keys::PIE);
-                    if let Some(pie) = Self::parse_schlib_pie(pie_json) {
-                        symbol.add_pie(pie);
-                    }
-                }
-            }
-
-            if let Some(images) = sym_json.get("images").and_then(Value::as_array) {
-                for image_json in images {
-                    check_keys!(image_json, allowed_keys::IMAGE);
-                    if let Some(image) = Self::parse_schlib_image(image_json) {
-                        symbol.add_image(image);
-                    }
-                }
-            }
-
-            if let Some(text_frames) = sym_json.get("text_frames").and_then(Value::as_array) {
-                for frame_json in text_frames {
-                    check_keys!(frame_json, allowed_keys::TEXT_FRAME);
-                    if let Some(text_frame) = Self::parse_schlib_text_frame(frame_json) {
-                        symbol.add_text_frame(text_frame);
-                    }
-                }
-            }
-
-            if let Some(beziers) = sym_json.get("beziers").and_then(Value::as_array) {
-                for bezier_json in beziers {
-                    check_keys!(bezier_json, allowed_keys::BEZIER);
-                    if let Some(bezier) = Self::parse_schlib_bezier(bezier_json) {
-                        symbol.add_bezier(bezier);
-                    }
-                }
-            }
-
-            if let Some(ell_arcs) = sym_json.get("elliptical_arcs").and_then(Value::as_array) {
-                for ell_arc_json in ell_arcs {
-                    check_keys!(ell_arc_json, allowed_keys::ELLIPTICAL_ARC);
-                    if let Some(ell_arc) = Self::parse_schlib_elliptical_arc(ell_arc_json) {
-                        symbol.add_elliptical_arc(ell_arc);
-                    }
-                }
-            }
-
-            // Parse ellipses
-            if let Some(ellipses) = sym_json.get("ellipses").and_then(Value::as_array) {
-                for ellipse_json in ellipses {
-                    check_keys!(ellipse_json, allowed_keys::ELLIPSE);
-                    if let Some(ellipse) = Self::parse_schlib_ellipse(ellipse_json) {
-                        symbol.add_ellipse(ellipse);
-                    }
-                }
-            }
-
-            // Parse labels
-            if let Some(labels) = sym_json.get("labels").and_then(Value::as_array) {
-                for label_json in labels {
-                    check_keys!(label_json, allowed_keys::LABEL);
-                    if let Some(label) = Self::parse_schlib_label(label_json) {
-                        symbol.add_label(label);
-                    }
-                }
-            }
-
-            // Parse text annotations
-            if let Some(texts) = sym_json.get("text").and_then(Value::as_array) {
-                for text_json in texts {
-                    check_keys!(text_json, allowed_keys::TEXT);
-                    if let Some(text) = Self::parse_schlib_text(text_json) {
-                        symbol.add_text(text);
-                    }
-                }
-            }
-
-            // Parse parameters
-            if let Some(params) = sym_json.get("parameters").and_then(Value::as_array) {
-                for param_json in params {
-                    check_keys!(param_json, allowed_keys::PARAMETER);
-                    if let Some(param) = Self::parse_schlib_parameter(param_json) {
-                        symbol.add_parameter(param);
-                    }
-                }
-            }
-
-            // Parse footprint references
-            if let Some(footprints) = sym_json.get("footprints").and_then(Value::as_array) {
-                for fp_json in footprints {
-                    // A footprint reference is a model link, not an embedded
-                    // footprint: name, description, library_path, and the
-                    // read-preserved identity a replay carries back.
-                    check_keys!(fp_json, &keys.footprint);
-                    if let Some(fp_name) = fp_json.get("name").and_then(Value::as_str) {
-                        let mut fp = FootprintModel::new(fp_name);
-                        if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
-                            fp.description = desc.to_string();
-                        }
-                        // Optional PcbLib path -> ModelDatafile0, so Altium can
-                        // resolve the footprint instead of reporting "not found".
-                        if let Some(lib_path) = fp_json.get("library_path").and_then(Value::as_str)
-                        {
-                            fp.library_path = Some(lib_path.to_string());
-                        }
-                        fp.is_current = fp_json
-                            .get("is_current")
-                            .and_then(Value::as_bool)
-                            .unwrap_or(false);
-                        fp.unique_id = fp_json
-                            .get("unique_id")
-                            .and_then(Value::as_str)
-                            .map(str::to_string);
-                        symbol.add_footprint(fp);
-                    }
-                }
-            }
-
-            // The interleaved record order `read_schlib` reported; replaying it
-            // replaces the grouped order the add_* calls accumulated, so a
-            // read-modify-write keeps the source's record order.
-            if let Some(order) = sym_json.get("primitive_order") {
-                match serde_json::from_value(order.clone()) {
-                    Ok(kinds) => symbol.primitive_order = kinds,
-                    Err(e) => {
-                        tracing::debug!(error = %e, "invalid primitive_order; using default order");
-                    }
-                }
-            }
-
-            // Validate coordinates before adding
-            if let Err(e) = Self::validate_symbol_coordinates(&symbol) {
-                return ToolCallResult::error(e);
-            }
+            let symbol = match self.parse_symbol_json(
+                sym_json,
+                &keys,
+                "write_schlib",
+                filepath,
+                "Unnamed",
+            ) {
+                Ok(symbol) => symbol,
+                Err(result) => return result,
+            };
 
             written_names.insert(symbol.name.clone());
             library.add(symbol);
@@ -1797,9 +1469,9 @@ impl McpServer {
 
 #[cfg(test)]
 mod tests {
-    use super::ieee_designator_prefix;
     use super::{body_3d_summary, pin_tip, symbol_geometry};
     use crate::altium::schlib::{Pin, PinOrientation, Rectangle, Symbol};
+    use crate::mcp::tools::parsing::ieee_designator_prefix;
 
     #[test]
     fn segment_rect_intersection_detects_silk_over_pad_geometry() {
@@ -2766,6 +2438,213 @@ mod tests {
                 first.len(),
                 "a save must not grow the file"
             );
+        }
+
+        /// The `SchLib` in-place twin: every golden symbol read through
+        /// `read_schlib` and handed back to `update_component` as its own
+        /// replacement — one save per symbol, each re-reading the last — ends
+        /// identical to the library-level save (IDs the golden lacks masked).
+        #[test]
+        fn update_component_replays_every_golden_symbol_byte_for_byte() {
+            use crate::altium::SchLib;
+
+            let dir = test_temp_dir();
+            let samples = std::path::Path::new("scripts/samples")
+                .canonicalize()
+                .unwrap();
+            let server =
+                crate::mcp::server::McpServer::new(vec![dir.path().to_path_buf(), samples.clone()]);
+            let src = samples.join("symbols.SchLib");
+
+            let baseline = dir.path().join("Baseline.SchLib");
+            SchLib::open(&src).unwrap().save(&baseline).unwrap();
+            let work = dir.path().join("Work.SchLib");
+            std::fs::copy(&src, &work).unwrap();
+
+            let read = server.call_read_schlib(&json!({ "filepath": src.to_string_lossy() }));
+            assert!(!read.is_error, "{}", get_result_text(&read));
+            let symbols = parse_result_json(&read)["symbols"].clone();
+            // Every third symbol is enough saves to surface per-save drift
+            // on all of them while keeping the test under a quarter minute.
+            for symbol in symbols.as_array().unwrap().iter().step_by(3) {
+                let updated = server.call_update_component(&json!({
+                    "filepath": work.to_string_lossy(),
+                    "component_name": symbol["name"],
+                    "symbol": symbol,
+                }));
+                assert!(
+                    !updated.is_error,
+                    "{}: {}",
+                    symbol["name"],
+                    get_result_text(&updated)
+                );
+            }
+
+            let golden_ids: std::collections::HashSet<Vec<u8>> = component_streams(&src)
+                .values()
+                .flat_map(|streams| streams.values())
+                .flat_map(|bytes| unique_ids(bytes))
+                .collect();
+            let (expected, ours) = (component_streams(&baseline), component_streams(&work));
+            assert_eq!(
+                expected.keys().collect::<Vec<_>>(),
+                ours.keys().collect::<Vec<_>>(),
+                "symbol storages differ"
+            );
+            for (name, e) in &expected {
+                let o = &ours[name];
+                assert_eq!(
+                    e.keys().collect::<Vec<_>>(),
+                    o.keys().collect::<Vec<_>>(),
+                    "{name}: streams differ"
+                );
+                for (stream, a) in e {
+                    let a = mask_generated_ids(a, &golden_ids);
+                    let b = o.get(stream).map(|b| mask_generated_ids(b, &golden_ids));
+                    assert_same_stream(&format!("{name}/{stream}"), Some(&a), b.as_ref());
+                }
+            }
+        }
+
+        /// `update_component` parses a symbol with `write_schlib`'s parser: a
+        /// typo on any object is refused, and the designator is derived the
+        /// same way when the replacement carries none.
+        #[test]
+        fn update_component_parses_exactly_what_write_schlib_does() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let lib = dir.path().join("Upd.SchLib");
+            let written = server.call_write_schlib(&json!({
+                "filepath": lib.to_string_lossy(),
+                "symbols": [{ "name": "S", "designator": "U?" }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+
+            for (kind, symbol) in [
+                ("symbol", json!({ "name": "S", "descripton": "x" })),
+                (
+                    "pin",
+                    json!({ "name": "S", "pins": [{ "name": "A", "designator": "1", "x": 0, "y": 0, "lenght": 10 }] }),
+                ),
+                (
+                    "rectangle",
+                    json!({ "name": "S", "rectangles": [{ "x1": 0, "y1": 0, "x2": 10, "y2": 10, "fillcolor": 1 }] }),
+                ),
+                (
+                    "polygon",
+                    json!({ "name": "S", "polygons": [{ "points": [{ "x": 0, "y": 0 }, { "x": 5, "y": 0 }, { "x": 0, "y": 5 }], "filed": true }] }),
+                ),
+                (
+                    "parameter",
+                    json!({ "name": "S", "parameters": [{ "name": "Value", "value": "1k", "hiden": true }] }),
+                ),
+                (
+                    "footprint",
+                    json!({ "name": "S", "footprints": [{ "name": "R0402", "library_pat": "x.PcbLib" }] }),
+                ),
+            ] {
+                let result = server.call_update_component(&json!({
+                    "filepath": lib.to_string_lossy(),
+                    "component_name": "S",
+                    "symbol": symbol,
+                }));
+                let text = get_result_text(&result);
+                assert!(result.is_error, "{kind}: a typo was accepted: {text}");
+                assert!(text.contains("Unknown field"), "{kind}: {text}");
+            }
+
+            let result = server.call_update_component(&json!({
+                "filepath": lib.to_string_lossy(),
+                "component_name": "S",
+                "symbol": { "name": "S", "component_type": "resistor" },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let back = server.call_read_schlib(&json!({ "filepath": lib.to_string_lossy() }));
+            assert_eq!(parse_result_json(&back)["symbols"][0]["designator"], "R?");
+        }
+
+        /// A record its parser cannot build is refused and named, like a
+        /// malformed pad — never silently left out of the file.
+        #[test]
+        fn malformed_records_are_refused_not_dropped() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let pad = json!({ "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0 });
+            let pcb = dir.path().join("Bad.PcbLib");
+            for (kind, footprint) in [
+                (
+                    "region",
+                    json!({ "name": "B", "pads": [pad], "regions": [{ "layer": "Top Overlay" }] }),
+                ),
+                (
+                    "text",
+                    json!({ "name": "B", "pads": [pad], "text": [{ "x": 0.0, "y": 0.0 }] }),
+                ),
+            ] {
+                let r = server.call_write_pcblib(&json!({
+                    "filepath": pcb.to_string_lossy(),
+                    "footprints": [footprint],
+                }));
+                let text = get_result_text(&r);
+                assert!(
+                    r.is_error,
+                    "{kind}: a malformed record was accepted: {text}"
+                );
+                assert!(
+                    text.contains(&format!("Failed to parse {kind} at index 0")),
+                    "{text}"
+                );
+                assert!(text.contains("Malformed"), "{text}");
+            }
+
+            let sch = dir.path().join("Bad.SchLib");
+            let empty = json!([{}]);
+            for (kind, symbol) in [
+                ("pin", json!({ "name": "B", "pins": [{ "name": "A" }] })),
+                ("rectangle", json!({ "name": "B", "rectangles": empty })),
+                ("round_rect", json!({ "name": "B", "round_rects": empty })),
+                ("line", json!({ "name": "B", "lines": empty })),
+                ("polyline", json!({ "name": "B", "polylines": empty })),
+                (
+                    "polygon",
+                    json!({ "name": "B", "polygons": [{ "points": [{ "x": 0, "y": 0 }] }] }),
+                ),
+                ("arc", json!({ "name": "B", "arcs": empty })),
+                ("pie", json!({ "name": "B", "pies": empty })),
+                ("image", json!({ "name": "B", "images": empty })),
+                ("text_frame", json!({ "name": "B", "text_frames": empty })),
+                ("bezier", json!({ "name": "B", "beziers": empty })),
+                (
+                    "elliptical_arc",
+                    json!({ "name": "B", "elliptical_arcs": empty }),
+                ),
+                ("ellipse", json!({ "name": "B", "ellipses": empty })),
+                ("label", json!({ "name": "B", "labels": empty })),
+                ("text", json!({ "name": "B", "text": empty })),
+                (
+                    "parameter",
+                    json!({ "name": "B", "parameters": [{ "value": "1k" }] }),
+                ),
+                (
+                    "footprint link",
+                    json!({ "name": "B", "footprints": [{ "description": "no name" }] }),
+                ),
+            ] {
+                let r = server.call_write_schlib(&json!({
+                    "filepath": sch.to_string_lossy(),
+                    "symbols": [symbol],
+                }));
+                let text = get_result_text(&r);
+                assert!(
+                    r.is_error,
+                    "{kind}: a malformed record was accepted: {text}"
+                );
+                assert!(
+                    text.contains(&format!("Failed to parse {kind} at index 0")),
+                    "{text}"
+                );
+            }
+            assert!(!pcb.exists() && !sch.exists(), "nothing was written");
         }
 
         /// From scratch the designator is still added by default, and


### PR DESCRIPTION
Bugs #15–#16 of the sweep, the SchLib mirror of #422 plus a class the coverage report pointed at.

## 1. `update_component` (SchLib) had its own hand parser

Same drift as the PcbLib path had: no unknown-field check on any object (typos ignored), the designator left at the struct default where `write_schlib` derives one from `designator_prefix`/`component_type`, records pushed without the `add_*` bookkeeping. Both tools now go through **one `parse_symbol_json`** — `write_schlib`'s parsing lifted out verbatim — so neither can fall behind again. The IEEE designator table moves with it.

## 2. Malformed records were silently dropped

Every `Option`-returning parser — regions and text on the PcbLib side, all **sixteen** SchLib record kinds, and a footprint link without a `name` — sat behind `if let Some(..)`: a record with a required field missing or mistyped was left out of the file **without a word**, while pads/tracks/vias/fills/arcs were refused and named. All are refused now with the same structured context (`Failed to parse region at index 2`, `Failed to parse footprint link at index 0`) and nothing is written.

## Tests

The **SchLib in-place twin** (golden symbols through `update_component`, one save per updated symbol, each re-reading the last — identical to the library-level save, golden-less IDs masked; every third symbol, to stay under 25 s), `update_component` typo refusal on six SchLib object kinds + designator derivation parity, and malformed-record refusal on every kind of both formats.

## Housekeeping

`TODO.md` gains a section for findings deferred from the sweep (header `UniqueID` dropped, pies' per-save `UniqueID`, `EllipticalArc`/`Text` display flags, the non-embedded STEP form); `docs/FIXTURE_COVERAGE.md` lists the record kinds the golden lacks (RECORD=11/3/45, non-embedded model, text beyond U+00FF). `docs/errors.md` documents both.

Gates: fmt ✅ clippy ✅ 1408 tests ✅ coverage **99.08%** (405/44,010) — unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
