### PR TITLE
fix(pcblib): hold hand-authored libraries byte-identical — flag bits, model group, body key order

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,9 +24,6 @@ Found while fixing something else; each needs its own verification or a fixture 
       (`graphically_locked`, `disabled`, `dimmed`, `owner_part_display_mode`) in the model,
       while the other 13 graphics do — almost certainly a gap, but no golden record exists
       to verify the keys AD24 emits. Blocked on the fixture (see `docs/FIXTURE_COVERAGE.md`).
-- [ ] **Non-embedded STEP reference form is unverified** — `step_model.embed: false` now
-      writes `MODELID` + `MODEL.EMBED=FALSE` + `MODEL.NAME=<path>`; whether Altium also
-      expects an entry in `/Library/ModelsNoEmbed` is unknown. Blocked on the fixture.
 
 ## B. On-site Altium tooling
 

--- a/docs/FIXTURE_COVERAGE.md
+++ b/docs/FIXTURE_COVERAGE.md
@@ -133,10 +133,9 @@ its `ImplementationList`/`MapDefiner` children) — the `FootprintModel` replay 
 `unique_id`/`is_current` is unit-tested only.
 
 **PcbLib:** region net and the cavity/subpoly params, raw-outline precision for ComponentBody.
-A **non-embedded STEP reference** (`MODEL.EMBED=FALSE` + `MODEL.NAME`, and whatever
-`/Library/ModelsNoEmbed` holds for it) — `write_pcblib`'s `step_model.embed: false`
-now writes the MODEL group with a fresh MODELID, but the form is unverified against
-Altium. A **text beyond U+00FF** (Ω, CJK) so a golden pins `WideStrings` as UTF-16
+A **non-embedded STEP reference** in the *generated* golden — the form itself is settled
+by a UI-authored library (`MODELID=` empty, `MODEL.EMBED=FALSE`, `MODEL.NAME`, the full
+group; `/Library/ModelsNoEmbed` stays empty) and `write_pcblib` follows it. A **text beyond U+00FF** (Ω, CJK) so a golden pins `WideStrings` as UTF-16
 code units (today only AltiumSharp and the Latin-1 `10µF` of `TEXT_WIN1252` do).
 Pad thermal-relief / power-plane is
 🚫 **FINAL** on the scripting side (native crash on a fresh library pad in every sequence

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -812,8 +812,8 @@ snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 | `BODYCOLOR3D` | 3D body colour | `8421504` |
 | `BODYOPACITY3D` | 3D body opacity | `1.000` |
 | `IDENTIFIER` | Body name as comma-separated decimal Unicode code points (`µΩ电` = `181,937,30005`; empty stays empty) | `` |
-| `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields, round-tripped verbatim (a UI-authored body can carry `TEXTUREROTATION= 9.00000000000000E+0001`); from-scratch defaults `0mil` / ` 0.00000000000000E+0000` | |
-| `MODELID` | Model GUID; **empty** for a STEP reference the library does not embed (`MODELID=|MODEL.CHECKSUM=0|MODEL.EMBED=FALSE|MODEL.NAME=test_0805.step`, UI-authored) | `{GUID}` |
+| `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields, round-tripped verbatim (a UI-authored body can carry a rotation of `9.00000000000000E+0001`, leading space included); from-scratch defaults `0mil` and a zero rotation | |
+| `MODELID` | Model GUID; **empty** for a STEP reference the library does not embed (`MODELID=` followed by `MODEL.CHECKSUM=0`, `MODEL.EMBED=FALSE`, `MODEL.NAME=test_0805.step` — UI-authored) | `{GUID}` |
 | `MODEL.CHECKSUM` | Model integrity checksum (round-tripped verbatim, see below) | `0` |
 | `MODEL.EMBED` | `TRUE` / `FALSE` | |
 | `MODEL.NAME` | Model filename | `RESC1005X04L.step` |

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -380,6 +380,7 @@ fill byte-identically.
 | `0x0080` | TestPointTop | Fabrication test point, top |
 | `0x0100` | TestPointBottom | Fabrication test point, bottom |
 | `0x0200` | Keepout | Keep-out primitive |
+| `0x0001`, `0x0002`, `0x0010`, `0x0400`–`0x8000` | — | Not modelled (AltiumSharp reads them as selection / display state). Hand-authored libraries do set them — every track of a pin-header footprint carries `0x001C` — so they are carried verbatim through a read-modify-write as `PcbFlags::DISK_BIT_n` |
 
 A normal saved primitive therefore carries `0x000C` (Saved + Unlocked), not `0x0000`; a keepout
 primitive carries `0x020C`.
@@ -811,8 +812,8 @@ snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 | `BODYCOLOR3D` | 3D body colour | `8421504` |
 | `BODYOPACITY3D` | 3D body opacity | `1.000` |
 | `IDENTIFIER` | Body name as comma-separated decimal Unicode code points (`µΩ电` = `181,937,30005`; empty stays empty) | `` |
-| `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields (fixed defaults) | |
-| `MODELID` | Model GUID (model-backed bodies ONLY) | `{GUID}` |
+| `TEXTURE`, `TEXTURECENTERX/Y`, `TEXTURESIZEX/Y`, `TEXTUREROTATION` | Texture fields, round-tripped verbatim (a UI-authored body can carry `TEXTUREROTATION= 9.00000000000000E+0001`); from-scratch defaults `0mil` / ` 0.00000000000000E+0000` | |
+| `MODELID` | Model GUID; **empty** for a STEP reference the library does not embed (`MODELID=|MODEL.CHECKSUM=0|MODEL.EMBED=FALSE|MODEL.NAME=test_0805.step`, UI-authored) | `{GUID}` |
 | `MODEL.CHECKSUM` | Model integrity checksum (round-tripped verbatim, see below) | `0` |
 | `MODEL.EMBED` | `TRUE` / `FALSE` | |
 | `MODEL.NAME` | Model filename | `RESC1005X04L.step` |
@@ -824,7 +825,7 @@ snap-point or reserved blocks, and there is no `MODEL.SNAPCOUNT` parameter.
 | `MODEL.MODELSOURCE` | Model source | `Undefined` |
 
 **Extruded vs model-backed — and the MODEL group's presence:** the group is present exactly
-when the body carries a `MODELID`, which depends on the authoring route. A *script-authored*
+when the body carries a `MODELID` or names a model file, which depends on the authoring route. A *script-authored*
 extruded body (the golden's `BODY3D`, `PRIMPROPS`) has none and ends at `TEXTUREROTATION`; a
 *UI-authored* extruded body (`manual/identifier.PcbLib`) carries a stable `MODELID` and the
 full group with `MODEL.MODELTYPE=0`, `MODEL.EXTRUDED.MINZ/MAXZ` (standoff..overall), real
@@ -833,8 +834,10 @@ scripted route writes `0mil` (both round-trip verbatim). A model-backed body (`E
 `MODEL.MODELTYPE=1` plus `MODEL.MODELSOURCE=Undefined` and no `EXTRUDED` range. `ISSHAPEBASED`
 stays `FALSE` throughout.
 
-Unmodelled keys captured on read are re-emitted verbatim after the canonical set (with canonical
-duplicates dropped) so read-modify-write round-trips.
+Unmodelled keys captured on read are re-emitted verbatim **at their read position** — the key
+order is carried as `param_key_order`, as for regions, because Altium interleaves them
+(`BODYOVERRIDECOLOR=TRUE` sits right after `BODYOPACITY3D` in a UI-authored body) and writes
+`ARCRESOLUTION` twice; a from-scratch body emits the canonical set and appends any extras.
 
 > **Note:** Height values can be in "mil" or "mm" units on read. The tool parses both formats;
 > mil values are converted using 1 mil = 0.0254 mm.

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -2397,6 +2397,7 @@ mod tests {
             texture_center_y: None,
             texture_size_x: None,
             texture_size_y: None,
+            texture_rotation: None,
             model_name: "TEST_MODEL.step".to_string(),
             embedded: true,
             rotation_x: 0.0,
@@ -2426,6 +2427,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             additional_parameters: Vec::new(),
+            param_key_order: Vec::new(),
         };
         original.add_component_body(body);
 
@@ -2477,6 +2479,7 @@ mod tests {
                 texture_center_y: None,
                 texture_size_x: None,
                 texture_size_y: None,
+                texture_rotation: None,
                 model_name: format!("M{i}.step"),
                 embedded: true,
                 rotation_x: 0.0,
@@ -2506,6 +2509,7 @@ mod tests {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 additional_parameters: Vec::new(),
+                param_key_order: Vec::new(),
             });
         }
 

