### PR TITLE
fix: reproduce what the second corpus showed a rewrite losing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,10 @@ Found while fixing something else; each needs its own verification or a fixture 
       (`graphically_locked`, `disabled`, `dimmed`, `owner_part_display_mode`) in the model,
       while the other 13 graphics do — almost certainly a gap, but no golden record exists
       to verify the keys AD24 emits. Blocked on the fixture (see `docs/FIXTURE_COVERAGE.md`).
+- [ ] **Mechanical 17-32 on pads, arcs, text, fills, regions and bodies** is stored the way
+      hand-authored *tracks* store it (byte 72 + V7 id `0x010200nn`, `MECHANICAL{nn}` token
+      for regions/bodies) — inferred from the one kind seen, not verified per kind. Blocked on
+      the fixture (`docs/FIXTURE_COVERAGE.md`, PcbLib backlog).
 
 ## B. On-site Altium tooling
 

--- a/docs/FIXTURE_COVERAGE.md
+++ b/docs/FIXTURE_COVERAGE.md
@@ -130,9 +130,18 @@ structs, not to Altium: an elliptical arc (RECORD=11; also the reason `Elliptica
 carries no display flags in the model — nothing to verify them against), a text
 annotation (RECORD=3; same for `Text`), and a footprint model link (RECORD=45, with
 its `ImplementationList`/`MapDefiner` children) — the `FootprintModel` replay of
-`unique_id`/`is_current` is unit-tested only.
+`unique_id`/`is_current`/`raw_params` is unit-tested only, and its UI-authored form
+(`IntegratedModel=T|DatabaseModel=T`, no empty `Description`) is known from a hand-authored
+library, not a golden.
 
 **PcbLib:** region net and the cavity/subpoly params, raw-outline precision for ComponentBody.
+A **primitive of every kind on Mechanical 17-32** (`eMechanical20` or
+`LayerUtils.MechanicalLayer(20)` if the AD24 API names it): the header byte 72 + V7 id
+`0x01020014` pair is settled by hand-authored tracks, but the same pair on a pad, arc,
+text, fill, region and body — and the `MECHANICAL20` token on the last two — is inferred
+from the track, not seen. A **via block longer than the 321-byte template** (an older
+Altium's 351-byte vias are known only from a hand-authored library) so the golden pins
+that the extra bytes go back verbatim.
 A **non-embedded STEP reference** in the *generated* golden — the form itself is settled
 by a UI-authored library (`MODELID=` empty, `MODEL.EMBED=FALSE`, `MODEL.NAME`, the full
 group; `/Library/ModelsNoEmbed` stays empty) and `write_pcblib` follows it. A **text beyond U+00FF** (Ω, CJK) so a golden pins `WideStrings` as UTF-16

--- a/docs/PCBLIB_FORMAT.md
+++ b/docs/PCBLIB_FORMAT.md
@@ -298,7 +298,19 @@ Every sub-block is length-prefixed:
 | 56 | Keep-Out Layer |
 | 57-72 | Mechanical 1-16 |
 | 73 | Drill Drawing |
-| 186-201 | Mechanical 17-32 (Altium Designer 18+) |
+| 186-201 | Mechanical 17-32 — read only; see below |
+
+Mechanical 17-32 have no header byte of their own. Altium stores a primitive on one of them
+under byte **72** (Mechanical 16, the last the byte can hold) and names the real layer in the
+[V7 layer id](#v7-layer-ids) — a hand-authored `Mechanical 20` track is `72` + `0x01020014` —
+or, for a region or body, in the `V7_LAYER` token (`MECHANICAL20`). The reader lets a V7 id or
+token past sixteen decide for a mechanical byte, and the writer stores such a layer the same
+way. Bytes 186-201 are accepted on read for files earlier versions of this crate wrote; they are
+never written.
+
+A header byte the table does not map reads as Multi-Layer and is carried as the primitive's
+`raw_layer_id`, so a rewrite stores the byte as read rather than `74`; moving the primitive to a
+layer the model can name discards it.
 
 ### Component Layer Pairs
 
@@ -345,6 +357,7 @@ Several primitives carry a derived 32-bit "v7 saved layer id" alongside the laye
 | 32 (bottom) | `0x0100FFFF` |
 | 39-54 (internal plane n) | `0x01010000 + n` |
 | 57-72 (mechanical n) | `0x01020000 + n` |
+| Mechanical 17-32 (byte 72) | `0x01020011`-`0x01020020` |
 | 33 / 34 (overlay) | `0x01030006` / `0x01030007` |
 | 35 / 36 (paste) | `0x01030008` / `0x01030009` |
 | 37 / 38 (solder) | `0x0103000A` / `0x0103000B` |
@@ -357,7 +370,7 @@ All primitives start with a common header:
 
 | Offset | Size | Field |
 |--------|------|-------|
-| 0 | 1 | Layer ID |
+| 0 | 1 | Layer ID (byte 72 for Mechanical 17-32 — see [Layer IDs](#layer-ids)) |
 | 1-2 | 2 | Flags word (u16, see below) |
 | 3-4 | 2 | NetIndex (u16; `0xFFFF` when unconnected) |
 | 5-6 | 2 | PolygonIndex (u16; `0xFFFF` = none) |
@@ -886,16 +899,17 @@ constant regions are replayed verbatim.
 | 75-202 | 128 | Per-layer diameters (32 × i32; a Simple via repeats its diameter) | yes |
 | 242-245 | 4 | Solder mask expansion, back/bottom face (i32; mirrors the front when unset) | yes |
 | 258 | 1 | Solder-mask expansion measured from the hole edge (bool) | yes |
-| 312 | 1 | Drill-pair classification (0=Through, 1=BlindBuriedStart, 2=Mid, 3=End) | yes |
-| 258 | 1 | Solder-mask-from-hole-edge flag | unmodelled (template) |
-| 259-274 | 16 | Identity GUID A (fresh per via on write) | write-only |
-| 275-290 | 16 | Identity GUID B (fresh per via on write) | write-only |
+| 259-274 | 16 | Identity GUID A — zeros in every AD-authored library via; replayed from the read block, zeroed from scratch | replay |
+| 275-290 | 16 | Identity GUID B — as GUID A | replay |
 | 291-294 | 4 | Hole positive tolerance (i32; `0x7FFFFFFF` = unset) | yes |
 | 295-298 | 4 | Hole negative tolerance (i32; `0x7FFFFFFF` = unset) | yes |
-| 312 | 1 | Drill layer-pair type (0=Through, 1/2/3 = blind/buried) | unmodelled (template) |
+| 312 | 1 | Drill-pair classification (0=Through, 1=BlindBuriedStart, 2=Mid, 3=End) | yes |
 | 320 | 1 | Trailing constant (`0x01`) | template |
 
-The reader accepts any block ≥ 31 bytes and defaults every absent field.
+The reader accepts any block ≥ 31 bytes and defaults every absent field. The whole block as
+read is the via's `raw_block` and the write base, **length included**: an older library stores
+351-byte vias, and the thirty bytes past the template go back verbatim. A read block shorter
+than the template cannot take the overlays, so the template is the base instead.
 
 ### 3D Model Storage
 

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -19,12 +19,17 @@ SchLib files are OLE Compound Documents (CFB format, OLE v3) containing:
 └── {ComponentName}/        # One storage per symbol
     ├── Data                # Symbol records stream
     ├── PinFrac             # OPTIONAL: fractional pin coordinates (compressed storage)
-    └── PinSymbolLineWidth  # OPTIONAL: per-pin symbol line widths (compressed storage)
+    ├── PinSymbolLineWidth  # OPTIONAL: per-pin symbol line widths (compressed storage)
+    ├── PinWideText         # OPTIONAL: wide form of non-ASCII pin names
+    └── PinFunctionData     # OPTIONAL: written by newer Altium; carried verbatim, not read
 ```
 
-The two pin auxiliary streams are emitted only when at least one pin needs them (see
-[Pin auxiliary streams](#pin-auxiliary-streams)); a symbol with on-grid, default-width pins has
-only its `Data` stream, byte-identical to Altium's own output.
+The pin auxiliary streams are emitted only when at least one pin needs them (see
+[Pin auxiliary streams](#pin-auxiliary-streams)); a symbol with on-grid, default-width,
+ASCII-named pins has only its `Data` stream, byte-identical to Altium's own output. Any other
+stream a symbol's storage holds — a `PinFunctionData` from a newer Altium — is carried as read
+(`Symbol::extra_streams`, base64 in JSON) and written back beside the ones this crate does
+read, so nothing Altium stored is dropped for being unknown.
 
 ## Cross-Cutting Conventions
 
@@ -794,6 +799,11 @@ A parameter-record variant selected by `Name=Designator`. As written by this cra
   | `ModelDatafileEntity0` | string | Footprint entity (resolution key) |
   | `ModelDatafileKind0` | string | `PCBLib` |
   | `IsCurrent` | bool | `T` on the default footprint; omitted on every other (never `F`) |
+
+  The record is carried and replayed like every content record (`raw_params`, see
+  [Component Header Record](#component-header-record1)): a UI-authored link also carries
+  `IntegratedModel=T|DatabaseModel=T`, which this crate does not model, and omits `Description`
+  while it is empty, all of which come back as stored.
 
 - **RECORD=46 (MapDefinerList)** and **RECORD=48 (ImplementationParameters)** — written as empty
   children of each RECORD=45 (`|RECORD=46|OwnerIndex={45's index}` / `|RECORD=48|OwnerIndex=...`).

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -17,10 +17,10 @@ _34 tools._
 
 Read an Altium .PcbLib file and return its contents including footprints with their primitives (pads, vias, tracks, arcs, regions, fills, text, component_bodies). Returns
 structured data that can be used to understand existing footprint styles. All coordinates and dimensions are in millimetres (mm). Fields such as guid, unique_id,
-raw_tail, raw_block, raw_geometry, param_key_order and primitive_order are fidelity carriers: pass them back unchanged to write_pcblib or update_component and the rewrite
-is byte-identical to the source; omit them when authoring from scratch. Each footprint is the same JSON shape get_component, export_library and write_pcblib use; a list
-with no entries and an optional field with no value are omitted rather than empty/null. For large libraries, use component_name to fetch specific footprints, or use
-limit/offset for pagination.
+raw_tail, raw_block, raw_geometry, raw_layer_id, param_key_order and primitive_order are fidelity carriers: pass them back unchanged to write_pcblib or update_component
+and the rewrite is byte-identical to the source; omit them when authoring from scratch. Each footprint is the same JSON shape get_component, export_library and
+write_pcblib use; a list with no entries and an optional field with no value are omitted rather than empty/null. For large libraries, use component_name to fetch specific
+footprints, or use limit/offset for pagination.
 
 **Example**
 
@@ -47,10 +47,10 @@ limit/offset for pagination.
 
 Read an Altium .SchLib file and return its contents including symbols with their primitives (pins, rectangles, round_rects, lines, polylines, polygons, arcs, pies,
 images, text_frames, beziers, ellipses, elliptical_arcs, labels, text), parameters and footprint links. Coordinates are in schematic units (10 units = 1 grid square, not
-mm). Fields such as unique_id and primitive_order are fidelity carriers: pass them back unchanged to write_schlib or update_component to keep the source's record
-identities and order; omit them when authoring from scratch. Each symbol is the same JSON shape get_component, export_library and write_schlib use; a list with no entries
-and an optional field with no value are omitted rather than empty/null. For large libraries, use component_name to fetch specific symbols, or use limit/offset for
-pagination.
+mm). Fields such as unique_id, primitive_order, header_params, raw_params, all_pin_count and extra_streams are fidelity carriers: pass them back unchanged to write_schlib
+or update_component and the rewrite is byte-identical to the source; omit them when authoring from scratch. Each symbol is the same JSON shape get_component,
+export_library and write_schlib use; a list with no entries and an optional field with no value are omitted rather than empty/null. For large libraries, use
+component_name to fetch specific symbols, or use limit/offset for pagination.
 
 **Example**
 

--- a/src/altium/base64_opt.rs
+++ b/src/altium/base64_opt.rs
@@ -112,3 +112,36 @@ mod tests {
         );
     }
 }
+
+/// (De)serialises a list of named binary streams as `[[name, base64], …]`.
+/// Used via `#[serde(with = "crate::altium::base64_opt::named")]` for the
+/// streams a symbol carries verbatim.
+pub mod named {
+    use super::{Deserialize, Deserializer, Serializer, STANDARD};
+    use base64::Engine as _;
+
+    pub fn serialize<S: Serializer>(
+        value: &[(String, Vec<u8>)],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let encoded: Vec<(&str, String)> = value
+            .iter()
+            .map(|(name, bytes)| (name.as_str(), STANDARD.encode(bytes)))
+            .collect();
+        serde::Serialize::serialize(&encoded, serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<(String, Vec<u8>)>, D::Error> {
+        Vec::<(String, String)>::deserialize(deserializer)?
+            .into_iter()
+            .map(|(name, text)| {
+                STANDARD
+                    .decode(text.as_bytes())
+                    .map(|bytes| (name, bytes))
+                    .map_err(serde::de::Error::custom)
+            })
+            .collect()
+    }
+}

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -922,6 +922,7 @@ mod tests {
         body.unique_id = uid.clone();
         fp.add_component_body(body);
         fp.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1381,6 +1382,7 @@ mod tests {
 
         // Add text with different rotations
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1420,6 +1422,7 @@ mod tests {
             raw_geometry: None,
         });
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1487,6 +1490,7 @@ mod tests {
         // round-trip rather than inheriting the template's 4-mil stroke.
         let mut original = Footprint::new("TEXT_STROKE");
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1542,6 +1546,7 @@ mod tests {
         // A TrueType italic text must round-trip italic@45 and derive baseFontType@43=1.
         let mut original = Footprint::new("TT_ITALIC");
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1597,6 +1602,7 @@ mod tests {
         // PR-10 offsets (mirror@35, bold@44, font-name@46-109, justification@132).
         let geom = writer::encode_text_geometry(
             &Text {
+                raw_layer_id: None,
                 barcode_full_width: None,
                 barcode_full_height: None,
                 barcode_x_margin: None,
@@ -1672,6 +1678,7 @@ mod tests {
         // mirror, bold, font_name, a non-default justification, kind, italic.
         let mut original = Footprint::new("TEXT_PR10");
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1735,6 +1742,7 @@ mod tests {
         // survive encode -> decode; a plain text keeps both false.
         let mut original = Footprint::new("TEXT_FLAGS");
         let mut text = Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1877,6 +1885,7 @@ mod tests {
         // InvertedRectTextOffset@133 (offsets verified against AltiumSharp ReadText).
         let mut original = Footprint::new("TEXT_INVRECT");
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -1947,6 +1956,7 @@ mod tests {
         // a locked / tented text round-trips its flags.
         let mut original = Footprint::new("TEXT_FLAGS");
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -2009,6 +2019,7 @@ mod tests {
 
         let long = "A".repeat(260) + "_END";
         let text_at = |content: &str, y: f64| Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -2192,6 +2203,7 @@ mod tests {
         original.add_track(track);
 
         original.add_text(Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -2326,6 +2338,7 @@ mod tests {
 
         // Add a rotated fill
         original.add_fill(Fill {
+            raw_layer_id: None,
             x1: -1.5,
             y1: -0.5,
             x2: 1.5,

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -55,11 +55,11 @@ pub struct Pad {
     #[serde(default)]
     pub shape: PadShape,
 
-    /// The header layer byte exactly as read, kept when it is not the byte
-    /// `layer` would get: a library can store a mechanical layer past the
-    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
-    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
-    /// was for as long as it still describes `layer`.
+    /// The header layer byte exactly as read, kept only when the layer table
+    /// does not map it — the primitive then sits on the `MultiLayer`
+    /// catch-all, and without the byte a rewrite would store `74` in its
+    /// place. Replayed while the primitive still sits there; moving it to a
+    /// layer the model can name discards the byte for that layer's own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_layer_id: Option<u8>,
 

--- a/src/altium/pcblib/primitives/pads.rs
+++ b/src/altium/pcblib/primitives/pads.rs
@@ -55,6 +55,14 @@ pub struct Pad {
     #[serde(default)]
     pub shape: PadShape,
 
+    /// The header layer byte exactly as read, kept when it is not the byte
+    /// `layer` would get: a library can store a mechanical layer past the
+    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
+    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
+    /// was for as long as it still describes `layer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
+
     /// Layer the pad is on.
     #[serde(default)]
     pub layer: Layer,
@@ -357,6 +365,7 @@ impl Pad {
     #[must_use]
     pub fn smd(designator: impl Into<String>, x: f64, y: f64, width: f64, height: f64) -> Self {
         Self {
+            raw_layer_id: None,
             designator: designator.into(),
             x,
             y,
@@ -413,6 +422,7 @@ impl Pad {
         hole_size: f64,
     ) -> Self {
         Self {
+            raw_layer_id: None,
             designator: designator.into(),
             x,
             y,
@@ -830,9 +840,11 @@ pub struct Via {
     /// The via's whole record block exactly as read (base64 in JSON), used as
     /// the write-side base with every typed field overlaid — so unmodelled
     /// bytes (the two in-record identity GUID slots, cache values, template
-    /// drift between AD versions) round-trip verbatim. `None` (from scratch)
-    /// uses the template with the GUID slots zeroed, which is what AD24 itself
-    /// writes for library vias (the golden's are all zeros).
+    /// drift between AD versions, the thirty bytes an older library's
+    /// 351-byte vias carry past the 321-byte template) round-trip verbatim,
+    /// length included. `None` (from scratch) uses the template with the GUID
+    /// slots zeroed, which is what AD24 itself writes for library vias (the
+    /// golden's are all zeros).
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -58,11 +58,11 @@ pub struct Track {
     /// Line width in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
-    /// The header layer byte exactly as read, kept when it is not the byte
-    /// `layer` would get: a library can store a mechanical layer past the
-    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
-    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
-    /// was for as long as it still describes `layer`.
+    /// The header layer byte exactly as read, kept only when the layer table
+    /// does not map it — the primitive then sits on the `MultiLayer`
+    /// catch-all, and without the byte a rewrite would store `74` in its
+    /// place. Replayed while the primitive still sits there; moving it to a
+    /// layer the model can name discards the byte for that layer's own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_layer_id: Option<u8>,
     /// Layer the track is on.
@@ -191,11 +191,11 @@ pub struct Arc {
     /// Line width in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
-    /// The header layer byte exactly as read, kept when it is not the byte
-    /// `layer` would get: a library can store a mechanical layer past the
-    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
-    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
-    /// was for as long as it still describes `layer`.
+    /// The header layer byte exactly as read, kept only when the layer table
+    /// does not map it — the primitive then sits on the `MultiLayer`
+    /// catch-all, and without the byte a rewrite would store `74` in its
+    /// place. Replayed while the primitive still sits there; moving it to a
+    /// layer the model can name discards the byte for that layer's own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_layer_id: Option<u8>,
     /// Layer the arc is on.

--- a/src/altium/pcblib/primitives/shapes.rs
+++ b/src/altium/pcblib/primitives/shapes.rs
@@ -58,6 +58,13 @@ pub struct Track {
     /// Line width in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
+    /// The header layer byte exactly as read, kept when it is not the byte
+    /// `layer` would get: a library can store a mechanical layer past the
+    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
+    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
+    /// was for as long as it still describes `layer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
     /// Layer the track is on.
     pub layer: Layer,
     /// Primitive flags (locked, keepout, etc.).
@@ -104,6 +111,7 @@ impl Track {
     #[must_use]
     pub const fn new(x1: f64, y1: f64, x2: f64, y2: f64, width: f64, layer: Layer) -> Self {
         Self {
+            raw_layer_id: None,
             x1,
             y1,
             x2,
@@ -152,6 +160,7 @@ impl Track {
 ///     end_angle: 90.0,
 ///     width: 0.15,
 ///     layer: Layer::TopOverlay,
+///     raw_layer_id: None,
 ///     flags: Default::default(),
 ///     net_index: 0xFFFF,
 ///     polygon_index: 0xFFFF,
@@ -182,6 +191,13 @@ pub struct Arc {
     /// Line width in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub width: f64,
+    /// The header layer byte exactly as read, kept when it is not the byte
+    /// `layer` would get: a library can store a mechanical layer past the
+    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
+    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
+    /// was for as long as it still describes `layer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
     /// Layer the arc is on.
     pub layer: Layer,
     /// Primitive flags (locked, keepout, etc.).
@@ -228,6 +244,7 @@ impl Arc {
     #[must_use]
     pub const fn circle(x: f64, y: f64, radius: f64, width: f64, layer: Layer) -> Self {
         Self {
+            raw_layer_id: None,
             x,
             y,
             radius,

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -99,6 +99,13 @@ pub struct Text {
     /// Text height in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub height: f64,
+    /// The header layer byte exactly as read, kept when it is not the byte
+    /// `layer` would get: a library can store a mechanical layer past the
+    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
+    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
+    /// was for as long as it still describes `layer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
     /// Layer the text is on.
     pub layer: Layer,
     /// Rotation angle in degrees.
@@ -308,6 +315,13 @@ pub struct Fill {
     /// Second corner Y position in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y2: f64,
+    /// The header layer byte exactly as read, kept when it is not the byte
+    /// `layer` would get: a library can store a mechanical layer past the
+    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
+    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
+    /// was for as long as it still describes `layer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_layer_id: Option<u8>,
     /// Layer the fill is on.
     pub layer: Layer,
     /// Rotation angle in degrees.
@@ -357,6 +371,7 @@ impl Fill {
     #[must_use]
     pub const fn new(x1: f64, y1: f64, x2: f64, y2: f64, layer: Layer) -> Self {
         Self {
+            raw_layer_id: None,
             x1,
             y1,
             x2,
@@ -380,6 +395,7 @@ impl Fill {
         let half_w = width / 2.0;
         let half_h = height / 2.0;
         Self {
+            raw_layer_id: None,
             x1: x - half_w,
             y1: y - half_h,
             x2: x + half_w,

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -99,11 +99,11 @@ pub struct Text {
     /// Text height in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub height: f64,
-    /// The header layer byte exactly as read, kept when it is not the byte
-    /// `layer` would get: a library can store a mechanical layer past the
-    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
-    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
-    /// was for as long as it still describes `layer`.
+    /// The header layer byte exactly as read, kept only when the layer table
+    /// does not map it — the primitive then sits on the `MultiLayer`
+    /// catch-all, and without the byte a rewrite would store `74` in its
+    /// place. Replayed while the primitive still sits there; moving it to a
+    /// layer the model can name discards the byte for that layer's own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_layer_id: Option<u8>,
     /// Layer the text is on.
@@ -315,11 +315,11 @@ pub struct Fill {
     /// Second corner Y position in mm.
     #[serde(serialize_with = "crate::altium::serde_round::serialize")]
     pub y2: f64,
-    /// The header layer byte exactly as read, kept when it is not the byte
-    /// `layer` would get: a library can store a mechanical layer past the
-    /// legacy sixteen under byte 72 with the real layer in the V7 layer id
-    /// (an AD-authored `Mechanical 20` track), so the byte goes back as it
-    /// was for as long as it still describes `layer`.
+    /// The header layer byte exactly as read, kept only when the layer table
+    /// does not map it — the primitive then sits on the `MultiLayer`
+    /// catch-all, and without the byte a rewrite would store `74` in its
+    /// place. Replayed while the primitive still sits there; moving it to a
+    /// layer the model can name discards the byte for that layer's own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_layer_id: Option<u8>,
     /// Layer the fill is on.

--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -469,7 +469,7 @@ pub fn read_flags_for_test(word: u16) -> PcbFlags {
 /// - 62 (Mech 6): Top 3D Body
 /// - 63 (Mech 7): Bottom 3D Body
 #[allow(clippy::too_many_lines)] // ID-to-layer lookup for all layer types
-const fn layer_from_id(id: u8) -> Layer {
+pub(super) const fn layer_from_id(id: u8) -> Layer {
     match id {
         1 => Layer::TopLayer,
         // Mid layers (IDs 2-31)

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -1217,7 +1217,6 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     let layer_id = *props_block
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Region layer"))?;
-    let layer = layer_from_id(layer_id);
     let flags = read_flags(props_block);
     let (net_index, polygon_index, component_index) = read_common_indices(props_block);
 
@@ -1243,6 +1242,11 @@ pub(super) fn parse_region(data: &[u8], offset: usize) -> ParseResult<Region> {
     }
     let params_str = crate::altium::decode_windows1252(&props_block[22..param_end]);
     let params = crate::altium::parse_pipe_params_raw(&params_str);
+
+    // The header byte names the layer, except that a mechanical byte defers
+    // to a `V7_LAYER` token past the sixteen it can hold (see `resolve_layer`).
+    let layer = mechanical_past_sixteen(layer_id, v7_token_mechanical(params.get("V7_LAYER")))
+        .unwrap_or_else(|| layer_from_id(layer_id));
 
     // Capture every key the typed model does NOT consume, in read order, so a
     // read-modify-write round-trips the board-region keys (LAYER, KEEPOUT, ...)
@@ -1371,27 +1375,46 @@ fn capture_additional_params(params_str: &str, modelled: &[&str]) -> Vec<(String
         .collect()
 }
 
-/// Resolves a record's layer from its legacy byte and the V7 layer id at
-/// `v7_at`, and keeps the byte when `layer` would not reproduce it.
+/// Resolves a record's layer from its header byte and the V7 layer id at
+/// `v7_at`, and returns the byte to carry when the layer cannot reproduce it.
 ///
-/// The legacy byte holds sixteen mechanical layers; a library using more
-/// stores such a primitive under byte 72 (the last legacy one) with the real
-/// layer in the V7 id (`0x0102_0014` is Mechanical 20), so the id decides and
-/// the byte is carried for the rewrite.
+/// The header byte holds sixteen mechanical layers; Altium stores a
+/// primitive on Mechanical 17-32 under byte 72 (the last the byte can hold)
+/// and names the real layer in the V7 id (`0x0102_0014` is Mechanical 20),
+/// so a mechanical byte defers to a V7 id past sixteen. A byte the table does
+/// not map lands on the `MultiLayer` catch-all and is carried as is, so the
+/// rewrite puts the byte back rather than `74` (see `raw_layer_id`).
 fn resolve_layer(byte: u8, block: &[u8], v7_at: usize) -> (Layer, Option<u8>) {
-    let mut layer = layer_from_id(byte);
-    if let Some(v7) = read_u32(block, v7_at) {
-        let mechanical = v7 >> 16 == 0x0102;
-        let index = v7 & 0xFFFF;
-        if mechanical && (17..=32).contains(&index) && (57..=72).contains(&byte) {
-            // Bytes 186-201 are Mechanical 17-32 in the extended scheme.
-            #[allow(clippy::cast_possible_truncation)]
-            let extended = (169 + index) as u8;
-            layer = layer_from_id(extended);
-        }
-    }
-    let raw = (crate::altium::pcblib::writer::layer_to_id(layer) != byte).then_some(byte);
-    (layer, raw)
+    let v7_mechanical = read_u32(block, v7_at)
+        .filter(|v7| v7 >> 16 == 0x0102)
+        .map(|v7| v7 & 0xFFFF);
+    let layer = mechanical_past_sixteen(byte, v7_mechanical).unwrap_or_else(|| layer_from_id(byte));
+    (layer, unmapped_layer_byte(byte, layer))
+}
+
+/// The layer a mechanical header byte and a V7 mechanical index past
+/// sixteen name together, when they do.
+fn mechanical_past_sixteen(byte: u8, v7_mechanical: Option<u32>) -> Option<Layer> {
+    let index = v7_mechanical.filter(|index| (17..=32).contains(index))?;
+    (57..=72).contains(&byte).then(|| {
+        // Mechanical 17-32 sit at 186-201 in the layer table.
+        #[allow(clippy::cast_possible_truncation)]
+        let id = (169 + index) as u8;
+        layer_from_id(id)
+    })
+}
+
+/// The V7 mechanical index a `V7_LAYER` token names (`MECHANICAL20` is 20).
+fn v7_token_mechanical(token: Option<&String>) -> Option<u32> {
+    token?.strip_prefix("MECHANICAL")?.parse().ok()
+}
+
+/// The header byte to carry: the byte as read when the table does not map
+/// it and the primitive therefore sits on the `MultiLayer` catch-all (#391);
+/// nothing for a byte the layer reproduces, `74` included.
+fn unmapped_layer_byte(byte: u8, layer: Layer) -> Option<u8> {
+    (layer == Layer::MultiLayer && byte != crate::altium::pcblib::writer::layer_to_id(layer))
+        .then_some(byte)
 }
 
 /// Parses a Fill primitive (filled rectangle).
@@ -1599,21 +1622,19 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
 
     // The body's layer is the CommonPrimitiveData layer byte at block offset 0 — the
     // authoritative source, exactly as AltiumSharp does (`result.Layer = layer`,
-    // PcbLibReader.ReadComponentBody). Decoding only the `V7_LAYER` parameter
-    // string and falling back to `Top3DBody` silently collapses every mechanical
-    // layer that fallback does not cover (e.g. MECHANICAL13 / id 69) to the top
-    // 3D-body layer on read. The header byte
-    // covers the full Mechanical1-32 range through `layer_from_id`, so a body authored
-    // on any layer now reads back on its true layer. The writer already emits the
-    // matching header byte and `V7_LAYER` token, so this is a read-only fix.
+    // PcbLibReader.ReadComponentBody) — except that a mechanical byte defers to
+    // a `V7_LAYER` token past the sixteen it can hold (see `resolve_layer`).
+    // Decoding only the `V7_LAYER` parameter string and falling back to
+    // `Top3DBody` would collapse every mechanical layer that fallback does not
+    // cover (e.g. MECHANICAL13 / id 69) to the top 3D-body layer on read.
     //
     // There is deliberately no `V7_LAYER` fallback for a missing header byte:
     // `params` is decoded from this same block, so the only block that lacks the
-    // byte — an empty one — has no parameter string to fall back to either. The
-    // fallback that used to sit here could not run for any input.
-    let layer = block0
-        .first()
-        .map_or(Layer::Top3DBody, |&id| layer_from_id(id));
+    // byte — an empty one — has no parameter string to fall back to either.
+    let layer = block0.first().map_or(Layer::Top3DBody, |&id| {
+        mechanical_past_sixteen(id, v7_token_mechanical(params.get("V7_LAYER")))
+            .unwrap_or_else(|| layer_from_id(id))
+    });
 
     // #391's one-byte replay base: when the byte is an id `layer_from_id`
     // does not map, the decode above collapses it to the `MultiLayer`
@@ -1621,9 +1642,9 @@ pub(super) fn parse_component_body(data: &[u8], offset: usize) -> ParseResult<Co
     // the byte (and, below, its `V7_LAYER` token) verbatim so the pair
     // round-trips; a genuine `MultiLayer` body (the canonical id itself)
     // keeps `None`.
-    let raw_layer_id = block0.first().copied().filter(|&id| {
-        layer == Layer::MultiLayer && id != crate::altium::pcblib::writer::layer_to_id(layer)
-    });
+    let raw_layer_id = block0
+        .first()
+        .and_then(|&id| unmapped_layer_byte(id, layer));
     let v7_layer = params
         .get("V7_LAYER")
         .filter(|token| **token != crate::altium::pcblib::writer::v7_layer_token(layer))
@@ -3109,35 +3130,69 @@ mod tests {
 
     #[test]
     fn the_v7_layer_id_names_a_mechanical_layer_past_the_legacy_sixteen() {
-        // Byte 72 is Mechanical 16, the last the legacy byte can hold; a
+        // Byte 72 is Mechanical 16, the last the header byte can hold; a
         // track on Mechanical 20 carries 72 there and `0x0102_0014` in the
-        // V7 id at @41, which decides. The byte is kept for the rewrite only
-        // when the layer would not reproduce it.
+        // V7 id at @41, which decides. Nothing is carried: the writer stores
+        // Mechanical 20 the same way.
         let mut b = vec![0_u8; 46];
         write_common_header(&mut b, 72);
         b[29..33].copy_from_slice(&50_000_i32.to_le_bytes());
         b[41..45].copy_from_slice(&0x0102_0014_u32.to_le_bytes());
         let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
         assert_eq!(track.layer, Layer::Mechanical20);
-        assert_eq!(track.raw_layer_id, Some(72));
+        assert_eq!(track.raw_layer_id, None);
 
-        // A consistent V7 id carries nothing extra.
+        // A V7 id within the sixteen leaves the byte in charge.
         b[41..45].copy_from_slice(&0x0102_0010_u32.to_le_bytes());
         let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
         assert_eq!(track.layer, Layer::Mechanical16);
-        assert_eq!(track.raw_layer_id, None);
 
         // A legacy-only record (no V7 id) is its byte.
         let (track, _) = parse_track(&block(&b[..33]), 0).expect("a whole track");
         assert_eq!(track.layer, Layer::Mechanical16);
-        assert_eq!(track.raw_layer_id, None);
 
-        // The extension applies to mechanical bytes only: a copper byte with
-        // a stray mechanical V7 id stays copper.
+        // The deferral is for mechanical bytes only: a copper byte with a
+        // stray mechanical V7 id stays copper.
         write_common_header(&mut b, 1);
         b[41..45].copy_from_slice(&0x0102_0014_u32.to_le_bytes());
         let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
         assert_eq!(track.layer, Layer::TopLayer);
-        assert_eq!(track.raw_layer_id, None);
+
+        // A byte the table does not map is carried for the rewrite; the
+        // Multi-Layer byte itself is not.
+        for (byte, carried) in [(100, Some(100)), (74, None)] {
+            write_common_header(&mut b, byte);
+            let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
+            assert_eq!(track.layer, Layer::MultiLayer);
+            assert_eq!(track.raw_layer_id, carried, "byte {byte}");
+        }
+    }
+
+    #[test]
+    fn a_v7_layer_token_names_a_region_or_body_layer_past_the_legacy_sixteen() {
+        // Regions and bodies carry the layer as a `V7_LAYER` token instead of
+        // an id; under byte 72 a `MECHANICAL20` token is the layer, and the
+        // token is then derived, not carried.
+        let mut b = vec![0_u8; 22];
+        write_common_header(&mut b, 72);
+        let params = b"V7_LAYER=MECHANICAL20|NAME=\0";
+        b[18..22].copy_from_slice(&u32::try_from(params.len()).expect("len").to_le_bytes());
+        b.extend_from_slice(params);
+        b.extend_from_slice(&0_u32.to_le_bytes()); // no vertices
+        let (region, _) = parse_region(&block(&b), 0).expect("a whole region");
+        assert_eq!(region.layer, Layer::Mechanical20);
+        assert_eq!(region.v7_layer, None, "the token follows from the layer");
+
+        let mut props = b"V7_LAYER=MECHANICAL20|NAME=body\0".to_vec();
+        let mut block0 = vec![72_u8, 0x0C, 0x00];
+        block0.extend_from_slice(&[0xFF; 10]);
+        block0.extend_from_slice(&[0; 5]);
+        block0.extend_from_slice(&u32::try_from(props.len()).expect("len").to_le_bytes());
+        block0.append(&mut props);
+        block0.extend_from_slice(&0_u32.to_le_bytes());
+        let (body, _) = parse_component_body(&block(&block0), 0).expect("a whole body");
+        assert_eq!(body.layer, Layer::Mechanical20);
+        assert_eq!(body.v7_layer, None);
+        assert_eq!(body.raw_layer_id, None);
     }
 }

--- a/src/altium/pcblib/reader/parsers.rs
+++ b/src/altium/pcblib/reader/parsers.rs
@@ -115,7 +115,7 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
     let layer_id = *geometry
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Pad layer"))?;
-    let layer = layer_from_id(layer_id);
+    let (layer, raw_layer_id) = resolve_layer(layer_id, geometry, 114);
     let flags = read_flags(geometry);
     // Common-header connectivity indices @3-8 (net/polygon/component).
     let (net_index, polygon_index, component_index) = read_common_indices(geometry);
@@ -323,6 +323,7 @@ pub(super) fn parse_pad(data: &[u8], offset: usize) -> ParseResult<Pad> {
         height,
         shape: adjusted_shape,
         layer,
+        raw_layer_id,
         hole_size,
         is_plated,
         jumper_id,
@@ -659,7 +660,7 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
     let layer_id = *block
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Track layer"))?;
-    let layer = layer_from_id(layer_id);
+    let (layer, raw_layer_id) = resolve_layer(layer_id, block, 41);
     let flags = read_flags(block);
     // Common-header connectivity indices @3-8 (net/polygon/component).
     let (net_index, polygon_index, component_index) = read_common_indices(block);
@@ -699,6 +700,7 @@ pub(super) fn parse_track(data: &[u8], offset: usize) -> ParseResult<Track> {
         y2,
         width,
         layer,
+        raw_layer_id,
         flags,
         net_index,
         polygon_index,
@@ -724,7 +726,7 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
     let layer_id = *block
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Arc layer"))?;
-    let layer = layer_from_id(layer_id);
+    let (layer, raw_layer_id) = resolve_layer(layer_id, block, 52);
     let flags = read_flags(block);
     // Common-header connectivity indices @3-8 (net/polygon/component).
     let (net_index, polygon_index, component_index) = read_common_indices(block);
@@ -767,6 +769,7 @@ pub(super) fn parse_arc(data: &[u8], offset: usize) -> ParseResult<Arc> {
         end_angle,
         width,
         layer,
+        raw_layer_id,
         flags,
         net_index,
         polygon_index,
@@ -818,7 +821,7 @@ pub(super) fn parse_text(
     let layer_id = *geometry_block
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Text layer"))?;
-    let layer = layer_from_id(layer_id);
+    let (layer, raw_layer_id) = resolve_layer(layer_id, geometry_block, 226);
     // Decode the lock/tenting/keepout flag word like every other primitive does,
     // rather than discarding it (the write side already encodes these correctly).
     let flags = read_flags(geometry_block);
@@ -989,6 +992,7 @@ pub(super) fn parse_text(
         text: text_content,
         height,
         layer,
+        raw_layer_id,
         rotation,
         kind,
         stroke_font,
@@ -1367,6 +1371,29 @@ fn capture_additional_params(params_str: &str, modelled: &[&str]) -> Vec<(String
         .collect()
 }
 
+/// Resolves a record's layer from its legacy byte and the V7 layer id at
+/// `v7_at`, and keeps the byte when `layer` would not reproduce it.
+///
+/// The legacy byte holds sixteen mechanical layers; a library using more
+/// stores such a primitive under byte 72 (the last legacy one) with the real
+/// layer in the V7 id (`0x0102_0014` is Mechanical 20), so the id decides and
+/// the byte is carried for the rewrite.
+fn resolve_layer(byte: u8, block: &[u8], v7_at: usize) -> (Layer, Option<u8>) {
+    let mut layer = layer_from_id(byte);
+    if let Some(v7) = read_u32(block, v7_at) {
+        let mechanical = v7 >> 16 == 0x0102;
+        let index = v7 & 0xFFFF;
+        if mechanical && (17..=32).contains(&index) && (57..=72).contains(&byte) {
+            // Bytes 186-201 are Mechanical 17-32 in the extended scheme.
+            #[allow(clippy::cast_possible_truncation)]
+            let extended = (169 + index) as u8;
+            layer = layer_from_id(extended);
+        }
+    }
+    let raw = (crate::altium::pcblib::writer::layer_to_id(layer) != byte).then_some(byte);
+    (layer, raw)
+}
+
 /// Parses a Fill primitive (filled rectangle).
 /// Returns the parsed `Fill` and the new offset on success.
 ///
@@ -1393,7 +1420,7 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
     let layer_id = *block
         .first()
         .ok_or_else(|| AltiumError::parse_error(offset, "failed to read Fill layer"))?;
-    let layer = layer_from_id(layer_id);
+    let (layer, raw_layer_id) = resolve_layer(layer_id, block, 42);
     let flags = read_flags(block);
     // Common-header connectivity indices @3-8 (net/polygon/component).
     let (net_index, polygon_index, component_index) = read_common_indices(block);
@@ -1427,6 +1454,7 @@ pub(super) fn parse_fill(data: &[u8], offset: usize) -> ParseResult<Fill> {
         x2,
         y2,
         layer,
+        raw_layer_id,
         rotation,
         flags,
         net_index,
@@ -3077,5 +3105,39 @@ mod tests {
         assert!((parse_mil_value(Some(" 100 mil")) - expected).abs() < 1e-9);
         assert!(parse_mil_value(None).abs() < EPS);
         assert!(parse_mil_value(Some("not-a-number")).abs() < EPS);
+    }
+
+    #[test]
+    fn the_v7_layer_id_names_a_mechanical_layer_past_the_legacy_sixteen() {
+        // Byte 72 is Mechanical 16, the last the legacy byte can hold; a
+        // track on Mechanical 20 carries 72 there and `0x0102_0014` in the
+        // V7 id at @41, which decides. The byte is kept for the rewrite only
+        // when the layer would not reproduce it.
+        let mut b = vec![0_u8; 46];
+        write_common_header(&mut b, 72);
+        b[29..33].copy_from_slice(&50_000_i32.to_le_bytes());
+        b[41..45].copy_from_slice(&0x0102_0014_u32.to_le_bytes());
+        let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
+        assert_eq!(track.layer, Layer::Mechanical20);
+        assert_eq!(track.raw_layer_id, Some(72));
+
+        // A consistent V7 id carries nothing extra.
+        b[41..45].copy_from_slice(&0x0102_0010_u32.to_le_bytes());
+        let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
+        assert_eq!(track.layer, Layer::Mechanical16);
+        assert_eq!(track.raw_layer_id, None);
+
+        // A legacy-only record (no V7 id) is its byte.
+        let (track, _) = parse_track(&block(&b[..33]), 0).expect("a whole track");
+        assert_eq!(track.layer, Layer::Mechanical16);
+        assert_eq!(track.raw_layer_id, None);
+
+        // The extension applies to mechanical bytes only: a copper byte with
+        // a stray mechanical V7 id stays copper.
+        write_common_header(&mut b, 1);
+        b[41..45].copy_from_slice(&0x0102_0014_u32.to_le_bytes());
+        let (track, _) = parse_track(&block(&b), 0).expect("a whole track");
+        assert_eq!(track.layer, Layer::TopLayer);
+        assert_eq!(track.raw_layer_id, None);
     }
 }

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -268,26 +268,30 @@ const fn encode_altium_flags(flags: PcbFlags) -> u16 {
 
 /// Writes the common 13-byte header for primitives.
 fn write_common_header(data: &mut Vec<u8>, layer: Layer, flags: PcbFlags) {
-    write_common_header_with_byte(data, layer_to_id(layer), flags);
+    write_common_header_with_byte(data, disk_layer_byte(layer), flags);
 }
 
-/// The layer byte a read primitive goes back out with: its own byte while
-/// that byte still describes `layer` (the legacy byte 72 an AD-authored
-/// `Mechanical 20` track carries, the V7 id holding the real layer), else
-/// the canonical byte for the layer it now has.
+/// The header layer byte Altium stores for a layer. Mechanical 17-32 have
+/// no byte of their own: Altium writes 72 (Mechanical 16, the last the byte
+/// can hold) and names the real layer in the V7 layer id or `V7_LAYER`
+/// token — an AD-authored `Mechanical 20` track is `72` + `0x0102_0014` —
+/// so that is what a from-scratch primitive gets too. Every other layer is
+/// its [`layer_to_id`] byte.
+pub(super) const fn disk_layer_byte(layer: Layer) -> u8 {
+    match layer_to_id(layer) {
+        186..=201 => 72,
+        id => id,
+    }
+}
+
+/// The layer byte a read primitive goes back out with: the byte as read
+/// while the primitive still sits on the `MultiLayer` catch-all an unmapped
+/// byte decodes to (see `raw_layer_id` on every layered primitive), else
+/// the byte Altium stores for the layer it now has.
 fn layer_byte(raw: Option<u8>, layer: Layer) -> u8 {
-    let canonical = layer_to_id(layer);
     match raw {
-        Some(byte) if byte != canonical => {
-            let same_layer = super::reader::layer_from_id(byte) == layer;
-            let clamped_mechanical = (57..=72).contains(&byte) && (186..=201).contains(&canonical);
-            if same_layer || clamped_mechanical {
-                byte
-            } else {
-                canonical
-            }
-        }
-        _ => canonical,
+        Some(byte) if layer == Layer::MultiLayer => byte,
+        _ => disk_layer_byte(layer),
     }
 }
 
@@ -1717,12 +1721,8 @@ fn encode_component_body_block(body: &ComponentBody, outline: &[(f64, f64)]) -> 
     // Layer ID (1 byte). An unmapped byte the reader could not decode is
     // replayed verbatim while the body still sits on the `MultiLayer`
     // catch-all its decode produced (#391); a retargeted body gets the
-    // canonical id for its new layer.
-    let layer_id = match body.raw_layer_id {
-        Some(id) if body.layer == Layer::MultiLayer => id,
-        _ => layer_to_id(body.layer),
-    };
-    block.push(layer_id);
+    // byte Altium stores for its new layer.
+    block.push(layer_byte(body.raw_layer_id, body.layer));
 
     // Record type marker (2 bytes): 0x0C 0x00
     block.push(0x0C);
@@ -4330,36 +4330,37 @@ mod tests {
     }
 
     #[test]
-    fn a_read_layer_byte_goes_back_while_it_still_describes_the_layer() {
-        // An AD-authored Mechanical 20 track is stored under legacy byte 72
-        // with the real layer in the V7 id. The byte goes back as read, the
-        // V7 id still names Mechanical 20, and the carried byte is dropped
-        // the moment the layer is edited to one it does not describe.
+    fn a_mechanical_layer_past_sixteen_is_stored_the_way_altium_stores_it() {
+        // Altium keeps a Mechanical 20 track under legacy byte 72 with the
+        // real layer in the V7 id at @41; a track placed there from scratch
+        // gets the same pair, and so does one read from such a file.
         let mut track = Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::Mechanical20);
-        track.raw_layer_id = Some(72);
         let mut data = Vec::new();
         encode_track(&mut data, &track);
-        assert_eq!(data[4], 72, "the clamped legacy byte as read");
+        assert_eq!(data[4], 72, "the legacy byte Altium writes");
         assert_eq!(&data[4 + 41..4 + 45], &0x0102_0014_u32.to_le_bytes());
+        for layer in [
+            Layer::Mechanical17,
+            Layer::Mechanical32,
+            Layer::Mechanical16,
+        ] {
+            assert_eq!(disk_layer_byte(layer), 72, "{layer:?}");
+        }
+        assert_eq!(disk_layer_byte(Layer::Mechanical15), 71);
+        assert_eq!(disk_layer_byte(Layer::TopOverlay), 33);
 
-        // From scratch the extended byte scheme names the layer itself.
-        track.raw_layer_id = None;
+        // A byte outside every documented range reads as Multi-Layer and, the
+        // primitive unmoved, goes back as the byte it was rather than as 74;
+        // moved to a layer the model can name, it gets that layer's byte.
+        track.layer = Layer::MultiLayer;
+        track.raw_layer_id = Some(100);
         let mut data = Vec::new();
         encode_track(&mut data, &track);
-        assert_eq!(data[4], 189, "Mechanical 20 is byte 186 + 3");
-
-        // Edited onto a layer the byte does not describe: the canonical byte.
-        track.raw_layer_id = Some(72);
+        assert_eq!(data[4], 100);
         track.layer = Layer::TopOverlay;
         let mut data = Vec::new();
         encode_track(&mut data, &track);
-        assert_eq!(data[4], layer_to_id(Layer::TopOverlay));
-
-        // A byte outside every documented range reads as Multi-Layer and, the
-        // layer unedited, goes back as the byte it was rather than as 74.
-        assert_eq!(layer_byte(Some(100), Layer::MultiLayer), 100);
-        assert_eq!(layer_byte(Some(100), Layer::TopLayer), 1);
-        assert_eq!(layer_byte(None, Layer::Mechanical17), 186);
-        assert_eq!(layer_byte(Some(57), Layer::Mechanical17), 57);
+        assert_eq!(data[4], 33);
+        assert_eq!(layer_byte(None, Layer::MultiLayer), 74);
     }
 }

--- a/src/altium/pcblib/writer.rs
+++ b/src/altium/pcblib/writer.rs
@@ -268,8 +268,33 @@ const fn encode_altium_flags(flags: PcbFlags) -> u16 {
 
 /// Writes the common 13-byte header for primitives.
 fn write_common_header(data: &mut Vec<u8>, layer: Layer, flags: PcbFlags) {
+    write_common_header_with_byte(data, layer_to_id(layer), flags);
+}
+
+/// The layer byte a read primitive goes back out with: its own byte while
+/// that byte still describes `layer` (the legacy byte 72 an AD-authored
+/// `Mechanical 20` track carries, the V7 id holding the real layer), else
+/// the canonical byte for the layer it now has.
+fn layer_byte(raw: Option<u8>, layer: Layer) -> u8 {
+    let canonical = layer_to_id(layer);
+    match raw {
+        Some(byte) if byte != canonical => {
+            let same_layer = super::reader::layer_from_id(byte) == layer;
+            let clamped_mechanical = (57..=72).contains(&byte) && (186..=201).contains(&canonical);
+            if same_layer || clamped_mechanical {
+                byte
+            } else {
+                canonical
+            }
+        }
+        _ => canonical,
+    }
+}
+
+/// [`write_common_header`] with an explicit layer byte.
+fn write_common_header_with_byte(data: &mut Vec<u8>, layer_byte: u8, flags: PcbFlags) {
     // Byte 0: Layer ID
-    data.push(layer_to_id(layer));
+    data.push(layer_byte);
     // Bytes 1-2: Altium flag word (saved/unlocked/tenting/keepout)
     data.extend_from_slice(&encode_altium_flags(flags).to_le_bytes());
     // Bytes 3-12: net index / polygon index / component index / reserved, all
@@ -759,7 +784,11 @@ fn encode_pad_geometry(pad: &Pad) -> Vec<u8> {
     let mut block = Vec::with_capacity(PAD_MAIN_BLOCK_LEN);
 
     // Common header (13 bytes) - offsets 0-12 + connectivity indices @3-8.
-    write_common_header(&mut block, pad.layer, pad.flags);
+    write_common_header_with_byte(
+        &mut block,
+        layer_byte(pad.raw_layer_id, pad.layer),
+        pad.flags,
+    );
     write_common_indices(
         &mut block,
         pad.net_index,
@@ -882,20 +911,24 @@ const VIA_SR1_TEMPLATE: [u8; 321] = [
 /// [`VIA_SR1_TEMPLATE`]. Our previous 6-block layout (copied from the pad
 /// encoder) was misread by Altium; this matches `PcbLibWriter.WriteVia` (#113).
 fn encode_via(data: &mut Vec<u8>, via: &Via) {
-    // Base = the block as read (when its length matches the template layout
-    // the overlays below assume), so unmodelled bytes round-trip; else the
-    // template with its identity-GUID slots zeroed — AD24 writes zeros there
-    // for every library via (the golden), and the old fresh-GUIDs-per-save
-    // behaviour meant the record changed on every write.
-    let mut block = via
+    // Base = the block as read whenever it is at least as long as the
+    // template the overlays below assume — length included, so a library's
+    // 351-byte vias keep the thirty bytes past the template this crate does
+    // not model and every other unmodelled byte round-trips; else the
+    // template with its identity-GUID slots zeroed, which is what AD24 writes
+    // there for every library via (the golden).
+    let mut block: Vec<u8> = via
         .raw_block
         .as_deref()
-        .and_then(|raw| <[u8; VIA_SR1_TEMPLATE.len()]>::try_from(raw).ok())
-        .unwrap_or_else(|| {
-            let mut b = VIA_SR1_TEMPLATE;
-            b[259..291].fill(0);
-            b
-        });
+        .filter(|raw| raw.len() >= VIA_SR1_TEMPLATE.len())
+        .map_or_else(
+            || {
+                let mut b = VIA_SR1_TEMPLATE;
+                b[259..291].fill(0);
+                b.to_vec()
+            },
+            <[u8]>::to_vec,
+        );
 
     // Common header (offsets 0-12): MultiLayer + the via's flag word
     // (locked/keepout/tenting top+bottom).
@@ -1075,7 +1108,11 @@ fn encode_track(data: &mut Vec<u8>, track: &Track) {
     let mut block = Vec::with_capacity(64);
 
     // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
-    write_common_header(&mut block, track.layer, track.flags);
+    write_common_header_with_byte(
+        &mut block,
+        layer_byte(track.raw_layer_id, track.layer),
+        track.flags,
+    );
     write_common_indices(
         &mut block,
         track.net_index,
@@ -1114,7 +1151,11 @@ fn encode_arc(data: &mut Vec<u8>, arc: &Arc) {
     let mut block = Vec::with_capacity(64);
 
     // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
-    write_common_header(&mut block, arc.layer, arc.flags);
+    write_common_header_with_byte(
+        &mut block,
+        layer_byte(arc.raw_layer_id, arc.layer),
+        arc.flags,
+    );
     write_common_indices(
         &mut block,
         arc.net_index,
@@ -1226,7 +1267,11 @@ pub fn encode_text_geometry(text: &Text, wide_index: Option<u32>) -> Vec<u8> {
 
     // Common header (offsets 0-12): layer + Altium flag word + 0xFF net/poly/comp.
     let mut header = Vec::with_capacity(13);
-    write_common_header(&mut header, text.layer, text.flags);
+    write_common_header_with_byte(
+        &mut header,
+        layer_byte(text.raw_layer_id, text.layer),
+        text.flags,
+    );
     block[..13].copy_from_slice(&header);
 
     // Connectivity indices @3-8 (net/polygon/component). Overlays the header's
@@ -1606,7 +1651,11 @@ fn encode_fill_block(fill: &Fill) -> Vec<u8> {
     let mut block = Vec::with_capacity(50);
 
     // Common header (13 bytes) + connectivity indices @3-8 (net/polygon/component).
-    write_common_header(&mut block, fill.layer, fill.flags);
+    write_common_header_with_byte(
+        &mut block,
+        layer_byte(fill.raw_layer_id, fill.layer),
+        fill.flags,
+    );
     write_common_indices(
         &mut block,
         fill.net_index,
@@ -2462,6 +2511,7 @@ mod tests {
         // IsComment@40 / IsDesignator@41 overlay the template's 0x00 bytes
         // (offsets verified against AltiumSharp b[40]/b[41]).
         let text = Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -2555,6 +2605,7 @@ mod tests {
         use crate::altium::TextJustification;
         // A default Text's geometry block keeps the template's 0xFF header bytes @3-8.
         let text = Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -2629,6 +2680,7 @@ mod tests {
         use crate::altium::TextJustification;
         // A framed inverted text overlays every descriptor field at its offset.
         let text = Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -4035,6 +4087,7 @@ mod tests {
     fn wide_strings_nonempty_has_no_trailing_pipe() {
         use crate::altium::TextJustification;
         let mk = |s: &str| Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,
@@ -4243,5 +4296,70 @@ mod tests {
         assert_eq!(encode_pad_per_layer_data(&pad)[288 + 3], 50);
         pad.per_layer_corner_radii = Some(vec![7; 32]);
         assert_eq!(&encode_pad_per_layer_data(&pad)[288..292], &[7, 7, 7, 7]);
+    }
+
+    #[test]
+    fn a_via_block_longer_than_the_template_keeps_its_length() {
+        // An older library stores 351-byte vias: thirty bytes past the
+        // 321-byte template, unmodelled here, that a rewrite must not cut off.
+        let mut raw = vec![0_u8; 351];
+        raw[..VIA_SR1_TEMPLATE.len()].copy_from_slice(&VIA_SR1_TEMPLATE);
+        for (i, byte) in raw[VIA_SR1_TEMPLATE.len()..].iter_mut().enumerate() {
+            *byte = u8::try_from(0xA0 + i).expect("fits");
+        }
+        let mut via = Via::new(0.0, 0.0, 0.6, 0.3);
+        via.raw_block = Some(raw.clone());
+
+        let mut data = Vec::new();
+        encode_via(&mut data, &via);
+        let len = u32::from_le_bytes(data[..4].try_into().expect("prefix")) as usize;
+        assert_eq!(len, raw.len(), "the read length is the written length");
+        assert_eq!(
+            &data[4 + VIA_SR1_TEMPLATE.len()..],
+            &raw[VIA_SR1_TEMPLATE.len()..],
+            "the bytes past the template go back verbatim"
+        );
+
+        // A block shorter than the template cannot take the overlays: the
+        // template is the base instead.
+        via.raw_block = Some(raw[..300].to_vec());
+        let mut data = Vec::new();
+        encode_via(&mut data, &via);
+        let len = u32::from_le_bytes(data[..4].try_into().expect("prefix")) as usize;
+        assert_eq!(len, VIA_SR1_TEMPLATE.len());
+    }
+
+    #[test]
+    fn a_read_layer_byte_goes_back_while_it_still_describes_the_layer() {
+        // An AD-authored Mechanical 20 track is stored under legacy byte 72
+        // with the real layer in the V7 id. The byte goes back as read, the
+        // V7 id still names Mechanical 20, and the carried byte is dropped
+        // the moment the layer is edited to one it does not describe.
+        let mut track = Track::new(0.0, 0.0, 1.0, 0.0, 0.2, Layer::Mechanical20);
+        track.raw_layer_id = Some(72);
+        let mut data = Vec::new();
+        encode_track(&mut data, &track);
+        assert_eq!(data[4], 72, "the clamped legacy byte as read");
+        assert_eq!(&data[4 + 41..4 + 45], &0x0102_0014_u32.to_le_bytes());
+
+        // From scratch the extended byte scheme names the layer itself.
+        track.raw_layer_id = None;
+        let mut data = Vec::new();
+        encode_track(&mut data, &track);
+        assert_eq!(data[4], 189, "Mechanical 20 is byte 186 + 3");
+
+        // Edited onto a layer the byte does not describe: the canonical byte.
+        track.raw_layer_id = Some(72);
+        track.layer = Layer::TopOverlay;
+        let mut data = Vec::new();
+        encode_track(&mut data, &track);
+        assert_eq!(data[4], layer_to_id(Layer::TopOverlay));
+
+        // A byte outside every documented range reads as Multi-Layer and, the
+        // layer unedited, goes back as the byte it was rather than as 74.
+        assert_eq!(layer_byte(Some(100), Layer::MultiLayer), 100);
+        assert_eq!(layer_byte(Some(100), Layer::TopLayer), 1);
+        assert_eq!(layer_byte(None, Layer::Mechanical17), 186);
+        assert_eq!(layer_byte(Some(57), Layer::Mechanical17), 57);
     }
 }

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -369,6 +369,17 @@ pub struct Symbol {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub header_params: Vec<(String, String)>,
 
+    /// Streams of the symbol's storage this crate does not read — a
+    /// `PinFunctionData` from a newer Altium, say — carried verbatim and
+    /// written back beside the ones it does, so nothing Altium stored is
+    /// dropped for being unknown.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "crate::altium::base64_opt::named"
+    )]
+    pub extra_streams: Vec<(String, Vec<u8>)>,
+
     /// `AllPinCount` as stored. Altium keeps a stale value here — a 32-pin
     /// UI-drawn MCU stores 1, a one-pin header 2 — so it is carried rather
     /// than recomputed; `None` (a symbol built from scratch) writes the pin
@@ -2127,5 +2138,60 @@ mod tests {
         assert!(lib.get_mut("R1").is_some());
         assert_eq!(lib.iter().count(), 1);
         assert_eq!(lib.iter_mut().count(), 1);
+    }
+
+    #[test]
+    fn streams_this_crate_does_not_read_go_back_as_they_were() {
+        // A newer Altium adds streams beside Data (a `PinFunctionData`); a
+        // rewrite carries them verbatim rather than dropping what it does not
+        // understand, and a reopen offers them back the same way.
+        let mut symbol = Symbol::new("U1");
+        symbol.add_pin(Pin::new("1", "A", -10, 0, 10, PinOrientation::Right));
+        symbol.extra_streams = vec![
+            ("PinFunctionData".to_string(), vec![0x01, 0x00, 0xFF, 0x7E]),
+            ("Future".to_string(), b"|FUTURE=1".to_vec()),
+        ];
+        let mut lib = SchLib::new();
+        lib.add(symbol);
+
+        let mut buffer = Cursor::new(Vec::new());
+        lib.write(&mut buffer).expect("write");
+        buffer.set_position(0);
+        let mut cfb = cfb::CompoundFile::open(buffer).expect("cfb");
+        let mut stream = cfb
+            .open_stream("/U1/PinFunctionData")
+            .expect("the stream is written");
+        let mut bytes = Vec::new();
+        std::io::Read::read_to_end(&mut stream, &mut bytes).expect("read");
+        assert_eq!(bytes, vec![0x01, 0x00, 0xFF, 0x7E]);
+
+        let mut buffer = cfb.into_inner();
+        buffer.set_position(0);
+        let read_lib = SchLib::read(buffer).expect("read");
+        let read_symbol = read_lib.get("U1").expect("symbol");
+        let mut carried = read_symbol.extra_streams.clone();
+        carried.sort();
+        assert_eq!(
+            carried,
+            vec![
+                ("Future".to_string(), b"|FUTURE=1".to_vec()),
+                ("PinFunctionData".to_string(), vec![0x01, 0x00, 0xFF, 0x7E]),
+            ]
+        );
+        // The streams this crate reads are not doubled up as extras.
+        assert!(read_symbol
+            .extra_streams
+            .iter()
+            .all(|(name, _)| name != "Data"));
+
+        // The JSON form is a base64 string per stream, and reads back.
+        let json = serde_json::to_value(read_symbol).expect("json");
+        assert_eq!(
+            json["extra_streams"].as_array().map(Vec::len),
+            Some(2),
+            "{json}"
+        );
+        let back: Symbol = serde_json::from_value(json).expect("from json");
+        assert_eq!(back.extra_streams.len(), 2);
     }
 }

--- a/src/altium/schlib/primitives/models.rs
+++ b/src/altium/schlib/primitives/models.rs
@@ -27,6 +27,11 @@ pub struct FootprintModel {
     /// re-emits the same id; a from-scratch model generates a fresh one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_id: Option<String>,
+    /// The `RECORD=45` exactly as read (see `raw_params` on every graphic):
+    /// a UI-authored link carries `IntegratedModel=T|DatabaseModel=T` and
+    /// omits an empty `Description`, all of which come back as stored.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub raw_params: Vec<(String, String)>,
 }
 
 impl FootprintModel {
@@ -34,6 +39,7 @@ impl FootprintModel {
     #[must_use]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
+            raw_params: Vec::new(),
             name: name.into(),
             description: String::new(),
             library_path: None,

--- a/src/altium/schlib/read_io.rs
+++ b/src/altium/schlib/read_io.rs
@@ -123,6 +123,7 @@ impl SchLib {
             reader::parse_data_stream(&mut symbol, &data);
 
             apply_pin_aux_streams(&mut cfb, &comp_name, &mut symbol);
+            carry_extra_streams(&mut cfb, &comp_name, &mut symbol);
 
             // Use the symbol's actual name (from LibReference) as the key
             // This handles long names that were truncated in the OLE storage path
@@ -175,6 +176,36 @@ fn apply_pin_aux_streams<R: Read + Seek>(
         crate::altium::read_stream_opt(&mut *cfb, format!("{comp_name}/PinWideText"))
     {
         pin_aux::apply_pin_wide_text(&mut symbol.pins, &wide);
+    }
+}
+
+/// The streams of the component's storage this crate does not read — a
+/// `PinFunctionData` from a newer Altium — are the names beside `Data` and
+/// the pin auxiliaries, kept verbatim as [`Symbol::extra_streams`].
+const READ_STREAMS: &[&str] = &["Data", "PinFrac", "PinSymbolLineWidth", "PinWideText"];
+
+/// Carries every stream of the component's storage that nothing above reads.
+fn carry_extra_streams<R: Read + Seek>(
+    cfb: &mut CompoundFile<R>,
+    comp_name: &str,
+    symbol: &mut Symbol,
+) {
+    let extra: Vec<String> = cfb
+        .read_storage(format!("/{comp_name}"))
+        .map(|entries| {
+            entries
+                .filter(cfb::Entry::is_stream)
+                .map(|entry| entry.name().to_string())
+                .filter(|name| !READ_STREAMS.contains(&name.as_str()))
+                .collect()
+        })
+        .unwrap_or_default();
+    for name in extra {
+        if let Some(bytes) =
+            crate::altium::read_stream_opt(&mut *cfb, format!("{comp_name}/{name}"))
+        {
+            symbol.extra_streams.push((name, bytes));
+        }
     }
 }
 

--- a/src/altium/schlib/reader/mod.rs
+++ b/src/altium/schlib/reader/mod.rs
@@ -235,6 +235,7 @@ fn parse_text_record_from_string(symbol: &mut Symbol, text: &str) {
             // Model (footprint reference)
             if let Some(name) = props.get("modelname") {
                 let mut fp = FootprintModel::new(name);
+                fp.raw_params = record_segments(text);
                 if let Some(desc) = props.get("description") {
                     fp.description.clone_from(desc);
                 }

--- a/src/altium/schlib/write_io.rs
+++ b/src/altium/schlib/write_io.rs
@@ -96,6 +96,10 @@ impl SchLib {
             if let Some(wide) = pin_aux::encode_pin_wide_text(&symbol.pins)? {
                 crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/PinWideText"), &wide)?;
             }
+            // Streams read but not understood go back as they were.
+            for (name, bytes) in &symbol.extra_streams {
+                crate::altium::write_stream(&mut cfb, &format!("/{ole_name}/{name}"), bytes)?;
+            }
         }
 
         // Root Storage stream (Altium's icon storage). Always present. EVERY

--- a/src/altium/schlib/writer.rs
+++ b/src/altium/schlib/writer.rs
@@ -355,7 +355,7 @@ const POSITIONAL_KEYS: &[&str] = &["IndexInSheet", "OwnerIndex"];
 /// out: left out when the read record lacked it and the value is still the
 /// implicit one, so the file comes back as Altium wrote it; emitted once the
 /// field is edited away from it.
-const IMPLICIT_DEFAULTS: &[(&str, &str)] = &[("LineWidth", "1")];
+const IMPLICIT_DEFAULTS: &[(&str, &str)] = &[("LineWidth", "1"), ("Description", "")];
 
 /// Every key a content record's encoder can emit — the keys a struct field
 /// stands behind. A read key in this set that the canonical form now omits
@@ -435,6 +435,14 @@ const MODELLED_RECORD_KEYS: &[&str] = &[
     "Transparent",
     "UniqueID",
     "WordWrap",
+    // RECORD=45, the footprint link
+    "ModelName",
+    "ModelType",
+    "DatafileCount",
+    "ModelDatafile0",
+    "ModelDatafileEntity0",
+    "ModelDatafileKind0",
+    "IsCurrent",
 ];
 
 /// Whether `key` is one an encoder can emit: a vertex key (`X3`, `Y12`) or
@@ -1735,10 +1743,13 @@ pub fn encode_data_stream(symbol: &Symbol) -> crate::altium::error::AltiumResult
         let model_index = count_records(&data);
         write_text_record(
             &mut data,
-            &encode_footprint_model(
-                model,
-                impl_index,
-                model.is_current || (!has_current && i == 0),
+            &replay_record(
+                &encode_footprint_model(
+                    model,
+                    impl_index,
+                    model.is_current || (!has_current && i == 0),
+                ),
+                &model.raw_params,
             ),
         )?;
         write_text_record(&mut data, &encode_model_datafile_link(model_index))?;
@@ -3461,5 +3472,46 @@ mod tests {
                 "designator must survive UTF-8 round-trip intact"
             );
         }
+    }
+
+    #[test]
+    fn a_read_footprint_link_is_replayed_verbatim() {
+        // As the UI stores it: IntegratedModel and DatabaseModel, which this
+        // crate does not model, and no Description while it is empty.
+        let raw: Vec<(String, String)> = [
+            ("RECORD", "45"),
+            ("OwnerIndex", "1"),
+            ("IndexInSheet", "-1"),
+            ("ModelName", "MOUNTING_HOLE"),
+            ("ModelType", "PCBLIB"),
+            ("DatafileCount", "1"),
+            ("ModelDatafileEntity0", "MOUNTING_HOLE"),
+            ("ModelDatafileKind0", "PCBLib"),
+            ("IsCurrent", "T"),
+            ("IntegratedModel", "T"),
+            ("DatabaseModel", "T"),
+            ("UniqueID", "ABCDEFGH"),
+        ]
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+        let mut model = FootprintModel::new("MOUNTING_HOLE");
+        model.unique_id = Some("ABCDEFGH".to_string());
+        model.raw_params = raw;
+
+        let verbatim = replay_record(&encode_footprint_model(&model, 1, true), &model.raw_params);
+        assert_eq!(
+            verbatim,
+            "|RECORD=45|OwnerIndex=1|IndexInSheet=-1|ModelName=MOUNTING_HOLE|ModelType=PCBLIB|DatafileCount=1|ModelDatafileEntity0=MOUNTING_HOLE|ModelDatafileKind0=PCBLib|IsCurrent=T|IntegratedModel=T|DatabaseModel=T|UniqueID=ABCDEFGH"
+        );
+
+        // No longer current, a description given: the unmodelled keys stay,
+        // IsCurrent goes, the description is appended.
+        model.description = "M3".to_string();
+        let edited = replay_record(&encode_footprint_model(&model, 1, false), &model.raw_params);
+        assert_eq!(
+            edited,
+            "|RECORD=45|OwnerIndex=1|IndexInSheet=-1|ModelName=MOUNTING_HOLE|ModelType=PCBLIB|DatafileCount=1|ModelDatafileEntity0=MOUNTING_HOLE|ModelDatafileKind0=PCBLib|IntegratedModel=T|DatabaseModel=T|UniqueID=ABCDEFGH|Description=M3"
+        );
     }
 }

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -38,9 +38,10 @@ impl McpServer {
                      component_bodies). Returns structured data that can be used to understand \
                      existing footprint styles. All coordinates and dimensions are in millimetres \
                      (mm). Fields such as guid, unique_id, raw_tail, raw_block, raw_geometry, \
-                     param_key_order and primitive_order are fidelity carriers: pass them back \
-                     unchanged to write_pcblib or update_component and the rewrite is \
-                     byte-identical to the source; omit them when authoring from scratch. \
+                     raw_layer_id, param_key_order and primitive_order are fidelity carriers: \
+                     pass them back unchanged to write_pcblib or update_component and the \
+                     rewrite is byte-identical to the source; omit them when authoring from \
+                     scratch. \
                      Each footprint is the same JSON shape get_component, export_library and \
                      write_pcblib use; a list with no entries and an optional field with no \
                      value are omitted rather than empty/null. \
@@ -84,10 +85,11 @@ impl McpServer {
                      polygons, arcs, pies, images, text_frames, beziers, ellipses, \
                      elliptical_arcs, labels, text), parameters and footprint links. \
                      Coordinates are in schematic units (10 units = 1 grid square, not mm). \
-                     Fields such as unique_id and primitive_order are fidelity carriers: pass \
-                     them back unchanged to write_schlib or update_component to keep the \
-                     source's record identities and order; omit them when authoring from \
-                     scratch. Each symbol is the same JSON shape get_component, \
+                     Fields such as unique_id, primitive_order, header_params, raw_params, \
+                     all_pin_count and extra_streams are fidelity carriers: pass them back \
+                     unchanged to write_schlib or update_component and the rewrite is \
+                     byte-identical to the source; omit them when authoring from scratch. \
+                     Each symbol is the same JSON shape get_component, \
                      export_library and write_schlib use; a list with no entries and an \
                      optional field with no value are omitted rather than empty/null. \
                      For large libraries, use component_name to fetch specific \

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -1544,6 +1544,7 @@ mod tests {
     /// Builds a minimal stroke text at the given position.
     fn make_text(content: &str, x: f64, y: f64) -> Text {
         Text {
+            raw_layer_id: None,
             barcode_full_width: None,
             barcode_full_height: None,
             barcode_x_margin: None,

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -583,6 +583,7 @@ mod tests {
 
         fn pcb_text() -> Text {
             Text {
+                raw_layer_id: None,
                 barcode_full_width: None,
                 barcode_full_height: None,
                 barcode_x_margin: None,

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -2050,6 +2050,7 @@ mod tests {
             fp.add_region(Region::rectangle(-1.0, -1.0, 1.0, 1.0, Layer::TopLayer));
             fp.add_via(Via::new(0.6, 0.6, 0.6, 0.3));
             fp.add_text(Text {
+                raw_layer_id: None,
                 barcode_full_width: None,
                 barcode_full_height: None,
                 barcode_x_margin: None,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -186,8 +186,21 @@ fn json_guid(json: &Value) -> Option<String> {
     json.get("guid").and_then(Value::as_str).map(str::to_string)
 }
 
+/// The streams a symbol carries verbatim (`extra_streams`), in the
+/// `[[name, base64], …]` form `read_schlib` emits; anything else is no
+/// streams, like every other carrier this parser reads leniently.
+fn json_extra_streams(json: &Value) -> Vec<(String, Vec<u8>)> {
+    #[derive(serde::Deserialize)]
+    struct Streams(#[serde(with = "crate::altium::base64_opt::named")] Vec<(String, Vec<u8>)>);
+    json.get("extra_streams")
+        .cloned()
+        .and_then(|v| serde_json::from_value::<Streams>(v).ok())
+        .map_or_else(Vec::new, |streams| streams.0)
+}
+
 /// A read primitive's header layer byte (`raw_layer_id`), carried so the
-/// rewrite keeps a clamped legacy byte while it still describes the layer.
+/// rewrite keeps an unmapped byte while the primitive still sits on the
+/// Multi-Layer catch-all it decoded to.
 fn json_raw_layer_id(json: &Value) -> Option<u8> {
     json.get("raw_layer_id")
         .and_then(Value::as_u64)
@@ -542,23 +555,7 @@ impl McpServer {
         }
 
         // The streams this crate does not read, carried verbatim.
-        if let Some(streams) = sym_json.get("extra_streams") {
-            symbol.extra_streams = serde_json::from_value::<Vec<(String, String)>>(streams.clone())
-                .ok()
-                .map(|pairs| {
-                    pairs
-                        .into_iter()
-                        .filter_map(|(name, text)| {
-                            use base64::Engine as _;
-                            base64::engine::general_purpose::STANDARD
-                                .decode(text.as_bytes())
-                                .ok()
-                                .map(|bytes| (name, bytes))
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-        }
+        symbol.extra_streams = json_extra_streams(sym_json);
         // The header exactly as read — key order, unmodelled keys and the
         // stale AllPinCount — so a read-modify-write reproduces it.
         if let Some(params) = sym_json.get("header_params") {
@@ -3820,12 +3817,12 @@ mod tests {
 
     #[test]
     fn every_layered_primitive_carries_its_read_layer_byte() {
-        // The clamped legacy byte of an AD-authored Mechanical 20 primitive
-        // survives the JSON boundary on each of the five kinds that have one.
+        // An unmapped header byte read onto the Multi-Layer catch-all
+        // survives the JSON boundary on each of the five kinds that carry one.
         let with = |fields: serde_json::Value| {
             let mut json = fields;
-            json["layer"] = json!("Mechanical 20");
-            json["raw_layer_id"] = json!(72);
+            json["layer"] = json!("Multi-Layer");
+            json["raw_layer_id"] = json!(100);
             json
         };
         let pad = McpServer::parse_pad(&with(json!({
@@ -3856,9 +3853,9 @@ mod tests {
                 text.raw_layer_id,
                 fill.raw_layer_id,
             ],
-            [Some(72); 5]
+            [Some(100); 5]
         );
-        assert_eq!(track.layer, crate::altium::pcblib::Layer::Mechanical20);
+        assert_eq!(track.layer, crate::altium::pcblib::Layer::MultiLayer);
         // An out-of-range value is not a byte.
         let plain = McpServer::parse_fill(&json!({
             "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0, "layer": "Top Layer", "raw_layer_id": 300,

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -186,6 +186,14 @@ fn json_guid(json: &Value) -> Option<String> {
     json.get("guid").and_then(Value::as_str).map(str::to_string)
 }
 
+/// A read primitive's header layer byte (`raw_layer_id`), carried so the
+/// rewrite keeps a clamped legacy byte while it still describes the layer.
+fn json_raw_layer_id(json: &Value) -> Option<u8> {
+    json.get("raw_layer_id")
+        .and_then(Value::as_u64)
+        .and_then(|v| u8::try_from(v).ok())
+}
+
 /// Reads a base64-encoded byte field: the raw replay bases `read_pcblib`
 /// emits (a pad's `raw_tail`, a via's `raw_block`, a text's `raw_geometry`)
 /// and embedded image bytes. Passing one back through the tool layer keeps
@@ -527,11 +535,30 @@ impl McpServer {
                         .get("unique_id")
                         .and_then(Value::as_str)
                         .map(str::to_string);
+                    fp.raw_params = json_raw_params(fp_json);
                     symbol.add_footprint(fp);
                 }
             }
         }
 
+        // The streams this crate does not read, carried verbatim.
+        if let Some(streams) = sym_json.get("extra_streams") {
+            symbol.extra_streams = serde_json::from_value::<Vec<(String, String)>>(streams.clone())
+                .ok()
+                .map(|pairs| {
+                    pairs
+                        .into_iter()
+                        .filter_map(|(name, text)| {
+                            use base64::Engine as _;
+                            base64::engine::general_purpose::STANDARD
+                                .decode(text.as_bytes())
+                                .ok()
+                                .map(|bytes| (name, bytes))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+        }
         // The header exactly as read — key order, unmodelled keys and the
         // stale AllPinCount — so a read-modify-write reproduces it.
         if let Some(params) = sym_json.get("header_params") {
@@ -1175,6 +1202,7 @@ impl McpServer {
             });
 
         Ok(Pad {
+            raw_layer_id: json_raw_layer_id(json),
             designator: designator.to_string(),
             x,
             y,
@@ -1268,6 +1296,7 @@ impl McpServer {
         track.keepout_restrictions = json_keepout(json);
         track.unique_id = json_unique_id(json);
         track.guid = json_guid(json);
+        track.raw_layer_id = json_raw_layer_id(json);
         Ok(track)
     }
 
@@ -1312,6 +1341,7 @@ impl McpServer {
         };
 
         Ok(Arc {
+            raw_layer_id: json_raw_layer_id(json),
             x,
             y,
             radius,
@@ -1571,6 +1601,7 @@ impl McpServer {
             .and_then(Value::as_f64);
 
         Some(Text {
+            raw_layer_id: json_raw_layer_id(json),
             x,
             y,
             text: text.to_string(),
@@ -1671,10 +1702,7 @@ impl McpServer {
             texture_size_x: json_guidless_opt(body_json, "texture_size_x"),
             texture_size_y: json_guidless_opt(body_json, "texture_size_y"),
             texture_rotation: json_guidless_opt(body_json, "texture_rotation"),
-            raw_layer_id: body_json
-                .get("raw_layer_id")
-                .and_then(Value::as_u64)
-                .and_then(|v| u8::try_from(v).ok()),
+            raw_layer_id: json_raw_layer_id(body_json),
             v7_layer: json_guidless_opt(body_json, "v7_layer"),
             model_id: str_or("model_id", ""),
             model_name: str_or("model_name", ""),
@@ -2000,6 +2028,7 @@ impl McpServer {
         fill.keepout_restrictions = json_keepout(json);
         fill.unique_id = json_unique_id(json);
         fill.guid = json_guid(json);
+        fill.raw_layer_id = json_raw_layer_id(json);
 
         Ok(fill)
     }
@@ -3787,6 +3816,55 @@ mod tests {
         }))
         .expect("fill should parse");
         assert_eq!(fill.guid.as_deref(), Some(guid));
+    }
+
+    #[test]
+    fn every_layered_primitive_carries_its_read_layer_byte() {
+        // The clamped legacy byte of an AD-authored Mechanical 20 primitive
+        // survives the JSON boundary on each of the five kinds that have one.
+        let with = |fields: serde_json::Value| {
+            let mut json = fields;
+            json["layer"] = json!("Mechanical 20");
+            json["raw_layer_id"] = json!(72);
+            json
+        };
+        let pad = McpServer::parse_pad(&with(json!({
+            "designator": "1", "x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0,
+        })))
+        .expect("pad");
+        let track = McpServer::parse_track(&with(json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.2,
+        })))
+        .expect("track");
+        let arc = McpServer::parse_arc(&with(json!({
+            "x": 0.0, "y": 0.0, "radius": 1.0, "start_angle": 0.0, "end_angle": 90.0, "width": 0.2,
+        })))
+        .expect("arc");
+        let text = McpServer::parse_text(&with(json!({
+            "x": 0.0, "y": 0.0, "text": "T", "height": 1.0,
+        })))
+        .expect("text");
+        let fill = McpServer::parse_fill(&with(json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0,
+        })))
+        .expect("fill");
+        assert_eq!(
+            [
+                pad.raw_layer_id,
+                track.raw_layer_id,
+                arc.raw_layer_id,
+                text.raw_layer_id,
+                fill.raw_layer_id,
+            ],
+            [Some(72); 5]
+        );
+        assert_eq!(track.layer, crate::altium::pcblib::Layer::Mechanical20);
+        // An out-of-range value is not a byte.
+        let plain = McpServer::parse_fill(&json!({
+            "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 1.0, "layer": "Top Layer", "raw_layer_id": 300,
+        }))
+        .expect("fill");
+        assert_eq!(plain.raw_layer_id, None);
     }
 
     #[test]

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -505,6 +505,7 @@ impl McpServer {
                     .fold(f64::NEG_INFINITY, f64::max);
                 let y = if top.is_finite() { top + 0.6 } else { 0.0 };
                 footprint.add_text(Text {
+                    raw_layer_id: None,
                     barcode_full_width: None,
                     barcode_full_height: None,
                     barcode_x_margin: None,
@@ -1588,6 +1589,7 @@ mod tests {
             let mut fp = Footprint::new("REPLAY");
             fp.guid = Some("{11111111-2222-3333-4444-555555555555}".to_string());
             fp.add_text(Text {
+                raw_layer_id: None,
                 barcode_full_width: None,
                 barcode_full_height: None,
                 barcode_x_margin: None,

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -2120,6 +2120,41 @@ mod tests {
             assert_eq!(link["library_path"], "Lib.PcbLib", "{link}");
         }
 
+        /// A stream this crate does not read (a newer Altium's
+        /// `PinFunctionData`) crosses the JSON boundary as `read_schlib`
+        /// emits it and is written back; a malformed carrier is no streams,
+        /// not an error, like the other carriers.
+        #[test]
+        fn write_schlib_carries_a_symbol_stream_it_does_not_read() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let out = dir.path().join("Extra.SchLib");
+            let written = server.call_write_schlib(&json!({
+                "filepath": out.to_string_lossy(),
+                "symbols": [{
+                    "name": "X",
+                    "extra_streams": [["PinFunctionData", "AQD/fg=="]],
+                }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+            let back = server.call_read_schlib(&json!({ "filepath": out.to_string_lossy() }));
+            let symbol = parse_result_json(&back)["symbols"][0].clone();
+            assert_eq!(
+                symbol["extra_streams"],
+                json!([["PinFunctionData", "AQD/fg=="]]),
+                "{symbol}"
+            );
+
+            let written = server.call_write_schlib(&json!({
+                "filepath": out.to_string_lossy(),
+                "symbols": [{ "name": "X", "extra_streams": [["PinFunctionData", "not base64!"]] }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+            let back = server.call_read_schlib(&json!({ "filepath": out.to_string_lossy() }));
+            let symbol = parse_result_json(&back)["symbols"][0].clone();
+            assert!(symbol.get("extra_streams").is_none(), "{symbol}");
+        }
+
         /// The in-place twin: every golden footprint read through
         /// `read_pcblib` and handed back to `update_component` as its own
         /// replacement leaves the library byte-for-byte as the library-level

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -146,6 +146,7 @@ fn pcblib_file_roundtrip_all_primitives() {
 
     // Text
     let text = Text {
+        raw_layer_id: None,
         barcode_full_width: None,
         barcode_full_height: None,
         barcode_x_margin: None,
@@ -890,6 +891,7 @@ fn pcblib_roundtrip_preserves_numeric_silkscreen_text() {
     let file_path = temp_dir.path().join("numeric_text.PcbLib");
 
     let numeric_text = |content: &str, y: f64| Text {
+        raw_layer_id: None,
         barcode_full_width: None,
         barcode_full_height: None,
         barcode_x_margin: None,

--- a/tests/golden_fidelity.rs
+++ b/tests/golden_fidelity.rs
@@ -712,6 +712,12 @@ fn schlib_golden_survives_a_round_trip() {
 /// elsewhere at build time (a compile-time constant, not a runtime path);
 /// ignored by default and never writes into the corpus.
 ///
+/// A library Altium did not author is normalised rather than reproduced —
+/// the sibling corpus's `test_component.*` pair (a third-party writer's
+/// explicit defaults, trailing pipes and an `OwnerIndex=0` footprint link)
+/// is reported as a divergence by design, so a clean sweep is "every
+/// Altium-authored library OK", not an empty report.
+///
 /// ```text
 /// ALTIUM_CORPUS_DIR=../my-libraries cargo test --test golden_fidelity corpus -- --ignored --nocapture
 /// ```

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -541,6 +541,7 @@ fn test_text_special_strings() {
 
     // Standard designator reference
     let text1 = Text {
+        raw_layer_id: None,
         barcode_full_width: None,
         barcode_full_height: None,
         barcode_x_margin: None,
@@ -583,6 +584,7 @@ fn test_text_special_strings() {
 
     // Comment reference
     let text2 = Text {
+        raw_layer_id: None,
         barcode_full_width: None,
         barcode_full_height: None,
         barcode_x_margin: None,


### PR DESCRIPTION
## Summary

Sweeping a **second real-world corpus** (`altium-library`, 10 hand-authored libraries) through the read/write cycle surfaced four more things a rewrite lost. All four are fixed; both corpora now rewrite **byte-identical** for every Altium-authored library (the only remaining divergence is the known third-party-written `test_component.*` pair, which is normalised by design and now documented as such in the sweep).

| # | Finding | Fix |
|---|---------|-----|
| 1 | **Vias truncated.** An older Altium stores **351-byte** via blocks; `encode_via` used the read block as its base only when it was *exactly* the 321-byte template, so 30 bytes per via were cut off. | A read block at least as long as the template is the base, **length included**; a shorter one falls back to the template. |
| 2 | **Mechanical 17–32 silently relayered.** Altium stores e.g. Mechanical 20 as header byte **72** (Mechanical 16, the last the byte can hold) with the real layer in the V7 id (`0x01020014`) / `V7_LAYER=MECHANICAL20` token. We read the byte as Mechanical 16 and rewrote the V7 id to match — a silent layer change. | The reader lets a V7 id or token past sixteen decide for a mechanical byte (tracks, arcs, pads, text, fills, regions, bodies). The writer stores such a layer **the way Altium does** (`disk_layer_byte`); bytes 186–201, which we wrote on the strength of #282 and which Altium never writes, stay readable but are no longer written. |
| 3 | **SchLib footprint links (`RECORD=45`)** dropped `IntegratedModel=T\|DatabaseModel=T` and invented an empty `Description=`. | `FootprintModel.raw_params` + the same `replay_record` as every other record; `("Description", "")` joins `IMPLICIT_DEFAULTS`. |
| 4 | **Unknown per-symbol streams dropped** (`PinFunctionData` from a newer Altium). | `Symbol::extra_streams` (base64 in JSON) read by `carry_extra_streams` and written back beside the streams we do read. |

Also: `raw_layer_id` now exists on Pad/Track/Arc/Text/Fill with the body's existing rule (an unmapped header byte is carried while the primitive sits on the Multi-Layer catch-all, so a rewrite stores the byte as read rather than `74`); all carriers cross the JSON boundary through the tool parsers.

## Docs

- `PCBLIB_FORMAT.md`: how Mechanical 17–32 are stored, the V7 id row, the via block length, and two stale via rows fixed (offsets 258/312 were listed twice with contradicting "modelled" verdicts; the GUID slots were described as fresh-per-save when they are zeroed from scratch and replayed when read).
- `SCHLIB_FORMAT.md`: `RECORD=45` replay, the carried streams in the storage tree.
- `TOOLS.md` (regenerated) / tool descriptions: the carrier lists for `read_pcblib` and `read_schlib`.
- `TODO.md` § A + `FIXTURE_COVERAGE.md` backlog: the byte-72 pair is settled by hand-authored *tracks*; the same pair on the other kinds is inferred, not seen — a fixture item.

## Verification

- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `cargo doc -D warnings`: clean
- 1205 lib tests + integration suites: green; coverage **99.10%** (production metric)
- Corpus sweeps: `altium-library` 10/10 OK; sibling corpus 17/17 Altium-authored OK
- New tests: via block length, `disk_layer_byte`/`layer_byte`, V7 id and `V7_LAYER` token resolution (track, region, body), RECORD=45 replay, extra streams (library API, JSON boundary, malformed carrier), `raw_layer_id` on all five kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
