### PR TITLE
fix(mcp): refuse a tool argument the tool's schema does not document

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -171,7 +171,13 @@ The structured document inside `text` always carries these keys:
 - **`component`** — the component being processed, or `null` if not applicable.
 - **`details`** — additional context about what was happening, or `null`.
 
-### Unknown-Field Rejection
+### Unknown-Argument and Unknown-Field Rejection
+
+Every `tools/call` is first checked against the called tool's own schema (the one
+`tools/list` serves): an argument the schema does not document —
+`Unknown argument 'dryrun' for tool 'update_pad'. Accepted arguments are: [...]` — is
+refused before the handler runs, because every handler would otherwise ignore it and
+silently take the default (`src/mcp/server.rs`, `check_tool_arguments`).
 
 `write_pcblib`, `write_schlib`, `update_component`, `update_pad`, `update_primitive` and
 `batch_update` refuse any JSON object key they do not know —

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -334,6 +334,45 @@ impl McpServer {
         self
     }
 
+    /// Every tool's documented argument names, from the same schemas
+    /// `tools/list` serves and `docs/TOOLS.md` is generated from.
+    fn tool_argument_names() -> &'static std::collections::HashMap<String, Vec<String>> {
+        static NAMES: std::sync::OnceLock<std::collections::HashMap<String, Vec<String>>> =
+            std::sync::OnceLock::new();
+        NAMES.get_or_init(|| {
+            Self::get_tool_definitions()
+                .into_iter()
+                .map(|tool| {
+                    let names = tool.input_schema["properties"]
+                        .as_object()
+                        .map(|props| props.keys().cloned().collect())
+                        .unwrap_or_default();
+                    (tool.name, names)
+                })
+                .collect()
+        })
+    }
+
+    /// Refuses a call carrying an argument the tool's schema does not
+    /// document — a typo (`dryrun`, `compnent_name`) every handler would
+    /// otherwise ignore, silently taking the default. An unknown tool name
+    /// is left to dispatch to report.
+    fn check_tool_arguments(name: &str, arguments: &Value) -> Result<(), String> {
+        let (Some(known), Some(given)) =
+            (Self::tool_argument_names().get(name), arguments.as_object())
+        else {
+            return Ok(());
+        };
+        given
+            .keys()
+            .find(|key| !known.contains(key))
+            .map_or(Ok(()), |unknown| {
+                Err(format!(
+                    "Unknown argument '{unknown}' for tool '{name}'. Accepted arguments are: {known:?}"
+                ))
+            })
+    }
+
     /// Returns `true` if the named tool mutates a library file on disk.
     ///
     /// Only these destructive operations are rate limited; read-only tools
@@ -789,9 +828,9 @@ impl McpServer {
 
         // Throttle mutating operations so a runaway AI loop cannot thrash the
         // disk with repeated full-file rewrites + backups. Reads are unmetered.
-        let result = if Self::is_mutating_tool(params.name.as_str())
-            && !self.rate_limiter.try_acquire()
-        {
+        let result = if let Err(e) = Self::check_tool_arguments(&params.name, &params.arguments) {
+            ToolCallResult::error(e)
+        } else if Self::is_mutating_tool(params.name.as_str()) && !self.rate_limiter.try_acquire() {
             tracing::warn!(
                 tool = %params.name,
                 "Rate limit exceeded; rejecting mutating operation"
@@ -3029,6 +3068,45 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("Unknown tool"));
+        }
+
+        /// Every tool refuses an argument its schema does not document, and
+        /// every tool's own documented example passes the same check — so
+        /// the schemas, the examples and the handlers cannot drift apart.
+        #[test]
+        fn tools_call_refuses_an_undocumented_argument_on_every_tool() {
+            let dir = test_temp_dir();
+            let server = running_server(dir.path());
+            for tool in McpServer::get_tool_definitions() {
+                let r = req(
+                    "tools/call",
+                    Some(
+                        json!({ "name": tool.name, "arguments": { "filepath": "x", "dryrun": true } }),
+                    ),
+                );
+                let resp = server.handle_tools_call(&r).unwrap();
+                let text = resp.result["content"][0]["text"]
+                    .as_str()
+                    .unwrap()
+                    .to_string();
+                assert_eq!(resp.result["isError"], json!(true), "{}: {text}", tool.name);
+                assert!(
+                    text.contains("Unknown argument 'dryrun'") && text.contains(&tool.name),
+                    "{}: {text}",
+                    tool.name
+                );
+
+                let example = tool.example.expect("every tool documents an example");
+                assert_eq!(example["name"], tool.name);
+                assert!(
+                    McpServer::check_tool_arguments(&tool.name, &example["arguments"]).is_ok(),
+                    "{}: its own example carries an undocumented argument",
+                    tool.name
+                );
+            }
+            // Non-object arguments and unknown tools are left to dispatch.
+            assert!(McpServer::check_tool_arguments("read_pcblib", &json!(null)).is_ok());
+            assert!(McpServer::check_tool_arguments("no_such_tool", &json!({ "x": 1 })).is_ok());
         }
 
         #[test]


### PR DESCRIPTION
Bug #18 — the structural close of the "silently ignored key" class, one level up.

No handler ever checked the **top-level arguments** of a call: `dryrun`, `compnent_name`, `apend` were ignored and the default silently taken. One check at dispatch now holds every `tools/call` to the called tool's own schema (the one `tools/list` serves and `docs/TOOLS.md` is generated from) and refuses an undocumented argument naming the accepted ones — before rate limiting, before the handler. Unknown tool names / non-object arguments are left to dispatch as before.

Verified first that all 33 handlers read only documented arguments. The test drives **every tool** through `tools/call` with a misspelt argument, and runs each tool's own documented `example` through the same check, so schema, example and handler cannot drift apart. `docs/errors.md` documents it.

**Stacked on #424** (base `fix/update-tool-allow-lists`); will retarget to `main` as the stack lands.

Gates: fmt ✅ clippy ✅ 1409 tests ✅ coverage **99.09%** (400/44,144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)