--- a/src/altium/pcblib/primitives/mod.rs
+++ b/src/altium/pcblib/primitives/mod.rs
@@ -78,7 +78,45 @@ bitflags! {
         const TESTPOINT_TOP = 0x0020;
         /// Fabrication test point on the bottom layer, likewise locked by Altium.
         const TESTPOINT_BOTTOM = 0x0040;
+        /// On-disk flag bit 0, which nothing here models; carried verbatim so a
+        /// read-modify-write leaves the flag word as Altium wrote it (hand-authored
+        /// libraries set bits the scripted golden never does).
+        const DISK_BIT_0 = 0x0080;
+        /// On-disk flag bit 1, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_1 = 0x0100;
+        /// On-disk flag bit 4, carried verbatim (see [`Self::DISK_BIT_0`]); set on
+        /// every track of a hand-authored pin-header footprint.
+        const DISK_BIT_4 = 0x0200;
+        /// On-disk flag bit 10, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_10 = 0x0400;
+        /// On-disk flag bit 11, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_11 = 0x0800;
+        /// On-disk flag bit 12, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_12 = 0x1000;
+        /// On-disk flag bit 13, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_13 = 0x2000;
+        /// On-disk flag bit 14, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_14 = 0x4000;
+        /// On-disk flag bit 15, carried verbatim (see [`Self::DISK_BIT_0`]).
+        const DISK_BIT_15 = 0x8000;
     }
+}
+
+impl PcbFlags {
+    /// The on-disk flag bits nothing here models, paired with the flag that
+    /// carries each one verbatim. Everything else in the word is a modelled
+    /// bit (`flags.rs`).
+    pub(crate) const DISK_BITS: [(u16, Self); 9] = [
+        (0x0001, Self::DISK_BIT_0),
+        (0x0002, Self::DISK_BIT_1),
+        (0x0010, Self::DISK_BIT_4),
+        (0x0400, Self::DISK_BIT_10),
+        (0x0800, Self::DISK_BIT_11),
+        (0x1000, Self::DISK_BIT_12),
+        (0x2000, Self::DISK_BIT_13),
+        (0x4000, Self::DISK_BIT_14),
+        (0x8000, Self::DISK_BIT_15),
+    ];
 }
 
 #[cfg(test)]

