### PR TITLE
fix(schlib): hold hand-authored symbols to their own header, order and numbering

### DIFF
--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -481,17 +481,30 @@ The first record of each component's Data stream. Keys as written (in order):
 | `IndexInSheet` | int | -1 for the component root |
 | `OwnerPartId` | int | -1 for the component root |
 | `CurrentPartId` | int | Currently displayed part (default 1) |
-| `LibraryPath` | string | `*` sentinel |
+| `LibraryPath` | string | `*` sentinel — scripted headers carry it, UI-authored ones omit it |
 | `SourceLibraryName` | string | `*` sentinel |
-| `SheetPartFileName` | string | `*` sentinel |
+| `SheetPartFileName` | string | `*` sentinel — scripted headers carry it, UI-authored ones omit it |
 | `TargetFileName` | string | `*` sentinel |
-| `AllPinCount` | int | Total number of pins (calculated from the symbol) |
+| `AllPinCount` | int | A **stale** count Altium does not maintain (a UI-drawn 32-pin MCU stores `1`, a one-pin header `2`); carried verbatim on a read-modify-write, the pin count for a symbol built from scratch |
 | `AreaColor` | int | Fill colour (BGR, 11599871 = light yellow) |
 | `Color` | int | Border colour (BGR, 128 = dark red) |
 | `PartIDLocked` | bool | `T`/`F` |
 
 > **Note:** Altium-authored headers also carry a component `UniqueID` and may carry
-> `DesignItemId` / `ComponentKind`; these are currently unmodelled (dropped on read).
+> `DesignItemId` / `ComponentKind`; the `UniqueID` is currently unmodelled (dropped on
+> read). Every other key the model does not name — a UI-authored
+> `COMPONENTKINDVERSION2=5` — rides along verbatim: the whole header is carried as read
+> (`Symbol::header_params`, every segment in order) and replayed byte for byte unless the
+> field behind a segment was edited, so the two `%UTF8%` layouts Altium uses both survive.
+> A UI-typed Latin-1 description is stored as `%UTF8%ComponentDescription=<UTF-8 bytes>|||`
+> `ComponentDescription=<Windows-1252 bytes>` (twin first, two empty segments, code-page
+> plain key); a scripted one puts UTF-8 bytes in both keys.
+
+The **system parameter** is Altium's own `Comment` record alone (with the Designator
+record): stored after the designator with `IndexInSheet=-1` and no counter slot. A user
+parameter is a content record with a counter slot in authoring order — the UI stores it
+with `OwnerPartId=-1` too (a script sets `1`), and before the graphics, so `OwnerPartId`
+does not mark a parameter as system.
 
 ## Primitive Records
 
@@ -765,7 +778,7 @@ A parameter-record variant selected by `Name=Designator`. As written by this cra
   | `ModelDatafile0` | string | Optional `.PcbLib` path — what lets Altium resolve the footprint directly |
   | `ModelDatafileEntity0` | string | Footprint entity (resolution key) |
   | `ModelDatafileKind0` | string | `PCBLib` |
