### PR TITLE
fix: resolve component names the way the file does — regardless of case, in place

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -198,6 +198,19 @@ likewise refused, never silently left out: the error names the kind and index
 (`Failed to parse region at index 2`, `Failed to parse footprint link at index 0`) in the
 structured context above, and nothing is written.
 
+### Component Names Are Case-Insensitive
+
+A component name is resolved regardless of case — `get_component` for `lm358` finds
+`LM358` — because that is how the file's own OLE directory compares the storage names a
+component becomes, and how Altium resolves one. Every tool that creates a name
+(`copy_component`, `rename_component`, `bulk_rename`, `write_*` append, `import_library`,
+`merge_libraries`, `update_component` with a new name) therefore treats a name differing
+from an existing one only in case as taken, and says so with the spelling on file:
+`Component 'res_0402' already exists in library as 'RES_0402' (component names are
+case-insensitive)`. Renaming a component to its own name in another case is allowed. Two
+such names within one `write_*` request are reported as a duplicate. A rename keeps the
+component's position in the library.
+
 ---
 
 ## Path Sanitisation

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -248,6 +248,32 @@ pub fn fold_ansi_widened(text: &str) -> Option<String> {
 /// empty, since there is no storage name to derive from nothing.
 pub const OLE_NAME_FORBIDDEN: &[char] = &['/', '\\', ':', '!'];
 
+/// Whether two component names are the same name, regardless of case.
+///
+/// That is how the OLE directory compares the storage names they become
+/// (`RES_0402` and `res_0402` cannot both be stored) and how Altium resolves
+/// a component by name.
+#[must_use]
+pub fn same_name(a: &str, b: &str) -> bool {
+    a.chars()
+        .flat_map(char::to_uppercase)
+        .eq(b.chars().flat_map(char::to_uppercase))
+}
+
+/// A name's case-folded form, for sets that must hold names the way the OLE
+/// directory does (see [`same_name`]).
+#[must_use]
+pub fn folded_name(name: &str) -> String {
+    name.chars().flat_map(char::to_uppercase).collect()
+}
+
+/// Whether `candidate` is already taken in `used_names`, ignoring case — a
+/// storage name that differs only in case from one in use is the same
+/// storage to the OLE directory, and creating it fails.
+fn ole_name_taken<S: BuildHasher>(used_names: &HashSet<String, S>, candidate: &str) -> bool {
+    used_names.contains(candidate) || used_names.iter().any(|used| same_name(used, candidate))
+}
+
 #[must_use]
 pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String, S>) -> String {
     // OLE/CFB storage names cannot contain `/`, `\`, `:` or `!`: the `cfb`
@@ -273,7 +299,7 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
     // The OLE/CFB limit is 31 UTF-16 code units — not bytes or chars. Measure
     // it correctly so supplementary-plane characters (2 units each) cannot slip
     // a name past the limit and make the whole save fail.
-    if utf16_len(name) <= MAX_OLE_NAME_LEN && !used_names.contains(name) {
+    if utf16_len(name) <= MAX_OLE_NAME_LEN && !ole_name_taken(used_names, name) {
         return name.to_string();
     }
 
@@ -283,7 +309,7 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
     // a wire name (one byte per char) truncating by UTF-16 unit is the same
     // cut, minus the ability to split a char in two.
     let plain = truncate_utf16(name, MAX_OLE_NAME_LEN);
-    if !used_names.contains(&plain) {
+    if !ole_name_taken(used_names, &plain) {
         return plain;
     }
 
@@ -293,7 +319,7 @@ pub fn generate_ole_name<S: BuildHasher>(name: &str, used_names: &HashSet<String
     let prefix = truncate_utf16(name, MAX_OLE_NAME_LEN - SUFFIX_LEN);
     for i in 1..1000 {
         let candidate = format!("{prefix}~{i:03}");
-        if !used_names.contains(&candidate) {
+        if !ole_name_taken(used_names, &candidate) {
             return candidate;
         }
     }
@@ -584,18 +610,45 @@ pub(crate) fn parse_pipe_params_ordered(text: &str) -> Vec<(String, String)> {
 /// Shared by both libraries' `reorder` methods, which differ only in their
 /// backing collection (`IndexMap` vs `Vec`).
 pub(crate) fn order_ranker<'a>(new_order: &[&'a str]) -> impl Fn(&str) -> usize + 'a {
-    let order_map: std::collections::HashMap<&'a str, usize> = new_order
+    // Names compare the way the library resolves them (see `same_name`).
+    let order_map: std::collections::HashMap<String, usize> = new_order
         .iter()
         .enumerate()
-        .map(|(i, name)| (*name, i))
+        .map(|(i, name)| (folded_name(name), i))
         .collect();
     let max_pos = new_order.len();
-    move |name: &str| order_map.get(name).copied().unwrap_or(max_pos)
+    move |name: &str| {
+        order_map
+            .get(&folded_name(name))
+            .copied()
+            .unwrap_or(max_pos)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn names_differing_only_in_case_are_one_storage_name() {
+        // The OLE directory compares storage names without regard to case,
+        // so the second of two such names gets a distinct storage name (the
+        // real name still travels in SectionKeys) instead of failing the
+        // whole save inside the directory.
+        assert!(same_name("RES_0402", "res_0402"));
+        assert!(same_name("Ω_MODULE", "ω_module"));
+        assert!(!same_name("RES_0402", "RES_0403"));
+        assert_eq!(folded_name("res_0402"), "RES_0402");
+
+        let names = generate_ole_names(["RES_0402", "res_0402", "Res_0402"]);
+        assert_eq!(names, ["RES_0402", "res_0402~001", "Res_0402~002"]);
+
+        // A ranker ranks a case variant with the name it stands for.
+        let rank = order_ranker(&["b", "A"]);
+        assert_eq!(rank("B"), 0);
+        assert_eq!(rank("a"), 1);
+        assert_eq!(rank("c"), 2);
+    }
 
     #[test]
     fn short_name_unchanged() {

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -695,16 +695,32 @@ impl PcbLib {
         self.filepath.as_deref()
     }
 
-    /// Gets a footprint by name.
-    #[must_use]
-    pub fn get(&self, name: &str) -> Option<&Footprint> {
-        self.footprints.iter().find(|f| f.name == name)
+    /// The index of the footprint `name` resolves to: the exact name, else
+    /// the footprint whose name is the same regardless of case — the way the
+    /// file's own directory resolves it (see [`crate::altium::same_name`]).
+    fn position(&self, name: &str) -> Option<usize> {
+        self.footprints
+            .iter()
+            .position(|f| f.name == name)
+            .or_else(|| {
+                self.footprints
+                    .iter()
+                    .position(|f| crate::altium::same_name(&f.name, name))
+            })
     }
 
-    /// Gets a mutable reference to a footprint by name.
+    /// Gets a footprint by name — the exact name, else the one the name
+    /// resolves to regardless of case.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Footprint> {
+        self.position(name).map(|i| &self.footprints[i])
+    }
+
+    /// Gets a mutable reference to a footprint by name (resolved as
+    /// [`Self::get`] resolves it).
     #[must_use]
     pub fn get_mut(&mut self, name: &str) -> Option<&mut Footprint> {
-        self.footprints.iter_mut().find(|f| f.name == name)
+        self.position(name).map(move |i| &mut self.footprints[i])
     }
 
     /// Adds a footprint to the library.
@@ -716,11 +732,7 @@ impl PcbLib {
     ///
     /// Returns the removed footprint if found, or `None` if no footprint with that name exists.
     pub fn remove(&mut self, name: &str) -> Option<Footprint> {
-        if let Some(idx) = self.footprints.iter().position(|f| f.name == name) {
-            Some(self.footprints.remove(idx))
-        } else {
-            None
-        }
+        self.position(name).map(|idx| self.footprints.remove(idx))
     }
 
     /// Updates a footprint in-place, preserving its position in the library.
@@ -730,11 +742,34 @@ impl PcbLib {
     ///
     /// Returns the old footprint if found, or `None` if no footprint with that name exists.
     pub fn update(&mut self, name: &str, replacement: Footprint) -> Option<Footprint> {
-        if let Some(idx) = self.footprints.iter().position(|f| f.name == name) {
-            Some(std::mem::replace(&mut self.footprints[idx], replacement))
-        } else {
-            None
+        self.position(name)
+            .map(|i| std::mem::replace(&mut self.footprints[i], replacement))
+    }
+
+    /// Renames a footprint in place, so it keeps its position in the
+    /// library and in the file. Returns whether `old_name` resolved to one.
+    pub fn rename(&mut self, old_name: &str, new_name: &str) -> bool {
+        self.rename_all(&[(old_name.to_string(), new_name.to_string())])
+            .is_empty()
+    }
+
+    /// Renames several footprints at once, each in place. Every `(old, new)`
+    /// pair resolves against the names as they were before the call, so a
+    /// chain such as `A -> B, B -> C` renames both rather than renaming the
+    /// new `B` twice. Returns the old names that resolved to nothing.
+    pub fn rename_all(&mut self, renames: &[(String, String)]) -> Vec<String> {
+        let mut missing = Vec::new();
+        let mut resolved: Vec<(usize, &str)> = Vec::with_capacity(renames.len());
+        for (old, new) in renames {
+            match self.position(old) {
+                Some(i) => resolved.push((i, new.as_str())),
+                None => missing.push(old.clone()),
+            }
         }
+        for (i, new) in resolved {
+            self.footprints[i].name = new.to_string();
+        }
+        missing
     }
 
     /// Reorders footprints according to the given name order.

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -140,16 +140,33 @@ impl SchLib {
         self.filepath.as_deref()
     }
 
-    /// Gets a symbol by name.
-    #[must_use]
-    pub fn get(&self, name: &str) -> Option<&Symbol> {
-        self.symbols.get(name)
+    /// The index of the symbol `name` resolves to: the exact name, else the
+    /// symbol whose name is the same regardless of case — the way the file's
+    /// own directory resolves it (see [`crate::altium::same_name`]).
+    fn index_of(&self, name: &str) -> Option<usize> {
+        self.symbols.get_index_of(name).or_else(|| {
+            self.symbols
+                .keys()
+                .position(|key| crate::altium::same_name(key, name))
+        })
     }
 
-    /// Gets a mutable reference to a symbol by name.
+    /// Gets a symbol by name — the exact name, else the one the name
+    /// resolves to regardless of case.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&Symbol> {
+        self.index_of(name)
+            .and_then(|i| self.symbols.get_index(i))
+            .map(|(_, symbol)| symbol)
+    }
+
+    /// Gets a mutable reference to a symbol by name (resolved as
+    /// [`Self::get`] resolves it).
     #[must_use]
     pub fn get_mut(&mut self, name: &str) -> Option<&mut Symbol> {
-        self.symbols.get_mut(name)
+        self.index_of(name)
+            .and_then(move |i| self.symbols.get_index_mut(i))
+            .map(|(_, symbol)| symbol)
     }
 
     /// Returns an iterator over all symbols.
@@ -183,20 +200,68 @@ impl SchLib {
     ///
     /// Returns the removed symbol if found, or `None` if no symbol with that name exists.
     pub fn remove(&mut self, name: &str) -> Option<Symbol> {
-        self.symbols.shift_remove(name)
+        self.index_of(name)
+            .and_then(|i| self.symbols.shift_remove_index(i))
+            .map(|(_, symbol)| symbol)
     }
 
     /// Updates a symbol in-place, preserving its position in the library.
     ///
-    /// The symbol is matched by the `name` parameter. The replacement symbol
-    /// will be stored under the same key, preserving position. If you need to
-    /// rename the symbol, use `rename` after updating.
+    /// The symbol is matched by the `name` parameter; a replacement that
+    /// carries another name renames it, and the library resolves the new
+    /// name from then on.
     ///
     /// Returns the old symbol if found, or `None` if no symbol with that name exists.
     pub fn update(&mut self, name: &str, replacement: Symbol) -> Option<Symbol> {
-        self.symbols
+        let renamed = self
+            .get(name)
+            .is_some_and(|old| old.name != replacement.name);
+        let old = self
             .get_mut(name)
-            .map(|old| std::mem::replace(old, replacement))
+            .map(|old| std::mem::replace(old, replacement));
+        if renamed {
+            self.rekey();
+        }
+        old
+    }
+
+    /// Renames a symbol in place, so it keeps its position in the library
+    /// and in the file. Returns whether `old_name` resolved to one.
+    pub fn rename(&mut self, old_name: &str, new_name: &str) -> bool {
+        self.rename_all(&[(old_name.to_string(), new_name.to_string())])
+            .is_empty()
+    }
+
+    /// Renames several symbols at once, each in place. Every `(old, new)`
+    /// pair resolves against the names as they were before the call, so a
+    /// chain such as `A -> B, B -> C` renames both rather than renaming the
+    /// new `B` twice. Returns the old names that resolved to nothing.
+    pub fn rename_all(&mut self, renames: &[(String, String)]) -> Vec<String> {
+        let mut missing = Vec::new();
+        let mut resolved: Vec<(usize, &str)> = Vec::with_capacity(renames.len());
+        for (old, new) in renames {
+            match self.index_of(old) {
+                Some(i) => resolved.push((i, new.as_str())),
+                None => missing.push(old.clone()),
+            }
+        }
+        for (i, new) in resolved {
+            if let Some((_, symbol)) = self.symbols.get_index_mut(i) {
+                symbol.name = new.to_string();
+            }
+        }
+        self.rekey();
+        missing
+    }
+
+    /// Re-derives every key from its symbol's name, in order, after names
+    /// were changed in place.
+    fn rekey(&mut self) {
+        self.symbols = self
+            .symbols
+            .drain(..)
+            .map(|(_, symbol)| (symbol.name.clone(), symbol))
+            .collect();
     }
 
     /// Returns a list of symbol names in order.

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -80,9 +80,11 @@ impl McpServer {
         };
 
         // Check if target already exists
-        if library.get(target_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{target_name}' already exists in library"
+        if let Some(existing) = library.get(target_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{target_name}' already exists in library"),
+                target_name,
+                &existing.name,
             ));
         }
 
@@ -160,9 +162,11 @@ impl McpServer {
         };
 
         // Check if target already exists
-        if library.get(target_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{target_name}' already exists in library"
+        if let Some(existing) = library.get(target_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{target_name}' already exists in library"),
+                target_name,
+                &existing.name,
             ));
         }
 
@@ -289,21 +293,20 @@ impl McpServer {
             Err(e) => return ToolCallResult::error(format!("Failed to read library: {e}")),
         };
 
-        // Check if new name already exists
-        if library.get(new_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{new_name}' already exists in library"
+        // Check if new name already exists. The component's own name in
+        // another case resolves to itself and is a legitimate rename.
+        if let Some(existing) = library.get(new_name).filter(|c| c.name != old_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{new_name}' already exists in library"),
+                new_name,
+                &existing.name,
             ));
         }
 
-        // Find and remove the source component
-        let Some(mut footprint) = library.remove(old_name) else {
+        // Renamed in place: the component keeps its position in the library.
+        if !library.rename(old_name, new_name) {
             return ToolCallResult::error(format!("Component '{old_name}' not found in library"));
-        };
-
-        // Rename and add back
-        footprint.name = new_name.to_string();
-        library.add(footprint);
+        }
 
         // If dry_run, return what would happen without writing
         if dry_run {
@@ -356,21 +359,20 @@ impl McpServer {
             Err(e) => return ToolCallResult::error(format!("Failed to read library: {e}")),
         };
 
-        // Check if new name already exists
-        if library.get(new_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{new_name}' already exists in library"
+        // Check if new name already exists. The component's own name in
+        // another case resolves to itself and is a legitimate rename.
+        if let Some(existing) = library.get(new_name).filter(|c| c.name != old_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{new_name}' already exists in library"),
+                new_name,
+                &existing.name,
             ));
         }
 
-        // Find and remove the source component
-        let Some(mut symbol) = library.remove(old_name) else {
+        // Renamed in place: the symbol keeps its position in the library.
+        if !library.rename(old_name, new_name) {
             return ToolCallResult::error(format!("Component '{old_name}' not found in library"));
-        };
-
-        // Rename and add back
-        symbol.name = new_name.to_string();
-        library.add(symbol);
+        }
 
         // If dry_run, return what would happen without writing
         if dry_run {
@@ -599,9 +601,11 @@ impl McpServer {
         };
 
         // Check if target already exists
-        if target_library.get(target_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{target_name}' already exists in target library"
+        if let Some(existing) = target_library.get(target_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{target_name}' already exists in target library"),
+                target_name,
+                &existing.name,
             ));
         }
 
@@ -726,9 +730,11 @@ impl McpServer {
         };
 
         // Check if target already exists
-        if target_library.get(target_name).is_some() {
-            return ToolCallResult::error(format!(
-                "Component '{target_name}' already exists in target library"
+        if let Some(existing) = target_library.get(target_name) {
+            return ToolCallResult::error(Self::taken_name_error(
+                format!("Component '{target_name}' already exists in target library"),
+                target_name,
+                &existing.name,
             ));
         }
 
@@ -897,9 +903,13 @@ impl McpServer {
             PcbLib::new()
         };
 
-        // For dry_run, we track names that "would be" added to detect duplicates
-        let mut simulated_names: std::collections::HashSet<String> =
-            target_library.names().into_iter().collect();
+        // For dry_run, we track names that "would be" added to detect
+        // duplicates — case-folded, as the library resolves them.
+        let mut simulated_names: std::collections::HashSet<String> = target_library
+            .names()
+            .iter()
+            .map(|name| crate::altium::folded_name(name))
+            .collect();
 
         let initial_count = target_library.len();
         let mut merged_count = 0;
@@ -933,7 +943,7 @@ impl McpServer {
                 let mut fp_to_add = footprint.clone();
 
                 let name_exists = if dry_run {
-                    simulated_names.contains(&original_name)
+                    simulated_names.contains(&crate::altium::folded_name(&original_name))
                 } else {
                     target_library.get(&original_name).is_some()
                 };
@@ -954,7 +964,8 @@ impl McpServer {
                             // Find a unique name
                             let mut counter = 1;
                             let mut new_name = format!("{original_name}_{counter}");
-                            while (dry_run && simulated_names.contains(&new_name))
+                            while (dry_run
+                                && simulated_names.contains(&crate::altium::folded_name(&new_name)))
                                 || (!dry_run && target_library.get(&new_name).is_some())
                             {
                                 counter += 1;
@@ -962,7 +973,7 @@ impl McpServer {
                             }
                             fp_to_add.name.clone_from(&new_name);
                             if dry_run {
-                                simulated_names.insert(new_name);
+                                simulated_names.insert(crate::altium::folded_name(&new_name));
                             }
                             source_renamed += 1;
                             renamed_count += 1;
@@ -999,7 +1010,7 @@ impl McpServer {
                 }
 
                 if dry_run {
-                    simulated_names.insert(fp_to_add.name.clone());
+                    simulated_names.insert(crate::altium::folded_name(&fp_to_add.name));
                 } else {
                     target_library.add(fp_to_add);
                 }
@@ -1090,9 +1101,12 @@ impl McpServer {
             SchLib::new()
         };
 
-        // For dry_run, we track names that "would be" added to detect duplicates
-        let mut simulated_names: std::collections::HashSet<String> =
-            target_library.iter().map(|s| s.name.clone()).collect();
+        // For dry_run, we track names that "would be" added to detect
+        // duplicates — case-folded, as the library resolves them.
+        let mut simulated_names: std::collections::HashSet<String> = target_library
+            .iter()
+            .map(|s| crate::altium::folded_name(&s.name))
+            .collect();
 
         let initial_count = target_library.len();
         let mut merged_count = 0;
@@ -1122,7 +1136,7 @@ impl McpServer {
                 let mut sym_to_add = symbol;
 
                 let name_exists = if dry_run {
-                    simulated_names.contains(&original_name)
+                    simulated_names.contains(&crate::altium::folded_name(&original_name))
                 } else {
                     target_library.get(&original_name).is_some()
                 };
@@ -1143,7 +1157,8 @@ impl McpServer {
                             // Find a unique name
                             let mut counter = 1;
                             let mut new_name = format!("{original_name}_{counter}");
-                            while (dry_run && simulated_names.contains(&new_name))
+                            while (dry_run
+                                && simulated_names.contains(&crate::altium::folded_name(&new_name)))
                                 || (!dry_run && target_library.get(&new_name).is_some())
                             {
                                 counter += 1;
@@ -1151,7 +1166,7 @@ impl McpServer {
                             }
                             sym_to_add.name.clone_from(&new_name);
                             if dry_run {
-                                simulated_names.insert(new_name);
+                                simulated_names.insert(crate::altium::folded_name(&new_name));
                             }
                             source_renamed += 1;
                             renamed_count += 1;
@@ -1161,7 +1176,7 @@ impl McpServer {
                 }
 
                 if dry_run {
-                    simulated_names.insert(sym_to_add.name.clone());
+                    simulated_names.insert(crate::altium::folded_name(&sym_to_add.name));
                 } else {
                     target_library.add(sym_to_add);
                 }
@@ -1309,16 +1324,24 @@ impl McpServer {
             return ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Determine which components were not in the requested order
-        let requested_set: std::collections::HashSet<&str> = order.iter().copied().collect();
+        // Determine which components were not in the requested order; a
+        // name resolves the way the library resolves it, regardless of case.
+        let requested_set: std::collections::HashSet<String> = order
+            .iter()
+            .map(|name| crate::altium::folded_name(name))
+            .collect();
+        let original_set: std::collections::HashSet<String> = original_order
+            .iter()
+            .map(|name| crate::altium::folded_name(name))
+            .collect();
         let not_found: Vec<&str> = order
             .iter()
-            .filter(|name| !original_order.contains(&(**name).to_string()))
+            .filter(|name| !original_set.contains(&crate::altium::folded_name(name)))
             .copied()
             .collect();
         let not_requested: Vec<String> = original_order
             .iter()
-            .filter(|name| !requested_set.contains(name.as_str()))
+            .filter(|name| !requested_set.contains(&crate::altium::folded_name(name)))
             .cloned()
             .collect();
 
@@ -1393,16 +1416,24 @@ impl McpServer {
             return ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap());
         }
 
-        // Determine which components were not in the requested order
-        let requested_set: std::collections::HashSet<&str> = order.iter().copied().collect();
+        // Determine which components were not in the requested order; a
+        // name resolves the way the library resolves it, regardless of case.
+        let requested_set: std::collections::HashSet<String> = order
+            .iter()
+            .map(|name| crate::altium::folded_name(name))
+            .collect();
+        let original_set: std::collections::HashSet<String> = original_order
+            .iter()
+            .map(|name| crate::altium::folded_name(name))
+            .collect();
         let not_found: Vec<&str> = order
             .iter()
-            .filter(|name| !original_order.contains(&(**name).to_string()))
+            .filter(|name| !original_set.contains(&crate::altium::folded_name(name)))
             .copied()
             .collect();
         let not_requested: Vec<String> = original_order
             .iter()
-            .filter(|name| !requested_set.contains(name.as_str()))
+            .filter(|name| !requested_set.contains(&crate::altium::folded_name(name)))
             .cloned()
             .collect();
 
@@ -3208,5 +3239,105 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A name that differs from an existing one only in case is the same
+    /// storage to the OLE directory and the same component to Altium. Every
+    /// tool that creates a name refuses it — naming the existing spelling —
+    /// and a rename onto the component's own name in another case is the
+    /// one such rename that is allowed.
+    #[test]
+    fn a_name_differing_only_in_case_is_taken() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Case.PcbLib");
+        create_test_pcblib(&path); // CHIP_0402 + CHIP_0603
+
+        let result = server.call_copy_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "source_name": "CHIP_0402",
+            "target_name": "chip_0603",
+        }));
+        assert!(result.is_error);
+        assert!(
+            get_result_text(&result).contains(
+                "already exists in library as 'CHIP_0603' (component names are case-insensitive)"
+            ),
+            "{}",
+            get_result_text(&result)
+        );
+
+        let result = server.call_rename_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "old_name": "CHIP_0402",
+            "new_name": "chip_0603",
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("as 'CHIP_0603'"));
+
+        // The component's own name in another case is a legitimate rename.
+        let result = server.call_rename_component(&json!({
+            "filepath": path.to_string_lossy(),
+            "old_name": "CHIP_0402",
+            "new_name": "chip_0402",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let lib = PcbLib::open(&path).unwrap();
+        assert_eq!(
+            lib.names(),
+            ["chip_0402", "CHIP_0603"],
+            "renamed in place, not moved to the end"
+        );
+
+        // Across libraries too.
+        let other = dir.path().join("Other.PcbLib");
+        create_test_pcblib(&other);
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": other.to_string_lossy(),
+            "target_filepath": path.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "new_name": "Chip_0402",
+        }));
+        assert!(result.is_error);
+        assert!(
+            get_result_text(&result).contains("as 'chip_0402'"),
+            "{}",
+            get_result_text(&result)
+        );
+
+        // A merge sees the clash the same way in a dry run and for real.
+        for dry_run in [true, false] {
+            let result = server.call_merge_libraries(&json!({
+                "source_filepaths": [other.to_string_lossy()],
+                "target_filepath": path.to_string_lossy(),
+                "on_duplicate": "skip",
+                "dry_run": dry_run,
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(parsed["skipped_count"], 2, "dry_run={dry_run}: {parsed}");
+        }
+        assert_eq!(PcbLib::open(&path).unwrap().len(), 2, "nothing merged");
+
+        // The same for symbols.
+        let sch = dir.path().join("Case.SchLib");
+        create_test_schlib(&sch); // RESISTOR + CAPACITOR
+        let result = server.call_copy_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "source_name": "RESISTOR",
+            "target_name": "capacitor",
+        }));
+        assert!(result.is_error);
+        assert!(get_result_text(&result).contains("as 'CAPACITOR'"));
+        let result = server.call_rename_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "old_name": "RESISTOR",
+            "new_name": "Resistor",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(
+            SchLib::open(&sch).unwrap().names(),
+            ["Resistor", "CAPACITOR"]
+        );
     }
 }

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1276,9 +1276,11 @@ impl McpServer {
                 return ToolCallResult::error(format!("Footprint {idx}: {e}"));
             }
             // Check for duplicate
-            if library.get(name).is_some() {
-                return ToolCallResult::error(format!(
-                    "Component '{name}' already exists in library"
+            if let Some(existing) = library.get(name) {
+                return ToolCallResult::error(Self::taken_name_error(
+                    format!("Component '{name}' already exists in library"),
+                    name,
+                    &existing.name,
                 ));
             }
 
@@ -1484,9 +1486,11 @@ impl McpServer {
                 return ToolCallResult::error(format!("Symbol {idx}: {e}"));
             }
             // Check for duplicate
-            if library.get(name).is_some() {
-                return ToolCallResult::error(format!(
-                    "Component '{name}' already exists in library"
+            if let Some(existing) = library.get(name) {
+                return ToolCallResult::error(Self::taken_name_error(
+                    format!("Component '{name}' already exists in library"),
+                    name,
+                    &existing.name,
                 ));
             }
 

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -198,8 +198,11 @@ impl McpServer {
         }
 
         // Check for conflicts (new name already exists or duplicates in renames)
-        let existing_names: std::collections::HashSet<&str> =
-            names.iter().map(String::as_str).collect();
+        // Names clash the way the library resolves them: regardless of case.
+        let existing_names: std::collections::HashSet<String> = names
+            .iter()
+            .map(|n| crate::altium::folded_name(n))
+            .collect();
         let mut new_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for (old_name, new_name) in &renames {
@@ -210,8 +213,10 @@ impl McpServer {
                 continue;
             }
             // Check if new name conflicts with an existing name that's not being renamed
-            if existing_names.contains(new_name.as_str()) {
-                let is_being_renamed = renames.iter().any(|(o, _)| o == new_name);
+            if existing_names.contains(&crate::altium::folded_name(new_name)) {
+                let is_being_renamed = renames
+                    .iter()
+                    .any(|(o, _)| crate::altium::same_name(o, new_name));
                 if !is_being_renamed {
                     errors.push(format!(
                         "Cannot rename '{old_name}' to '{new_name}': target name already exists"
@@ -219,7 +224,7 @@ impl McpServer {
                 }
             }
             // Check for duplicate new names
-            if !new_names.insert(new_name.clone()) {
+            if !new_names.insert(crate::altium::folded_name(new_name)) {
                 errors.push(format!(
                     "Multiple components would be renamed to '{new_name}' (conflict)"
                 ));
@@ -240,20 +245,10 @@ impl McpServer {
                 return ToolCallResult::error(e);
             }
 
-            // Two-phase remove-then-add (see the SchLib path): `add` overwrites on
-            // key collision, so a one-pass loop loses a footprint on a chained
-            // rename like A->B, B->C.
-            let mut pending: Vec<crate::altium::pcblib::Footprint> =
-                Vec::with_capacity(renames.len());
-            for (old_name, new_name) in &renames {
-                if let Some(mut footprint) = library.remove(old_name) {
-                    footprint.name.clone_from(new_name);
-                    pending.push(footprint);
-                }
-            }
-            for footprint in pending {
-                library.add(footprint);
-            }
+            // Every rename resolves against the names before the call and is
+            // applied in place, so a chained rename like A->B, B->C renames
+            // both and every footprint keeps its position in the library.
+            library.rename_all(&renames);
 
             if let Err(e) = library.save(filepath) {
                 return ToolCallResult::error(format!("Failed to save library: {e}"));
@@ -305,8 +300,11 @@ impl McpServer {
         }
 
         // Check for conflicts
-        let existing_names: std::collections::HashSet<&str> =
-            names.iter().map(String::as_str).collect();
+        // Names clash the way the library resolves them: regardless of case.
+        let existing_names: std::collections::HashSet<String> = names
+            .iter()
+            .map(|n| crate::altium::folded_name(n))
+            .collect();
         let mut new_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for (old_name, new_name) in &renames {
@@ -316,15 +314,17 @@ impl McpServer {
                 errors.push(format!("Cannot rename '{old_name}': {e}"));
                 continue;
             }
-            if existing_names.contains(new_name.as_str()) {
-                let is_being_renamed = renames.iter().any(|(o, _)| o == new_name);
+            if existing_names.contains(&crate::altium::folded_name(new_name)) {
+                let is_being_renamed = renames
+                    .iter()
+                    .any(|(o, _)| crate::altium::same_name(o, new_name));
                 if !is_being_renamed {
                     errors.push(format!(
                         "Cannot rename '{old_name}' to '{new_name}': target name already exists"
                     ));
                 }
             }
-            if !new_names.insert(new_name.clone()) {
+            if !new_names.insert(crate::altium::folded_name(new_name)) {
                 errors.push(format!(
                     "Multiple components would be renamed to '{new_name}' (conflict)"
                 ));
@@ -347,20 +347,11 @@ impl McpServer {
 
             // Two-phase: remove EVERY source before adding ANY target. `add` is
             // IndexMap::insert (overwrites on key collision), so a one-pass
-            // remove-then-add loses a symbol on a chained rename like A->B, B->C —
-            // adding B (still present) clobbers the original B before B->C removes
-            // it. The conflict check permits such chains (target is itself being
-            // renamed), so the application must be collision-safe.
-            let mut pending: Vec<crate::altium::schlib::Symbol> = Vec::with_capacity(renames.len());
-            for (old_name, new_name) in &renames {
-                if let Some(mut symbol) = library.remove(old_name) {
-                    symbol.name.clone_from(new_name);
-                    pending.push(symbol);
-                }
-            }
-            for symbol in pending {
-                library.add(symbol);
-            }
+            // Every rename resolves against the names before the call and is
+            // applied in place, so a chained rename like A->B, B->C (which the
+            // conflict check permits, the target being itself renamed) renames
+            // both and every symbol keeps its position in the library.
+            library.rename_all(&renames);
 
             if let Err(e) = library.save(filepath) {
                 return ToolCallResult::error(format!("Failed to save library: {e}"));

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -103,9 +103,15 @@ impl McpServer {
             if let Err(e) = Self::validate_ole_name(name) {
                 return ToolCallResult::error(e);
             }
-            if library.get(name).is_some() {
-                return ToolCallResult::error(format!(
-                    "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
+            // The footprint's own name in another case resolves to itself
+            // and is a legitimate rename; any other holder is a clash.
+            if let Some(existing) = library.get(name).filter(|f| f.name != component_name) {
+                return ToolCallResult::error(Self::taken_name_error(
+                    format!(
+                        "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
+                    ),
+                    name,
+                    &existing.name,
                 ));
             }
         }
@@ -303,9 +309,15 @@ impl McpServer {
             if let Err(e) = Self::validate_ole_name(name) {
                 return ToolCallResult::error(e);
             }
-            if library.get(name).is_some() {
-                return ToolCallResult::error(format!(
-                    "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
+            // The symbol's own name in another case resolves to itself and
+            // is a legitimate rename; any other holder is a clash.
+            if let Some(existing) = library.get(name).filter(|s| s.name != component_name) {
+                return ToolCallResult::error(Self::taken_name_error(
+                    format!(
+                        "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
+                    ),
+                    name,
+                    &existing.name,
                 ));
             }
         }
@@ -330,7 +342,7 @@ impl McpServer {
                     if name == component_name {
                         String::new()
                     } else {
-                        format!(" and change its saved name to '{name}' (use rename_component if you also need the in-session lookup key updated)")
+                        format!(" and rename it to '{name}'")
                     }
                 ),
             });
@@ -2298,5 +2310,56 @@ mod tests {
                 assert_eq!(results[1]["exists"], false, "{parsed}");
             }
         }
+    }
+
+    /// A component is found by its name regardless of case, as Altium and
+    /// the file's own directory find it; a rename onto another component's
+    /// name in a different case is refused, onto its own is allowed.
+    #[test]
+    fn names_resolve_regardless_of_case() {
+        use crate::altium::PcbLib;
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let pcb = dir.path().join("Case.PcbLib");
+        create_test_pcblib(&pcb); // CHIP_0402 + CHIP_0603
+
+        let result = server.call_get_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "chip_0402",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["component"]["name"], "CHIP_0402");
+
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "footprint": {
+                "name": "chip_0603",
+                "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+            },
+        }));
+        assert!(result.is_error);
+        assert!(
+            get_result_text(&result)
+                .contains("as 'CHIP_0603' (component names are case-insensitive)"),
+            "{}",
+            get_result_text(&result)
+        );
+
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "footprint": {
+                "name": "Chip_0402",
+                "pads": [{ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 }],
+            },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["renamed"], true);
+        assert_eq!(
+            PcbLib::open(&pcb).unwrap().names(),
+            ["Chip_0402", "CHIP_0603"]
+        );
     }
 }

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -382,11 +382,12 @@ impl McpServer {
             .filter_map(|fp| fp.get("name").and_then(Value::as_str))
             .collect();
 
-        // Check for duplicates within the new footprints
+        // Check for duplicates within the new footprints — regardless of
+        // case, which is how the library and the file's directory resolve them.
         {
             let mut seen = std::collections::HashSet::new();
             for name in &new_names {
-                if !seen.insert(*name) {
+                if !seen.insert(crate::altium::folded_name(name)) {
                     return ToolCallResult::error_with_context(
                         ErrorContext::new(
                             "write_pcblib",
@@ -450,12 +451,12 @@ impl McpServer {
 
         // Check for duplicates with existing footprints in append mode
         if append {
-            let existing_names: std::collections::HashSet<_> =
-                library.names().into_iter().collect();
             for name in &new_names {
-                if existing_names.contains(*name) {
-                    return ToolCallResult::error(format!(
-                        "Footprint '{name}' already exists in the library"
+                if let Some(existing) = library.get(name) {
+                    return ToolCallResult::error(Self::taken_name_error(
+                        format!("Footprint '{name}' already exists in the library"),
+                        name,
+                        &existing.name,
                     ));
                 }
             }
@@ -759,11 +760,12 @@ impl McpServer {
             .filter_map(|sym| sym.get("name").and_then(Value::as_str))
             .collect();
 
-        // Check for duplicates within the new symbols
+        // Check for duplicates within the new symbols — regardless of
+        // case, which is how the library and the file's directory resolve them.
         {
             let mut seen = std::collections::HashSet::new();
             for name in &new_names {
-                if !seen.insert(*name) {
+                if !seen.insert(crate::altium::folded_name(name)) {
                     return ToolCallResult::error_with_context(
                         ErrorContext::new(
                             "write_schlib",
@@ -815,9 +817,11 @@ impl McpServer {
         // Check for duplicates with existing symbols in append mode
         if append {
             for name in &new_names {
-                if library.get(name).is_some() {
-                    return ToolCallResult::error(format!(
-                        "Symbol '{name}' already exists in the library"
+                if let Some(existing) = library.get(name) {
+                    return ToolCallResult::error(Self::taken_name_error(
+                        format!("Symbol '{name}' already exists in the library"),
+                        name,
+                        &existing.name,
                     ));
                 }
             }
@@ -2153,6 +2157,69 @@ mod tests {
             let back = server.call_read_schlib(&json!({ "filepath": out.to_string_lossy() }));
             let symbol = parse_result_json(&back)["symbols"][0].clone();
             assert!(symbol.get("extra_streams").is_none(), "{symbol}");
+        }
+
+        /// Two names differing only in case are one storage to the OLE
+        /// directory: within one request that is a duplicate, and against an
+        /// existing library it is a clash, named after the spelling on file.
+        #[test]
+        fn write_tools_treat_a_case_variant_as_the_same_name() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let out = dir.path().join("Case.PcbLib");
+            let pad = json!({ "designator": "1", "x": 0.0, "y": 0.0, "width": 0.6, "height": 0.5 });
+            let written = server.call_write_pcblib(&json!({
+                "filepath": out.to_string_lossy(),
+                "footprints": [
+                    { "name": "RES_0402", "pads": [pad] },
+                    { "name": "res_0402", "pads": [pad] },
+                ],
+            }));
+            assert!(written.is_error);
+            assert!(get_result_text(&written).contains("Duplicate footprint name: 'res_0402'"));
+
+            let written = server.call_write_pcblib(&json!({
+                "filepath": out.to_string_lossy(),
+                "footprints": [{ "name": "RES_0402", "pads": [pad] }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+            let appended = server.call_write_pcblib(&json!({
+                "filepath": out.to_string_lossy(),
+                "append": true,
+                "footprints": [{ "name": "res_0402", "pads": [pad] }],
+            }));
+            assert!(appended.is_error);
+            assert!(
+                get_result_text(&appended).contains(
+                    "Footprint 'res_0402' already exists in the library as 'RES_0402' (component names are case-insensitive)"
+                ),
+                "{}",
+                get_result_text(&appended)
+            );
+
+            let out = dir.path().join("Case.SchLib");
+            let written = server.call_write_schlib(&json!({
+                "filepath": out.to_string_lossy(),
+                "symbols": [{ "name": "LM358" }, { "name": "lm358" }],
+            }));
+            assert!(written.is_error);
+            assert!(get_result_text(&written).contains("Duplicate symbol name: 'lm358'"));
+            let written = server.call_write_schlib(&json!({
+                "filepath": out.to_string_lossy(),
+                "symbols": [{ "name": "LM358" }],
+            }));
+            assert!(!written.is_error, "{}", get_result_text(&written));
+            let appended = server.call_write_schlib(&json!({
+                "filepath": out.to_string_lossy(),
+                "append": true,
+                "symbols": [{ "name": "lm358" }],
+            }));
+            assert!(appended.is_error);
+            assert!(
+                get_result_text(&appended).contains("as 'LM358'"),
+                "{}",
+                get_result_text(&appended)
+            );
         }
 
         /// The in-place twin: every golden footprint read through

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -35,6 +35,19 @@ impl McpServer {
     /// Note: OLE storage names are limited to 31 characters, but the library layer
     /// handles this by truncating storage names while preserving full names in
     /// the PATTERN/LIBREFERENCE fields.
+    /// The error for a name the library already holds: `message` as given
+    /// when the spelling is the same, and with the existing spelling named
+    /// when only the case differs — the two are one storage to the OLE
+    /// directory and one component to Altium, so the clash is real even
+    /// though the strings are not equal.
+    pub(crate) fn taken_name_error(message: String, requested: &str, existing: &str) -> String {
+        if existing == requested {
+            message
+        } else {
+            format!("{message} as '{existing}' (component names are case-insensitive)")
+        }
+    }
+
     pub(crate) fn validate_ole_name(name: &str) -> Result<(), String> {
         const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
 

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -953,3 +953,107 @@ fn pcblib_roundtrip_preserves_numeric_silkscreen_text() {
         "numeric silkscreen must round-trip verbatim"
     );
 }
+
+// =============================================================================
+// Component names that differ only in case
+// =============================================================================
+
+/// The OLE directory compares storage names without regard to case, so two
+/// components whose names differ only in case used to fail the whole save
+/// inside the directory (`Cannot create storage ... already exists`). They
+/// now get distinct storage names and both read back under their real
+/// names; a lookup resolves a name regardless of case, the exact spelling
+/// first when both exist.
+#[test]
+fn names_differing_only_in_case_save_and_resolve() {
+    let dir = test_temp_dir();
+
+    let mut lib = PcbLib::new();
+    let mut upper = Footprint::new("RES_0402");
+    upper.add_pad(Pad::smd("1", 0.0, 0.0, 0.5, 0.5));
+    let mut lower = Footprint::new("res_0402");
+    lower.add_pad(Pad::smd("1", 0.0, 0.0, 0.5, 0.5));
+    lower.add_pad(Pad::smd("2", 1.0, 0.0, 0.5, 0.5));
+    lib.add(upper);
+    lib.add(lower);
+    let path = dir.path().join("case.PcbLib");
+    lib.save(&path).expect("two case variants save");
+    let back = PcbLib::open(&path).expect("reopen");
+    assert_eq!(back.names(), ["RES_0402", "res_0402"]);
+    assert_eq!(back.get("res_0402").expect("exact").pads.len(), 2);
+    assert_eq!(back.get("RES_0402").expect("exact").pads.len(), 1);
+    assert_eq!(
+        back.get("Res_0402").expect("case-insensitive").name,
+        "RES_0402",
+        "the first match in library order when no spelling is exact"
+    );
+    assert!(back.get("RES_0603").is_none());
+
+    let mut lib = SchLib::new();
+    lib.add(Symbol::new("LM358"));
+    lib.add(Symbol::new("lm358"));
+    let path = dir.path().join("case.SchLib");
+    lib.save(&path).expect("two case variants save");
+    let mut back = SchLib::open(&path).expect("reopen");
+    assert_eq!(back.names(), ["LM358", "lm358"]);
+    assert_eq!(back.get("Lm358").expect("case-insensitive").name, "LM358");
+    assert_eq!(back.get_mut("LM358").expect("exact").name, "LM358");
+    assert_eq!(back.remove("lm358").expect("exact").name, "lm358");
+    assert_eq!(
+        back.remove("lm358")
+            .expect("now resolves to the other")
+            .name,
+        "LM358"
+    );
+    assert!(back.is_empty());
+}
+
+/// A rename keeps the component where it was, and a set of renames resolves
+/// every old name before any is applied, so a chain renames each once.
+#[test]
+fn renames_keep_positions_and_resolve_before_applying() {
+    let mut lib = PcbLib::new();
+    for name in ["A", "B", "C"] {
+        lib.add(Footprint::new(name));
+    }
+    assert!(lib.rename("A", "A2"));
+    assert!(!lib.rename("NOPE", "X"));
+    assert_eq!(lib.names(), ["A2", "B", "C"]);
+    let missing = lib.rename_all(&[
+        ("B".to_string(), "C".to_string()),
+        ("C".to_string(), "D".to_string()),
+        ("Z".to_string(), "Y".to_string()),
+    ]);
+    assert_eq!(missing, ["Z"]);
+    assert_eq!(
+        lib.names(),
+        ["A2", "C", "D"],
+        "B became C and the old C became D"
+    );
+
+    let mut lib = SchLib::new();
+    for name in ["A", "B", "C"] {
+        lib.add(Symbol::new(name));
+    }
+    assert!(lib.rename("a", "A2"), "resolved regardless of case");
+    assert_eq!(lib.names(), ["A2", "B", "C"]);
+    let missing = lib.rename_all(&[
+        ("B".to_string(), "C".to_string()),
+        ("C".to_string(), "D".to_string()),
+    ]);
+    assert!(missing.is_empty());
+    assert_eq!(lib.names(), ["A2", "C", "D"]);
+    assert_eq!(lib.get("D").expect("the old C under its new key").name, "D");
+
+    // An update that carries another name renames the symbol too, and the
+    // library resolves the new name from then on.
+    let mut replacement = Symbol::new("D2");
+    replacement.description = "updated".to_string();
+    assert_eq!(
+        lib.update("D", replacement).expect("the old symbol").name,
+        "D"
+    );
+    assert_eq!(lib.names(), ["A2", "C", "D2"]);
+    assert_eq!(lib.get("D2").expect("new key").description, "updated");
+    assert!(lib.get("D").is_none());
+}


### PR DESCRIPTION
## Summary

A class of name-handling bugs found while reviewing the remaining hand-parsing tools (copy / merge / import):

1. **Case-only name clashes slipped every uniqueness check and then failed inside the OLE layer.** Two names differing only in case (`RES_0402` / `res_0402`) are one storage to the CFB directory, but every tool compared names exactly, so `copy_component`, `rename_component`, `bulk_rename`, `copy_component_cross_library`, `merge_libraries`, `import_library`, `write_*` append and `update_component`-with-rename all accepted the clash — and the save then failed with `Failed to create storage /res_0402: Cannot create storage ... because a storage already exists there` (after the backup was taken). The same happened through the library API.
   - Library layer: `same_name` / `folded_name`; `generate_ole_name` now gives the second such name a distinct storage name, so the library API saves and reads both back (test: both formats).
   - `get` / `get_mut` / `remove` / `update` on both libraries resolve a name exactly first, else regardless of case — the way the file's directory and Altium resolve it. Every tool's "already exists" check therefore sees the clash and says so with the spelling on file: `Component 'res_0402' already exists in library as 'RES_0402' (component names are case-insensitive)`. A rename onto the component's *own* name in another case is allowed; two such names in one `write_*` request are a duplicate; merge dry runs now fold the names they simulate (so dry run and real run agree).
2. **`rename_component` and `bulk_rename` moved the renamed component to the end of the library** (remove + add). New `rename` / `rename_all` rename in place; `rename_all` resolves every old name before applying, so a chain `A→B, B→C` renames both.
3. **`SchLib::update` left a stale in-session key after a rename** (documented as a caveat in the tool's dry-run message, and its doc pointed at a `rename` method that did not exist). It now re-keys.

Docs: `errors.md` gains *Component Names Are Case-Insensitive*.

## Verification

- fmt / clippy `-D warnings` / `cargo doc -D warnings`: clean; 1457 tests green; coverage 99.09%
- New tests: library API (`names_differing_only_in_case_save_and_resolve`, `renames_keep_positions_and_resolve_before_applying`, helper unit test), and one per tool file: copy/rename/cross-copy/merge (`a_name_differing_only_in_case_is_taken`), `get_component`/`update_component` (`names_resolve_regardless_of_case`), `write_pcblib`/`write_schlib` duplicate + append (`write_tools_treat_a_case_variant_as_the_same_name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)