--- a/src/altium/pcblib/primitives/models3d.rs
+++ b/src/altium/pcblib/primitives/models3d.rs
@@ -225,6 +225,11 @@ pub struct ComponentBody {
     /// The `TEXTURESIZEY` value, verbatim wire text (see `texture_center_x`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub texture_size_y: Option<String>,
+    /// The `TEXTUREROTATION` value, verbatim wire text (see `texture_center_x`);
+    /// a UI-authored body rotates its texture (`terminal_block_5mm_3way` carries
+    /// ` 9.00000000000000E+0001`), so it is carried rather than reset to zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub texture_rotation: Option<String>,
 
     /// The header layer byte exactly as read, kept only when `layer_from_id`
     /// hit its `MultiLayer` catch-all on an id it does not map — the byte
@@ -271,6 +276,13 @@ pub struct ComponentBody {
     /// the output stays byte-identical to the canonical form.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_parameters: Vec<(String, String)>,
+    /// The keys of the parameter block in the order they were read, canonical
+    /// and unmodelled alike, so the writer emits them in Altium's order — a
+    /// UI-authored body stores `BODYOVERRIDECOLOR=TRUE` right after
+    /// `BODYOPACITY3D`, not appended. Empty for a from-scratch body, which
+    /// emits the canonical order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub param_key_order: Vec<String>,
 }
 
 const fn default_body_color() -> u32 {
@@ -343,12 +355,14 @@ impl ComponentBody {
             texture_center_y: None,
             texture_size_x: None,
             texture_size_y: None,
+            texture_rotation: None,
             raw_layer_id: None,
             v7_layer: None,
             net_index: default_net_index(),
             polygon_index: default_polygon_index(),
             component_index: default_component_index(),
             additional_parameters: Vec::new(),
+            param_key_order: Vec::new(),
         }
     }
 }

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -435,7 +435,20 @@ fn read_flags(data: &[u8]) -> PcbFlags {
     if bits & ALT_FLAG_KEEPOUT != 0 {
         flags |= PcbFlags::KEEPOUT;
     }
+    // Bits nothing models are carried verbatim, not dropped.
+    for (disk_bit, carrier) in PcbFlags::DISK_BITS {
+        if bits & disk_bit != 0 {
+            flags |= carrier;
+        }
+    }
     flags
+}
+
+/// [`read_flags`] on a bare flag word, for the writer's round-trip test.
+#[cfg(test)]
+pub fn read_flags_for_test(word: u16) -> PcbFlags {
+    let [lo, hi] = word.to_le_bytes();
+    read_flags(&[0, lo, hi])
 }
 
 /// Converts Altium layer ID to our Layer enum.

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1457,7 +1457,7 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
 /// scripted-body default.
 fn parse_body_identity_params(
     params: &std::collections::HashMap<String, String>,
-) -> (String, [Option<String>; 4]) {
+) -> (String, [Option<String>; 5]) {
     let identifier = params
         .get("IDENTIFIER")
         .map(|v| decode_identifier(v))
@@ -1470,6 +1470,7 @@ fn parse_body_identity_params(
             texture("TEXTURECENTERY"),
             texture("TEXTURESIZEX"),
             texture("TEXTURESIZEY"),
+            texture("TEXTUREROTATION"),
         ],
     )
 }
@@ -1529,6 +1530,14 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
     // exactly those backed by a ComponentBody struct field.
     let additional_parameters = block_str.find("V7_LAYER").map_or_else(Vec::new, |start| {
         capture_additional_params(&block_str[start..], BODY_MODELLED_PARAM_KEYS)
+    });
+    // Every key in read order, so the writer can put the unmodelled ones
+    // back where Altium had them.
+    let param_key_order: Vec<String> = block_str.find("V7_LAYER").map_or_else(Vec::new, |start| {
+        crate::altium::parse_pipe_params_ordered(&block_str[start..])
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect()
     });
 
     // Extract key values
@@ -1643,6 +1652,7 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         texture_center_y: textures[1].clone(),
         texture_size_x: textures[2].clone(),
         texture_size_y: textures[3].clone(),
+        texture_rotation: textures[4].clone(),
         model_id,
         model_name,
         embedded,
@@ -1675,6 +1685,7 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
         polygon_index,
         component_index,
         additional_parameters,
+        param_key_order,
     };
 
     Ok((body, current))
@@ -1765,10 +1776,36 @@ pub(super) fn parse_component_body_outline(block0: &[u8]) -> Vec<(f64, f64)> {
 
 /// Parses key=value parameters from a `ComponentBody` block string.
 pub(super) fn parse_component_body_params(s: &str) -> std::collections::HashMap<String, String> {
-    // Parameters begin at the first `V7_LAYER=` key (after the binary header).
+    // Parameters begin at the first `V7_LAYER=` key (after the binary header)
+    // and end at the NUL terminator: the outline polygon follows it in the
+    // same block, and without the cut the last key's value (TEXTUREROTATION on
+    // an Altium-authored body) would carry the outline bytes.
     s.find("V7_LAYER")
-        .map(|start| crate::altium::parse_pipe_params_raw(&s[start..]))
+        .map(|start| {
+            let text = &s[start..];
+            let end = text.find('\0').unwrap_or(text.len());
+            crate::altium::parse_pipe_params_raw(&text[..end])
+        })
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod body_param_tests {
+    use super::parse_component_body_params;
+
+    /// The parameter text ends at its NUL; the outline bytes after it must
+    /// not leak into the last key's value.
+    #[test]
+    fn body_params_stop_at_the_nul_terminator() {
+        let block = "\u{1}\u{2}V7_LAYER=MECHANICAL13|NAME= |TEXTUREROTATION= 0.00000000000000E+0000\0\u{4}\0\0\0\u{80}binary";
+        let params = parse_component_body_params(block);
+        assert_eq!(
+            params.get("TEXTUREROTATION").map(String::as_str),
+            Some(" 0.00000000000000E+0000")
+        );
+        assert_eq!(params.get("NAME").map(String::as_str), Some(" "));
+        assert!(parse_component_body_params("no parameters here").is_empty());
+    }
 }
 
 /// Parses a value in mils (e.g., "15.748mil") to mm.

--- a/src/altium/pcblib/write_io.rs
+++ b/src/altium/pcblib/write_io.rs
@@ -176,6 +176,7 @@ impl PcbLib {
                 texture_center_y: None,
                 texture_size_x: None,
                 texture_size_y: None,
+                texture_rotation: None,
                 raw_layer_id: None,
                 v7_layer: None,
                 model_name: filename,
@@ -207,6 +208,7 @@ impl PcbLib {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 additional_parameters: Vec::new(),
+                param_key_order: Vec::new(),
             });
 
             tracing::debug!(

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -254,6 +254,15 @@ const fn encode_altium_flags(flags: PcbFlags) -> u16 {
         f |= ALT_FLAG_TESTPOINT_BOTTOM;
         f &= !ALT_FLAG_UNLOCKED;
     }
+    // The bits read verbatim go back where they came from.
+    let mut i = 0;
+    while i < PcbFlags::DISK_BITS.len() {
+        let (disk_bit, carrier) = PcbFlags::DISK_BITS[i];
+        if flags.contains(carrier) {
+            f |= disk_bit;
+        }
+        i += 1;
+    }
     f
 }
 
@@ -1842,19 +1851,26 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         "TEXTURESIZEY={}",
         texture(&body.texture_size_y, "0mil")
     ));
