### PR TITLE
fix: validate_library counts every shape kind as a symbol body

### DIFF
--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -760,6 +760,31 @@ impl Symbol {
         sequence
     }
 
+    /// How many body graphics the symbol draws: every shape kind — rectangle,
+    /// rounded rectangle, line, polyline, polygon, arc, elliptical arc, pie,
+    /// ellipse, bezier, image, text frame — but not pins, labels, IEEE
+    /// symbols or parameters, which decorate a body rather than form one.
+    #[must_use]
+    pub fn body_graphic_count(&self) -> usize {
+        [
+            SchPrimitiveKind::Rectangle,
+            SchPrimitiveKind::RoundRect,
+            SchPrimitiveKind::Line,
+            SchPrimitiveKind::Polyline,
+            SchPrimitiveKind::Polygon,
+            SchPrimitiveKind::Arc,
+            SchPrimitiveKind::EllipticalArc,
+            SchPrimitiveKind::Pie,
+            SchPrimitiveKind::Ellipse,
+            SchPrimitiveKind::Bezier,
+            SchPrimitiveKind::Image,
+            SchPrimitiveKind::TextFrame,
+        ]
+        .into_iter()
+        .map(|kind| self.count_of(kind))
+        .sum()
+    }
+
     /// How many content records of one kind the symbol holds.
     #[must_use]
     pub fn count_of(&self, kind: SchPrimitiveKind) -> usize {

--- a/src/altium/schlib/primitives/shapes.rs
+++ b/src/altium/schlib/primitives/shapes.rs
@@ -283,6 +283,28 @@ pub struct Polygon {
     pub raw_params: Vec<(String, String)>,
 }
 
+impl Polygon {
+    /// Creates a filled polygon through `points`, with the same defaults as a
+    /// rectangle (dark-red border, light-yellow fill, not accessible).
+    #[must_use]
+    pub fn new(points: Vec<(f64, f64)>) -> Self {
+        Self {
+            points,
+            line_width: 1,
+            line_color: 0x00_00_80,
+            fill_color: 0xB0_FF_FF,
+            line_style: 0,
+            filled: true,
+            transparent: false,
+            is_not_accessible: true,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: None,
+            raw_params: Vec::new(),
+        }
+    }
+}
+
 /// An arc or circle.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Arc {

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1805,7 +1805,7 @@ mod tests {
             (
                 "POLY",
                 Box::new(|s| {
-                    s.add_polygon(Polygon::new(vec![(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)]))
+                    s.add_polygon(Polygon::new(vec![(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)]));
                 }),
             ),
             (

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -1795,12 +1795,12 @@ mod tests {
         use crate::altium::schlib::{
             Bezier, Ellipse, EllipticalArc, Image, Pie, Polygon, RoundRect, TextFrame,
         };
+        type Draw = Box<dyn Fn(&mut Symbol)>;
 
         let dir = test_temp_dir();
         let server = create_test_server(dir.path());
         let mut lib = SchLib::new();
         let pin = || Pin::new("1", "A", -10, 0, 10, PinOrientation::Right);
-        type Draw = Box<dyn Fn(&mut Symbol)>;
         let bodies: Vec<(&str, Draw)> = vec![
             (
                 "POLY",

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -649,14 +649,9 @@ impl McpServer {
                 }
             }
 
-            // Check for symbols with no body (no rectangles, lines, or other graphics)
-            let has_body = !symbol.rectangles.is_empty()
-                || !symbol.lines.is_empty()
-                || !symbol.polylines.is_empty()
-                || !symbol.arcs.is_empty()
-                || !symbol.ellipses.is_empty();
-
-            if !has_body && !symbol.pins.is_empty() {
+            // A symbol with pins but nothing drawn: every shape kind counts as
+            // a body, so a polygon- or bezier-drawn symbol is not flagged.
+            if symbol.body_graphic_count() == 0 && !symbol.pins.is_empty() {
                 issues.push(json!({
                     "severity": "warning",
                     "component": name,
@@ -1789,6 +1784,85 @@ mod tests {
             .any(|i| i["issue"] == "Duplicate pin designator: '1'"));
         // The symbol has pins but no body graphics → also a warning.
         assert!(issues.iter().any(|i| i["severity"] == "warning"));
+    }
+
+    /// A body is any drawn shape, not only a rectangle, line, polyline, arc
+    /// or ellipse: a symbol drawn with a polygon, a rounded rectangle, a
+    /// bezier, a pie, an elliptical arc, an image or a text frame has one,
+    /// and is not warned about.
+    #[test]
+    fn validate_library_counts_every_shape_kind_as_a_body() {
+        use crate::altium::schlib::{
+            Bezier, Ellipse, EllipticalArc, Image, Pie, Polygon, RoundRect, TextFrame,
+        };
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let mut lib = SchLib::new();
+        let pin = || Pin::new("1", "A", -10, 0, 10, PinOrientation::Right);
+        type Draw = Box<dyn Fn(&mut Symbol)>;
+        let bodies: Vec<(&str, Draw)> = vec![
+            (
+                "POLY",
+                Box::new(|s| {
+                    s.add_polygon(Polygon::new(vec![(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)]))
+                }),
+            ),
+            (
+                "RRECT",
+                Box::new(|s| s.add_round_rect(RoundRect::new(0, 0, 10, 10, 2, 2))),
+            ),
+            (
+                "BEZ",
+                Box::new(|s| s.add_bezier(Bezier::new(0, 0, 3, 5, 7, 5, 10, 0))),
+            ),
+            ("PIE", Box::new(|s| s.add_pie(Pie::new(0, 0, 5, 0.0, 90.0)))),
+            (
+                "EARC",
+                Box::new(|s| s.add_elliptical_arc(EllipticalArc::new(0, 0, 5, 3, 0.0, 180.0))),
+            ),
+            ("ELL", Box::new(|s| s.add_ellipse(Ellipse::new(0, 0, 5, 3)))),
+            (
+                "IMG",
+                Box::new(|s| s.add_image(Image::new(0, 0, 10, 10, "logo.bmp"))),
+            ),
+            (
+                "FRAME",
+                Box::new(|s| s.add_text_frame(TextFrame::new(0, 0, 10, 10, "note"))),
+            ),
+        ];
+        for (name, draw) in &bodies {
+            let mut sym = Symbol::new(*name);
+            sym.add_pin(pin());
+            draw(&mut sym);
+            lib.add(sym);
+        }
+        let mut bare = Symbol::new("BARE");
+        bare.add_pin(pin());
+        lib.add(bare);
+        let path = dir.path().join("Bodies.SchLib");
+        lib.save(&path).unwrap();
+
+        let result = server.call_validate_library(&json!({ "filepath": path.to_string_lossy() }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let parsed = parse_result_json(&result);
+        let warned: Vec<&str> = parsed["issues"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|i| {
+                i["issue"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("no body graphics")
+            })
+            .map(|i| i["component"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            warned,
+            ["BARE"],
+            "only the symbol with nothing drawn: {parsed}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug #53 — the same hand-enumerated-kinds pattern as `rename_layer` (#440), on the validation side. `validate_library`'s "Symbol has pins but no body graphics" warning considered only rectangles, lines, polylines, arcs and ellipses, so a symbol whose body is a **polygon, rounded rectangle, bezier, pie, elliptical arc, image or text frame** was flagged as body-less — a false warning that turns a valid library's status to `warnings`.

`Symbol::body_graphic_count()` now defines the set once (every drawn shape kind; pins, labels, IEEE symbols and parameters decorate a body rather than form one) and the check uses it. `Polygon::new` added alongside the other shapes' constructors.

## Verification

- fmt / clippy `-D warnings` / `cargo doc -D warnings`: clean; **1473 tests** green
- New test `validate_library_counts_every_shape_kind_as_a_body`: nine symbols, one per formerly-missed kind plus a truly bare one — only `BARE` is warned about

🤖 Generated with [Claude Code](https://claude.com/claude-code)