### PR TITLE
refactor(mcp): read tools emit the struct's own JSON shape; guard the README tool index

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -18,8 +18,9 @@ _34 tools._
 Read an Altium .PcbLib file and return its contents including footprints with their primitives (pads, vias, tracks, arcs, regions, fills, text, component_bodies). Returns
 structured data that can be used to understand existing footprint styles. All coordinates and dimensions are in millimetres (mm). Fields such as guid, unique_id,
 raw_tail, raw_block, raw_geometry, param_key_order and primitive_order are fidelity carriers: pass them back unchanged to write_pcblib or update_component and the rewrite
-is byte-identical to the source; omit them when authoring from scratch. For large libraries, use component_name to fetch specific footprints, or use limit/offset for
-pagination.
+is byte-identical to the source; omit them when authoring from scratch. Each footprint is the same JSON shape get_component, export_library and write_pcblib use; a list
+with no entries and an optional field with no value are omitted rather than empty/null. For large libraries, use component_name to fetch specific footprints, or use
+limit/offset for pagination.
 
 **Example**
 
@@ -47,7 +48,9 @@ pagination.
 Read an Altium .SchLib file and return its contents including symbols with their primitives (pins, rectangles, round_rects, lines, polylines, polygons, arcs, pies,
 images, text_frames, beziers, ellipses, elliptical_arcs, labels, text), parameters and footprint links. Coordinates are in schematic units (10 units = 1 grid square, not
 mm). Fields such as unique_id and primitive_order are fidelity carriers: pass them back unchanged to write_schlib or update_component to keep the source's record
-identities and order; omit them when authoring from scratch. For large libraries, use component_name to fetch specific symbols, or use limit/offset for pagination.
+identities and order; omit them when authoring from scratch. Each symbol is the same JSON shape get_component, export_library and write_schlib use; a list with no entries
+and an optional field with no value are omitted rather than empty/null. For large libraries, use component_name to fetch specific symbols, or use limit/offset for
+pagination.
 
 **Example**
 

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -41,6 +41,9 @@ impl McpServer {
                      param_key_order and primitive_order are fidelity carriers: pass them back \
                      unchanged to write_pcblib or update_component and the rewrite is \
                      byte-identical to the source; omit them when authoring from scratch. \
+                     Each footprint is the same JSON shape get_component, export_library and \
+                     write_pcblib use; a list with no entries and an optional field with no \
+                     value are omitted rather than empty/null. \
                      For large libraries, use component_name to fetch specific footprints, \
                      or use limit/offset for pagination."
                         .to_string(),
@@ -84,7 +87,10 @@ impl McpServer {
                      Fields such as unique_id and primitive_order are fidelity carriers: pass \
                      them back unchanged to write_schlib or update_component to keep the \
                      source's record identities and order; omit them when authoring from \
-                     scratch. For large libraries, use component_name to fetch specific \
+                     scratch. Each symbol is the same JSON shape get_component, \
+                     export_library and write_schlib use; a list with no entries and an \
+                     optional field with no value are omitted rather than empty/null. \
+                     For large libraries, use component_name to fetch specific \
                      symbols, or use limit/offset for pagination."
                         .to_string(),
                 ),

--- a/src/mcp/tool_docs.rs
+++ b/src/mcp/tool_docs.rs
@@ -310,6 +310,59 @@ mod tests {
         );
     }
 
