### PR TITLE
fix: diff_libraries reports a change in every primitive kind

### DIFF
--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -231,6 +231,23 @@ impl PrimitiveKind {
         Self::ComponentBody,
     ];
 
+    /// The kind's name as the JSON boundary spells it (`component_body`,
+    /// `pad`, …): the serde form, so a report key built from it matches the
+    /// list the kind fills.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Arc => "arc",
+            Self::Pad => "pad",
+            Self::Via => "via",
+            Self::Track => "track",
+            Self::Text => "text",
+            Self::Region => "region",
+            Self::Fill => "fill",
+            Self::ComponentBody => "component_body",
+        }
+    }
+
     /// Altium's numeric object id for this kind, as a `PrimitiveGuids`
     /// record stores it.
     #[must_use]

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -513,6 +513,31 @@ pub enum SchPrimitiveKind {
 }
 
 impl SchPrimitiveKind {
+    /// The kind's name as the JSON boundary spells it (`round_rect`,
+    /// `ieee_symbol`, …): the serde form, so a report key built from it
+    /// matches the list the kind fills.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Rectangle => "rectangle",
+            Self::Pin => "pin",
+            Self::Line => "line",
+            Self::Polyline => "polyline",
+            Self::Polygon => "polygon",
+            Self::Arc => "arc",
+            Self::Pie => "pie",
+            Self::Image => "image",
+            Self::TextFrame => "text_frame",
+            Self::Bezier => "bezier",
+            Self::Ellipse => "ellipse",
+            Self::RoundRect => "round_rect",
+            Self::EllipticalArc => "elliptical_arc",
+            Self::Label => "label",
+            Self::IeeeSymbol => "ieee_symbol",
+            Self::Parameter => "parameter",
+        }
+    }
+
     /// The order a symbol with no recorded order of its own is written in.
     ///
     /// Rectangles lead so a solid-filled body sits behind the pins; emitting

--- a/src/altium/schlib/primitives/shapes.rs
+++ b/src/altium/schlib/primitives/shapes.rs
@@ -228,6 +228,29 @@ pub struct Polyline {
     pub raw_params: Vec<(String, String)>,
 }
 
+impl Polyline {
+    /// Creates a plain polyline through `points`: a small black solid stroke
+    /// with no end shapes, not accessible.
+    #[must_use]
+    pub fn new(points: Vec<(f64, f64)>) -> Self {
+        Self {
+            points,
+            line_width: 1,
+            color: 0,
+            line_style: 0,
+            start_line_shape: 0,
+            end_line_shape: 0,
+            line_shape_size: 0,
+            transparent: false,
+            is_not_accessible: true,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: None,
+            raw_params: Vec::new(),
+        }
+    }
+}
+
 /// A filled polygon.
 ///
 /// Vertex coordinates are `f64` schematic units (see `super::coord`); `Eq` is
@@ -358,6 +381,36 @@ pub struct Arc {
     /// canonical form.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub raw_params: Vec<(String, String)>,
+}
+
+impl Arc {
+    /// Creates an arc centred on (`x`, `y`) with the given radius, from
+    /// `start_angle` to `end_angle` in degrees, at the defaults a from-scratch
+    /// arc gets (small black stroke, not accessible).
+    #[must_use]
+    pub fn new(
+        x: impl Into<f64>,
+        y: impl Into<f64>,
+        radius: impl Into<f64>,
+        start_angle: f64,
+        end_angle: f64,
+    ) -> Self {
+        Self {
+            x: x.into(),
+            y: y.into(),
+            radius: radius.into(),
+            is_not_accessible: true,
+            start_angle,
+            end_angle,
+            line_width: 1,
+            color: 0,
+            fill_color: 0,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: None,
+            raw_params: Vec::new(),
+        }
+    }
 }
 
 const fn default_end_angle() -> f64 {

--- a/src/altium/schlib/primitives/text.rs
+++ b/src/altium/schlib/primitives/text.rs
@@ -52,6 +52,29 @@ pub struct Label {
     pub raw_params: Vec<(String, String)>,
 }
 
+impl Label {
+    /// Creates a label reading `text` at (`x`, `y`) with Altium's defaults:
+    /// font 1, black, bottom-left anchored, unrotated, visible.
+    #[must_use]
+    pub fn new(x: impl Into<f64>, y: impl Into<f64>, text: impl Into<String>) -> Self {
+        Self {
+            x: x.into(),
+            y: y.into(),
+            text: text.into(),
+            font_id: 1,
+            color: 0,
+            justification: TextJustification::BottomLeft,
+            rotation: 0.0,
+            is_mirrored: false,
+            is_hidden: false,
+            owner_part_id: 1,
+            display_flags: ShapeDisplayFlags::default(),
+            unique_id: None,
+            raw_params: Vec::new(),
+        }
+    }
+}
+
 /// A bordered multi-line text box — `SchLib` `RECORD=28`.
 ///
 /// Distinct from [`Label`]: the text lives inside a frame rectangle

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -117,41 +117,13 @@ impl McpServer {
                 ));
             }
 
