### PR TITLE
fix(schlib): replay every content record as read; store non-ASCII pin names as UTF-8

### DIFF
--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -76,6 +76,10 @@ long name goes `FileHeader` → `SectionKeys` → storage.
 
 ## PinWideText Stream
 
+A non-ASCII pin **name** is stored in the binary pin record as its **UTF-8 bytes** (every one
+of the golden's 52 such pins, `Résistance` included although Windows-1252 could hold it), with
+this stream carrying the wide form beside it; the pin's other strings are Windows-1252.
+
 Per-component, alongside `PinFrac` / `PinSymbolLineWidth`, in the shared compressed-storage
 framing (see the `/Storage` section): one zlib entry per pin whose name leaves ASCII, keyed by pin
 ordinal, payload a Unicode parameter block `[u32 LE byte_len][UTF-16LE "|NAME=<text>"]`.
@@ -499,6 +503,13 @@ The first record of each component's Data stream. Keys as written (in order):
 > A UI-typed Latin-1 description is stored as `%UTF8%ComponentDescription=<UTF-8 bytes>|||`
 > `ComponentDescription=<Windows-1252 bytes>` (twin first, two empty segments, code-page
 > plain key); a scripted one puts UTF-8 bytes in both keys.
+
+Every content record is carried the same way — `raw_params` on each record struct holds its
+segments as read — and replayed verbatim where the field behind a segment is unchanged: the
+UI omits `LineWidth=1` on a rectangle where a script writes it, stores a Latin-1 label as
+`%UTF8%Text=<UTF-8>|||Text=<Windows-1252>`, and may carry keys this crate does not model,
+all of which come back as stored; an edited field takes its canonical form, a cleared flag's
+key is dropped, and the positional `IndexInSheet` is always recomputed.
 
 The **system parameter** is Altium's own `Comment` record alone (with the Designator
 record): stored after the designator with `IndexInSheet=-1` and no counter slot. A user

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -954,6 +954,7 @@ mod tests {
         // annotation round-tripped back as a Label (reader: 3 => Text, 4 => Label).
         let mut symbol = Symbol::new("TXT");
         symbol.add_text(Text {
+            raw_params: Vec::new(),
             x: 5.0,
             y: 7.0,
             text: "NOTE".to_string(),
@@ -1388,6 +1389,7 @@ mod tests {
 
         // Add a filled triangle polygon
         let mut polygon = Polygon {
+            raw_params: Vec::new(),
             points: vec![(-30.0, 40.0), (-20.0, 30.0), (-10.0, 40.0)],
             line_width: 2,
             line_color: 0x00_00_FF, // Red border
@@ -1404,6 +1406,7 @@ mod tests {
 
         // Add an unfilled rectangle polygon
         polygon = Polygon {
+            raw_params: Vec::new(),
             points: vec![(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
             line_width: 1,
             line_color: 0x00_80_00, // Green border
@@ -1469,6 +1472,7 @@ mod tests {
         // and NO LineStyle / Transparent tokens.
         let mut sym = Symbol::new("POLY_DEFAULT");
         sym.add_polygon(Polygon {
+            raw_params: Vec::new(),
             points: vec![(0.0, 0.0), (5.0, 0.0), (2.5, 5.0)],
             line_width: 1,
             line_color: 0,
@@ -1625,6 +1629,7 @@ mod tests {
 
         // AreaColor on Arc (Arc has no ::new — build a struct literal).
         let arc = Arc {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             radius: 10.0,
@@ -1927,6 +1932,7 @@ mod tests {
         sym.add_round_rect(RoundRect::new(-5.5, -5.5, 5.5, 5.5, 1.25, 2.75));
         sym.add_ellipse(Ellipse::new(-1.5, 2.5, 7.5, 3.25));
         let arc = Arc {
+            raw_params: Vec::new(),
             x: -3.5,
             y: 4.25,
             radius: 6.75,
@@ -1943,6 +1949,7 @@ mod tests {
         sym.add_arc(arc);
         sym.add_bezier(Bezier::new(-0.5, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5, -6.5));
         sym.add_polyline(Polyline {
+            raw_params: Vec::new(),
             points: vec![(-1.25, 0.0), (2.5, -3.75), (10.0, 0.5)],
             line_width: 1,
             color: 0,
@@ -1957,6 +1964,7 @@ mod tests {
             unique_id: None,
         });
         sym.add_polygon(Polygon {
+            raw_params: Vec::new(),
             points: vec![(-2.5, -2.5), (2.5, -2.5), (0.0, 3.125)],
             line_width: 1,
             line_color: 0,
@@ -1970,6 +1978,7 @@ mod tests {
             unique_id: None,
         });
         let label = Label {
+            raw_params: Vec::new(),
             x: -7.5,
             y: 0.25,
             text: "L".to_string(),

--- a/src/altium/schlib/primitives/shapes.rs
+++ b/src/altium/schlib/primitives/shapes.rs
@@ -51,6 +51,14 @@ pub struct Rectangle {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 const fn default_line_width() -> u8 {
@@ -67,6 +75,7 @@ impl Rectangle {
         y2: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -126,6 +135,14 @@ pub struct Line {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Line {
@@ -139,6 +156,7 @@ impl Line {
         y2: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -200,6 +218,14 @@ pub struct Polyline {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 /// A filled polygon.
@@ -247,6 +273,14 @@ pub struct Polygon {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 /// An arc or circle.
@@ -294,6 +328,14 @@ pub struct Arc {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 const fn default_end_angle() -> f64 {
@@ -354,6 +396,14 @@ pub struct Pie {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Pie {
@@ -367,6 +417,7 @@ impl Pie {
         end_angle: f64,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x: x.into(),
             y: y.into(),
             radius: radius.into(),
@@ -466,6 +517,14 @@ pub struct Image {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Image {
@@ -480,6 +539,7 @@ impl Image {
         file_name: impl Into<String>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -559,6 +619,14 @@ pub struct Bezier {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Bezier {
@@ -576,6 +644,7 @@ impl Bezier {
         y4: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -642,6 +711,14 @@ pub struct Ellipse {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Ellipse {
@@ -654,6 +731,7 @@ impl Ellipse {
         radius_y: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x: x.into(),
             y: y.into(),
             radius_x: radius_x.into(),
@@ -731,6 +809,14 @@ pub struct RoundRect {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl RoundRect {
@@ -746,6 +832,7 @@ impl RoundRect {
         corner_y_radius: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -809,6 +896,14 @@ pub struct EllipticalArc {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl EllipticalArc {
@@ -823,6 +918,7 @@ impl EllipticalArc {
         end_angle: impl Into<f64>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x: x.into(),
             y: y.into(),
             radius: radius.into(),

--- a/src/altium/schlib/primitives/text.rs
+++ b/src/altium/schlib/primitives/text.rs
@@ -42,6 +42,14 @@ pub struct Label {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 /// A text annotation (RECORD=3).
@@ -83,6 +91,14 @@ pub struct Text {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 /// A bordered multi-line text box — `SchLib` `RECORD=28`.
@@ -175,6 +191,14 @@ pub struct TextFrame {
     /// shape identity; a from-scratch shape generates a fresh one on write (#113).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl TextFrame {
@@ -190,6 +214,7 @@ impl TextFrame {
         text: impl Into<String>,
     ) -> Self {
         Self {
+            raw_params: Vec::new(),
             x1: x1.into(),
             y1: y1.into(),
             x2: x2.into(),
@@ -358,6 +383,14 @@ pub struct Parameter {
     /// parameter identity; a from-scratch parameter generates a fresh one on write.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The record exactly as read: every `key=value` segment in stored order
+    /// (an empty segment as `("", "")`), so the writer replays it verbatim
+    /// where the field behind a segment is unchanged and emits only the keys
+    /// Altium wrote — the UI omits `LineWidth=1` on a rectangle, a script
+    /// does not. Empty for a record built from scratch, which emits the
+    /// canonical form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl Parameter {
@@ -365,6 +398,7 @@ impl Parameter {
     #[must_use]
     pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
+            raw_params: Vec::new(),
             name: name.into(),
             value: value.into(),
             x: 0.0,

--- a/src/altium/schlib/reader/mod.rs
+++ b/src/altium/schlib/reader/mod.rs
@@ -122,6 +122,21 @@ fn contains_utf8_marker(data: &[u8]) -> bool {
         .any(|w| w.eq_ignore_ascii_case(MARKER))
 }
 
+/// A text record's segments exactly as stored: every `key=value` in order,
+/// an empty segment (the UI's `%UTF8%Key=…|||Key=…` form) as `("", "")`.
+fn record_segments(text: &str) -> Vec<(String, String)> {
+    text.trim_end_matches('\0')
+        .split('|')
+        .skip(1)
+        .map(|segment| {
+            segment.split_once('=').map_or_else(
+                || (segment.to_string(), String::new()),
+                |(key, value)| (key.to_string(), value.to_string()),
+            )
+        })
+        .collect()
+}
+
 /// [`parse_text_record_from_string`] for the writer's tests.
 #[cfg(test)]
 pub(crate) fn parse_text_record_from_string_for_test(symbol: &mut Symbol, text: &str) {
@@ -180,27 +195,19 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
             // included, because the UI writes a `%UTF8%` twin as
             // `%UTF8%Key=…|||Key=…` — so the writer reproduces this header
             // rather than the canonical one.
-            symbol.header_params = text
-                .trim_end_matches('\0')
-                .split('|')
-                .skip(1)
-                .map(|segment| {
-                    segment.split_once('=').map_or_else(
-                        || (segment.to_string(), String::new()),
-                        |(key, value)| (key.to_string(), value.to_string()),
-                    )
-                })
-                .collect();
+            symbol.header_params = record_segments(text);
         }
         14 => {
             // Rectangle
-            if let Some(rect) = parse_rectangle(&props) {
+            if let Some(mut rect) = parse_rectangle(&props) {
+                rect.raw_params = record_segments(text);
                 symbol.add_rectangle(rect);
             }
         }
         13 => {
             // Line
-            if let Some(line) = parse_line(&props) {
+            if let Some(mut line) = parse_line(&props) {
+                line.raw_params = record_segments(text);
                 symbol.add_line(line);
             }
         }
@@ -219,7 +226,8 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
         }
         41 => {
             // Parameter
-            if let Some(param) = parse_parameter(&props) {
+            if let Some(mut param) = parse_parameter(&props) {
+                param.raw_params = record_segments(text);
                 symbol.add_parameter(param);
             }
         }
@@ -244,73 +252,85 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
         }
         6 => {
             // Polyline
-            if let Some(polyline) = parse_polyline(&props) {
+            if let Some(mut polyline) = parse_polyline(&props) {
+                polyline.raw_params = record_segments(text);
                 symbol.add_polyline(polyline);
             }
         }
         8 => {
             // Ellipse
-            if let Some(ellipse) = parse_ellipse(&props) {
+            if let Some(mut ellipse) = parse_ellipse(&props) {
+                ellipse.raw_params = record_segments(text);
                 symbol.add_ellipse(ellipse);
             }
         }
         9 => {
             // Pie (filled circular sector)
-            if let Some(pie) = parse_pie(&props) {
+            if let Some(mut pie) = parse_pie(&props) {
+                pie.raw_params = record_segments(text);
                 symbol.add_pie(pie);
             }
         }
         30 => {
             // Image (embedded/linked picture)
-            if let Some(image) = parse_image(&props) {
+            if let Some(mut image) = parse_image(&props) {
+                image.raw_params = record_segments(text);
                 symbol.add_image(image);
             }
         }
         28 => {
             // Text frame (bordered multi-line text box)
-            if let Some(text_frame) = parse_text_frame(&props) {
+            if let Some(mut text_frame) = parse_text_frame(&props) {
+                text_frame.raw_params = record_segments(text);
                 symbol.add_text_frame(text_frame);
             }
         }
         12 => {
             // Arc
-            if let Some(arc) = parse_arc(&props) {
+            if let Some(mut arc) = parse_arc(&props) {
+                arc.raw_params = record_segments(text);
                 symbol.add_arc(arc);
             }
         }
         3 => {
             // Text annotation
-            if let Some(text) = parse_text(&props) {
-                symbol.add_text(text);
+            if let Some(mut annotation) = parse_text(&props) {
+                annotation.raw_params = record_segments(text);
+                symbol.add_text(annotation);
             }
         }
         4 => {
             // Label
-            if let Some(label) = parse_label(&props) {
+            if let Some(mut label) = parse_label(&props) {
+                label.raw_params = record_segments(text);
                 symbol.add_label(label);
             }
         }
         5 => {
             // Bezier curve
-            if let Some(bezier) = parse_bezier(&props) {
+            if let Some(mut bezier) = parse_bezier(&props) {
+                bezier.raw_params = record_segments(text);
                 symbol.add_bezier(bezier);
             }
         }
         7 => {
             // Polygon
-            if let Some(polygon) = parse_polygon(&props) {
+            if let Some(mut polygon) = parse_polygon(&props) {
+                polygon.raw_params = record_segments(text);
                 symbol.add_polygon(polygon);
             }
         }
         10 => {
             // Rounded Rectangle
-            if let Some(round_rect) = parse_round_rect(&props) {
+            if let Some(mut round_rect) = parse_round_rect(&props) {
+                round_rect.raw_params = record_segments(text);
                 symbol.add_round_rect(round_rect);
             }
         }
         11 => {
             // Elliptical Arc
-            if let Some(elliptical_arc) = parse_elliptical_arc(&props) {
+            if let Some(mut elliptical_arc) = parse_elliptical_arc(&props) {
+                elliptical_arc.raw_params = record_segments(text);
                 symbol.add_elliptical_arc(elliptical_arc);
             }
         }
@@ -484,6 +504,7 @@ mod tests {
         // encode -> decode via the writer/reader keeps the four flags on a shape.
         use crate::altium::schlib::writer;
         let mut label = Label {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             text: "L".to_string(),

--- a/src/altium/schlib/reader/parsers.rs
+++ b/src/altium/schlib/reader/parsers.rs
@@ -156,6 +156,7 @@ pub(super) fn parse_rectangle(props: &HashMap<String, String>) -> Option<Rectang
     let transparent = props.get("transparent").is_some_and(|s| s == "T");
 
     Some(Rectangle {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -203,6 +204,7 @@ pub(super) fn parse_line(props: &HashMap<String, String>) -> Option<Line> {
         .unwrap_or(1);
 
     Some(Line {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -276,6 +278,7 @@ pub(super) fn parse_parameter(props: &HashMap<String, String>) -> Option<Paramet
         .unwrap_or(1);
 
     Some(Parameter {
+        raw_params: Vec::new(),
         name,
         value,
         x,
@@ -358,6 +361,7 @@ pub(super) fn parse_polyline(props: &HashMap<String, String>) -> Option<Polyline
         .unwrap_or(1);
 
     Some(Polyline {
+        raw_params: Vec::new(),
         points,
         line_width,
         color,
@@ -416,6 +420,7 @@ pub(super) fn parse_polygon(props: &HashMap<String, String>) -> Option<Polygon> 
         .unwrap_or(1);
 
     Some(Polygon {
+        raw_params: Vec::new(),
         points,
         line_width,
         line_color,
@@ -463,6 +468,7 @@ pub(super) fn parse_ellipse(props: &HashMap<String, String>) -> Option<Ellipse> 
         .unwrap_or(1);
 
     Some(Ellipse {
+        raw_params: Vec::new(),
         x,
         y,
         radius_x,
@@ -510,6 +516,7 @@ pub(super) fn parse_arc(props: &HashMap<String, String>) -> Option<Arc> {
         .unwrap_or(1);
 
     Some(Arc {
+        raw_params: Vec::new(),
         x,
         y,
         radius,
@@ -558,6 +565,7 @@ pub(super) fn parse_pie(props: &HashMap<String, String>) -> Option<Pie> {
         .unwrap_or(1);
 
     Some(Pie {
+        raw_params: Vec::new(),
         x,
         y,
         radius,
@@ -608,6 +616,7 @@ pub(super) fn parse_image(props: &HashMap<String, String>) -> Option<Image> {
         .unwrap_or(1);
 
     Some(Image {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -686,6 +695,7 @@ pub(super) fn parse_text_frame(props: &HashMap<String, String>) -> Option<TextFr
         .unwrap_or(1);
 
     Some(TextFrame {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -739,6 +749,7 @@ pub(super) fn parse_bezier(props: &HashMap<String, String>) -> Option<Bezier> {
         .unwrap_or(1);
 
     Some(Bezier {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -789,6 +800,7 @@ pub(super) fn parse_round_rect(props: &HashMap<String, String>) -> Option<RoundR
         .unwrap_or(1);
 
     Some(RoundRect {
+        raw_params: Vec::new(),
         x1,
         y1,
         x2,
@@ -848,6 +860,7 @@ pub(super) fn parse_elliptical_arc(props: &HashMap<String, String>) -> Option<El
         .unwrap_or(1);
 
     Some(EllipticalArc {
+        raw_params: Vec::new(),
         x,
         y,
         radius,
@@ -890,6 +903,7 @@ pub(super) fn parse_label(props: &HashMap<String, String>) -> Option<Label> {
         .unwrap_or(1);
 
     Some(Label {
+        raw_params: Vec::new(),
         x,
         y,
         text,
@@ -933,6 +947,7 @@ pub(super) fn parse_text(props: &HashMap<String, String>) -> Option<Text> {
         .unwrap_or(1);
 
     Some(Text {
+        raw_params: Vec::new(),
         x,
         y,
         text,

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -129,7 +129,16 @@ pub(crate) fn write_binary_pin(
     // ENCODED byte length (what the u8 length prefix actually holds), not the
     // UTF-8 String length — otherwise non-ASCII text is wrongly rejected even
     // though it fits in 255 encoded bytes.
-    let name = crate::altium::encode_windows1252(&pin.name);
+    //
+    // The name is the exception: Altium stores a non-ASCII pin name as its
+    // UTF-8 bytes (every one of the golden's 52 such pins, `Résistance`
+    // included though Windows-1252 could hold it) with the `PinWideText`
+    // stream beside it, so the record and the stream agree on every reader.
+    let name = if pin.name.is_ascii() {
+        crate::altium::encode_windows1252(&pin.name)
+    } else {
+        pin.name.as_bytes().to_vec()
+    };
     let designator = crate::altium::encode_windows1252(&pin.designator);
     let description = crate::altium::encode_windows1252(&pin.description);
     let swap_id_group = crate::altium::encode_windows1252(&pin.swap_id_group);
@@ -335,6 +344,196 @@ fn replay_header(symbol: &Symbol, canonical: &[(String, String)]) -> Vec<String>
         }
     }
     parts
+}
+
+/// Keys whose value is positional — assigned by the writer from the record's
+/// place in the stream — so the canonical value always wins and a stale read
+/// value is never replayed.
+const POSITIONAL_KEYS: &[&str] = &["IndexInSheet", "OwnerIndex"];
+
+/// A `key=value` the UI omits when it holds this value and a script writes
+/// out: left out when the read record lacked it and the value is still the
+/// implicit one, so the file comes back as Altium wrote it; emitted once the
+/// field is edited away from it.
+const IMPLICIT_DEFAULTS: &[(&str, &str)] = &[("LineWidth", "1")];
+
+/// Every key a content record's encoder can emit — the keys a struct field
+/// stands behind. A read key in this set that the canonical form now omits
+/// is a field edited to its omitted default (`IsHidden` cleared) and is
+/// dropped; a read key outside it is an Altium key this crate does not model
+/// and is replayed verbatim. Held complete against the golden by
+/// `every_golden_record_key_is_modelled`.
+const MODELLED_RECORD_KEYS: &[&str] = &[
+    "RECORD",
+    "Alignment",
+    "AreaColor",
+    "ClipToRect",
+    "Color",
+    "Corner.X",
+    "Corner.X_Frac",
+    "Corner.Y",
+    "Corner.Y_Frac",
+    "CornerXRadius",
+    "CornerXRadius_Frac",
+    "CornerYRadius",
+    "CornerYRadius_Frac",
+    "Description",
+    "%UTF8%Description",
+    "Dimmed",
+    "Disabled",
+    "EmbedImage",
+    "EndAngle",
+    "EndLineShape",
+    "FileName",
+    "%UTF8%FileName",
+    "FontID",
+    "GraphicallyLocked",
+    "HideName",
+    "IndexInSheet",
+    "IsConfigurable",
+    "IsHidden",
+    "IsMirrored",
+    "IsNotAccesible",
+    "IsRule",
+    "IsSolid",
+    "IsSystemParameter",
+    "Justification",
+    "KeepAspect",
+    "LineShapeSize",
+    "LineStyle",
+    "LineStyleExt",
+    "LineWidth",
+    "Location.X",
+    "Location.X_Frac",
+    "Location.Y",
+    "Location.Y_Frac",
+    "LocationCount",
+    "Name",
+    "%UTF8%Name",
+    "NotAutoPosition",
+    "Orientation",
+    "OwnerIndex",
+    "OwnerPartDisplayMode",
+    "OwnerPartId",
+    "ParamType",
+    "Radius",
+    "Radius_Frac",
+    "ReadOnlyState",
+    "SecondaryRadius",
+    "SecondaryRadius_Frac",
+    "ShowBorder",
+    "ShowName",
+    "StartAngle",
+    "StartLineShape",
+    "Text",
+    "%UTF8%Text",
+    "TextColor",
+    "TextHorzAnchor",
+    "TextMargin",
+    "TextMargin_Frac",
+    "TextVertAnchor",
+    "Transparent",
+    "UniqueID",
+    "WordWrap",
+];
+
+/// Whether `key` is one an encoder can emit: a vertex key (`X3`, `Y12`) or
+/// one of [`MODELLED_RECORD_KEYS`].
+fn is_modelled_record_key(key: &str) -> bool {
+    let vertex = key
+        .strip_prefix('X')
+        .or_else(|| key.strip_prefix('Y'))
+        .is_some_and(|rest| {
+            let rest = rest.strip_suffix("_Frac").unwrap_or(rest);
+            !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+        });
+    vertex
+        || MODELLED_RECORD_KEYS
+            .iter()
+            .any(|k| k.eq_ignore_ascii_case(key))
+}
+
+/// Replays a record read from a file over the canonical encoding of its
+/// current state (see `raw_params` on every record struct).
+///
+/// Segment by segment in the read order: a key the canonical form carries
+/// goes back verbatim when the two values decode to the same text (the UI
+/// stores a Latin-1 value as Windows-1252 where the canonical form uses
+/// UTF-8 bytes) and as the canonical value otherwise — an edit, or a
+/// positional key such as `IndexInSheet`. A key the canonical form lacks is
+/// dropped when an encoder could have emitted it (the field was edited to
+/// its omitted default — see [`MODELLED_RECORD_KEYS`]) and replayed verbatim
+/// otherwise, as an Altium key this crate does not model. Canonical keys the
+/// record lacked are appended, except an [`IMPLICIT_DEFAULTS`] value the
+/// file left implicit. A record without raw segments — built from scratch —
+/// is the canonical form.
+fn replay_record(canonical: &str, raw: &[(String, String)]) -> String {
+    if raw.is_empty() {
+        return canonical.to_string();
+    }
+    let canonical_pairs: Vec<(&str, &str)> = canonical
+        .split('|')
+        .skip(1)
+        .map(|segment| segment.split_once('=').unwrap_or((segment, "")))
+        .collect();
+    let canonical_value = |key: &str| {
+        canonical_pairs
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| *v)
+    };
+    let decoded =
+        |value: &str| crate::altium::from_wire_text(value).unwrap_or_else(|| value.to_string());
+    let is_positional = |key: &str| POSITIONAL_KEYS.iter().any(|k| k.eq_ignore_ascii_case(key));
+
+    // A `%UTF8%` twin's bytes are a locale artefact of the writing machine
+    // (the golden's were widened through Windows-1250), so whether it goes
+    // back verbatim follows its plain key, not its own bytes.
+    let raw_value = |key: &str| {
+        raw.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v.as_str())
+    };
+    let plain_unchanged = |key: &str| {
+        let plain = key.strip_prefix("%UTF8%").unwrap_or(key);
+        match (raw_value(plain), canonical_value(plain)) {
+            (Some(read), Some(current)) => read == current || decoded(read) == decoded(current),
+            _ => false,
+        }
+    };
+
+    let mut placed: Vec<bool> = vec![false; canonical_pairs.len()];
+    let mut parts: Vec<String> = Vec::with_capacity(raw.len() + 2);
+    for (key, read) in raw {
+        if key.is_empty() {
+            parts.push(String::new());
+            continue;
+        }
+        if let Some(i) = canonical_pairs
+            .iter()
+            .position(|(k, _)| k.eq_ignore_ascii_case(key))
+        {
+            placed[i] = true;
+            let current = canonical_pairs[i].1;
+            let unchanged = !is_positional(key)
+                && (read == current
+                    || decoded(read) == decoded(current)
+                    || (key.starts_with("%UTF8%") && plain_unchanged(key)));
+            let value = if unchanged { read.as_str() } else { current };
+            parts.push(format!("{key}={value}"));
+        } else if !is_positional(key) && !is_modelled_record_key(key) {
+            parts.push(format!("{key}={read}"));
+        }
+    }
+    for (i, (key, value)) in canonical_pairs.iter().enumerate() {
+        let implicit = IMPLICIT_DEFAULTS
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case(key) && v == value);
+        if !placed[i] && !implicit {
+            parts.push(format!("{key}={value}"));
+        }
+    }
+    format!("|{}", parts.join("|"))
 }
 
 /// Whether a parameter is Altium's own system `Comment` record — stored after
@@ -1428,30 +1627,64 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
                 if is_system_parameter(param) {
                     continue;
                 }
-                encode_parameter(param, index_counter)
+                replay_record(&encode_parameter(param, index_counter), &param.raw_params)
             }
-            SchPrimitiveKind::Rectangle => {
-                encode_rectangle(&symbol.rectangles[index], index_counter)
-            }
-            SchPrimitiveKind::Line => encode_line(&symbol.lines[index], index_counter),
-            SchPrimitiveKind::Polyline => encode_polyline(&symbol.polylines[index], index_counter),
-            SchPrimitiveKind::Polygon => encode_polygon(&symbol.polygons[index], index_counter),
-            SchPrimitiveKind::Arc => encode_arc(&symbol.arcs[index], index_counter),
-            SchPrimitiveKind::Pie => encode_pie(&symbol.pies[index], index_counter),
-            SchPrimitiveKind::Image => encode_image(&symbol.images[index], index_counter),
-            SchPrimitiveKind::TextFrame => {
-                encode_text_frame(&symbol.text_frames[index], index_counter)
-            }
-            SchPrimitiveKind::Bezier => encode_bezier(&symbol.beziers[index], index_counter),
-            SchPrimitiveKind::Ellipse => encode_ellipse(&symbol.ellipses[index], index_counter),
-            SchPrimitiveKind::RoundRect => {
-                encode_round_rect(&symbol.round_rects[index], index_counter)
-            }
-            SchPrimitiveKind::EllipticalArc => {
-                encode_elliptical_arc(&symbol.elliptical_arcs[index], index_counter)
-            }
-            SchPrimitiveKind::Label => encode_label(&symbol.labels[index], index_counter),
-            SchPrimitiveKind::Text => encode_text(&symbol.text[index], index_counter),
+            SchPrimitiveKind::Rectangle => replay_record(
+                &encode_rectangle(&symbol.rectangles[index], index_counter),
+                &symbol.rectangles[index].raw_params,
+            ),
+            SchPrimitiveKind::Line => replay_record(
+                &encode_line(&symbol.lines[index], index_counter),
+                &symbol.lines[index].raw_params,
+            ),
+            SchPrimitiveKind::Polyline => replay_record(
+                &encode_polyline(&symbol.polylines[index], index_counter),
+                &symbol.polylines[index].raw_params,
+            ),
+            SchPrimitiveKind::Polygon => replay_record(
+                &encode_polygon(&symbol.polygons[index], index_counter),
+                &symbol.polygons[index].raw_params,
+            ),
+            SchPrimitiveKind::Arc => replay_record(
+                &encode_arc(&symbol.arcs[index], index_counter),
+                &symbol.arcs[index].raw_params,
+            ),
+            SchPrimitiveKind::Pie => replay_record(
+                &encode_pie(&symbol.pies[index], index_counter),
+                &symbol.pies[index].raw_params,
+            ),
+            SchPrimitiveKind::Image => replay_record(
+                &encode_image(&symbol.images[index], index_counter),
+                &symbol.images[index].raw_params,
+            ),
+            SchPrimitiveKind::TextFrame => replay_record(
+                &encode_text_frame(&symbol.text_frames[index], index_counter),
+                &symbol.text_frames[index].raw_params,
+            ),
+            SchPrimitiveKind::Bezier => replay_record(
+                &encode_bezier(&symbol.beziers[index], index_counter),
+                &symbol.beziers[index].raw_params,
+            ),
+            SchPrimitiveKind::Ellipse => replay_record(
+                &encode_ellipse(&symbol.ellipses[index], index_counter),
+                &symbol.ellipses[index].raw_params,
+            ),
+            SchPrimitiveKind::RoundRect => replay_record(
+                &encode_round_rect(&symbol.round_rects[index], index_counter),
+                &symbol.round_rects[index].raw_params,
+            ),
+            SchPrimitiveKind::EllipticalArc => replay_record(
+                &encode_elliptical_arc(&symbol.elliptical_arcs[index], index_counter),
+                &symbol.elliptical_arcs[index].raw_params,
+            ),
+            SchPrimitiveKind::Label => replay_record(
+                &encode_label(&symbol.labels[index], index_counter),
+                &symbol.labels[index].raw_params,
+            ),
+            SchPrimitiveKind::Text => replay_record(
+                &encode_text(&symbol.text[index], index_counter),
+                &symbol.text[index].raw_params,
+            ),
         };
         write_text_record(&mut data, &record)?;
         index_counter += 1;
@@ -1473,7 +1706,7 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
     // Part Number carries OwnerPartId=-1 too and is still a content record
     // with a counter slot, stored before the graphics in authoring order.
     for param in symbol.parameters.iter().filter(|p| is_system_parameter(p)) {
-        let record = encode_parameter(param, 0);
+        let record = replay_record(&encode_parameter(param, 0), &param.raw_params);
         write_text_record(&mut data, &record)?;
     }
 
@@ -1676,15 +1909,43 @@ mod tests {
 
         #[test]
         fn the_limit_is_encoded_bytes_not_characters() {
-            // Windows-1252 is single-byte, so 255 non-ASCII characters fit
-            // where a UTF-8 length check would have wrongly rejected them.
+            // The description is Windows-1252 (single-byte), so 255 non-ASCII
+            // characters fit where a UTF-8 length check would have wrongly
+            // rejected them.
             let mut subject = pin();
-            subject.name = "\u{b5}".repeat(255); // 255 x MICRO SIGN
+            subject.description = "\u{b5}".repeat(255); // 255 x MICRO SIGN
             write_binary_pin(&mut Vec::new(), &subject)
                 .expect("255 encoded bytes is within the prefix");
+            subject.description = "\u{b5}".repeat(256);
+            rejects(
+                write_binary_pin(&mut Vec::new(), &subject),
+                "pin.description",
+            );
 
-            subject.name = "\u{b5}".repeat(256);
+            // The name is stored as UTF-8 bytes once it leaves ASCII, as
+            // Altium stores it, so its limit is the UTF-8 length: 127 micro
+            // signs are 254 bytes, 128 are 256.
+            let mut subject = pin();
+            subject.name = "\u{b5}".repeat(127);
+            write_binary_pin(&mut Vec::new(), &subject).expect("254 UTF-8 bytes fit");
+            subject.name = "\u{b5}".repeat(128);
             rejects(write_binary_pin(&mut Vec::new(), &subject), "pin.name");
+        }
+
+        /// A non-ASCII pin name is stored as its UTF-8 bytes — every one of
+        /// the golden's 52 such pins, `Résistance` included — never the code
+        /// page; an ASCII name stays single-byte.
+        #[test]
+        fn a_non_ascii_pin_name_is_stored_as_utf8_bytes() {
+            let mut subject = pin();
+            subject.name = "R\u{e9}sistance".to_string();
+            let mut data = Vec::new();
+            write_binary_pin(&mut data, &subject).unwrap();
+            let needle = b"\x0bR\xc3\xa9sistance";
+            assert!(
+                data.windows(needle.len()).any(|w| w == needle),
+                "UTF-8 bytes with an 11-byte length prefix: {data:?}"
+            );
         }
 
         #[test]
@@ -2116,6 +2377,165 @@ mod tests {
         );
     }
 
+    /// Every key any golden record carries is one an encoder can emit (or a
+    /// vertex key), so the replay's "a read key the canonical form lacks was
+    /// edited to its default" rule never mistakes an Altium key for one of
+    /// ours — and `MODELLED_RECORD_KEYS` cannot silently fall behind.
+    #[test]
+    fn every_golden_record_key_is_modelled() {
+        let lib = crate::altium::SchLib::open("scripts/samples/symbols.SchLib").unwrap();
+        let mut unmodelled = std::collections::BTreeSet::new();
+        for symbol in lib.iter() {
+            let records: Vec<&Vec<(String, String)>> = symbol
+                .rectangles
+                .iter()
+                .map(|r| &r.raw_params)
+                .chain(symbol.lines.iter().map(|r| &r.raw_params))
+                .chain(symbol.polylines.iter().map(|r| &r.raw_params))
+                .chain(symbol.polygons.iter().map(|r| &r.raw_params))
+                .chain(symbol.arcs.iter().map(|r| &r.raw_params))
+                .chain(symbol.pies.iter().map(|r| &r.raw_params))
+                .chain(symbol.images.iter().map(|r| &r.raw_params))
+                .chain(symbol.text_frames.iter().map(|r| &r.raw_params))
+                .chain(symbol.beziers.iter().map(|r| &r.raw_params))
+                .chain(symbol.ellipses.iter().map(|r| &r.raw_params))
+                .chain(symbol.round_rects.iter().map(|r| &r.raw_params))
+                .chain(symbol.elliptical_arcs.iter().map(|r| &r.raw_params))
+                .chain(symbol.labels.iter().map(|r| &r.raw_params))
+                .chain(symbol.text.iter().map(|r| &r.raw_params))
+                .chain(symbol.parameters.iter().map(|r| &r.raw_params))
+                .collect();
+            assert!(
+                !records.is_empty(),
+                "{}: every record carries its raw segments",
+                symbol.name
+            );
+            for raw in records {
+                assert!(
+                    !raw.is_empty(),
+                    "{}: a read record has raw segments",
+                    symbol.name
+                );
+                for (key, _) in raw {
+                    if !key.is_empty() && !is_modelled_record_key(key) {
+                        unmodelled.insert(key.clone());
+                    }
+                }
+            }
+        }
+        assert!(
+            unmodelled.is_empty(),
+            "golden keys no encoder emits: {unmodelled:?}"
+        );
+    }
+
+    /// The replay's four rules on one rectangle read from a UI-authored
+    /// library: verbatim while unchanged (no `LineWidth` invented), the
+    /// canonical value for an edited field, a cleared flag's key dropped, an
+    /// unmodelled Altium key kept in place, and the positional index renumbered.
+    #[test]
+    fn a_read_record_is_replayed_verbatim_until_edited() {
+        // As the UI stores it: no LineWidth, an unmodelled key in the middle.
+        let raw: Vec<(String, String)> = [
+            ("RECORD", "14"),
+            ("IsNotAccesible", "T"),
+            ("IndexInSheet", "3"),
+            ("OwnerPartId", "1"),
+            ("Location.X", "-20"),
+            ("Location.Y", "-10"),
+            ("Corner.X", "30"),
+            ("Corner.Y", "20"),
+            ("FUTUREKEY", "7"),
+            ("Color", "128"),
+            ("AreaColor", "11599871"),
+            ("IsSolid", "T"),
+            ("UniqueID", "GOHQXBJE"),
+        ]
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+        let mut rect = Rectangle::new(-20, -10, 30, 20);
+        rect.filled = true;
+        rect.unique_id = Some("GOHQXBJE".to_string());
+        rect.raw_params = raw;
+
+        let verbatim = replay_record(&encode_rectangle(&rect, 3), &rect.raw_params);
+        assert_eq!(
+            verbatim,
+            "|RECORD=14|IsNotAccesible=T|IndexInSheet=3|OwnerPartId=1|Location.X=-20|Location.Y=-10|Corner.X=30|Corner.Y=20|FUTUREKEY=7|Color=128|AreaColor=11599871|IsSolid=T|UniqueID=GOHQXBJE"
+        );
+
+        // Moved to slot 0, corner edited, fill cleared, line width set.
+        rect.x2 = 35.0;
+        rect.filled = false;
+        rect.line_width = 2;
+        let edited = replay_record(&encode_rectangle(&rect, 0), &rect.raw_params);
+        assert_eq!(
+            edited,
+            "|RECORD=14|IsNotAccesible=T|OwnerPartId=1|Location.X=-20|Location.Y=-10|Corner.X=35|Corner.Y=20|FUTUREKEY=7|Color=128|AreaColor=11599871|UniqueID=GOHQXBJE|LineWidth=2"
+        );
+
+        // No raw segments: the canonical form, LineWidth and all.
+        rect.raw_params.clear();
+        assert!(
+            replay_record(&encode_rectangle(&rect, 0), &rect.raw_params).contains("|LineWidth=2|")
+        );
+        rect.line_width = 1;
+        assert!(
+            replay_record(&encode_rectangle(&rect, 0), &rect.raw_params).contains("|LineWidth=1|")
+        );
+    }
+
+    /// A `%UTF8%` twin goes back with the bytes it was read with — a locale
+    /// artefact of the writing machine — for as long as its plain key is
+    /// unchanged, and in the canonical form once the text is edited.
+    #[test]
+    fn a_utf8_twin_follows_its_plain_key() {
+        let raw: Vec<(String, String)> = [
+            ("RECORD", "4"),
+            ("OwnerPartId", "1"),
+            ("FontID", "1"),
+            ("%UTF8%Text", "R\u{c4}\u{82}\u{c2}\u{a9}sistance"),
+            ("", ""),
+            ("", ""),
+            ("Text", "R\u{c3}\u{a9}sistance"),
+            ("UniqueID", "ADKXLEQV"),
+        ]
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+        let mut label = Label {
+            x: 0.0,
+            y: 0.0,
+            text: "R\u{e9}sistance".to_string(),
+            font_id: 1,
+            color: 0,
+            justification: TextJustification::BottomLeft,
+            rotation: 0.0,
+            is_mirrored: false,
+            is_hidden: false,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: Some("ADKXLEQV".to_string()),
+            raw_params: raw,
+        };
+        let replayed = replay_record(&encode_label(&label, 0), &label.raw_params);
+        assert!(
+            replayed.contains(
+                "|%UTF8%Text=R\u{c4}\u{82}\u{c2}\u{a9}sistance|||Text=R\u{c3}\u{a9}sistance|"
+            ),
+            "{replayed}"
+        );
+
+        label.text = "R2".to_string();
+        let edited = replay_record(&encode_label(&label, 0), &label.raw_params);
+        assert!(edited.contains("|||Text=R2|UniqueID=ADKXLEQV"), "{edited}");
+        assert!(
+            !edited.contains("%UTF8%"),
+            "an ASCII edit drops the twin: {edited}"
+        );
+    }
+
     #[test]
     fn a_symbol_with_no_recorded_order_leads_with_the_rectangles() {
         // Populating the lists directly leaves `primitive_order` empty, which is
@@ -2264,6 +2684,7 @@ mod tests {
         symbol.add_pin(Pin::new("B", "2", 15, 0, 5, PinOrientation::Right));
         symbol.add_line(Line::new(-10, 0, 10, 0));
         symbol.add_label(Label {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 12.0,
             text: "hello".to_string(),
@@ -2601,6 +3022,7 @@ mod tests {
     #[test]
     fn test_label_booleans_only_when_true() {
         let mut label = Label {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             text: "R".to_string(),
@@ -2632,6 +3054,7 @@ mod tests {
     #[test]
     fn test_arc_tags_is_not_accessible() {
         let arc = Arc {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             radius: 10.0,
@@ -2656,6 +3079,7 @@ mod tests {
     fn test_colour_omitted_when_zero() {
         // Altium omits Color / AreaColor when 0 (AddNonZero); emits them otherwise.
         let mut arc = Arc {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             radius: 10.0,
@@ -2681,6 +3105,7 @@ mod tests {
 
         let s = encode_text(
             &Text {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 text: "hi".to_string(),
@@ -2731,6 +3156,7 @@ mod tests {
         let line = encode_line(&Line::new(-5, 0, 5, 0), 1);
         let poly_line = encode_polyline(
             &Polyline {
+                raw_params: Vec::new(),
                 points: vec![(0.0, 0.0), (5.0, 5.0)],
                 line_width: 1,
                 color: 0,
@@ -2748,6 +3174,7 @@ mod tests {
         );
         let poly = encode_polygon(
             &Polygon {
+                raw_params: Vec::new(),
                 points: vec![(0.0, 0.0), (5.0, 0.0), (2.5, 5.0)],
                 line_width: 1,
                 line_color: 0,
@@ -2764,6 +3191,7 @@ mod tests {
         );
         let arc = encode_arc(
             &Arc {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 radius: 10.0,
@@ -2781,6 +3209,7 @@ mod tests {
         );
         let label = encode_label(
             &Label {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 text: "R".to_string(),
@@ -2870,6 +3299,7 @@ mod tests {
         // non-zero (the FRACSHAPES golden arc carries `Location.X_Frac=5000`
         // with no `Location.X` key); an on-grid zero still emits `=0`.
         let arc = Arc {
+            raw_params: Vec::new(),
             x: 0.05,
             y: 0.05,
             radius: 4.05,
@@ -2919,6 +3349,7 @@ mod tests {
         );
 
         let mut label = Label {
+            raw_params: Vec::new(),
             x: 0.0,
             y: 0.0,
             text: "caf\u{00E9}".to_string(), // "café" — non-ASCII, so promoted
@@ -2981,6 +3412,7 @@ mod tests {
             p.unique_id = Some("WXYZ7890".to_string());
             symbol.add_parameter(p);
             symbol.add_label(Label {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 text: value.to_string(),

--- a/src/mcp/tools/allowed_keys.rs
+++ b/src/mcp/tools/allowed_keys.rs
@@ -120,7 +120,7 @@ impl SchLibKeys {
 }
 
 /// Spells out one `SchLib` graphic's key list: its own fields, the display
-/// flags, then its authoring-only extras.
+/// flags, the `raw_params` replay carrier, then its authoring-only extras.
 macro_rules! graphic_keys {
     ($(#[$doc:meta])* $name:ident = [$($key:literal),* $(,)?] $(+ [$($extra:literal),* $(,)?])?) => {
         $(#[$doc])*
@@ -130,6 +130,7 @@ macro_rules! graphic_keys {
             "disabled",
             "dimmed",
             "owner_part_display_mode",
+            "raw_params",
             $($($extra,)*)?
         ];
     };
@@ -358,6 +359,7 @@ pub const ELLIPTICAL_ARC: &[&str] = &[
     "fill_color",
     "owner_part_id",
     "unique_id",
+    "raw_params",
 ];
 
 /// A text annotation (record 3) carries no display flags; `hidden` is the
@@ -374,6 +376,7 @@ pub const TEXT: &[&str] = &[
     "rotation",
     "owner_part_id",
     "unique_id",
+    "raw_params",
     "hidden",
 ];
 

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -625,6 +625,7 @@ mod tests {
 
         fn sch_arc() -> crate::altium::schlib::Arc {
             crate::altium::schlib::Arc {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 radius: 6.0,
@@ -642,6 +643,7 @@ mod tests {
 
         fn sch_poly() -> Polyline {
             Polyline {
+                raw_params: Vec::new(),
                 points: vec![(0.0, 0.0), (5.0, 5.0)],
                 line_width: 1,
                 color: 0,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -171,6 +171,15 @@ fn json_unique_id(json: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Reads a `SchLib` record's raw segments (`raw_params`) from its JSON, so a
+/// read-modify-write replays the record as Altium wrote it.
+fn json_raw_params(json: &Value) -> Vec<(String, String)> {
+    json.get("raw_params")
+        .cloned()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
 /// Reads a primitive's Altium identity GUID from its JSON, so a
 /// read-modify-write that passes through the tool layer keeps it.
 fn json_guid(json: &Value) -> Option<String> {
@@ -2222,6 +2231,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2278,6 +2288,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2321,6 +2332,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2407,6 +2419,7 @@ impl McpServer {
         let owner_part_id = json_i32(json, "owner_part_id").unwrap_or(1);
 
         Some(Parameter {
+            raw_params: json_raw_params(json),
             name: name.to_string(),
             value,
             x,
@@ -2504,6 +2517,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2565,6 +2579,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2613,6 +2628,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2661,6 +2677,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2712,6 +2729,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2773,6 +2791,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2817,6 +2836,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2861,6 +2881,7 @@ impl McpServer {
             fill_color,
             owner_part_id,
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2913,6 +2934,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -2974,6 +2996,7 @@ impl McpServer {
             owner_part_id,
             display_flags: parse_schlib_display_flags(json),
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 
@@ -3034,6 +3057,7 @@ impl McpServer {
             is_hidden,
             owner_part_id,
             unique_id: json_unique_id(json),
+            raw_params: json_raw_params(json),
         })
     }
 }

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -912,6 +912,7 @@ mod tests {
 
         fn poly(owner_part_id: i32) -> Polyline {
             Polyline {
+                raw_params: Vec::new(),
                 points: vec![(-5.0, 0.0), (0.0, 8.0), (5.0, 0.0)],
                 line_width: 1,
                 color: 0,
@@ -929,6 +930,7 @@ mod tests {
 
         fn sch_arc(owner_part_id: i32) -> SchArc {
             SchArc {
+                raw_params: Vec::new(),
                 x: 0.0,
                 y: 0.0,
                 radius: 6.0,

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -458,6 +458,25 @@ fn pcblib_golden_survives_a_round_trip() {
     );
 }
 
+/// Every binary (pin) record of a `SchLib` `Data` stream, bytes included,
+/// in stream order.
+fn binary_records(data: &[u8]) -> Vec<Vec<u8>> {
+    let mut records = Vec::new();
+    let mut offset = 0;
+    while offset + 4 <= data.len() {
+        let len = usize::from(data[offset])
+            | usize::from(data[offset + 1]) << 8
+            | usize::from(data[offset + 2]) << 16;
+        let flags = data[offset + 3];
+        let end = (offset + 4 + len).min(data.len());
+        if flags == 1 {
+            records.push(data[offset + 4..end].to_vec());
+        }
+        offset = end;
+    }
+    records
+}
+
 /// The kind of every record in a `SchLib` `Data` stream, in stream order.
 ///
 /// Framing is `[len: 3 bytes LE][flags: 1]` then the payload; `flags == 1`
@@ -535,6 +554,22 @@ fn schlib_golden_survives_a_round_trip() {
                 "{name}: record order changed\n  golden: {}\n  ours:   {}",
                 gk.join(" "),
                 ok.join(" ")
+            ));
+        }
+        // The binary pin records are not parameter blocks, so the passes
+        // above never see them: every one must come back byte for byte (a
+        // non-ASCII name is stored as UTF-8 bytes, not the code page).
+        let (gp, op) = (binary_records(&g), binary_records(&o));
+        if gp != op && !is_known(name) {
+            let first = gp
+                .iter()
+                .zip(op.iter())
+                .position(|(a, b)| a != b)
+                .map_or_else(|| "count".to_string(), |i| format!("pin {i}"));
+            failures.push(format!(
+                "{name}: binary pin records differ ({} golden, {} ours, first at {first})",
+                gp.len(),
+                op.len()
             ));
         }
     }

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -1423,6 +1423,7 @@ fn test_schlib_rename_component() {
     sym.description = "Test symbol".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -40.0,
         x2: 40.0,
@@ -1653,6 +1654,7 @@ fn test_schlib_copy_cross_library() {
     sym.description = "Source symbol".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -40.0,
         x2: 40.0,
@@ -1805,6 +1807,7 @@ fn test_schlib_json_roundtrip() {
     sym.description = "Test symbol for round-trip".to_string();
     sym.designator = "U".to_string();
     sym.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -40.0,
         x2: 40.0,
@@ -2074,6 +2077,7 @@ fn test_schlib_merge_libraries() {
     sym1.description = "Symbol A".to_string();
     sym1.designator = "U".to_string();
     sym1.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -40.0,
         x2: 40.0,
@@ -2263,6 +2267,7 @@ fn test_schlib_search() {
     let mut lib = SchLib::new();
     let mut sym1 = Symbol::new("LM7805");
     sym1.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -20.0,
         x2: 40.0,
@@ -2281,6 +2286,7 @@ fn test_schlib_search() {
 
     let mut sym2 = Symbol::new("LM7812");
     sym2.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -20.0,
         x2: 40.0,
@@ -2299,6 +2305,7 @@ fn test_schlib_search() {
 
     let mut sym3 = Symbol::new("NE555");
     sym3.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -40.0,
         x2: 40.0,
@@ -2398,6 +2405,7 @@ fn test_schlib_get_component() {
     let mut sym1 = Symbol::new("LM7805");
     sym1.description = "5V Regulator".to_string();
     sym1.rectangles.push(Rectangle {
+        raw_params: Vec::new(),
         x1: -40.0,
         y1: -30.0,
         x2: 40.0,


### PR DESCRIPTION
Bugs #27–#28: the last corpus finding generalised, plus a gap the golden suite was blind to.

## 1. Every content record is replayed as read

A UI-authored rectangle omits `LineWidth=1` where a scripted one writes it; a UI label stores a Latin-1 value as `%UTF8%Text=<UTF-8>\|\|\|Text=<Windows-1252>`; a record may carry keys this crate does not model. No flag recovers any of that once values are decoded, so every content record now carries its segments as read (`raw_params` — the header's mechanism from #428, generalised to all 15 text-record kinds) and the writer replays them: **verbatim** where the two values decode to the same text, the **canonical value** for an edited field or the positional `IndexInSheet`, **dropped** for a flag cleared back to its omitted default (`IsHidden`), **kept** for an Altium key no encoder emits, and an implicit default the file left out (`LineWidth=1`) stays implicit. From scratch: the canonical form, unchanged. A test holds the modelled-key table complete against every golden record — and found `TextMargin_Frac` missing on its first run.

## 2. Non-ASCII pin names were written as Windows-1252

The tool-layer twin exposed it: Altium stores a non-ASCII pin **name** as its **UTF-8 bytes** in the binary pin record — all 52 such golden pins, `Résistance` included — and the writer encoded Windows-1252 (`?` for anything beyond Latin-1, relying on `PinWideText`). The library-level golden suite never saw it because it byte-compares *text* records only; it now compares every binary pin record byte for byte too.

**Result: all 17 modern-format libraries of the corpus, both formats, round-trip clean** (the old-format pair is upgraded by design). `SCHLIB_FORMAT.md` documents both rules.

Gates: fmt ✅ clippy ✅ 1440 tests ✅ markdownlint ✅ coverage **99.09%** (409/45,176).

🤖 Generated with [Claude Code](https://claude.com/claude-code)