+    /// Guards the hand-written tool index in `README.md` and every "N tools"
+    /// count in the docs against `tool_definitions.rs`: the index links
+    /// exactly the tools that exist, and each stated count is the real one.
+    /// Neither is generated, so this is what keeps them honest.
+    #[test]
+    fn readme_tool_index_and_tool_counts_in_sync() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let tools: std::collections::BTreeSet<String> = McpServer::get_tool_definitions()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+
+        let readme = std::fs::read_to_string(root.join("README.md")).expect("read README.md");
+        let linked: std::collections::BTreeSet<String> = readme
+            .match_indices("](docs/TOOLS.md#")
+            .map(|(i, _)| {
+                let rest = &readme[i + "](docs/TOOLS.md#".len()..];
+                rest[..rest.find(')').expect("closing paren")].to_string()
+            })
+            .collect();
+        assert_eq!(
+            linked, tools,
+            "README.md's tool index must link exactly the tools that exist"
+        );
+
+        for doc in [
+            "README.md",
+            "docs/CLIENT_SETUP.md",
+            "docs/USAGE.md",
+            "docs/TOOLS.md",
+            ".github/release-assets/README.md",
+        ] {
+            let text = std::fs::read_to_string(root.join(doc)).expect(doc);
+            for (i, _) in text.match_indices(" tools") {
+                let before: String = text[..i]
+                    .chars()
+                    .rev()
+                    .take_while(char::is_ascii_digit)
+                    .collect();
+                if before.is_empty() {
+                    continue;
+                }
+                let stated: usize = before.chars().rev().collect::<String>().parse().unwrap();
+                // Cursor's cap across all servers, quoted in CLIENT_SETUP.md,
+                // is the one count that is not ours.
+                if stated == 100 {
+                    continue;
+                }
+                assert_eq!(stated, tools.len(), "{doc} states {stated} tools");
+            }
+        }
+    }
+
     /// Guards `docs/TOOLS.md` against drift from `tool_definitions.rs`. If a
     /// tool's schema, description, or example changes and the doc isn't
     /// regenerated, this fails. Regenerate with:

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -293,61 +293,34 @@ impl McpServer {
                     .skip(offset)
                     .take(limit.unwrap_or(usize::MAX))
                     .map(|fp| {
-                        // If compact mode, strip per-layer data when it's redundant
-                        let pads: Vec<Value> = if compact {
-                            fp.pads
-                                .iter()
-                                .map(|pad| {
-                                    let mut pad_json = serde_json::to_value(pad).unwrap();
-                                    // A Simple pad's per-layer arrays carry nothing the
-                                    // main size/shape do not, so they go. A stacked pad
-                                    // keeps them — and its stack_mode — even when every
-                                    // layer happens to match: the mode is a stored
-                                    // property Altium shows, and rewriting it to
-                                    // "simple" here silently changed the pad on the next
-                                    // write.
+                        // The struct's own serde shape — the one write_pcblib
+                        // and update_component accept in full, and the one
+                        // get_component and export_library emit — so every
+                        // fidelity carrier (identities, raw blocks, record
+                        // order) reaches the caller without a hand-kept list.
+                        let mut fp_json = serde_json::to_value(fp).unwrap_or(Value::Null);
+                        // Compact mode: a Simple pad's per-layer arrays carry
+                        // nothing the main size/shape do not, so they go. A
+                        // stacked pad keeps them — and its stack_mode — even
+                        // when every layer happens to match: the mode is a
+                        // stored property Altium shows, and rewriting it to
+                        // "simple" here silently changed the pad on the next
+                        // write.
+                        if compact {
+                            if let Some(pads) =
+                                fp_json.get_mut("pads").and_then(Value::as_array_mut)
+                            {
+                                for (pad, pad_json) in fp.pads.iter().zip(pads.iter_mut()) {
                                     if pad.stack_mode == PadStackMode::Simple {
-                                        if let Value::Object(ref mut obj) = pad_json {
+                                        if let Value::Object(obj) = pad_json {
                                             obj.remove("per_layer_sizes");
                                             obj.remove("per_layer_shapes");
                                             obj.remove("per_layer_corner_radii");
                                             obj.remove("per_layer_offsets");
                                         }
                                     }
-                                    pad_json
-                                })
-                                .collect()
-                        } else {
-                            fp.pads
-                                .iter()
-                                .map(|p| serde_json::to_value(p).unwrap())
-                                .collect()
-                        };
-
-                        let mut fp_json = json!({
-                            "name": fp.name,
-                            "description": fp.description,
-                            "pads": pads,
-                            "vias": fp.vias,
-                            "tracks": fp.tracks,
-                            "arcs": fp.arcs,
-                            "regions": fp.regions,
-                            "fills": fp.fills,
-                            "text": fp.text,
-                            "model_3d": fp.model_3d,
-                            "component_bodies": fp.component_bodies,
-                        });
-                        // Footprint-level fidelity fields, mirroring the
-                        // struct's own serde shape (get_component serialises
-                        // the whole struct): present only when carried, and
-                        // replayed by write_pcblib so a read-modify-write
-                        // keeps the kind-85 identity and the interleaved
-                        // stream order.
-                        if let Some(guid) = &fp.guid {
-                            fp_json["guid"] = json!(guid);
-                        }
-                        if !fp.primitive_order.is_empty() {
-                            fp_json["primitive_order"] = json!(fp.primitive_order);
+                                }
+                            }
                         }
                         fp_json
                     })
@@ -725,51 +698,8 @@ impl McpServer {
                     .skip(offset)
                     .take(limit.unwrap_or(usize::MAX))
                     .map(|symbol| {
-                        let mut sym_json = json!({
-                            "name": symbol.name,
-                            "description": symbol.description,
-                            "designator": symbol.designator,
-                            "designator_x": symbol.designator_x,
-                            "designator_y": symbol.designator_y,
-                            "designator_unique_id": symbol.designator_unique_id,
-                            "part_count": symbol.part_count,
-                            "display_mode_count": symbol.display_mode_count,
-                            "current_part_id": symbol.current_part_id,
-                            "part_id_locked": symbol.part_id_locked,
-                            "source_library_name": symbol.source_library_name,
-                            "target_file_name": symbol.target_file_name,
-                            "pins": symbol.pins,
-                            "rectangles": symbol.rectangles,
-                            "round_rects": symbol.round_rects,
-                            "lines": symbol.lines,
-                            "polylines": symbol.polylines,
-                            "polygons": symbol.polygons,
-                            "arcs": symbol.arcs,
-                            "pies": symbol.pies,
-                            "images": symbol.images,
-                            "text_frames": symbol.text_frames,
-                            "beziers": symbol.beziers,
-                            "ellipses": symbol.ellipses,
-                            "elliptical_arcs": symbol.elliptical_arcs,
-                            "labels": symbol.labels,
-                            "text": symbol.text,
-                            "parameters": symbol.parameters,
-                            "footprints": symbol.footprints,
-                        });
-                        // The interleaved record order, mirroring the struct's
-                        // serde shape (present only when carried) and replayed
-                        // by write_schlib so a read-modify-write keeps the
-                        // source's record order.
-                        if !symbol.primitive_order.is_empty() {
-                            sym_json["primitive_order"] = json!(symbol.primitive_order);
-                        }
-                        if !symbol.header_params.is_empty() {
-                            sym_json["header_params"] = json!(symbol.header_params);
-                        }
-                        if let Some(count) = symbol.all_pin_count {
-                            sym_json["all_pin_count"] = json!(count);
-                        }
-                        sym_json
+                        // The struct's own serde shape (see read_pcblib).
+                        serde_json::to_value(symbol).unwrap_or(Value::Null)
                     })
                     .collect();
 

--- a/tests/mcp_e2e.rs
+++ b/tests/mcp_e2e.rs
@@ -1982,15 +1982,19 @@ fn read_schlib_exposes_round_rects_and_polygons() {
     );
     assert_eq!(len_of(pg, "polygons"), 2, "POLYGONS exposes 2 polygons");
 
+    // A symbol without a family omits its key — the struct's own serde shape,
+    // which write_schlib and import_library default to empty — so a client
+    // must not rely on every list being present.
     let pins = find_by(symbols, "name", "PINS_ETYPE").expect("PINS_ETYPE symbol");
     assert!(
-        pins.get("round_rects").is_some(),
-        "PINS_ETYPE has 'round_rects' field"
+        pins.get("round_rects").is_none(),
+        "PINS_ETYPE carries no round_rects, so the key is omitted"
     );
     assert!(
-        pins.get("polygons").is_some(),
-        "PINS_ETYPE has 'polygons' field"
+        pins.get("polygons").is_none(),
+        "PINS_ETYPE carries no polygons, so the key is omitted"
     );
+    assert!(len_of(pins, "pins") > 0, "its pins are there");
 }
 
 /// Collects an `additional_parameters` array of `[key, value]` pairs.


### PR DESCRIPTION
The SSOT follow-up you asked about, for the two places it was still violated in code + docs. **Stacked on #429**; will retarget to `main` when it lands.

1. **One JSON shape for a footprint/symbol.** `read_pcblib`/`read_schlib` hand-built their JSON from a field list kept beside the struct, `get_component` serialised the struct, `export_library` kept a third list. Every fidelity carrier had to be remembered per list; the last one (the symbol header in #428) was missed in export until the mutation suite caught it. Both read tools now serialise the struct — four tools, one shape, the one the write tools accept in full. Consequence (pre-1.0, documented in the tool descriptions): an empty list / absent optional is omitted rather than `[]`/`null`, as the struct's serde attributes already did everywhere else.
2. **README's tool index is held to `tool_definitions.rs`** by a test, together with every hand-written "N tools" count across the docs (README, CLIENT_SETUP, USAGE, TOOLS, release bundle README).

Gates: fmt ✅ clippy ✅ 1432 tests ✅ coverage **99.09%** (405/44,617).

🤖 Generated with [Claude Code](https://claude.com/claude-code)