-    params.push("TEXTUREROTATION= 0.00000000000000E+0000".to_string());
+    params.push(format!(
+        "TEXTUREROTATION={}",
+        texture(&body.texture_rotation, " 0.00000000000000E+0000")
+    ));
 
-    // Model reference — present exactly when the body HAS a model identity.
-    // Both authoring routes are golden-pinned: a script-authored extruded body
-    // (BODY3D, PRIMPROPS) has no MODELID and ends at TEXTUREROTATION with no
-    // MODEL keys at all, while a UI-authored extruded body
-    // (manual/identifier.PcbLib) carries a MODELID and the full group with
-    // MODEL.MODELTYPE=0 plus the EXTRUDED Z range (standoff..overall) and no
-    // MODELSOURCE. A model-backed body (EMBSTEP) uses MODELTYPE=1 plus
-    // MODEL.MODELSOURCE=Undefined and no EXTRUDED range. Inventing a MODELID
-    // for a body that has none is what #377 removed; a body that has one
-    // keeps its group whatever its type.
-    if !body.model_id.is_empty() {
+    // Model reference — present exactly when the body HAS a model identity
+    // or a model file. Both authoring routes are golden-pinned: a
+    // script-authored extruded body (BODY3D, PRIMPROPS) has no MODELID and
+    // ends at TEXTUREROTATION with no MODEL keys at all, while a UI-authored
+    // extruded body (manual/identifier.PcbLib) carries a MODELID and the full
+    // group with MODEL.MODELTYPE=0 plus the EXTRUDED Z range
+    // (standoff..overall) and no MODELSOURCE. A model-backed body (EMBSTEP)
+    // uses MODELTYPE=1 plus MODEL.MODELSOURCE=Undefined and no EXTRUDED
+    // range. A body that references a STEP file it does not embed carries the
+    // same group under an EMPTY MODELID (`MODELID=|MODEL.CHECKSUM=0|
+    // MODEL.EMBED=FALSE|MODEL.NAME=test_0805.step`, a UI-authored library), so
+    // the group is keyed on the file name too, or the reference is lost.
+    // Inventing a MODELID for a body that has none is what #377 removed; a
+    // body that has one keeps its group whatever its type.
+    if !body.model_id.is_empty() || !body.model_name.is_empty() || body.embedded {
         params.push(format!("MODELID={}", body.model_id));
         // Round-trip the stored checksum verbatim.
         params.push(format!("MODEL.CHECKSUM={}", body.model_checksum));
@@ -1900,14 +1916,72 @@ fn build_component_body_params(body: &ComponentBody) -> String {
         .iter()
         .filter_map(|p| p.split_once('=').map(|(k, _)| k.to_string()))
         .collect();
-    for (key, value) in &body.additional_parameters {
-        if emitted.contains(key) {
-            continue;
-        }
-        params.push(format!("{key}={value}"));
-    }
+    let additional: Vec<&(String, String)> = body
+        .additional_parameters
+        .iter()
+        .filter(|(key, _)| !emitted.contains(key))
+        .collect();
 
-    params.join("|")
+    replay_body_key_order(&params, &additional, &body.param_key_order)
+}
+
+/// Emits a body's canonical `KEY=VALUE` tokens and the unmodelled ones it
+/// carried in the order they were read.
+///
+/// A body read from a file replays its own key order: Altium interleaves
+/// unmodelled keys with the canonical set (`BODYOVERRIDECOLOR=TRUE` sits right
+/// after `BODYOPACITY3D`), so each canonical key goes at its read position and
+/// the unmodelled ones fill theirs in read order. Canonical keys the original
+/// lacked — a typed edit, or a model group the body gained — are appended; a
+/// from-scratch body has no order and emits the canonical set followed by the
+/// unmodelled keys. A canonical key can repeat (Altium writes ARCRESOLUTION
+/// twice), so each key holds a queue of its values in emission order.
+fn replay_body_key_order(
+    params: &[String],
+    additional: &[&(String, String)],
+    order: &[String],
+) -> String {
+    if order.is_empty() {
+        let mut all: Vec<String> = params.to_vec();
+        all.extend(
+            additional
+                .iter()
+                .map(|(key, value)| format!("{key}={value}")),
+        );
+        return all.join("|");
+    }
+    let mut canonical: std::collections::HashMap<&str, std::collections::VecDeque<&str>> =
+        std::collections::HashMap::new();
+    for p in params {
+        if let Some((key, value)) = p.split_once('=') {
+            canonical.entry(key).or_default().push_back(value);
+        }
+    }
+    let mut ordered: Vec<String> = Vec::with_capacity(params.len() + additional.len());
+    let mut extra = additional.iter();
+    for key in order {
+        if let Some(value) = canonical
+            .get_mut(key.as_str())
+            .and_then(std::collections::VecDeque::pop_front)
+        {
+            ordered.push(format!("{key}={value}"));
+        } else if let Some((k, v)) = extra.next() {
+            ordered.push(format!("{k}={v}"));
+        }
+    }
+    for p in params {
+        if let Some((key, _)) = p.split_once('=') {
+            if canonical
+                .get_mut(key)
+                .and_then(std::collections::VecDeque::pop_front)
+                .is_some()
+            {
+                ordered.push(p.clone());
+            }
+        }
+    }
+    ordered.extend(extra.map(|(key, value)| format!("{key}={value}")));
+    ordered.join("|")
 }
 
 /// Appends `additional` `KEY=VALUE` pairs to an already-built `|`-joined parameter
@@ -3678,6 +3752,100 @@ mod tests {
         assert_eq!(data, data2, "unmapped-layer body is byte-stable");
     }
 
+    /// A STEP reference the library does not embed is stored by Altium with
+    /// an EMPTY `MODELID` and the full `MODEL.*` group (`test_0805.step` in a
+    /// UI-authored library); the group is keyed on the file name, so the
+    /// reference survives a write and a read.
+    #[test]
+    fn external_model_reference_keeps_its_model_group_under_an_empty_model_id() {
+        use super::super::reader;
+
+        let mut body = ComponentBody::new("", "models/test_0805.step");
+        body.embedded = false;
+        let params = build_component_body_params(&body);
+        assert!(
+            params.contains(
+                "|MODELID=|MODEL.CHECKSUM=0|MODEL.EMBED=FALSE|MODEL.NAME=models/test_0805.step|"
+            ),
+            "{params}"
+        );
+        assert!(
+            params.ends_with("|MODEL.MODELTYPE=1|MODEL.MODELSOURCE=Undefined"),
+            "{params}"
+        );
+
+        let mut fp = Footprint::new("EXT");
+        fp.add_component_body(body);
+        let data = encode_data_stream(&fp).expect("encode");
+        let mut decoded = Footprint::new("EXT");
+        reader::parse_data_stream(&mut decoded, &data, None);
+        let back = &decoded.component_bodies[0];
+        assert_eq!(back.model_name, "models/test_0805.step");
+        assert!(!back.embedded && back.model_id.is_empty());
+        assert_eq!(encode_data_stream(&decoded).unwrap(), data, "byte-stable");
+
+        // An extruded body — no file, not embedded — still carries no group.
+        let mut extruded = ComponentBody::new("", "");
+        extruded.embedded = false;
+        assert!(!build_component_body_params(&extruded).contains("MODELID"));
+    }
+
+    /// `TEXTUREROTATION` is carried verbatim (a UI-authored terminal block
+    /// rotates its texture by 90°); a from-scratch body emits the zero form.
+    #[test]
+    fn texture_rotation_round_trips_verbatim() {
+        let mut body = ComponentBody::new("", "");
+        assert!(
+            build_component_body_params(&body).contains("|TEXTUREROTATION= 0.00000000000000E+0000")
+        );
+        body.texture_rotation = Some(" 9.00000000000000E+0001".to_string());
+        assert!(
+            build_component_body_params(&body).contains("|TEXTUREROTATION= 9.00000000000000E+0001")
+        );
+    }
+
+    /// A body read from a file replays its key order — an unmodelled key
+    /// goes back between the canonical ones it sat between, and a canonical
+    /// key Altium writes twice (ARCRESOLUTION) keeps both positions.
+    #[test]
+    fn body_params_replay_the_read_key_order() {
+        let mut body = ComponentBody::new("", "");
+        body.additional_parameters = vec![("BODYOVERRIDECOLOR".to_string(), "TRUE".to_string())];
+        let canonical = build_component_body_params(&body);
+        let appended_last = canonical.ends_with("|BODYOVERRIDECOLOR=TRUE");
+        assert!(
+            appended_last,
+            "without an order the unmodelled key is appended: {canonical}"
+        );
+
+        // The order Altium wrote: the override colour right after the opacity.
+        let mut order: Vec<String> = canonical
+            .split('|')
+            .filter_map(|kv| kv.split_once('=').map(|(k, _)| k.to_string()))
+            .filter(|k| k != "BODYOVERRIDECOLOR")
+            .collect();
+        let at = order.iter().position(|k| k == "BODYOPACITY3D").unwrap() + 1;
+        order.insert(at, "BODYOVERRIDECOLOR".to_string());
+        assert_eq!(order.iter().filter(|k| *k == "ARCRESOLUTION").count(), 2);
+        body.param_key_order = order;
+
+        let replayed = build_component_body_params(&body);
+        assert!(
+            replayed.contains("|BODYOPACITY3D=1.000|BODYOVERRIDECOLOR=TRUE|IDENTIFIER="),
+            "{replayed}"
+        );
+        assert_eq!(replayed.matches("ARCRESOLUTION=").count(), 2, "{replayed}");
+        assert_eq!(
+            replayed.len(),
+            canonical.len(),
+            "same tokens, different order"
+        );
+
+        // A canonical key the order lacks (a typed edit) is still emitted.
+        body.param_key_order.retain(|k| k != "BODYCOLOR3D");
+        assert!(build_component_body_params(&body).contains("|BODYCOLOR3D="));
+    }
+
     /// Retargeting such a body to a real layer discards the stale pair and
     /// emits the canonical byte + token for the new layer.
     #[test]
@@ -4019,6 +4187,29 @@ mod tests {
         let mut short = Vec::new();
         encode_via(&mut short, &partial);
         assert_eq!(short.len(), stacked.len());
+    }
+
+    /// A flag word with bits nothing models — a hand-authored pin header's
+    /// tracks carry `0x001C` — comes back exactly, and so does every word
+    /// Altium can write: all sixteen bits, modelled or not.
+    #[test]
+    fn unmodelled_flag_bits_round_trip_verbatim() {
+        use crate::altium::pcblib::reader::read_flags_for_test;
+        assert_eq!(encode_altium_flags(read_flags_for_test(0x001C)), 0x001C);
+        // Every saved word (bit 3 set) whose unlocked/test-point combination
+        // Altium itself writes round-trips bit for bit.
+        for word in 0u16..=0xFFFF {
+            let saved = word & ALT_FLAG_SAVED != 0;
+            let testpoint = word & (ALT_FLAG_TESTPOINT_TOP | ALT_FLAG_TESTPOINT_BOTTOM) != 0;
+            let unlocked = word & ALT_FLAG_UNLOCKED != 0;
+            if saved && !(testpoint && unlocked) {
+                assert_eq!(
+                    encode_altium_flags(read_flags_for_test(word)),
+                    word,
+                    "{word:#06x}"
+                );
+            }
+        }
     }
 
     /// On disk a rounded rectangle is shape id 1 plus a radius in 1..=99, so

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -287,7 +287,7 @@ impl McpServer {
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
                                                 "identity_guid": { "type": "string", "description": "Per-pad identity GUID (braced string, e.g. \"{A5172B29-...}\"); preserved verbatim on read-modify-write, freshly generated if omitted" },
                                                 "identity_guid_b": { "type": "string", "description": "Pad-stack/footprint-scoped identity GUID (braced string); preserved verbatim on read-modify-write, freshly generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["designator", "x", "y", "width", "height"]
                                         }
@@ -310,7 +310,7 @@ impl McpServer {
                                                 "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
                                                 "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2", "width", "layer"]
                                         }
@@ -352,7 +352,7 @@ impl McpServer {
                                                 "hole_positive_tolerance": { "type": "number", "description": "Positive drill tolerance in mm (optional; omit to leave unset)" },
                                                 "hole_negative_tolerance": { "type": "number", "description": "Negative drill tolerance in mm (optional; omit to leave unset)" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"TENTING_TOP\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Tenting covers the via with solder mask. Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"TENTING_TOP\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Tenting covers the via with solder mask. Default: none" }
                                             },
                                             "required": ["x", "y", "diameter", "hole_size"]
                                         }
@@ -375,7 +375,7 @@ impl McpServer {
                                                 "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
                                                 "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["x1", "y1", "x2", "y2"]
                                         }
@@ -399,7 +399,7 @@ impl McpServer {
                                                 "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
                                                 "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["x", "y", "radius", "start_angle", "end_angle", "width", "layer"]
                                         }
@@ -447,7 +447,7 @@ impl McpServer {
                                                 },
                                                 "unique_id": { "type": "string", "description": "Unique ID (optional, 8-char alphanumeric). Default: none" },
                                                 "additional_parameters": { "type": "array", "description": "Unmodelled region parameter keys captured verbatim on read (e.g. board-region keys like LAYER, KEEPOUT, ISBOARDCUTOUT). Each entry is a [key, value] string pair. Round-tripped so a read-modify-write does not drop keys the tool does not model. Normally omitted; supply only the pairs read_pcblib returned.", "items": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 2 } },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["vertices", "layer"]
                                         }
