### PR TITLE
fix(mcp): refuse unknown keys in update_pad, update_primitive and batch_update

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1119,4 +1119,4 @@ read_pcblib's list for that type), apply only the specified updates.
 | `filepath` | string | yes | Path to the .PcbLib file |
 | `index` | integer | yes | Zero-based index of the primitive within its type array |
 | `primitive_type` | enum | yes | Type of primitive to update. Addressed by `index` into that primitive list. Pads are not here — they have a designator, so use update_pad. (one of: track, arc, region, text, fill, via) |
-| `updates` | object | yes | Properties to update (only specified properties are changed). Valid properties depend on primitive_type. |
+| `updates` | object | yes | Properties to update (only specified properties are changed). Valid properties depend on primitive_type — track: x1, y1, x2, y2, width, layer; arc: x/x1, y/y1, radius, start_angle, end_angle, width, layer; text: x, y, height, rotation, text, layer; fill: x/x1, y/y1, x2, y2, rotation, layer; region: layer; via: x, y, diameter, hole_size, from_layer, to_layer. Any other key is refused. |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -173,11 +173,13 @@ The structured document inside `text` always carries these keys:
 
 ### Unknown-Field Rejection
 
-`write_pcblib`, `write_schlib` and `update_component` refuse any JSON object key they do not know —
+`write_pcblib`, `write_schlib`, `update_component`, `update_pad`, `update_primitive` and
+`batch_update` refuse any JSON object key they do not know —
 `Unknown field 'widht'. Allowed fields are: [...]` — rather than ignoring it, because an
 ignored typo is a pad of the wrong shape or a track on the wrong layer, found only in Altium.
 Every object is checked: footprints and symbols, each primitive kind, 3D-model and
