### PR TITLE
fix(pcblib): rename_layer moves every kind, and a moved primitive drops its carried byte

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -163,6 +163,39 @@ pub struct Footprint {
     pub primitive_order: Vec<PrimitiveKind>,
 }
 
+/// How many primitives of each kind [`Footprint::move_layer`] moved.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LayerMove {
+    /// Tracks moved.
+    pub tracks: usize,
+    /// Arcs moved.
+    pub arcs: usize,
+    /// Text moved.
+    pub text: usize,
+    /// Fills moved.
+    pub fills: usize,
+    /// Regions moved.
+    pub regions: usize,
+    /// Pads moved.
+    pub pads: usize,
+    /// Component bodies moved.
+    pub component_bodies: usize,
+}
+
+impl LayerMove {
+    /// Every primitive moved, all kinds together.
+    #[must_use]
+    pub const fn total(self) -> usize {
+        self.tracks
+            + self.arcs
+            + self.text
+            + self.fills
+            + self.regions
+            + self.pads
+            + self.component_bodies
+    }
+}
+
 /// One of a [`Footprint`]'s primitive lists, as named by `primitive_order`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -422,6 +455,68 @@ impl Footprint {
     pub fn add_component_body(&mut self, body: primitives::ComponentBody) {
         self.component_bodies.push(body);
         self.primitive_order.push(PrimitiveKind::ComponentBody);
+    }
+
+    /// Moves every primitive on `from` to `to` — tracks, arcs, text, fills,
+    /// regions, pads and component bodies, every kind that sits on a layer —
+    /// and returns how many of each moved. A carrier that named the old
+    /// layer (a header byte kept as `raw_layer_id`, a region's or body's
+    /// `V7_LAYER` token) is dropped so the writer derives it from the new
+    /// layer instead of replaying a stale one. Vias span layers and are not
+    /// on one; they are untouched.
+    pub fn move_layer(&mut self, from: Layer, to: Layer) -> LayerMove {
+        let mut moved = LayerMove::default();
+        for track in &mut self.tracks {
+            if track.layer == from {
+                track.layer = to;
+                track.raw_layer_id = None;
+                moved.tracks += 1;
+            }
+        }
+        for arc in &mut self.arcs {
+            if arc.layer == from {
+                arc.layer = to;
+                arc.raw_layer_id = None;
+                moved.arcs += 1;
+            }
+        }
+        for text in &mut self.text {
+            if text.layer == from {
+                text.layer = to;
+                text.raw_layer_id = None;
+                moved.text += 1;
+            }
+        }
+        for fill in &mut self.fills {
+            if fill.layer == from {
+                fill.layer = to;
+                fill.raw_layer_id = None;
+                moved.fills += 1;
+            }
+        }
+        for region in &mut self.regions {
+            if region.layer == from {
+                region.layer = to;
+                region.v7_layer = None;
+                moved.regions += 1;
+            }
+        }
+        for pad in &mut self.pads {
+            if pad.layer == from {
+                pad.layer = to;
+                pad.raw_layer_id = None;
+                moved.pads += 1;
+            }
+        }
+        for body in &mut self.component_bodies {
+            if body.layer == from {
+                body.layer = to;
+                body.raw_layer_id = None;
+                body.v7_layer = None;
+                moved.component_bodies += 1;
+            }
+        }
+        moved
     }
 
     /// Keeps the component bodies `keep` accepts and drops the rest together