-            // Compare primitive counts
-            if fp_a.pads.len() != fp_b.pads.len() {
-                changes.push(format!(
-                    "pad_count: {} -> {}",
-                    fp_a.pads.len(),
-                    fp_b.pads.len()
-                ));
-            }
-            if fp_a.tracks.len() != fp_b.tracks.len() {
-                changes.push(format!(
-                    "track_count: {} -> {}",
-                    fp_a.tracks.len(),
-                    fp_b.tracks.len()
-                ));
-            }
-            if fp_a.arcs.len() != fp_b.arcs.len() {
-                changes.push(format!(
-                    "arc_count: {} -> {}",
-                    fp_a.arcs.len(),
-                    fp_b.arcs.len()
-                ));
-            }
-            if fp_a.regions.len() != fp_b.regions.len() {
-                changes.push(format!(
-                    "region_count: {} -> {}",
-                    fp_a.regions.len(),
-                    fp_b.regions.len()
-                ));
-            }
-            if fp_a.text.len() != fp_b.text.len() {
-                changes.push(format!(
-                    "text_count: {} -> {}",
-                    fp_a.text.len(),
-                    fp_b.text.len()
-                ));
+            // Every primitive kind, from the enum, so a new kind cannot be left
+            // out of the report.
+            for kind in crate::altium::pcblib::PrimitiveKind::WRITE_ORDER {
+                let (count_a, count_b) = (fp_a.count_of(kind), fp_b.count_of(kind));
+                if count_a != count_b {
+                    changes.push(format!("{}_count: {count_a} -> {count_b}", kind.name()));
+                }
             }
 
             // Compare 3D model presence (external references)
@@ -162,15 +134,6 @@ impl McpServer {
                     "external_3d_model: {} -> {}",
                     if has_model_a { "yes" } else { "no" },
                     if has_model_b { "yes" } else { "no" }
-                ));
-            }
-
-            // Compare embedded 3D bodies
-            if fp_a.component_bodies.len() != fp_b.component_bodies.len() {
-                changes.push(format!(
-                    "component_body_count: {} -> {}",
-                    fp_a.component_bodies.len(),
-                    fp_b.component_bodies.len()
                 ));
             }
 
@@ -266,41 +229,13 @@ impl McpServer {
                 ));
             }
 