-  | `IsCurrent` | bool | `T` on the default footprint |
+  | `IsCurrent` | bool | `T` on the default footprint; omitted on every other (never `F`) |
 
 - **RECORD=46 (MapDefinerList)** and **RECORD=48 (ImplementationParameters)** — written as empty
   children of each RECORD=45 (`|RECORD=46|OwnerIndex={45's index}` / `|RECORD=48|OwnerIndex=...`).

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -353,6 +353,25 @@ pub struct Symbol {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub footprints: Vec<FootprintModel>,
 
+    /// The header record (`RECORD=1`) exactly as read: every segment as a
+    /// `(key, value)` pair in stored order, an empty segment as `("", "")`.
+    /// The writer replays each verbatim unless the field behind it was
+    /// edited, so a header comes back byte for byte whichever way Altium
+    /// wrote it — a UI-authored one omits `LibraryPath` and
+    /// `SheetPartFileName`, carries `COMPONENTKINDVERSION2`, and stores a
+    /// Latin-1 description as `%UTF8%Key=<UTF-8>|||Key=<Windows-1252>`; a
+    /// scripted one puts UTF-8 bytes in both keys. Empty for a symbol built
+    /// from scratch, which emits the canonical header.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub header_params: Vec<(String, String)>,
+
+    /// `AllPinCount` as stored. Altium keeps a stale value here — a 32-pin
+    /// UI-drawn MCU stores 1, a one-pin header 2 — so it is carried rather
+    /// than recomputed; `None` (a symbol built from scratch) writes the pin
+    /// count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub all_pin_count: Option<u32>,
+
     /// The order the content records are stored in, one entry per record.
     ///
     /// Altium interleaves the record kinds in authoring order — the golden's
@@ -667,6 +686,36 @@ impl Symbol {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A name that exactly fills the 31-unit storage cap is listed in
+    /// `SectionKeys` although nothing was truncated — a UI-authored
+    /// `Generic Non-polarised Capacitor` is — while a shorter one is not.
+    #[test]
+    fn a_name_that_fills_the_storage_cap_is_listed_in_section_keys() {
+        std::fs::create_dir_all(".tmp").unwrap();
+        let dir =
+            tempfile::tempdir_in(std::path::Path::new(".tmp").canonicalize().unwrap()).unwrap();
+        for (name, listed) in [
+            ("Generic Non-polarised Capacitor", true),
+            ("Generic Resistor", false),
+        ] {
+            assert!(name.len() <= 31);
+            let mut lib = SchLib::new();
+            lib.add(Symbol::new(name));
+            let path = dir.path().join(format!("{}.SchLib", name.len()));
+            lib.save(&path).unwrap();
+            let mut cfb = cfb::open(&path).unwrap();
+            assert_eq!(cfb.is_stream("/SectionKeys"), listed, "{name}");
+            if listed {
+                let keys = crate::altium::read_stream_opt(&mut cfb, "/SectionKeys").unwrap();
+                let text = String::from_utf8_lossy(&keys);
+                assert!(
+                    text.contains("|KeyCount=1|LibRef0=Generic Non-polarised Capacitor|SectionKey0=Generic Non-polarised Capacitor"),
+                    "{text}"
+                );
+            }
+        }
+    }
 
     /// `reset_identities` clears the designator record's id and every
     /// record's unique id across all sixteen lists.

--- a/src/altium/schlib/reader/mod.rs
+++ b/src/altium/schlib/reader/mod.rs
@@ -122,6 +122,12 @@ fn contains_utf8_marker(data: &[u8]) -> bool {
         .any(|w| w.eq_ignore_ascii_case(MARKER))
 }
 
+/// [`parse_text_record_from_string`] for the writer's tests.
+#[cfg(test)]
+pub(crate) fn parse_text_record_from_string_for_test(symbol: &mut Symbol, text: &str) {
+    parse_text_record_from_string(symbol, text);
+}
+
 /// Parses a text record from a decoded string.
 #[allow(clippy::too_many_lines)] // Property parsing for all record types
 fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
@@ -167,6 +173,24 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
             if let Some(target_file) = props.get("targetfilename") {
                 symbol.target_file_name.clone_from(target_file);
             }
+            if let Some(count) = props.get("allpincount").and_then(|v| v.trim().parse().ok()) {
+                symbol.all_pin_count = Some(count);
+            }
+            // The record exactly as stored — every segment, an empty one
+            // included, because the UI writes a `%UTF8%` twin as
+            // `%UTF8%Key=…|||Key=…` — so the writer reproduces this header
+            // rather than the canonical one.
+            symbol.header_params = text
+                .trim_end_matches('\0')
+                .split('|')
+                .skip(1)
+                .map(|segment| {
+                    segment.split_once('=').map_or_else(
+                        || (segment.to_string(), String::new()),
+                        |(key, value)| (key.to_string(), value.to_string()),
+                    )
+                })
+                .collect();
         }
         14 => {
             // Rectangle

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -52,13 +52,17 @@ impl SchLib {
         )?;
 
         // Root SectionKeys stream: the LibRef -> storage-name map for every
-        // symbol whose name did not survive the storage cap, so the real name
-        // stays recoverable by Altium and by our own reader's ordering pass.
-        // With no truncated name the stream is not written, as in Altium.
+        // symbol whose name reaches the storage cap — truncated or, as a
+        // UI-authored `Generic Non-polarised Capacitor` (31 units exactly)
+        // shows, merely filling it — so the real name stays recoverable by
+        // Altium and by our own reader's ordering pass. With no such name the
+        // stream is not written, as in Altium.
         let truncated: Vec<(String, String)> = storage_names
             .iter()
             .zip(ole_names.iter())
-            .filter(|(wire, ole)| wire != ole)
+            .filter(|(wire, ole)| {
+                wire != ole || wire.encode_utf16().count() >= crate::altium::MAX_OLE_NAME_LEN
+            })
             .map(|(wire, ole)| (wire.clone(), ole.clone()))
             .collect();
         if let Some(section_keys) = crate::altium::encode_section_keys(&truncated) {

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -256,33 +256,167 @@ pub(crate) fn write_binary_pin(
     write_record_frame(data, &record, 1)
 }
 
+/// Header keys that exist only as constants: emitted for a symbol built from
+/// scratch (the scripted golden carries them) and otherwise only when the
+/// header read them — a UI-authored header omits them.
+const HEADER_CONSTANT_KEYS: &[&str] = &["LibraryPath", "SheetPartFileName"];
+
+/// Replays a read header segment by segment (see [`encode_component_header`]).
+///
+/// A segment whose field was not edited goes back verbatim: its plain value
+/// still names the same text once decoded the way the reader decoded it, or
+/// its canonical rendering is unchanged. A `%UTF8%` twin follows its plain
+/// key's verdict. An edited field is emitted in canonical form, its stale
+/// twin dropped when the new value is ASCII.
+fn replay_header(symbol: &Symbol, canonical: &[(String, String)]) -> Vec<String> {
+    let canonical_value = |key: &str| {
+        canonical
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v.as_str())
+    };
+    let is_text_key = |key: &str| {
+        ["LibReference", "ComponentDescription", "SourceLibraryName"]
+            .iter()
+            .any(|k| k.eq_ignore_ascii_case(key))
+    };
+    // The value the reader derived from a plain text key.
+    let read_text =
+        |raw: &str| crate::altium::from_wire_text(raw).unwrap_or_else(|| raw.to_string());
+    let current_text = |key: &str| -> Option<&str> {
+        if key.eq_ignore_ascii_case("LibReference") {
+            Some(symbol.name.as_str())
+        } else if key.eq_ignore_ascii_case("ComponentDescription") {
+            Some(symbol.description.as_str())
+        } else if key.eq_ignore_ascii_case("SourceLibraryName") {
+            Some(symbol.source_library_name.as_str())
+        } else {
+            None
+        }
+    };
+    let plain_unchanged = |key: &str| {
+        symbol
+            .header_params
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .is_some_and(|(_, raw)| current_text(key) == Some(read_text(raw).as_str()))
+    };
+
+    let mut placed: Vec<bool> = vec![false; canonical.len()];
+    let mut parts = Vec::with_capacity(symbol.header_params.len() + 4);
+    for (key, raw) in &symbol.header_params {
+        if key.is_empty() {
+            parts.push(String::new()); // an empty segment of `%UTF8%Key=…|||Key=…`
+            continue;
+        }
+        let plain_key = key.strip_prefix("%UTF8%").unwrap_or(key);
+        let index = canonical
+            .iter()
+            .position(|(k, _)| k.eq_ignore_ascii_case(key));
+        if let Some(i) = index {
+            placed[i] = true;
+        }
+        let unchanged = if is_text_key(plain_key) {
+            plain_unchanged(plain_key)
+        } else {
+            index.map_or(true, |i| canonical[i].1 == *raw)
+        };
+        if unchanged {
+            parts.push(format!("{key}={raw}"));
+        } else if let Some(value) = canonical_value(key) {
+            parts.push(format!("{key}={value}"));
+        }
+        // An edited text key whose stale twin is in canonical no longer:
+        // dropped with the segment (`canonical_value` found nothing).
+    }
+    for (i, (key, value)) in canonical.iter().enumerate() {
+        if !placed[i] && !HEADER_CONSTANT_KEYS.contains(&key.as_str()) {
+            parts.push(format!("{key}={value}"));
+        }
+    }
+    parts
+}
+
+/// Whether a parameter is Altium's own system `Comment` record — stored after
+/// the designator with the `IndexInSheet=-1` sentinel, outside the counter.
+/// `OwnerPartId=-1` alone does not make one: the UI stores every user
+/// parameter that way too, as a content record with its own slot.
+fn is_system_parameter(param: &super::Parameter) -> bool {
+    param.owner_part_id == -1 && param.name.eq_ignore_ascii_case("Comment")
+}
+
 /// Encodes a component header record.
+///
+/// A symbol read from a file replays its own header (`header_params`):
+/// every segment as read, verbatim, unless the field behind it was edited,
+/// in which case the canonical form of the new value takes its place. That
+/// keeps whichever `%UTF8%` layout Altium used (the UI's
+/// `%UTF8%Key=<UTF-8>|||Key=<Windows-1252>`, the scripted one's UTF-8 bytes
+/// in both keys), the keys it omitted and the ones this crate does not
+/// model. Modelled keys the record lacked are appended so a typed edit is
+/// never lost, except the constant ones it omitted on purpose. A symbol
+/// built from scratch emits the canonical header.
 fn encode_component_header(symbol: &Symbol) -> String {
+    let from_file = !symbol.header_params.is_empty();
+    let text = |key: &str, value: &str| -> Vec<(String, String)> {
+        if value.is_ascii() {
+            vec![(key.to_string(), value.to_string())]
+        } else {
+            let bytes = crate::altium::encode_utf8_param_value(value);
+            vec![
+                (key.to_string(), bytes.clone()),
+                (format!("%UTF8%{key}"), bytes),
+            ]
+        }
+    };
     let part_id_locked = if symbol.part_id_locked { "T" } else { "F" };
-    let parts = vec![
-        "RECORD=1".to_string(),
-        text_field("LibReference", &symbol.name),
-        text_field("ComponentDescription", &symbol.description),
-        format!("PartCount={}", symbol.part_count + 1), // Altium uses part_count + 1
-        format!("DisplayModeCount={}", symbol.display_mode_count),
-        "IndexInSheet=-1".to_string(),
-        "OwnerPartId=-1".to_string(),
-        format!("CurrentPartId={}", symbol.current_part_id),
-        "LibraryPath=*".to_string(),
-        text_field("SourceLibraryName", &symbol.source_library_name),
-        "SheetPartFileName=*".to_string(),
-        format!("TargetFileName={}", symbol.target_file_name),
-        format!("AllPinCount={}", symbol.pins.len()),
-        "AreaColor=11599871".to_string(), // Light yellow fill
-        "Color=128".to_string(),          // Dark red outline
-        format!("PartIDLocked={part_id_locked}"),
-    ];
-    // Omitted at zero, like every zero-valued integer key: the golden's
-    // pinless symbols carry no AllPinCount key at all.
-    let parts: Vec<String> = parts
-        .into_iter()
-        .filter(|p| !(symbol.pins.is_empty() && p == "AllPinCount=0"))
-        .collect();
+    let mut canonical: Vec<(String, String)> = vec![("RECORD".to_string(), "1".to_string())];
+    canonical.extend(text("LibReference", &symbol.name));
+    canonical.extend(text("ComponentDescription", &symbol.description));
+    canonical.extend([
+        ("PartCount".to_string(), (symbol.part_count + 1).to_string()), // Altium uses part_count + 1
+        (
+            "DisplayModeCount".to_string(),
+            symbol.display_mode_count.to_string(),
+        ),
+        ("IndexInSheet".to_string(), "-1".to_string()),
+        ("OwnerPartId".to_string(), "-1".to_string()),
+        (
+            "CurrentPartId".to_string(),
+            symbol.current_part_id.to_string(),
+        ),
+        ("LibraryPath".to_string(), "*".to_string()),
+    ]);
+    canonical.extend(text("SourceLibraryName", &symbol.source_library_name));
+    canonical.extend([
+        ("SheetPartFileName".to_string(), "*".to_string()),
+        (
+            "TargetFileName".to_string(),
+            symbol.target_file_name.clone(),
+        ),
+    ]);
+    // Altium keeps a stale count here, so a read value is carried; a
+    // from-scratch symbol writes its pin count, omitted at zero like every
+    // zero-valued integer key (the golden's pinless symbols carry none).
+    #[allow(clippy::cast_possible_truncation)]
+    let all_pin_count = symbol.all_pin_count.unwrap_or(symbol.pins.len() as u32);
+    if all_pin_count != 0 || symbol.all_pin_count.is_some() {
+        canonical.push(("AllPinCount".to_string(), all_pin_count.to_string()));
+    }
+    canonical.extend([
+        ("AreaColor".to_string(), "11599871".to_string()), // Light yellow fill
+        ("Color".to_string(), "128".to_string()),          // Dark red outline
+        ("PartIDLocked".to_string(), part_id_locked.to_string()),
+    ]);
+
+    let parts: Vec<String> = if from_file {
+        replay_header(symbol, &canonical)
+    } else {
+        canonical
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect()
+    };
 
     // Leading pipe, NO trailing pipe (matches Altium's ParametersToString).
     format!("|{}", parts.join("|"))
@@ -556,17 +690,18 @@ fn encode_line(line: &Line, index: usize) -> String {
 /// when set, `Text` / `Description` only when non-empty, and the read
 /// `UniqueID` is preserved.
 ///
-/// A **system** parameter — the Altium-authored `Comment`/`Designator`-class
-/// record with `owner_part_id == -1` — carries the `IndexInSheet=-1` sentinel
-/// (every golden symbol's system Comment stores
+/// The **system** parameter — Altium's own `Comment` record, see
+/// [`is_system_parameter`] — carries the `IndexInSheet=-1` sentinel (every
+/// golden symbol's system Comment stores
 /// `|RECORD=41|IndexInSheet=-1|OwnerPartId=-1|`) and never a content-counter
-/// slot; `index` is ignored for it. User parameters (`owner_part_id >= 1`)
-/// follow the shared 0-based content counter like every other record.
+/// slot; `index` is ignored for it. Every other parameter follows the shared
+/// 0-based content counter like every other record, whatever its owner — the
+/// UI stores user parameters with `OwnerPartId=-1` too.
 fn encode_parameter(param: &Parameter, index: usize) -> String {
     let mut parts = vec!["RECORD=41".to_string()];
     // IndexInSheet (system sentinel or counter, 0 omitted) directly after
     // RECORD, then OwnerPartId (parameters carry no IsNotAccesible token).
-    if param.owner_part_id == -1 {
+    if is_system_parameter(param) {
         parts.push("IndexInSheet=-1".to_string());
     } else {
         push_index_in_sheet(&mut parts, index);
@@ -1198,7 +1333,9 @@ fn count_records(data: &[u8]) -> usize {
 /// Encodes a footprint model record (`RECORD=45`).
 ///
 /// `owner_index` is the stream-index of the owning `RECORD=44` implementation list.
-/// `is_current` marks the default footprint (`IsCurrent=T`, set on one model).
+/// `is_current` marks the default footprint (`IsCurrent=T` on that model; a
+/// UI-authored library omits the key on every other one, like any false
+/// boolean, rather than writing `IsCurrent=F`).
 ///
 /// `DatafileCount=1` plus `ModelDatafileEntity0` is what lets Altium *resolve*
 /// the model to an actual footprint in a `PcbLib` (rendering the preview and
@@ -1216,13 +1353,13 @@ fn encode_footprint_model(model: &FootprintModel, owner_index: usize, is_current
     // from-scratch model gets a fresh one.
     let unique_id = model.unique_id.clone().unwrap_or_else(generate_unique_id);
     format!(
-        "|RECORD=45|OwnerIndex={}|IndexInSheet=-1|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=1{}|ModelDatafileEntity0={}|ModelDatafileKind0=PCBLib|IsCurrent={}|UniqueID={}",
+        "|RECORD=45|OwnerIndex={}|IndexInSheet=-1|Description={}|ModelName={}|ModelType=PCBLIB|DatafileCount=1{}|ModelDatafileEntity0={}|ModelDatafileKind0=PCBLib{}|UniqueID={}",
         owner_index,
         model.description,
         model.name,
         datafile,
         model.name,
-        if is_current { "T" } else { "F" },
+        if is_current { "|IsCurrent=T" } else { "" },
         unique_id
     )
 }
@@ -1288,7 +1425,7 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
             }
             SchPrimitiveKind::Parameter => {
                 let param = &symbol.parameters[index];
-                if param.owner_part_id == -1 {
+                if is_system_parameter(param) {
                     continue;
                 }
                 encode_parameter(param, index_counter)
@@ -1326,14 +1463,16 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
         write_text_record(&mut data, &record)?;
     }
 
-    // 15b. SYSTEM parameters (owner_part_id == -1, the Altium-authored
-    // Comment-class records): golden order puts them after the designator, and
-    // they carry the IndexInSheet=-1 sentinel WITHOUT consuming a counter slot
-    // (the golden DISPMODE system Comment stores
-    // `|RECORD=41|IndexInSheet=-1|OwnerPartId=-1|` while the rectangles keep
-    // slots 0 and 1). Regressing them onto the counter destroyed the -1 and
-    // shifted every later content index by one on read-modify-write.
-    for param in symbol.parameters.iter().filter(|p| p.owner_part_id == -1) {
+    // 15b. The SYSTEM parameter — Altium's own Comment record: golden order
+    // puts it after the designator, and it carries the IndexInSheet=-1
+    // sentinel WITHOUT consuming a counter slot (the golden DISPMODE system
+    // Comment stores `|RECORD=41|IndexInSheet=-1|OwnerPartId=-1|` while the
+    // rectangles keep slots 0 and 1). Regressing it onto the counter destroyed
+    // the -1 and shifted every later content index by one on
+    // read-modify-write. Only the Comment is system: a UI-authored Value or
+    // Part Number carries OwnerPartId=-1 too and is still a content record
+    // with a counter slot, stored before the graphics in authoring order.
+    for param in symbol.parameters.iter().filter(|p| is_system_parameter(p)) {
         let record = encode_parameter(param, 0);
         write_text_record(&mut data, &record)?;
     }
@@ -1838,6 +1977,142 @@ mod tests {
         assert!(
             line.contains("|IndexInSheet=4|"),
             "line after two pins takes slot 4 (pins consumed 2 and 3): {line}"
+        );
+    }
+
+    /// A UI-authored header comes back segment for segment: the twin-first
+    /// `%UTF8%Key=<UTF-8>|||Key=<Windows-1252>` description, the omitted
+    /// `LibraryPath`/`SheetPartFileName`, the unmodelled
+    /// `COMPONENTKINDVERSION2`, the stale `AllPinCount` — and an edited field
+    /// takes the canonical form in its own slot.
+    #[test]
+    fn a_read_header_is_replayed_verbatim_until_a_field_is_edited() {
+        use super::super::reader;
+
+        // Exactly what a UI-drawn 32-pin MCU stores (AllPinCount=1 and all).
+        let record = concat!(
+            "|RECORD=1|LibReference=STM32G0C1KET6N",
+            "|%UTF8%ComponentDescription=STM32G0, Arm\u{c2}\u{ae} Cortex\u{c2}\u{ae}-M0+",
+            "|||ComponentDescription=STM32G0, Arm\u{ae} Cortex\u{ae}-M0+",
+            "|PartCount=2|DisplayModeCount=1|IndexInSheet=-1|OwnerPartId=-1|CurrentPartId=1",
+            "|SourceLibraryName=*|TargetFileName=*|AllPinCount=1|AreaColor=11599871|Color=128",
+            "|PartIDLocked=F|COMPONENTKINDVERSION2=5"
+        );
+        let mut symbol = Symbol::new("placeholder");
+        reader::parse_text_record_from_string_for_test(&mut symbol, record);
+        assert_eq!(symbol.name, "STM32G0C1KET6N");
+        assert_eq!(symbol.description, "STM32G0, Arm\u{ae} Cortex\u{ae}-M0+");
+        assert_eq!(symbol.all_pin_count, Some(1));
+        assert_eq!(symbol.header_params.len(), 18, "{:?}", symbol.header_params);
+        for _ in 0..32 {
+            symbol.add_pin(Pin::new("P", "1", 0, 0, 10, PinOrientation::Left));
+        }
+
+        // Unchanged: byte-identical, stale count and all.
+        assert_eq!(encode_component_header(&symbol), record);
+
+        // An edit to the description replaces its two segments with the
+        // canonical form (ASCII here, so no twin) at the plain key's slot.
+        symbol.description = "CAN transceiver".to_string();
+        let edited = encode_component_header(&symbol);
+        assert!(
+            edited.contains(
+                "|LibReference=STM32G0C1KET6N|||ComponentDescription=CAN transceiver|PartCount=2|"
+            ),
+            "{edited}"
+        );
+        assert!(!edited.contains("%UTF8%"), "{edited}");
+        assert!(
+            edited.ends_with("|PartIDLocked=F|COMPONENTKINDVERSION2=5"),
+            "{edited}"
+        );
+
+        // A field the header never carried is appended when set; the
+        // constant keys it omitted stay omitted.
+        symbol.part_id_locked = true;
+        let locked = encode_component_header(&symbol);
+        assert!(locked.contains("|PartIDLocked=T|"), "{locked}");
+        assert!(!locked.contains("LibraryPath"), "{locked}");
+    }
+
+    /// From scratch the canonical header is unchanged: every constant key,
+    /// the pin count, and the scripted `%UTF8%` form for a non-ASCII value.
+    #[test]
+    fn a_fresh_header_is_canonical() {
+        let mut symbol = Symbol::new("R\u{e9}sistance");
+        symbol.add_pin(Pin::new("1", "1", 0, 0, 10, PinOrientation::Left));
+        let header = encode_component_header(&symbol);
+        let bytes = crate::altium::encode_utf8_param_value("R\u{e9}sistance");
+        assert!(
+            header.starts_with(&format!(
+                "|RECORD=1|LibReference={bytes}|%UTF8%LibReference={bytes}|ComponentDescription=|"
+            )),
+            "{header}"
+        );
+        assert!(header.contains("|LibraryPath=*|SourceLibraryName=*|SheetPartFileName=*|TargetFileName=*|AllPinCount=1|"), "{header}");
+        symbol.all_pin_count = Some(7);
+        assert!(encode_component_header(&symbol).contains("|AllPinCount=7|"));
+    }
+
+    /// Only Altium's own `Comment` is the system parameter: a user parameter
+    /// stored with `OwnerPartId=-1` — the UI's habit — is a content record
+    /// with a counter slot, in authoring order before the graphics.
+    #[test]
+    fn user_parameters_with_owner_minus_one_keep_their_slots_and_order() {
+        let mut symbol = Symbol::new("PESD1CAN");
+        symbol.designator = "U?".to_string();
+        for (name, value) in [("Value", "PESD1CAN"), ("Part Number", "PESD1CAN")] {
+            let mut p = Parameter::new(name, value);
+            p.owner_part_id = -1;
+            symbol.add_parameter(p);
+        }
+        symbol.add_rectangle(Rectangle::new(-20, -10, 30, 20));
+        let mut comment = Parameter::new("Comment", "=VALUE");
+        comment.owner_part_id = -1;
+        symbol.add_parameter(comment);
+
+        let data = encode_data_stream(&symbol).expect("encode");
+        let records = stream_records(&data);
+        let kinds: Vec<String> = records
+            .iter()
+            .map(|r| {
+                let kind = r.split('|').nth(1).unwrap_or("").to_string();
+                let index = r
+                    .split('|')
+                    .find_map(|t| t.strip_prefix("IndexInSheet="))
+                    .unwrap_or("(absent)")
+                    .to_string();
+                format!("{kind} {index}")
+            })
+            .collect();
+        assert_eq!(
+            &kinds[..5],
+            [
+                "RECORD=1 -1",
+                "RECORD=41 (absent)", // Value: slot 0, key omitted
+                "RECORD=41 1",        // Part Number
+                "RECORD=14 2",        // the rectangle
+                "RECORD=34 -1",       // the designator
+            ],
+            "{kinds:?}"
+        );
+        assert_eq!(
+            kinds[5], "RECORD=41 -1",
+            "the system Comment, after the designator"
+        );
+    }
+
+    /// A footprint model that is not the current one carries no `IsCurrent`
+    /// key at all, like every false boolean.
+    #[test]
+    fn is_current_is_written_only_when_true() {
+        let model = FootprintModel::new("SOT-23");
+        assert!(encode_footprint_model(&model, 1, true).contains("|IsCurrent=T|UniqueID="));
+        let other = encode_footprint_model(&model, 1, false);
+        assert!(!other.contains("IsCurrent"), "{other}");
+        assert!(
+            other.contains("|ModelDatafileKind0=PCBLib|UniqueID="),
+            "{other}"
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1449,13 +1449,14 @@ mod tests {
 
         let parsed: Value = serde_json::from_str(get_result_text(&result)).expect("valid JSON");
         let symbol = &parsed["symbols"][0];
+        // The export is the struct's own serde shape: every populated family
+        // is present (an empty one is omitted, and import defaults it).
         for key in [
             "part_count",
             "pies",
             "images",
             "beziers",
             "elliptical_arcs",
-            "text",
             "footprints",
         ] {
             assert!(
@@ -1466,6 +1467,7 @@ mod tests {
         assert_eq!(symbol["part_count"], 2);
         assert_eq!(symbol["pies"].as_array().map(Vec::len), Some(1));
         assert_eq!(symbol["images"].as_array().map(Vec::len), Some(1));
+        assert!(symbol.get("text").is_none(), "an empty family is omitted");
     }
 
     #[test]

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1068,48 +1068,13 @@ impl McpServer {
         };
 
         if format == "json" {
-            // Full JSON export
+            // Full JSON export: the struct's own serde shape, which is the
+            // shape write_schlib/import_library accept in full — every fidelity
+            // carrier included (record order, header key order, identities) —
+            // so an export is importable byte-for-byte.
             let symbols: Vec<Value> = library
                 .iter()
-                .map(|symbol| {
-                    let mut sym_json = json!({
-                        "name": symbol.name,
-                        "description": symbol.description,
-                        "designator": symbol.designator,
-                        "designator_x": symbol.designator_x,
-                        "designator_y": symbol.designator_y,
-                        "designator_unique_id": symbol.designator_unique_id,
-                        "part_count": symbol.part_count,
-                        "display_mode_count": symbol.display_mode_count,
-                        "current_part_id": symbol.current_part_id,
-                        "part_id_locked": symbol.part_id_locked,
-                        "source_library_name": symbol.source_library_name,
-                        "target_file_name": symbol.target_file_name,
-                        "pins": symbol.pins,
-                        "rectangles": symbol.rectangles,
-                        "round_rects": symbol.round_rects,
-                        "lines": symbol.lines,
-                        "polylines": symbol.polylines,
-                        "polygons": symbol.polygons,
-                        "arcs": symbol.arcs,
-                        "pies": symbol.pies,
-                        "images": symbol.images,
-                        "text_frames": symbol.text_frames,
-                        "beziers": symbol.beziers,
-                        "ellipses": symbol.ellipses,
-                        "elliptical_arcs": symbol.elliptical_arcs,
-                        "labels": symbol.labels,
-                        "text": symbol.text,
-                        "parameters": symbol.parameters,
-                        "footprints": symbol.footprints,
-                    });
-                    // The interleaved record order, mirroring the struct's
-                    // serde shape — export→import must not regroup records.
-                    if !symbol.primitive_order.is_empty() {
-                        sym_json["primitive_order"] = json!(symbol.primitive_order);
-                    }
-                    sym_json
-                })
+                .map(|symbol| serde_json::to_value(symbol).unwrap_or(Value::Null))
                 .collect();
 
             let result = json!({

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -523,6 +523,15 @@ impl McpServer {
             }
         }
 
+        // The header exactly as read — key order, unmodelled keys and the
+        // stale AllPinCount — so a read-modify-write reproduces it.
+        if let Some(params) = sym_json.get("header_params") {
+            symbol.header_params = serde_json::from_value(params.clone()).unwrap_or_default();
+        }
+        if let Some(count) = sym_json.get("all_pin_count").and_then(Value::as_u64) {
+            symbol.all_pin_count = u32::try_from(count).ok();
+        }
+
         // The interleaved record order `read_schlib` reported; replaying it
         // replaces the grouped order the add_* calls accumulated, so a
         // read-modify-write keeps the source's record order.

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -763,6 +763,12 @@ impl McpServer {
                         if !symbol.primitive_order.is_empty() {
                             sym_json["primitive_order"] = json!(symbol.primitive_order);
                         }
+                        if !symbol.header_params.is_empty() {
+                            sym_json["header_params"] = json!(symbol.header_params);
+                        }
+                        if let Some(count) = symbol.all_pin_count {
+                            sym_json["all_pin_count"] = json!(count);
+                        }
                         sym_json
                     })
                     .collect();


### PR DESCRIPTION
Bugs #23–#26, the SchLib half of the corpus sweep — each a place where the AD24 **UI** writes a symbol differently from the DelphiScript-generated golden, and the writer knew only the golden's way. **Stacked on #427**; will retarget to `main` when it lands.

| # | Bug | UI-authored evidence |
|---|-----|----------------------|
| 1 | **Header not replayable** — `LibraryPath`/`SheetPartFileName` invented, `COMPONENTKINDVERSION2` dropped, a Latin-1 description re-encoded into the wrong `%UTF8%` layout, `AllPinCount` recomputed | `%UTF8%ComponentDescription=<UTF-8>\|\|\|ComponentDescription=<Windows-1252>`; a 32-pin MCU storing `AllPinCount=1` |
| 2 | **User parameters moved and renumbered** — "system" was keyed on `OwnerPartId=-1`, which the UI sets on *every* user parameter | `Value`/`Part Number`/`Manufacturer` stored before the graphics with counter slots 0–2, the Comment alone at `-1` after the designator |
| 3 | `IsCurrent=F` invented on non-current footprint models | omitted like every false boolean |
| 4 | `SectionKeys` missing for a name that exactly fills the 31-unit cap | `Generic Non-polarised Capacitor` |

Fixes: `Symbol::header_params` carries the header as read (every segment, empty ones included) and the writer replays it verbatim unless the field behind a segment was edited — no flag could recover which `%UTF8%` layout a header had once decoded; the system parameter is Altium's `Comment` only; `IsCurrent` emitted only when true; SectionKeys at ≥ 31 units. Also `export_library` now emits the struct's own serde shape instead of a **third** hand-built one (the mutation suite caught it: export → import lost the new carriers).

Every modern-format symbol in the corpus now differs only in the `LineWidth` key the UI omits on rectangles — per-record key presence, the next PR.

Gates: fmt ✅ clippy ✅ 1436 tests ✅ markdownlint ✅ coverage **99.09%** (406/44,837).

🤖 Generated with [Claude Code](https://claude.com/claude-code)