-component-body objects, footprint links. The accepted keys are the fields the read tools
+component-body objects, footprint links, and the `updates` / `parameters` objects of the
+in-place tools (per primitive kind and per batch operation). The accepted keys are the fields the read tools
 emit for that object plus its authoring-only spellings (`step_model`, `vertices`, `hidden`,
 `designator_prefix`, …), so anything a read returned can be passed straight back
 (`src/mcp/tools/allowed_keys.rs`). A footprint or symbol is parsed by one routine whichever

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -2121,7 +2121,7 @@ impl McpServer {
                         },
                         "updates": {
                             "type": "object",
-                            "description": "Properties to update (only specified properties are changed). Valid properties depend on primitive_type.",
+                            "description": "Properties to update (only specified properties are changed). Valid properties depend on primitive_type — track: x1, y1, x2, y2, width, layer; arc: x/x1, y/y1, radius, start_angle, end_angle, width, layer; text: x, y, height, rotation, text, layer; fill: x/x1, y/y1, x2, y2, rotation, layer; region: layer; via: x, y, diameter, hole_size, from_layer, to_layer. Any other key is refused.",
                             "properties": {
                                 "x1": { "type": "number", "description": "Start X (track) or centre X (arc)" },
                                 "y1": { "type": "number", "description": "Start Y (track) or centre Y (arc)" },
@@ -2135,8 +2135,12 @@ impl McpServer {
                                 "start_angle": { "type": "number", "description": "Start angle in degrees (arc)" },
                                 "end_angle": { "type": "number", "description": "End angle in degrees (arc)" },
                                 "text": { "type": "string", "description": "Text content (text primitive)" },
-                                "rotation": { "type": "number", "description": "Rotation angle" },
-                                "layer": { "type": "string", "description": "Layer name" }
+                                "rotation": { "type": "number", "description": "Rotation angle (text, fill)" },
+                                "layer": { "type": "string", "description": "Layer name (track, arc, text, fill, region)" },
+                                "diameter": { "type": "number", "description": "Barrel diameter in mm (via)" },
+                                "hole_size": { "type": "number", "description": "Hole diameter in mm (via)" },
+                                "from_layer": { "type": "string", "description": "Start layer (via)" },
+                                "to_layer": { "type": "string", "description": "End layer (via)" }
                             }
                         },
                         "dry_run": {

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -18,6 +18,27 @@ impl McpServer {
         let Some(parameters) = arguments.get("parameters") else {
             return ToolCallResult::error("Missing required parameter: parameters");
         };
+        // The parameters each operation reads; a key outside them is a typo
+        // (`tolerence`) that would otherwise silently fall back to a default.
+        let keys: &[&str] = match operation {
+            "update_track_width" => &["from_width", "to_width", "tolerance"],
+            "rename_layer" => &["from_layer", "to_layer"],
+            "update_parameters" => &[
+                "param_name",
+                "param_value",
+                "symbol_filter",
+                "add_if_missing",
+            ],
+            _ => {
+                return ToolCallResult::error(format!(
+                    "Unknown operation '{operation}'. Valid: update_track_width, rename_layer, \
+                     update_parameters"
+                ))
+            }
+        };
+        if let Err(e) = Self::check_unknown_fields(parameters, keys) {
+            return ToolCallResult::error(e);
+        }
 
         let dry_run = arguments
             .get("dry_run")
@@ -557,7 +578,7 @@ mod tests {
             "parameters": {},
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Unknown PcbLib operation: frobnicate"));
+        assert!(get_result_text(&result).contains("Unknown operation 'frobnicate'"));
 
         let sch = dir.path().join("Syms.SchLib");
         create_test_schlib(&sch);
@@ -567,7 +588,26 @@ mod tests {
             "parameters": {},
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Unknown SchLib operation: frobnicate"));
+        assert!(get_result_text(&result).contains("Unknown operation 'frobnicate'"));
+
+        // A valid operation on the other format is still refused by that
+        // format's own dispatch.
+        let result = server.call_batch_update(&json!({
+            "filepath": sch.to_string_lossy(),
+            "operation": "rename_layer",
+            "parameters": { "from_layer": "Mechanical 1", "to_layer": "Mechanical 2" },
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("Unknown SchLib operation: rename_layer"));
+
+        // A misspelt parameter is refused rather than falling back to a default.
+        let result = server.call_batch_update(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "operation": "update_track_width",
+            "parameters": { "from_width": 0.2, "to_width": 0.25, "tolerence": 0.01 },
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("Unknown field 'tolerence'"));
     }
 
     #[test]

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -4,6 +4,41 @@ use serde_json::{json, Value};
 
 use crate::mcp::server::{McpServer, ToolCallResult};
 
+/// The properties `update_pad` applies.
+const UPDATE_PAD_KEYS: &[&str] = &[
+    "x",
+    "y",
+    "width",
+    "height",
+    "rotation",
+    "hole_size",
+    "shape",
+];
+
+/// The properties `update_primitive` applies to a primitive kind, or `None`
+/// for a kind it does not address.
+fn update_primitive_keys(primitive_type: &str) -> Option<&'static [&'static str]> {
+    Some(match primitive_type {
+        "track" => &["x1", "y1", "x2", "y2", "width", "layer"],
+        "arc" => &[
+            "x1",
+            "y1",
+            "x",
+            "y",
+            "radius",
+            "start_angle",
+            "end_angle",
+            "width",
+            "layer",
+        ],
+        "text" => &["x", "y", "height", "rotation", "text", "layer"],
+        "fill" => &["x1", "y1", "x", "y", "x2", "y2", "rotation", "layer"],
+        "region" => &["layer"],
+        "via" => &["x", "y", "diameter", "hole_size", "from_layer", "to_layer"],
+        _ => return None,
+    })
+}
+
 impl McpServer {
     /// Repairs a library by removing orphaned references.
     pub(crate) fn call_repair_library(&self, arguments: &Value) -> ToolCallResult {
@@ -687,6 +722,10 @@ impl McpServer {
         let Some(updates) = arguments.get("updates") else {
             return ToolCallResult::error("Missing required parameter: updates");
         };
+        // A key this tool does not apply is a typo to refuse, not a no-op.
+        if let Err(e) = Self::check_unknown_fields(updates, UPDATE_PAD_KEYS) {
+            return ToolCallResult::error(e);
+        }
 
         // Validate path
         if let Err(e) = self.validate_path(filepath) {
@@ -794,6 +833,16 @@ impl McpServer {
         let Some(updates) = arguments.get("updates") else {
             return ToolCallResult::error("Missing required parameter: updates");
         };
+        // The properties this primitive kind can take; anything else is a
+        // typo or a property of another kind, refused rather than ignored.
+        let Some(keys) = update_primitive_keys(primitive_type) else {
+            return ToolCallResult::error(format!(
+                "Invalid primitive_type '{primitive_type}'. Valid: track, arc, region, text, fill, via"
+            ));
+        };
+        if let Err(e) = Self::check_unknown_fields(updates, keys) {
+            return ToolCallResult::error(e);
+        }
 
         // Validate path
         if let Err(e) = self.validate_path(filepath) {
@@ -1824,12 +1873,23 @@ mod tests {
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("must be positive"));
 
-        // No recognised update keys.
+        // A key the tool does not apply is refused, naming the ones it does.
         let result = server.call_update_pad(&json!({
             "filepath": filepath,
             "component_name": "CHIP_0402",
             "designator": "1",
             "updates": { "bogus": 1.0 },
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("Unknown field 'bogus'"));
+        assert!(get_result_text(&result).contains("\"hole_size\""));
+
+        // An empty update set is a caller error rather than a silent no-op write.
+        let result = server.call_update_pad(&json!({
+            "filepath": filepath,
+            "component_name": "CHIP_0402",
+            "designator": "1",
+            "updates": {},
         }));
         assert!(result.is_error);
         assert_eq!(get_result_text(&result), "No valid updates specified");
@@ -3053,7 +3113,8 @@ mod tests {
             assert_error_mentions(&update(json!({ "height": -1.0 })), "must be positive");
             assert_error_mentions(&update(json!({ "hole_size": -0.5 })), "must be >= 0");
             assert_error_mentions(&update(json!({ "shape": "trapezoid" })), "Invalid shape");
-            assert_error_mentions(&update(json!({ "unknown_key": 1 })), "No valid updates");
+            assert_error_mentions(&update(json!({ "unknown_key": 1 })), "Unknown field");
+            assert_error_mentions(&update(json!({})), "No valid updates");
             assert_error_mentions(
                 &update(json!({ "x": 99_999.0 })),
                 "exceeds the maximum safe range",
@@ -3168,9 +3229,14 @@ mod tests {
             // Each family is addressed positionally, so each keeps its own
             // range check naming the family.
             for family in ["track", "arc", "text", "fill", "region", "via"] {
+                let updates = if family == "via" {
+                    json!({ "diameter": 0.6 })
+                } else {
+                    json!({ "layer": "Top Layer" })
+                };
                 let r = server.call_update_primitive(&json!({
                     "filepath": &lib, "component_name": "RICH",
-                    "primitive_type": family, "index": 99, "updates": { "layer": "Top Layer" },
+                    "primitive_type": family, "index": 99, "updates": updates,
                 }));
                 assert_error_mentions(&r, "out of range");
             }
@@ -3274,9 +3340,18 @@ mod tests {
                 "smaller than diameter",
             );
 
-            // Nothing recognised in `updates` is a caller error rather than a
-            // silent no-op write.
-            assert_error_mentions(&update("track", json!({ "nope": 1 })), "No valid updates");
+            // A key the family does not take is refused (a typo, or another
+            // family's property); nothing at all is a caller error rather than
+            // a silent no-op write.
+            assert_error_mentions(
+                &update("track", json!({ "nope": 1 })),
+                "Unknown field 'nope'",
+            );
+            assert_error_mentions(
+                &update("region", json!({ "width": 0.2 })),
+                "Unknown field 'width'",
+            );
+            assert_error_mentions(&update("track", json!({})), "No valid updates");
 
             // And the whole-footprint coordinate check still applies.
             assert_error_mentions(


### PR DESCRIPTION
Bug #17 of the sweep — the last of the "own parser" class: the in-place tools.

`update_pad`, `update_primitive` and `batch_update` took an `updates` / `parameters` object and applied the keys they knew, **ignoring the rest**:

- `update_pad {"widht": 1.2}` → "No valid updates specified" only if *nothing* matched; `{"width": 1.2, "hieght": 0.9}` silently applied half.
- `update_primitive` dropped a `width` on a region or a `layer` on a via without a word — and the via's `diameter`/`hole_size`/`from_layer`/`to_layer` were accepted but **absent from the schema**.
- `batch_update` with `tolerence` fell back to the default tolerance.

Each now carries an allow-list (per primitive kind / per operation) and refuses an unknown key up front naming the accepted ones, exactly like the write tools since #421. Empty update sets still get "No valid updates specified". Schema + `docs/TOOLS.md` + `docs/errors.md` updated.

**Stacked on #423** (base `fix/schlib-update-parser`); will retarget to `main` once it lands.

Gates: fmt ✅ clippy ✅ 1408 tests ✅ coverage **99.09%** (400/44,087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)