@@ -484,7 +484,7 @@ impl McpServer {
                                                 "polygon_index": { "type": "integer", "description": "Polygon index (common header; 65535 = none). Normally omitted; preserved on a read-modify-write. Default: 65535" },
                                                 "component_index": { "type": "integer", "description": "Component index into the board component list (common header; -1 = free primitive). Normally omitted; preserved on a read-modify-write. Default: -1" },
                                                 "unique_id": { "type": "string", "description": "8-char Altium unique ID; preserved on read-modify-write, auto-generated if omitted" },
-                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom). Default: none" }
+                                                "flags": { "type": ["string", "integer"], "description": "Primitive flags (optional). Accepts the name string read_pcblib emits (e.g. \"LOCKED\" or \"LOCKED | KEEPOUT\") or a raw bitmask integer (1=locked, 2=polygon, 4=keepout, 8=tenting-top, 16=tenting-bottom, 32=testpoint-top, 64=testpoint-bottom; 128 and above are on-disk bits read_pcblib carries verbatim as DISK_BIT_n — pass them back unchanged). Default: none" }
                                             },
                                             "required": ["x", "y", "text", "height", "layer"]
                                         }

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -2340,6 +2340,7 @@ mod tests {
                 texture_center_y: None,
                 texture_size_x: None,
                 texture_size_y: None,
+                texture_rotation: None,
                 model_name: String::new(),
                 embedded: false,
                 rotation_x: 0.0,
@@ -2369,6 +2370,7 @@ mod tests {
                 polygon_index: 0xFFFF,
                 component_index: -1,
                 additional_parameters: Vec::new(),
+                param_key_order: Vec::new(),
             }
         }
 

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -753,23 +753,21 @@ impl McpServer {
                     });
                 } else {
                     // External reference only: a model-backed body whose file
-                    // stays outside the library. The writer emits the MODEL.*
-                    // group — MODEL.EMBED=FALSE and MODEL.NAME carrying the
-                    // full path, so organised subfolders resolve — only for a
-                    // body with a MODELID, so the reference gets a fresh one
-                    // here or the path would not reach the file at all. No
-                    // golden carries a non-embedded model; the form follows
-                    // the group Altium writes for embedded ones.
+                    // stays outside the library. Altium stores such a body with
+                    // an EMPTY MODELID and the MODEL.* group carrying
+                    // MODEL.EMBED=FALSE and MODEL.NAME (a UI-authored
+                    // `test_0805.step` reference), and the writer emits the
+                    // group for any body that names a file. The full path is
+                    // kept so organised subfolders resolve.
                     use crate::altium::pcblib::{ComponentBody, Layer};
-                    let model_id =
-                        format!("{{{}}}", uuid::Uuid::new_v4().to_string().to_uppercase());
                     footprint.add_component_body(ComponentBody {
-                        model_id,
+                        model_id: String::new(),
                         identifier: String::new(),
                         texture_center_x: None,
                         texture_center_y: None,
                         texture_size_x: None,
                         texture_size_y: None,
+                        texture_rotation: None,
                         raw_layer_id: None,
                         v7_layer: None,
                         model_name: model_path.to_string(), // Preserve full path
@@ -808,6 +806,7 @@ impl McpServer {
                         polygon_index: 0xFFFF,
                         component_index: -1,
                         additional_parameters: Vec::new(),
+                        param_key_order: Vec::new(),
                     });
                 }
             }