@@ -1139,6 +1234,70 @@ mod tests {
         assert_eq!(kept.len(), 2);
         assert!(kept.iter().any(|cb| !cb.embedded));
         assert!(kept.iter().any(|cb| cb.model_id.is_empty()));
+    }
+
+    #[test]
+    fn moving_a_layer_takes_every_kind_and_drops_the_stale_carriers() {
+        // One of each layered kind on Mechanical 13, one track elsewhere, and
+        // the carriers a read primitive may hold: an unmapped header byte and
+        // a region's / body's V7_LAYER token, which named the old layer.
+        let mut fp = Footprint::new("MOVE");
+        let (from, to) = (Layer::Mechanical13, Layer::Mechanical20);
+        fp.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.1, from));
+        fp.add_track(Track::new(0.0, 1.0, 1.0, 1.0, 0.1, Layer::TopOverlay));
+        fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.1, from));
+        let mut text = Text::new(0.0, 0.0, "T", 1.0, from);
+        text.raw_layer_id = Some(100);
+        fp.add_text(text);
+        fp.add_fill(Fill::new(0.0, 0.0, 1.0, 1.0, from));
+        let mut region = Region::rectangle(0.0, 0.0, 1.0, 1.0, from);
+        region.v7_layer = Some("MECHANICAL13".to_string());
+        fp.add_region(region);
+        let mut pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        pad.layer = from;
+        fp.add_pad(pad);
+        let mut body = ComponentBody::new("", "body.step");
+        body.layer = from;
+        body.v7_layer = Some("MECHANICAL13".to_string());
+        fp.add_component_body(body);
+
+        let moved = fp.move_layer(from, to);
+        assert_eq!(
+            moved,
+            LayerMove {
+                tracks: 1,
+                arcs: 1,
+                text: 1,
+                fills: 1,
+                regions: 1,
+                pads: 1,
+                component_bodies: 1,
+            }
+        );
+        assert_eq!(moved.total(), 7);
+        assert_eq!(fp.tracks[0].layer, to);
+        assert_eq!(
+            fp.tracks[1].layer,
+            Layer::TopOverlay,
+            "another layer is untouched"
+        );
+        assert_eq!(fp.arcs[0].layer, to);
+        assert_eq!(fp.text[0].layer, to);
+        assert_eq!(
+            fp.text[0].raw_layer_id, None,
+            "the carried byte went with the move"
+        );
+        assert_eq!(fp.fills[0].layer, to);
+        assert_eq!(fp.regions[0].layer, to);
+        assert_eq!(fp.regions[0].v7_layer, None, "the stale token went too");
+        assert_eq!(fp.pads[0].layer, to);
+        assert_eq!(fp.component_bodies[0].layer, to);
+        assert_eq!(fp.component_bodies[0].v7_layer, None);
+        assert_eq!(
+            fp.move_layer(from, to),
+            LayerMove::default(),
+            "nothing left on it"
+        );
     }
 
     #[test]

--- a/src/altium/pcblib/primitives/text.rs
+++ b/src/altium/pcblib/primitives/text.rs
@@ -300,6 +300,54 @@ pub struct Text {
     pub raw_geometry: Option<Vec<u8>>,
 }
 