-            // Compare primitive counts
-            if sym_a.pins.len() != sym_b.pins.len() {
-                changes.push(format!(
-                    "pin_count: {} -> {}",
-                    sym_a.pins.len(),
-                    sym_b.pins.len()
-                ));
-            }
-            if sym_a.rectangles.len() != sym_b.rectangles.len() {
-                changes.push(format!(
-                    "rectangle_count: {} -> {}",
-                    sym_a.rectangles.len(),
-                    sym_b.rectangles.len()
-                ));
-            }
-            if sym_a.lines.len() != sym_b.lines.len() {
-                changes.push(format!(
-                    "line_count: {} -> {}",
-                    sym_a.lines.len(),
-                    sym_b.lines.len()
-                ));
-            }
-            if sym_a.polylines.len() != sym_b.polylines.len() {
-                changes.push(format!(
-                    "polyline_count: {} -> {}",
-                    sym_a.polylines.len(),
-                    sym_b.polylines.len()
-                ));
-            }
-            if sym_a.arcs.len() != sym_b.arcs.len() {
-                changes.push(format!(
-                    "arc_count: {} -> {}",
-                    sym_a.arcs.len(),
-                    sym_b.arcs.len()
-                ));
+            // Every record kind, from the enum, so a new kind cannot be left
+            // out of the report.
+            for kind in crate::altium::schlib::SchPrimitiveKind::WRITE_ORDER {
+                let (count_a, count_b) = (sym_a.count_of(kind), sym_b.count_of(kind));
+                if count_a != count_b {
+                    changes.push(format!("{}_count: {count_a} -> {count_b}", kind.name()));
+                }
             }
             if sym_a.footprints.len() != sym_b.footprints.len() {
                 changes.push(format!(
@@ -475,6 +410,142 @@ mod tests {
         assert!(changes
             .iter()
             .any(|c| c.as_str().unwrap() == "pad_count: 2 -> 3"));
+    }
+
+    /// Every kind is compared — a via, a fill or a bezier added on one side
+    /// is a reported change, not "unchanged".
+    #[test]
+    #[allow(clippy::too_many_lines)] // one library per format, one primitive per kind
+    fn diff_reports_a_change_in_every_primitive_kind() {
+        use crate::altium::pcblib::{Arc, ComponentBody, Fill, Layer, Region, Text, Track, Via};
+        use crate::altium::schlib::{
+            Bezier, Ellipse, EllipticalArc, IeeeSymbol, Image, Label, Line, Parameter, Pie, Pin,
+            PinOrientation, Polygon, Polyline, Rectangle, RoundRect, SchLib, Symbol, TextFrame,
+        };
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        // PcbLib: B has one more of every kind than A.
+        let path_a = dir.path().join("KindsA.PcbLib");
+        let path_b = dir.path().join("KindsB.PcbLib");
+        let add_one_of_each = |fp: &mut Footprint| {
+            let layer = Layer::TopOverlay;
+            fp.add_pad(Pad::smd("9", 0.0, 0.0, 1.0, 1.0));
+            fp.add_via(Via::new(0.0, 0.0, 0.6, 0.3));
+            fp.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.1, layer));
+            fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.1, layer));
+            fp.add_text(Text::new(0.0, 0.0, "T", 1.0, layer));
+            fp.add_region(Region::rectangle(0.0, 0.0, 1.0, 1.0, layer));
+            fp.add_fill(Fill::new(0.0, 0.0, 1.0, 1.0, layer));
+            let mut body = ComponentBody::new("", "b.step");
+            body.embedded = false;
+            fp.add_component_body(body);
+        };
+        for (path, extra) in [(&path_a, false), (&path_b, true)] {
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("KINDS");
+            add_one_of_each(&mut fp);
+            if extra {
+                add_one_of_each(&mut fp);
+            }
+            lib.add(fp);
+            lib.save(path).unwrap();
+        }
+        let result = server.call_diff_libraries(&json!({
+            "filepath_a": path_a.to_string_lossy(),
+            "filepath_b": path_b.to_string_lossy(),
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let parsed = parse_result_json(&result);
+        let changes: Vec<String> = parsed["modified"][0]["changes"]
+            .as_array()
+            .expect("changes")
+            .iter()
+            .map(|c| c.as_str().unwrap().to_string())
+            .collect();
+        for kind in [
+            "pad",
+            "via",
+            "track",
+            "arc",
+            "text",
+            "region",
+            "fill",
+            "component_body",
+        ] {
+            assert!(
+                changes.contains(&format!("{kind}_count: 1 -> 2")),
+                "{kind} change not reported: {changes:?}"
+            );
+        }
+
+        // SchLib: the same for every record kind.
+        let path_a = dir.path().join("KindsA.SchLib");
+        let path_b = dir.path().join("KindsB.SchLib");
+        let add_one_of_each = |sym: &mut Symbol| {
+            sym.add_pin(Pin::new("1", "A", -10, 0, 10, PinOrientation::Right));
+            sym.add_rectangle(Rectangle::new(0, 0, 10, 10));
+            sym.add_line(Line::new(0, 0, 10, 10));
+            sym.add_polyline(Polyline::new(vec![(0.0, 0.0), (5.0, 5.0), (10.0, 0.0)]));
+            sym.add_polygon(Polygon::new(vec![(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)]));
+            sym.add_arc(crate::altium::schlib::Arc::new(0, 0, 5, 0.0, 90.0));
+            sym.add_pie(Pie::new(0, 0, 5, 0.0, 90.0));
+            sym.add_image(Image::new(0, 0, 10, 10, "logo.bmp"));
+            sym.add_text_frame(TextFrame::new(0, 0, 10, 10, "note"));
+            sym.add_bezier(Bezier::new(0, 0, 3, 5, 7, 5, 10, 0));
+            sym.add_ellipse(Ellipse::new(0, 0, 5, 3));
+            sym.add_round_rect(RoundRect::new(0, 0, 10, 10, 2, 2));
+            sym.add_elliptical_arc(EllipticalArc::new(0, 0, 5, 3, 0.0, 180.0));
+            sym.add_label(Label::new(0, 0, "L"));
+            sym.add_ieee_symbol(IeeeSymbol::new(1, 0.0, 0.0));
+            sym.add_parameter(Parameter::new("Value", "1k"));
+        };
+        for (path, extra) in [(&path_a, false), (&path_b, true)] {
+            let mut lib = SchLib::new();
+            let mut sym = Symbol::new("KINDS");
+            add_one_of_each(&mut sym);
+            if extra {
+                add_one_of_each(&mut sym);
+            }
+            lib.add(sym);
+            lib.save(path).unwrap();
+        }
+        let result = server.call_diff_libraries(&json!({
+            "filepath_a": path_a.to_string_lossy(),
+            "filepath_b": path_b.to_string_lossy(),
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let parsed = parse_result_json(&result);
+        let changes: Vec<String> = parsed["modified"][0]["changes"]
+            .as_array()
+            .expect("changes")
+            .iter()
+            .map(|c| c.as_str().unwrap().to_string())
+            .collect();
+        for kind in [
+            "pin",
+            "rectangle",
+            "line",
+            "polyline",
+            "polygon",
+            "arc",
+            "pie",
+            "image",
+            "text_frame",
+            "bezier",
+            "ellipse",
+            "round_rect",
+            "elliptical_arc",
+            "label",
+            "ieee_symbol",
+            "parameter",
+        ] {
+            assert!(
+                changes.contains(&format!("{kind}_count: 1 -> 2")),
+                "{kind} change not reported: {changes:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug #54 — the hand-enumerated-kinds pattern (#440, #443) in `diff_libraries`. The per-component comparison listed pads, tracks, arcs, regions, text and bodies for a footprint (no **vias, no fills**) and pins, rectangles, lines, polylines and arcs for a symbol (no **polygons, pies, ellipses, round-rects, beziers, images, text frames, elliptical arcs, labels, IEEE symbols or parameters**). A library whose only change was in one of the missing kinds diffed as "unchanged".

Both sides now iterate the kind enums (`PrimitiveKind::WRITE_ORDER` / `SchPrimitiveKind::WRITE_ORDER`) and name the report key from a new `name()` accessor, so a kind cannot be left out — the same report keys as before (`pad_count: 2 -> 3`), now for every kind. `Polyline::new`, `Arc::new` and `Label::new` added alongside the other SchLib constructors.

## Verification

- fmt / clippy `-D warnings` / `cargo doc -D warnings`: clean; **1474 tests** green
- New test `diff_reports_a_change_in_every_primitive_kind`: two libraries per format, B holding one more of *every* kind than A, asserts a `<kind>_count: 1 -> 2` line for each of the 8 PcbLib and 16 SchLib kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)