@@ -1653,6 +1652,7 @@ impl McpServer {
             texture_center_y: json_guidless_opt(body_json, "texture_center_y"),
             texture_size_x: json_guidless_opt(body_json, "texture_size_x"),
             texture_size_y: json_guidless_opt(body_json, "texture_size_y"),
+            texture_rotation: json_guidless_opt(body_json, "texture_rotation"),
             raw_layer_id: body_json
                 .get("raw_layer_id")
                 .and_then(Value::as_u64)
@@ -1744,6 +1744,7 @@ impl McpServer {
                 .and_then(|v| i32::try_from(v).ok())
                 .unwrap_or(-1),
             additional_parameters: Self::parse_additional_parameters(body_json),
+            param_key_order: Self::parse_key_order(body_json),
         }
     }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -597,6 +597,7 @@ impl McpServer {
                     texture_center_y: None,
                     texture_size_x: None,
                     texture_size_y: None,
+                    texture_rotation: None,
                     raw_layer_id: None,
                     v7_layer: None,
                     model_name: String::new(),
@@ -629,6 +630,7 @@ impl McpServer {
                     polygon_index: 0xFFFF,
                     component_index: -1,
                     additional_parameters: Vec::new(),
+                    param_key_order: Vec::new(),
                 });
                 true
             } else {
@@ -1510,6 +1512,7 @@ mod tests {
             texture_center_y: None,
             texture_size_x: None,
             texture_size_y: None,
+            texture_rotation: None,
             model_name: name.to_string(),
             embedded: false,
             rotation_x: 0.0,
@@ -1539,6 +1542,7 @@ mod tests {
             polygon_index: 0xFFFF,
             component_index: -1,
             additional_parameters: Vec::new(),
+            param_key_order: Vec::new(),
         };
 
         // Explicit extruded body: reports its height, not assumed.

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -548,3 +548,122 @@ fn schlib_golden_survives_a_round_trip() {
         failures.join("\n")
     );
 }
+
+/// Sweeps every library under `ALTIUM_CORPUS_DIR` — real, hand-authored
+/// Altium libraries the scripted golden cannot stand in for — through a
+/// read/write cycle and reports what changed: streams dropped, parameter
+/// blocks that diverge, records reordered, and for a `PcbLib` every `Data` and
+/// `WideStrings` stream that is not byte-identical. Ignored unless the
+/// variable is set; never writes into the corpus.
+///
+/// ```text
+/// ALTIUM_CORPUS_DIR=../my-libraries cargo test --test golden_fidelity corpus -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "needs ALTIUM_CORPUS_DIR"]
+#[allow(clippy::too_many_lines)] // one straight-line sweep, reported per library
+fn corpus_survives_a_round_trip() {
+    let Some(corpus) = std::env::var_os("ALTIUM_CORPUS_DIR") else {
+        eprintln!("ALTIUM_CORPUS_DIR not set; nothing to sweep");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut libraries: Vec<PathBuf> = std::fs::read_dir(&corpus)
+        .expect("read corpus dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().and_then(|e| e.to_str()).is_some_and(|e| {
+                e.eq_ignore_ascii_case("pcblib") || e.eq_ignore_ascii_case("schlib")
+            })
+        })
+        .collect();
+    libraries.sort();
+    assert!(
+        !libraries.is_empty(),
+        "no libraries under {}",
+        corpus.to_string_lossy()
+    );
+
+    let mut report: Vec<String> = Vec::new();
+    for src in &libraries {
+        let file = src.file_name().unwrap().to_string_lossy().into_owned();
+        let is_pcb = file.to_ascii_lowercase().ends_with(".pcblib");
+        let out = dir.path().join(&file);
+        let opened = if is_pcb {
+            PcbLib::open(src).map(|mut lib| lib.save(&out))
+        } else {
+            SchLib::open(src).map(|lib| lib.save(&out))
+        };
+        match opened {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                report.push(format!("{file}: save failed: {e}"));
+                continue;
+            }
+            Err(e) => {
+                report.push(format!("{file}: open failed: {e}"));
+                continue;
+            }
+        }
+        let (before, after) = (stream_map(src), stream_map(&out));
+        let mut lines = Vec::new();
+        for missing in before.keys().filter(|k| !after.contains_key(*k)) {
+            if !is_known(missing) {
+                lines.push(format!("stream dropped: {missing}"));
+            }
+        }
+        for (canonical, g_path) in &before {
+            let Some(o_path) = after.get(canonical) else {
+                continue;
+            };
+            let (Some(g), Some(o)) = (stream_bytes(src, g_path), stream_bytes(&out, o_path)) else {
+                continue;
+            };
+            let component = canonical.split('/').next().unwrap_or("");
+            if component == "library" || is_known(canonical) {
+                continue;
+            }
+            if canonical.ends_with("/data") && !canonical.contains("primitiveguids") {
+                if is_pcb && !canonical.contains("uniqueidprimitiveinformation") && g != o {
+                    let first = g
+                        .iter()
+                        .zip(o.iter())
+                        .position(|(a, b)| a != b)
+                        .unwrap_or_else(|| g.len().min(o.len()));
+                    lines.push(format!(
+                        "{canonical}: not byte-identical (lens {}/{}, first divergence at {first:#x})",
+                        g.len(),
+                        o.len()
+                    ));
+                }
+                lines.extend(block_divergences(&g, &o, canonical));
+                if !is_pcb {
+                    let (gk, ok) = (record_kinds(&g), record_kinds(&o));
+                    if gk != ok {
+                        lines.push(format!("{canonical}: record order changed"));
+                    }
+                }
+            } else if canonical.ends_with("/widestrings") && g != o {
+                lines.push(format!(
+                    "{canonical}: WideStrings differ: {:?} vs {:?}",
+                    String::from_utf8_lossy(&g),
+                    String::from_utf8_lossy(&o)
+                ));
+            }
+        }
+        let n = lines.len();
+        lines.sort();
+        lines.dedup();
+        if lines.is_empty() {
+            eprintln!("OK   {file}");
+        } else {
+            eprintln!("DIFF {file}: {n} divergence(s)");
+            for line in &lines {
+                eprintln!("     {line}");
+            }
+            report.push(format!("{file}: {n} divergence(s)"));
+        }
+    }
+    assert!(report.is_empty(), "corpus sweep:\n{}", report.join("\n"));
+}

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -549,24 +549,28 @@ fn schlib_golden_survives_a_round_trip() {
     );
 }
 