+impl Text {
+    /// Creates a stroke-font text of `height` mm at (`x`, `y`) on `layer`,
+    /// every other field at the value a text placed from scratch gets.
+    #[must_use]
+    pub fn new(x: f64, y: f64, text: impl Into<String>, height: f64, layer: Layer) -> Self {
+        Self {
+            raw_layer_id: None,
+            barcode_full_width: None,
+            barcode_full_height: None,
+            barcode_x_margin: None,
+            barcode_y_margin: None,
+            barcode_kind: 0,
+            barcode_font_name: String::new(),
+            barcode_inverted: false,
+            barcode_show_text: false,
+            x,
+            y,
+            text: text.into(),
+            height,
+            layer,
+            kind: TextKind::Stroke,
+            rotation: 0.0,
+            stroke_font: None,
+            stroke_width: None,
+            italic: false,
+            bold: false,
+            mirror: false,
+            is_comment: false,
+            is_designator: false,
+            font_name: "Arial".to_string(),
+            justification: TextJustification::default(),
+            is_inverted: false,
+            inverted_border: None,
+            use_inverted_rectangle: false,
+            inverted_rect_width: None,
+            inverted_rect_height: None,
+            inverted_rect_text_offset: None,
+            flags: PcbFlags::default(),
+            net_index: 0xFFFF,
+            polygon_index: 0xFFFF,
+            component_index: -1,
+            unique_id: None,
+            guid: None,
+            raw_geometry: None,
+        }
+    }
+}
+
 /// A filled rectangle on a layer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Fill {

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -366,66 +366,25 @@ impl McpServer {
         let mut footprints_updated = Vec::new();
 
         for fp in library.iter_mut() {
-            let mut fp_changes = json!({
-                "name": fp.name,
-                "tracks": 0,
-                "arcs": 0,
-                "regions": 0,
-                "text": 0,
-            });
-            let mut fp_total = 0usize;
-
-            // Update tracks
-            for track in &mut fp.tracks {
-                if track.layer == from_layer {
-                    if !dry_run {
-                        track.layer = to_layer;
-                    }
-                    fp_changes["tracks"] = json!(fp_changes["tracks"].as_u64().unwrap_or(0) + 1);
-                    fp_total += 1;
-                }
-            }
-
-            // Update arcs
-            for arc in &mut fp.arcs {
-                if arc.layer == from_layer {
-                    if !dry_run {
-                        arc.layer = to_layer;
-                    }
-                    fp_changes["arcs"] = json!(fp_changes["arcs"].as_u64().unwrap_or(0) + 1);
-                    fp_total += 1;
-                }
-            }
-
-            // Update regions
-            for region in &mut fp.regions {
-                if region.layer == from_layer {
-                    if !dry_run {
-                        region.layer = to_layer;
-                        // The replayed V7_LAYER token named the old layer; let
-                        // the writer derive it from the new one.
-                        region.v7_layer = None;
-                    }
-                    fp_changes["regions"] = json!(fp_changes["regions"].as_u64().unwrap_or(0) + 1);
-                    fp_total += 1;
-                }
-            }
-
-            // Update text
-            for text in &mut fp.text {
-                if text.layer == from_layer {
-                    if !dry_run {
-                        text.layer = to_layer;
-                    }
-                    fp_changes["text"] = json!(fp_changes["text"].as_u64().unwrap_or(0) + 1);
-                    fp_total += 1;
-                }
-            }
-
-            if fp_total > 0 {
-                fp_changes["total"] = json!(fp_total);
-                footprints_updated.push(fp_changes);
-                total_updated += fp_total;
+            // A dry run moves a copy, so the report is the real move's report.
+            let moved = if dry_run {
+                fp.clone().move_layer(from_layer, to_layer)
+            } else {
+                fp.move_layer(from_layer, to_layer)
+            };
+            if moved.total() > 0 {
+                footprints_updated.push(json!({
+                    "name": fp.name,
+                    "tracks": moved.tracks,
+                    "arcs": moved.arcs,
+                    "regions": moved.regions,
+                    "text": moved.text,
+                    "fills": moved.fills,
+                    "pads": moved.pads,
+                    "component_bodies": moved.component_bodies,
+                    "total": moved.total(),
+                }));
+                total_updated += moved.total();
             }
         }
 
@@ -735,6 +694,81 @@ mod tests {
         let fp1 = lib.get("SOIC8").unwrap();
         assert_eq!(fp1.tracks[0].layer, Layer::Mechanical13);
         assert_eq!(fp1.tracks[2].layer, Layer::Mechanical1);
+    }
+
+    /// "Move every primitive" means every kind that sits on a layer: fills,
+    /// pads and component bodies move with the tracks, arcs, regions and
+    /// text, a dry run reports the same counts, and a moved region or body
+    /// writes the token of its new layer.
+    #[test]
+    fn rename_layer_moves_fills_pads_and_bodies_too() {
+        use crate::altium::pcblib::{Arc, ComponentBody, Fill, Region, Text};
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Kinds.PcbLib");
+        let mut lib = PcbLib::new();
+        let mut fp = Footprint::new("KINDS");
+        let from = Layer::Mechanical13;
+        fp.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.1, from));
+        fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.1, from));
+        fp.add_text(Text::new(0.0, 0.0, "T", 1.0, from));
+        fp.add_fill(Fill::new(0.0, 0.0, 1.0, 1.0, from));
+        fp.add_region(Region::rectangle(0.0, 0.0, 1.0, 1.0, from));
+        let mut pad = Pad::smd("1", 0.0, 0.0, 1.0, 1.0);
+        pad.layer = from;
+        fp.add_pad(pad);
+        let mut body = ComponentBody::new("", "body.step");
+        body.embedded = false;
+        body.layer = from;
+        fp.add_component_body(body);
+        lib.add(fp);
+        lib.save(&path).unwrap();
+
+        for dry_run in [true, false] {
+            let result = server.call_batch_update(&json!({
+                "filepath": path.to_string_lossy(),
+                "operation": "rename_layer",
+                "parameters": { "from_layer": "Mechanical 13", "to_layer": "Mechanical 20" },
+                "dry_run": dry_run,
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            assert_eq!(
+                parsed["total_primitives_updated"], 7,
+                "dry_run={dry_run}: {parsed}"
+            );
+            let report = &parsed["footprints_updated"][0];
+            for kind in [
+                "tracks",
+                "arcs",
+                "regions",
+                "text",
+                "fills",
+                "pads",
+                "component_bodies",
+            ] {
+                assert_eq!(report[kind], 1, "dry_run={dry_run} {kind}: {parsed}");
+            }
+            assert_eq!(report["total"], 7);
+        }
+
+        let lib = PcbLib::open(&path).unwrap();
+        let fp = lib.get("KINDS").unwrap();
+        let to = Layer::Mechanical20;
+        assert_eq!(fp.tracks[0].layer, to);
+        assert_eq!(fp.arcs[0].layer, to);
+        assert_eq!(fp.text[0].layer, to);
+        assert_eq!(fp.fills[0].layer, to);
+        assert_eq!(
+            fp.regions[0].layer, to,
+            "the region's token followed the move"
+        );
+        assert_eq!(fp.pads[0].layer, to);
+        assert_eq!(
+            fp.component_bodies[0].layer, to,
+            "the body's token followed the move"
+        );
     }
 
     #[test]

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -940,6 +940,9 @@ impl McpServer {
                     if let Some(layer) = parse_layer(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", track.layer), "new": layer_str}));
                         track.layer = layer;
+                        // A header byte carried from the read names the old
+                        // layer; the new one derives its own.
+                        track.raw_layer_id = None;
                     } else {
                         return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                     }
@@ -993,6 +996,9 @@ impl McpServer {
                     if let Some(layer) = parse_layer(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", arc.layer), "new": layer_str}));
                         arc.layer = layer;
+                        // A header byte carried from the read names the old
+                        // layer; the new one derives its own.
+                        arc.raw_layer_id = None;
                     } else {
                         return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                     }
@@ -1036,6 +1042,9 @@ impl McpServer {
                     if let Some(layer) = parse_layer(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", text.layer), "new": layer_str}));
                         text.layer = layer;
+                        // A header byte carried from the read names the old
+                        // layer; the new one derives its own.
+                        text.raw_layer_id = None;
                     } else {
                         return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                     }
@@ -1085,6 +1094,9 @@ impl McpServer {
                     if let Some(layer) = parse_layer(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", fill.layer), "new": layer_str}));
                         fill.layer = layer;
+                        // A header byte carried from the read names the old
+                        // layer; the new one derives its own.
+                        fill.raw_layer_id = None;
                     } else {
                         return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                     }
@@ -1897,6 +1909,45 @@ mod tests {
         fp.add_track(Track::new(-1.0, -1.0, 1.0, -1.0, 0.2, Layer::TopOverlay));
         lib.add(fp);
         lib.save(path).expect("Failed to create primitives PcbLib");
+    }
+
+    /// A primitive read off an unmapped header byte sits on the Multi-Layer
+    /// catch-all with the byte carried; moving it to a layer the model can
+    /// name drops the byte, so the file gets that layer's own, not 100.
+    #[test]
+    fn update_primitive_moving_a_primitive_drops_its_carried_byte() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Carried.PcbLib");
+        let mut lib = PcbLib::new();
+        let mut fp = Footprint::new("CARRY");
+        let mut track = Track::new(-1.0, 0.0, 1.0, 0.0, 0.2, Layer::MultiLayer);
+        track.raw_layer_id = Some(100);
+        fp.add_track(track);
+        lib.add(fp);
+        lib.save(&path).expect("save");
+        let read = PcbLib::open(&path).expect("reopen");
+        assert_eq!(
+            read.get("CARRY").unwrap().tracks[0].raw_layer_id,
+            Some(100),
+            "byte 100 was written and read back"
+        );
+
+        let result = server.call_update_primitive(&json!({
+            "filepath": path.to_string_lossy(),
+            "component_name": "CARRY",
+            "primitive_type": "track",
+            "index": 0,
+            "updates": { "layer": "Top Overlay" },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let moved = PcbLib::open(&path).expect("reopen");
+        let track = &moved.get("CARRY").unwrap().tracks[0];
+        assert_eq!(track.layer, Layer::TopOverlay);
+        assert_eq!(
+            track.raw_layer_id, None,
+            "the new layer's own byte is on file"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`batch_update` / `rename_layer` is documented as "move every primitive from from_layer to to_layer" but handled tracks, arcs, regions and text only. **Fills, pads and component bodies stayed on the old layer, silently** — a rename of a mechanical layer left the 3D bodies and any pad on it behind, and the report did not say so. Bug #51.

- The move now lives in the library as `Footprint::move_layer(from, to) -> LayerMove`, covering every kind that sits on a layer (vias span layers and are untouched), and returning per-kind counts. The tool's report gains `fills`, `pads`, `component_bodies`; a dry run moves a copy so the preview is the real move's report.
- A moved primitive drops the carriers that named its old layer: a region's **and now a body's** `V7_LAYER` token, and a header byte carried as `raw_layer_id` (the unmapped-byte case) — so the writer derives the new layer's own byte/token instead of replaying a stale one. `update_primitive`'s layer change drops the byte the same way.
- `Text::new` added: a from-scratch stroke text, which six test sites had been spelling out as a forty-field literal.

## Verification

- fmt / clippy `-D warnings` / `cargo doc -D warnings`: clean; **1471 tests** green
- New tests: `moving_a_layer_takes_every_kind_and_drops_the_stale_carriers` (library API: all seven kinds, counts, carriers), `rename_layer_moves_fills_pads_and_bodies_too` (tool: dry run and real run report 7 of 7, file reopened with every kind on the new layer), `update_primitive_moving_a_primitive_drops_its_carried_byte` (byte 100 on file → moved → the new layer's own byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)