-/// Sweeps every library under `ALTIUM_CORPUS_DIR` — real, hand-authored
-/// Altium libraries the scripted golden cannot stand in for — through a
-/// read/write cycle and reports what changed: streams dropped, parameter
-/// blocks that diverge, records reordered, and for a `PcbLib` every `Data` and
-/// `WideStrings` stream that is not byte-identical. Ignored unless the
-/// variable is set; never writes into the corpus.
+/// Sweeps every library of a corpus — real, hand-authored Altium libraries
+/// the scripted golden cannot stand in for — through a read/write cycle and
+/// reports what changed: streams dropped, parameter blocks that diverge,
+/// records reordered, and for a `PcbLib` every `Data` and `WideStrings`
+/// stream that is not byte-identical. The corpus is the sibling
+/// `altium-designer-pcb-libraries` checkout unless `ALTIUM_CORPUS_DIR` points
+/// elsewhere at build time (a compile-time constant, not a runtime path);
+/// ignored by default and never writes into the corpus.
 ///
 /// ```text
 /// ALTIUM_CORPUS_DIR=../my-libraries cargo test --test golden_fidelity corpus -- --ignored --nocapture
 /// ```
 #[test]
-#[ignore = "needs ALTIUM_CORPUS_DIR"]
+#[ignore = "sweeps a corpus outside the repository"]
 #[allow(clippy::too_many_lines)] // one straight-line sweep, reported per library
 fn corpus_survives_a_round_trip() {
-    let Some(corpus) = std::env::var_os("ALTIUM_CORPUS_DIR") else {
-        eprintln!("ALTIUM_CORPUS_DIR not set; nothing to sweep");
+    const DEFAULT_CORPUS: &str = "../altium-designer-pcb-libraries";
+    let corpus = PathBuf::from(option_env!("ALTIUM_CORPUS_DIR").unwrap_or(DEFAULT_CORPUS));
+    if !corpus.is_dir() {
+        eprintln!("no corpus at {}; nothing to sweep", corpus.display());
         return;
-    };
+    }
     let dir = tempfile::tempdir().expect("tempdir");
     let mut libraries: Vec<PathBuf> = std::fs::read_dir(&corpus)
         .expect("read corpus dir")
@@ -582,7 +586,7 @@ fn corpus_survives_a_round_trip() {
     assert!(
         !libraries.is_empty(),
         "no libraries under {}",
-        corpus.to_string_lossy()
+        corpus.display()
     );
 
     let mut report: Vec<String> = Vec::new();

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -871,6 +871,7 @@ fn test_component_body_roundtrip() {
         texture_center_y: None,
         texture_size_x: None,
         texture_size_y: None,
+        texture_rotation: None,
         model_name: "RESC0603.step".to_string(),
         embedded: false, // External reference (not embedded in library)
         rotation_x: 0.0,
@@ -900,6 +901,7 @@ fn test_component_body_roundtrip() {
         polygon_index: 0xFFFF,
         component_index: -1,
         additional_parameters: Vec::new(),
+        param_key_order: Vec::new(),
     };
     fp.component_bodies.push(body);
 
@@ -941,6 +943,7 @@ fn test_component_body_with_rotation() {
         texture_center_y: None,
         texture_size_x: None,
         texture_size_y: None,
+        texture_rotation: None,
         model_name: "SOIC8.step".to_string(),
         embedded: false,
         rotation_x: 0.0,
@@ -970,6 +973,7 @@ fn test_component_body_with_rotation() {
         polygon_index: 0xFFFF,
         component_index: -1,
         additional_parameters: Vec::new(),
+        param_key_order: Vec::new(),
     };
     fp.component_bodies.push(body);
 
@@ -2781,6 +2785,7 @@ fn test_component_body_external_model_reference() {
         texture_center_y: None,
         texture_size_x: None,
         texture_size_y: None,
+        texture_rotation: None,
         model_name: "external_model.step".to_string(),
         embedded: false, // External reference
         rotation_x: 0.0,
@@ -2810,6 +2815,7 @@ fn test_component_body_external_model_reference() {
         polygon_index: 0xFFFF,
         component_index: -1,
         additional_parameters: Vec::new(),
+        param_key_order: Vec::new(),
     };
     fp.component_bodies.push(body);
 


### PR DESCRIPTION
Bugs #19–#22, from a new source: a **corpus of 19 hand-authored Altium libraries** (real parts drawn in the AD24 UI — `altium-designer-pcb-libraries`) run through the round trip. The scripted golden could never show these. Every modern-format PcbLib in the corpus is **byte-identical** now; the one old-format library (112-byte pads, 33-byte tracks, no IDENTIFIER/TEXTURE keys) is upgraded to the current layout, as Altium itself does on re-save.

| # | Bug | Real-world trigger |
|---|-----|--------------------|
| 1 | **Flag bits dropped** — on-disk bits nothing models (0x0001/0x0002/0x0010/0x0400+; AltiumSharp: selection/display state) were lost | every track of a UI-drawn pin header carries `0x001C` |
| 2 | **External STEP reference dropped** — Altium stores it with an *empty* `MODELID` + the full `MODEL.*` group; the writer emitted the group only for a non-empty MODELID | `test_0805.step`, `MODEL.EMBED=FALSE` |
| 3 | **`TEXTUREROTATION` reset to zero** | a terminal block's texture rotated 90° / 180° |
| 4 | **Reader: body parameter text not cut at its NUL** — the last key's value silently held the outline bytes (invisible until that key was written back) | surfaced by #3 |
| 5 | **Unmodelled body keys re-emitted at the end** where Altium interleaves them | `BODYOVERRIDECOLOR=TRUE` right after `BODYOPACITY3D` |

Fixes: `PcbFlags::DISK_BIT_n` carriers (every 16-bit word round-trips bit for bit, exhaustively tested); model group keyed on the file name and `write_pcblib`'s `embed: false` now follows Altium's empty-MODELID form (settles the TODO item); `texture_rotation` carried verbatim; bodies carry `param_key_order` like regions and replay it, including the `ARCRESOLUTION` Altium writes twice.

Tooling: `tests/golden_fidelity.rs` gains an ignored **corpus sweep** (`ALTIUM_CORPUS_DIR=… cargo test --test golden_fidelity corpus -- --ignored --nocapture`) that reports every divergence per library and never writes into the corpus. Its SchLib findings (INDEXINSHEET numbering, record order, ALLPINCOUNT, header keys, a Latin-1 description promoted to UTF-8, SectionKeys) are the next PR.

Gates: fmt ✅ clippy ✅ 1414 tests ✅ coverage **99.09%** (404/44,318).

🤖 Generated with [Claude Code](https://claude.com/claude-code)