### PR TITLE
fix: render draws every primitive kind; the kind enums come from one list

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -803,7 +803,8 @@ and `.SchLib` files.
 
 ## `render_footprint`
 
-Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, tracks, and other primitives in a simple text format for quick preview.
+Render an ASCII art visualisation of a footprint from a PcbLib file: every primitive kind — pads (with designators), vias, tracks, arcs, fills, regions, text marks and
+3D-body outlines — each with its own marker, plus a per-kind count line and a legend. A quick preview, not a rendering.
 
 **Example**
 
@@ -832,8 +833,9 @@ Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads,
 
 ## `render_symbol`
 
-Render an ASCII art visualisation of a schematic symbol from a SchLib file. Shows pins, rectangles, lines, and other primitives in a simple text format for quick preview.
-Coordinates are in schematic units (10 units = 1 grid).
+Render an ASCII art visualisation of a schematic symbol from a SchLib file: every record kind of the requested part — pins (with designators), rectangles, rounded
+rectangles, lines, polylines, polygons, arcs, pies, ellipses, elliptical arcs, beziers, images, text frames, labels and IEEE symbols — each with its own marker, plus a
+per-kind count line and a legend. Coordinates are in schematic units (10 units = 1 grid).
 
 **Example**
 

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -25,6 +25,44 @@
 
 pub(crate) mod base64_opt;
 pub(crate) mod bytes;
+/// Declares a primitive-kind enum together with everything that must list
+/// every variant — the write order, the variant count and the JSON-boundary
+/// name — from ONE list, so adding a kind cannot leave a list short. The
+/// variants are declared in write order.
+macro_rules! primitive_kinds {
+    (
+        $(#[$enum_doc:meta])*
+        $enum_name:ident {
+            $( $(#[$doc:meta])* $variant:ident => $name:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_doc])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $enum_name {
+            $( $(#[$doc])* $variant, )+
+        }
+
+        impl $enum_name {
+            /// How many kinds there are.
+            pub const COUNT: usize = [$(stringify!($variant)),+].len();
+
+            /// Every kind, in the order a component with no recorded order of
+            /// its own is written in.
+            pub const WRITE_ORDER: [Self; Self::COUNT] = [$(Self::$variant,)+];
+
+            /// The kind's name as the JSON boundary spells it (the serde form),
+            /// so a report key built from it matches the list the kind fills.
+            #[must_use]
+            pub const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name,)+
+                }
+            }
+        }
+    };
+}
+
 pub mod error;
 pub(crate) mod framing;
 pub mod libpkg;

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -196,58 +196,29 @@ impl LayerMove {
     }
 }
 
-/// One of a [`Footprint`]'s primitive lists, as named by `primitive_order`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PrimitiveKind {
-    /// [`Footprint::arcs`].
-    Arc,
-    /// [`Footprint::pads`].
-    Pad,
-    /// [`Footprint::vias`].
-    Via,
-    /// [`Footprint::tracks`].
-    Track,
-    /// [`Footprint::text`].
-    Text,
-    /// [`Footprint::regions`].
-    Region,
-    /// [`Footprint::fills`].
-    Fill,
-    /// [`Footprint::component_bodies`].
-    ComponentBody,
+primitive_kinds! {
+    /// One of a [`Footprint`]'s primitive lists, as named by `primitive_order`.
+    PrimitiveKind {
+        /// [`Footprint::arcs`].
+        Arc => "arc",
+        /// [`Footprint::pads`].
+        Pad => "pad",
+        /// [`Footprint::vias`].
+        Via => "via",
+        /// [`Footprint::tracks`].
+        Track => "track",
+        /// [`Footprint::text`].
+        Text => "text",
+        /// [`Footprint::regions`].
+        Region => "region",
+        /// [`Footprint::fills`].
+        Fill => "fill",
+        /// [`Footprint::component_bodies`].
+        ComponentBody => "component_body",
+    }
 }
 
 impl PrimitiveKind {
-    /// The order a footprint with no recorded order of its own is written in.
-    pub const WRITE_ORDER: [Self; 8] = [
-        Self::Arc,
-        Self::Pad,
-        Self::Via,
-        Self::Track,
-        Self::Text,
-        Self::Region,
-        Self::Fill,
-        Self::ComponentBody,
-    ];
-
-    /// The kind's name as the JSON boundary spells it (`component_body`,
-    /// `pad`, …): the serde form, so a report key built from it matches the
-    /// list the kind fills.
-    #[must_use]
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::Arc => "arc",
-            Self::Pad => "pad",
-            Self::Via => "via",
-            Self::Track => "track",
-            Self::Text => "text",
-            Self::Region => "region",
-            Self::Fill => "fill",
-            Self::ComponentBody => "component_body",
-        }
-    }
-
     /// Altium's numeric object id for this kind, as a `PrimitiveGuids`
     /// record stores it.
     #[must_use]

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -470,96 +470,48 @@ pub struct Symbol {
     pub primitive_order: Vec<SchPrimitiveKind>,
 }
 
-/// One of a [`Symbol`]'s content-record lists, as named by `primitive_order`.
-///
-/// Footprint models are absent on purpose: they are written in the
-/// implementation section after the content records and take no `IndexInSheet`
-/// slot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SchPrimitiveKind {
-    /// [`Symbol::rectangles`].
-    Rectangle,
-    /// [`Symbol::pins`].
-    Pin,
-    /// [`Symbol::lines`].
-    Line,
-    /// [`Symbol::polylines`].
-    Polyline,
-    /// [`Symbol::polygons`].
-    Polygon,
-    /// [`Symbol::arcs`].
-    Arc,
-    /// [`Symbol::pies`].
-    Pie,
-    /// [`Symbol::images`].
-    Image,
-    /// [`Symbol::text_frames`].
-    TextFrame,
-    /// [`Symbol::beziers`].
-    Bezier,
-    /// [`Symbol::ellipses`].
-    Ellipse,
-    /// [`Symbol::round_rects`].
-    RoundRect,
-    /// [`Symbol::elliptical_arcs`].
-    EllipticalArc,
-    /// [`Symbol::labels`].
-    Label,
-    /// [`Symbol::ieee_symbols`].
-    IeeeSymbol,
-    /// [`Symbol::parameters`].
-    Parameter,
-}
-
-impl SchPrimitiveKind {
-    /// The kind's name as the JSON boundary spells it (`round_rect`,
-    /// `ieee_symbol`, …): the serde form, so a report key built from it
-    /// matches the list the kind fills.
-    #[must_use]
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::Rectangle => "rectangle",
-            Self::Pin => "pin",
-            Self::Line => "line",
-            Self::Polyline => "polyline",
-            Self::Polygon => "polygon",
-            Self::Arc => "arc",
-            Self::Pie => "pie",
-            Self::Image => "image",
-            Self::TextFrame => "text_frame",
-            Self::Bezier => "bezier",
-            Self::Ellipse => "ellipse",
-            Self::RoundRect => "round_rect",
-            Self::EllipticalArc => "elliptical_arc",
-            Self::Label => "label",
-            Self::IeeeSymbol => "ieee_symbol",
-            Self::Parameter => "parameter",
-        }
-    }
-
-    /// The order a symbol with no recorded order of its own is written in.
+primitive_kinds! {
+    /// One of a [`Symbol`]'s content-record lists, as named by `primitive_order`.
     ///
-    /// Rectangles lead so a solid-filled body sits behind the pins; emitting
-    /// pins first lets the body paint over the pin names inside it.
-    pub const WRITE_ORDER: [Self; 16] = [
-        Self::Rectangle,
-        Self::Pin,
-        Self::Line,
-        Self::Polyline,
-        Self::Polygon,
-        Self::Arc,
-        Self::Pie,
-        Self::Image,
-        Self::TextFrame,
-        Self::Bezier,
-        Self::Ellipse,
-        Self::RoundRect,
-        Self::EllipticalArc,
-        Self::Label,
-        Self::IeeeSymbol,
-        Self::Parameter,
-    ];
+    /// Footprint models are absent on purpose: they are written in the
+    /// implementation section after the content records and take no
+    /// `IndexInSheet` slot. The write order leads with rectangles so a
+    /// solid-filled body sits behind the pins; emitting pins first would let
+    /// the body paint over the pin names inside it.
+    SchPrimitiveKind {
+        /// [`Symbol::rectangles`].
+        Rectangle => "rectangle",
+        /// [`Symbol::pins`].
+        Pin => "pin",
+        /// [`Symbol::lines`].
+        Line => "line",
+        /// [`Symbol::polylines`].
+        Polyline => "polyline",
+        /// [`Symbol::polygons`].
+        Polygon => "polygon",
+        /// [`Symbol::arcs`].
+        Arc => "arc",
+        /// [`Symbol::pies`].
+        Pie => "pie",
+        /// [`Symbol::images`].
+        Image => "image",
+        /// [`Symbol::text_frames`].
+        TextFrame => "text_frame",
+        /// [`Symbol::beziers`].
+        Bezier => "bezier",
+        /// [`Symbol::ellipses`].
+        Ellipse => "ellipse",
+        /// [`Symbol::round_rects`].
+        RoundRect => "round_rect",
+        /// [`Symbol::elliptical_arcs`].
+        EllipticalArc => "elliptical_arc",
+        /// [`Symbol::labels`].
+        Label => "label",
+        /// [`Symbol::ieee_symbols`].
+        IeeeSymbol => "ieee_symbol",
+        /// [`Symbol::parameters`].
+        Parameter => "parameter",
+    }
 }
 
 const fn default_part_count() -> u32 {

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -1738,8 +1738,10 @@ impl McpServer {
                 name: "render_footprint".to_string(),
                 example: Some(serde_json::json!({"name": "render_footprint", "arguments": {"filepath": "./MyLibrary.PcbLib", "component_name": "RESC0603_IPC_MEDIUM", "scale": 2.0, "max_width": 80, "max_height": 40}})),
                 description: Some(
-                    "Render an ASCII art visualisation of a footprint from a PcbLib file. Shows pads, \
-                     tracks, and other primitives in a simple text format for quick preview."
+                    "Render an ASCII art visualisation of a footprint from a PcbLib file: every \
+                     primitive kind — pads (with designators), vias, tracks, arcs, fills, \
+                     regions, text marks and 3D-body outlines — each with its own marker, plus \
+                     a per-kind count line and a legend. A quick preview, not a rendering."
                         .to_string(),
                 ),
                 input_schema: json!({
@@ -1773,9 +1775,12 @@ impl McpServer {
                 name: "render_symbol".to_string(),
                 example: Some(serde_json::json!({"name": "render_symbol", "arguments": {"filepath": "./MyLibrary.SchLib", "component_name": "LM358", "scale": 1.0, "max_width": 80, "max_height": 40, "part_id": 1}})),
                 description: Some(
-                    "Render an ASCII art visualisation of a schematic symbol from a SchLib file. \
-                     Shows pins, rectangles, lines, and other primitives in a simple text format \
-                     for quick preview. Coordinates are in schematic units (10 units = 1 grid)."
+                    "Render an ASCII art visualisation of a schematic symbol from a SchLib file: \
+                     every record kind of the requested part — pins (with designators), \
+                     rectangles, rounded rectangles, lines, polylines, polygons, arcs, pies, \
+                     ellipses, elliptical arcs, beziers, images, text frames, labels and IEEE \
+                     symbols — each with its own marker, plus a per-kind count line and a \
+                     legend. Coordinates are in schematic units (10 units = 1 grid)."
                         .to_string(),
                 ),
                 input_schema: json!({

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -88,16 +88,8 @@ impl McpServer {
         ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
     }
 
-    /// Renders a footprint as ASCII art.
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_precision_loss,
-        clippy::similar_names,
-        clippy::too_many_lines,
-        clippy::float_cmp,
-        clippy::needless_range_loop
-    )]
+    /// Renders a footprint as ASCII art: every primitive kind, each with its
+    /// own marker, the origin as `+` where nothing else is drawn.
     pub(crate) fn render_footprint_ascii(
         footprint: &crate::altium::pcblib::Footprint,
         scale: f64,
@@ -106,213 +98,40 @@ impl McpServer {
     ) -> String {
         use std::fmt::Write;
 
-        // Find bounding box
-        let (mut min_x, mut max_x, mut min_y, mut max_y) = (f64::MAX, f64::MIN, f64::MAX, f64::MIN);
-
-        for pad in &footprint.pads {
-            let half_w = pad.width / 2.0;
-            let half_h = pad.height / 2.0;
-            min_x = min_x.min(pad.x - half_w);
-            max_x = max_x.max(pad.x + half_w);
-            min_y = min_y.min(pad.y - half_h);
-            max_y = max_y.max(pad.y + half_h);
-        }
-
-        for track in &footprint.tracks {
-            min_x = min_x.min(track.x1.min(track.x2) - track.width / 2.0);
-            max_x = max_x.max(track.x1.max(track.x2) + track.width / 2.0);
-            min_y = min_y.min(track.y1.min(track.y2) - track.width / 2.0);
-            max_y = max_y.max(track.y1.max(track.y2) + track.width / 2.0);
-        }
-
-        for arc in &footprint.arcs {
-            min_x = min_x.min(arc.x - arc.radius);
-            max_x = max_x.max(arc.x + arc.radius);
-            min_y = min_y.min(arc.y - arc.radius);
-            max_y = max_y.max(arc.y + arc.radius);
-        }
-
-        // Handle empty footprint
-        if min_x == f64::MAX {
+        let bounds = Self::footprint_bounds(footprint);
+        if bounds.is_empty() {
             return "Empty footprint (no primitives)".to_string();
         }
+        // scale is cells per mm; 0.5 mm of margin all round.
+        let mut canvas = Canvas::new(&bounds, 0.5, scale, max_width, max_height);
+        Self::draw_footprint(&mut canvas, footprint);
 
-        // Add margin
-        let margin = 0.5;
-        min_x -= margin;
-        max_x += margin;
-        min_y -= margin;
-        max_y += margin;
-
-        // Calculate canvas size
-        let width_mm = max_x - min_x;
-        let height_mm = max_y - min_y;
-        let mut canvas_width = (width_mm * scale).ceil() as usize;
-        let mut canvas_height = (height_mm * scale).ceil() as usize;
-
-        // Clamp to max dimensions
-        if canvas_width > max_width {
-            canvas_width = max_width;
-        }
-        if canvas_height > max_height {
-            canvas_height = max_height;
-        }
-
-        // Ensure minimum size
-        canvas_width = canvas_width.max(10);
-        canvas_height = canvas_height.max(5);
-
-        // Calculate actual scale after clamping
-        let actual_scale_x = canvas_width as f64 / width_mm;
-        let actual_scale_y = canvas_height as f64 / height_mm;
-
-        // Create canvas (y is inverted for display)
-        let mut canvas = vec![vec![' '; canvas_width]; canvas_height];
-
-        // Helper to convert coordinates
-        let to_canvas = |x: f64, y: f64| -> (usize, usize) {
-            let cx = ((x - min_x) * actual_scale_x).round() as usize;
-            // Clamp the scaled offset before subtracting: a point outside the
-            // bounding box (e.g. the origin crosshair) would otherwise underflow
-            // — a panic in debug builds — instead of clamping to the edge.
-            let dy = (((y - min_y) * actual_scale_y).round() as usize)
-                .min(canvas_height.saturating_sub(1));
-            let cy = canvas_height.saturating_sub(1) - dy;
-            (cx.min(canvas_width - 1), cy.min(canvas_height - 1))
-        };
-
-        // Draw tracks (as lines)
-        for track in &footprint.tracks {
-            Self::draw_line(
-                &mut canvas,
-                to_canvas(track.x1, track.y1),
-                to_canvas(track.x2, track.y2),
-                '-',
-            );
-        }
-
-        // Draw arcs (simplified as circles at centre)
-        for arc in &footprint.arcs {
-            let (cx, cy) = to_canvas(arc.x, arc.y);
-            if cx < canvas_width && cy < canvas_height {
-                canvas[cy][cx] = 'o';
-            }
-        }
-
-        // Draw pads (as rectangles with full designator)
-        for pad in &footprint.pads {
-            let half_w = pad.width / 2.0;
-            let half_h = pad.height / 2.0;
-            let (x1, y1) = to_canvas(pad.x - half_w, pad.y - half_h);
-            let (x2, y2) = to_canvas(pad.x + half_w, pad.y + half_h);
-
-            // Fill pad area
-            let (min_cy, max_cy) = (y1.min(y2), y1.max(y2));
-            let (min_cx, max_cx) = (x1.min(x2), x1.max(x2));
-
-            for cy in min_cy..=max_cy {
-                for cx in min_cx..=max_cx {
-                    if cy < canvas_height && cx < canvas_width {
-                        canvas[cy][cx] = '#';
-                    }
-                }
-            }
-
-            // Place full designator centred on pad
-            let (cx, cy) = to_canvas(pad.x, pad.y);
-            if cy < canvas_height {
-                let desig = &pad.designator;
-                let start_x = cx.saturating_sub(desig.len() / 2);
-                for (i, ch) in desig.chars().enumerate() {
-                    let x = start_x + i;
-                    if x < canvas_width {
-                        canvas[cy][x] = ch;
-                    }
-                }
-            }
-        }
-
-        // Draw origin crosshair only onto a blank cell, so it never hides a
-        // primitive (consistent with render_symbol_ascii).
-        let (ox, oy) = to_canvas(0.0, 0.0);
-        if ox < canvas_width && oy < canvas_height && canvas[oy][ox] == ' ' {
-            canvas[oy][ox] = '+';
-        }
-
-        // Build output string
         let mut output = String::new();
         let _ = writeln!(
             output,
             "Footprint: {} ({:.2} x {:.2} mm)",
             footprint.name,
-            width_mm - margin * 2.0,
-            height_mm - margin * 2.0
+            bounds.width(),
+            bounds.height()
         );
         let _ = writeln!(
             output,
-            "Pads: {}, Tracks: {}, Arcs: {}",
+            "Pads: {}, Tracks: {}, Arcs: {}, Vias: {}, Fills: {}, Regions: {}, Text: {}, Bodies: {}",
             footprint.pads.len(),
             footprint.tracks.len(),
-            footprint.arcs.len()
+            footprint.arcs.len(),
+            footprint.vias.len(),
+            footprint.fills.len(),
+            footprint.regions.len(),
+            footprint.text.len(),
+            footprint.component_bodies.len()
         );
-        output.push_str(&"-".repeat(canvas_width + 2));
-        output.push('\n');
-
-        for row in &canvas {
-            output.push('|');
-            for &ch in row {
-                output.push(ch);
-            }
-            output.push('|');
-            output.push('\n');
-        }
-
-        output.push_str(&"-".repeat(canvas_width + 2));
-        output.push('\n');
-        output.push_str("Legend: # = pad, - = track, o = arc, + = origin\n");
-
+        output.push_str(&canvas.framed());
+        output.push_str(
+            "Legend: # = pad, - = track, o = arc, O = via, = = fill, % = region, T = text, \
+             . = 3D body, + = origin\n",
+        );
         output
-    }
-
-    /// Draws a line on the canvas using Bresenham's algorithm.
-    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
-    pub(crate) fn draw_line(
-        canvas: &mut [Vec<char>],
-        (x0, y0): (usize, usize),
-        (x1, y1): (usize, usize),
-        ch: char,
-    ) {
-        let dx = (x1 as isize - x0 as isize).abs();
-        let dy = (y1 as isize - y0 as isize).abs();
-        let sx: isize = if x0 < x1 { 1 } else { -1 };
-        let sy: isize = if y0 < y1 { 1 } else { -1 };
-        let mut err = dx - dy;
-
-        let mut x = x0 as isize;
-        let mut y = y0 as isize;
-
-        let height = canvas.len();
-        let width = if height > 0 { canvas[0].len() } else { 0 };
-
-        loop {
-            if (x as usize) < width && (y as usize) < height {
-                canvas[y as usize][x as usize] = ch;
-            }
-
-            if x == x1 as isize && y == y1 as isize {
-                break;
-            }
-
-            let e2 = 2 * err;
-            if e2 > -dy {
-                err -= dy;
-                x += sx;
-            }
-            if e2 < dx {
-                err += dx;
-                y += sy;
-            }
-        }
     }
 
     /// Renders an ASCII art visualisation of a schematic symbol.
@@ -397,16 +216,98 @@ impl McpServer {
         ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
     }
 
-    /// Renders a schematic symbol as ASCII art.
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_sign_loss,
-        clippy::cast_precision_loss,
-        clippy::similar_names,
-        clippy::too_many_lines,
-        clippy::float_cmp,
-        clippy::needless_range_loop
-    )]
+    /// The extent of every primitive kind a footprint holds, so nothing it
+    /// holds renders as "empty" and nothing falls outside the canvas.
+    fn footprint_bounds(footprint: &crate::altium::pcblib::Footprint) -> Bounds {
+        let mut bounds = Bounds::default();
+        for pad in &footprint.pads {
+            bounds.add_rect(
+                pad.x - pad.width / 2.0,
+                pad.y - pad.height / 2.0,
+                pad.x + pad.width / 2.0,
+                pad.y + pad.height / 2.0,
+            );
+        }
+        for via in &footprint.vias {
+            bounds.add_circle(via.x, via.y, via.diameter / 2.0);
+        }
+        for track in &footprint.tracks {
+            let half = track.width / 2.0;
+            bounds.add_rect(
+                track.x1.min(track.x2) - half,
+                track.y1.min(track.y2) - half,
+                track.x1.max(track.x2) + half,
+                track.y1.max(track.y2) + half,
+            );
+        }
+        for arc in &footprint.arcs {
+            bounds.add_circle(arc.x, arc.y, arc.radius);
+        }
+        for text in &footprint.text {
+            bounds.add_rect(text.x, text.y, text.x + text.height, text.y + text.height);
+        }
+        for fill in &footprint.fills {
+            bounds.add_rect(fill.x1, fill.y1, fill.x2, fill.y2);
+        }
+        for region in &footprint.regions {
+            for v in &region.vertices {
+                bounds.add(v.x, v.y);
+            }
+        }
+        for body in &footprint.component_bodies {
+            bounds.add_points(&body.outline);
+        }
+        bounds
+    }
+
+    /// Draws every primitive kind back to front: bodies and regions as
+    /// outlines, fills, tracks, arcs, vias, text marks, then pads with their
+    /// designators on top, and the origin where nothing else is.
+    fn draw_footprint(canvas: &mut Canvas, footprint: &crate::altium::pcblib::Footprint) {
+        for body in &footprint.component_bodies {
+            canvas.polyline(&body.outline, true, '.');
+        }
+        for region in &footprint.regions {
+            let points: Vec<(f64, f64)> = region.vertices.iter().map(|v| (v.x, v.y)).collect();
+            canvas.polyline(&points, true, '%');
+        }
+        for fill in &footprint.fills {
+            canvas.rect_fill(fill.x1, fill.y1, fill.x2, fill.y2, '=');
+        }
+        for track in &footprint.tracks {
+            canvas.line(track.x1, track.y1, track.x2, track.y2, '-');
+        }
+        for arc in &footprint.arcs {
+            canvas.arc(
+                (arc.x, arc.y),
+                (arc.radius, arc.radius),
+                (arc.start_angle, arc.end_angle),
+                'o',
+            );
+        }
+        for via in &footprint.vias {
+            canvas.plot(via.x, via.y, 'O');
+        }
+        for text in &footprint.text {
+            canvas.plot(text.x, text.y, 'T');
+        }
+        for pad in &footprint.pads {
+            canvas.rect_fill(
+                pad.x - pad.width / 2.0,
+                pad.y - pad.height / 2.0,
+                pad.x + pad.width / 2.0,
+                pad.y + pad.height / 2.0,
+                '#',
+            );
+            canvas.label_centred(pad.x, pad.y, &pad.designator);
+        }
+        canvas.origin();
+    }
+
+    /// Renders a schematic symbol as ASCII art: every record kind of the
+    /// requested part (every part when `part_id` is 0), each with its own
+    /// marker.
+    #[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
     pub(crate) fn render_symbol_ascii(
         symbol: &crate::altium::schlib::Symbol,
         scale: f64,
@@ -417,313 +318,331 @@ impl McpServer {
         use crate::altium::schlib::PinOrientation;
         use std::fmt::Write;
 
-        // Find bounding box (in schematic units)
-        let (mut min_x, mut max_x, mut min_y, mut max_y) = (i32::MAX, i32::MIN, i32::MAX, i32::MIN);
-
-        // Helper to check if primitive belongs to requested part
-        let matches_part = |owner_part_id: i32| -> bool {
+        // Whether a primitive of `owner_part_id` belongs to the requested part.
+        let shown = |owner_part_id: i32| -> bool {
             part_id == 0 || owner_part_id == part_id || owner_part_id == 0
         };
-
-        // Calculate bounding box from pins (include pin length)
-        for pin in &symbol.pins {
-            if !matches_part(pin.owner_part_id) {
-                continue;
+        let pin_end = |pin: &crate::altium::schlib::Pin| -> (f64, f64) {
+            let (px, py) = (f64::from(pin.x), f64::from(pin.y));
+            let len = f64::from(pin.length);
+            match pin.orientation {
+                PinOrientation::Right => (px + len, py),
+                PinOrientation::Left => (px - len, py),
+                PinOrientation::Up => (px, py + len),
+                PinOrientation::Down => (px, py - len),
             }
-            let (px, py) = (pin.x, pin.y);
-            let (end_x, end_y) = match pin.orientation {
-                PinOrientation::Right => (px + pin.length, py),
-                PinOrientation::Left => (px - pin.length, py),
-                PinOrientation::Up => (px, py + pin.length),
-                PinOrientation::Down => (px, py - pin.length),
-            };
-            min_x = min_x.min(px).min(end_x);
-            max_x = max_x.max(px).max(end_x);
-            min_y = min_y.min(py).min(end_y);
-            max_y = max_y.max(py).max(end_y);
+        };
+        let bezier_points = |bezier: &crate::altium::schlib::Bezier| -> Vec<(f64, f64)> {
+            (0..=16)
+                .map(|step| {
+                    let t = f64::from(step) / 16.0;
+                    let u = 1.0 - t;
+                    // The cubic Bernstein weights of the four control points.
+                    let weights = [u * u * u, 3.0 * u * u * t, 3.0 * u * t * t, t * t * t];
+                    let xs = [bezier.x1, bezier.x2, bezier.x3, bezier.x4];
+                    let ys = [bezier.y1, bezier.y2, bezier.y3, bezier.y4];
+                    let blend = |values: [f64; 4]| {
+                        weights
+                            .iter()
+                            .zip(values)
+                            .fold(0.0_f64, |acc, (w, v)| w.mul_add(v, acc))
+                    };
+                    (blend(xs), blend(ys))
+                })
+                .collect()
+        };
+
+        // Bounds over every kind of the part, so nothing renders as "empty"
+        // and nothing falls outside the canvas.
+        let mut bounds = Bounds::default();
+        for pin in symbol.pins.iter().filter(|p| shown(p.owner_part_id)) {
+            bounds.add(f64::from(pin.x), f64::from(pin.y));
+            let (ex, ey) = pin_end(pin);
+            bounds.add(ex, ey);
         }
-
-        // Calculate bounding box from rectangles
-        for rect in &symbol.rectangles {
-            if !matches_part(rect.owner_part_id) {
-                continue;
-            }
-            let (rx1, ry1) = (rect.x1.round() as i32, rect.y1.round() as i32);
-            let (rx2, ry2) = (rect.x2.round() as i32, rect.y2.round() as i32);
-            min_x = min_x.min(rx1).min(rx2);
-            max_x = max_x.max(rx1).max(rx2);
-            min_y = min_y.min(ry1).min(ry2);
-            max_y = max_y.max(ry1).max(ry2);
+        for r in symbol.rectangles.iter().filter(|r| shown(r.owner_part_id)) {
+            bounds.add_rect(r.x1, r.y1, r.x2, r.y2);
         }
-
-        // Calculate bounding box from lines
-        for line in &symbol.lines {
-            if !matches_part(line.owner_part_id) {
-                continue;
-            }
-            // Lines carry f64 coordinates; round to the integer ASCII grid.
-            let (lx1, ly1) = (line.x1.round() as i32, line.y1.round() as i32);
-            let (lx2, ly2) = (line.x2.round() as i32, line.y2.round() as i32);
-            min_x = min_x.min(lx1).min(lx2);
-            max_x = max_x.max(lx1).max(lx2);
-            min_y = min_y.min(ly1).min(ly2);
-            max_y = max_y.max(ly1).max(ly2);
+        for r in symbol.round_rects.iter().filter(|r| shown(r.owner_part_id)) {
+            bounds.add_rect(r.x1, r.y1, r.x2, r.y2);
         }
-
-        // Calculate bounding box from polylines
-        for polyline in &symbol.polylines {
-            if !matches_part(polyline.owner_part_id) {
-                continue;
-            }
-            for &(x, y) in &polyline.points {
-                let (xi, yi) = (x.round() as i32, y.round() as i32);
-                min_x = min_x.min(xi);
-                max_x = max_x.max(xi);
-                min_y = min_y.min(yi);
-                max_y = max_y.max(yi);
-            }
+        for l in symbol.lines.iter().filter(|l| shown(l.owner_part_id)) {
+            bounds.add_rect(l.x1, l.y1, l.x2, l.y2);
         }
-
-        // Calculate bounding box from arcs
-        for arc in &symbol.arcs {
-            if !matches_part(arc.owner_part_id) {
-                continue;
-            }
-            min_x = min_x.min((arc.x - arc.radius).round() as i32);
-            max_x = max_x.max((arc.x + arc.radius).round() as i32);
-            min_y = min_y.min((arc.y - arc.radius).round() as i32);
-            max_y = max_y.max((arc.y + arc.radius).round() as i32);
+        for pl in symbol.polylines.iter().filter(|p| shown(p.owner_part_id)) {
+            bounds.add_points(&pl.points);
         }
-
-        // Calculate bounding box from ellipses
-        for ellipse in &symbol.ellipses {
-            if !matches_part(ellipse.owner_part_id) {
-                continue;
-            }
-            min_x = min_x.min((ellipse.x - ellipse.radius_x).round() as i32);
-            max_x = max_x.max((ellipse.x + ellipse.radius_x).round() as i32);
-            min_y = min_y.min((ellipse.y - ellipse.radius_y).round() as i32);
-            max_y = max_y.max((ellipse.y + ellipse.radius_y).round() as i32);
+        for pg in symbol.polygons.iter().filter(|p| shown(p.owner_part_id)) {
+            bounds.add_points(&pg.points);
         }
-
-        // Handle empty symbol
-        if min_x == i32::MAX {
+        for a in symbol.arcs.iter().filter(|a| shown(a.owner_part_id)) {
+            bounds.add_circle(a.x, a.y, a.radius);
+        }
+        for pie in symbol.pies.iter().filter(|p| shown(p.owner_part_id)) {
+            bounds.add_circle(pie.x, pie.y, pie.radius);
+        }
+        for e in symbol.ellipses.iter().filter(|e| shown(e.owner_part_id)) {
+            bounds.add_rect(
+                e.x - e.radius_x,
+                e.y - e.radius_y,
+                e.x + e.radius_x,
+                e.y + e.radius_y,
+            );
+        }
+        for ea in symbol
+            .elliptical_arcs
+            .iter()
+            .filter(|a| shown(a.owner_part_id))
+        {
+            bounds.add_rect(
+                ea.x - ea.radius,
+                ea.y - ea.secondary_radius,
+                ea.x + ea.radius,
+                ea.y + ea.secondary_radius,
+            );
+        }
+        for b in symbol.beziers.iter().filter(|b| shown(b.owner_part_id)) {
+            bounds.add_points(&bezier_points(b));
+        }
+        for img in symbol.images.iter().filter(|i| shown(i.owner_part_id)) {
+            bounds.add_rect(img.x1, img.y1, img.x2, img.y2);
+        }
+        for f in symbol.text_frames.iter().filter(|f| shown(f.owner_part_id)) {
+            bounds.add_rect(f.x1, f.y1, f.x2, f.y2);
+        }
+        for l in symbol.labels.iter().filter(|l| shown(l.owner_part_id)) {
+            bounds.add_rect(
+                l.x,
+                l.y,
+                10.0_f64.mul_add(l.text.chars().count() as f64, l.x),
+                l.y + 10.0,
+            );
+        }
+        for g in symbol
+            .ieee_symbols
+            .iter()
+            .filter(|g| shown(g.owner_part_id))
+        {
+            bounds.add_circle(g.x, g.y, g.scale_factor);
+        }
+        if bounds.is_empty() {
             return "Empty symbol (no primitives)".to_string();
         }
 
-        // Add margin (10 schematic units = 1 grid)
-        let margin = 10;
-        min_x -= margin;
-        max_x += margin;
-        min_y -= margin;
-        max_y += margin;
+        // scale is cells per grid square (10 schematic units); one grid of margin.
+        let mut canvas = Canvas::new(&bounds, 10.0, scale / 10.0, max_width, max_height);
 
-        // Calculate canvas size (scale is chars per 10 schematic units)
-        let width_units = f64::from(max_x - min_x);
-        let height_units = f64::from(max_y - min_y);
-        let mut canvas_width = ((width_units / 10.0) * scale).ceil() as usize;
-        let mut canvas_height = ((height_units / 10.0) * scale).ceil() as usize;
-
-        // Clamp to max dimensions
-        canvas_width = canvas_width.clamp(10, max_width);
-        canvas_height = canvas_height.clamp(5, max_height);
-
-        // Calculate actual scale after clamping
-        let actual_scale_x = canvas_width as f64 / width_units;
-        let actual_scale_y = canvas_height as f64 / height_units;
-
-        // Create canvas (y is inverted for display)
-        let mut canvas = vec![vec![' '; canvas_width]; canvas_height];
-
-        // Helper to convert schematic coordinates to canvas coordinates
-        let to_canvas = |x: i32, y: i32| -> (usize, usize) {
-            let cx = (f64::from(x - min_x) * actual_scale_x).round() as usize;
-            // Clamp before subtracting so an out-of-bbox point (e.g. the origin
-            // crosshair) clamps to the edge instead of underflowing (debug panic).
-            let dy = ((f64::from(y - min_y) * actual_scale_y).round() as usize)
-                .min(canvas_height.saturating_sub(1));
-            let cy = canvas_height.saturating_sub(1) - dy;
-            (cx.min(canvas_width - 1), cy.min(canvas_height - 1))
-        };
-
-        // Draw rectangles (as box outlines or filled)
-        for rect in &symbol.rectangles {
-            if !matches_part(rect.owner_part_id) {
-                continue;
-            }
-            let (x1, y1) = to_canvas(rect.x1.round() as i32, rect.y1.round() as i32);
-            let (x2, y2) = to_canvas(rect.x2.round() as i32, rect.y2.round() as i32);
-            let (min_cx, max_cx) = (x1.min(x2), x1.max(x2));
-            let (min_cy, max_cy) = (y1.min(y2), y1.max(y2));
-
-            // Draw top and bottom edges
-            for cx in min_cx..=max_cx {
-                if cx < canvas_width {
-                    if min_cy < canvas_height {
-                        canvas[min_cy][cx] = '-';
-                    }
-                    if max_cy < canvas_height {
-                        canvas[max_cy][cx] = '-';
-                    }
-                }
-            }
-            // Draw left and right edges
-            for cy in min_cy..=max_cy {
-                if cy < canvas_height {
-                    if min_cx < canvas_width {
-                        canvas[cy][min_cx] = '|';
-                    }
-                    if max_cx < canvas_width {
-                        canvas[cy][max_cx] = '|';
-                    }
-                }
-            }
-            // Draw corners
-            if min_cy < canvas_height && min_cx < canvas_width {
-                canvas[min_cy][min_cx] = '+';
-            }
-            if min_cy < canvas_height && max_cx < canvas_width {
-                canvas[min_cy][max_cx] = '+';
-            }
-            if max_cy < canvas_height && min_cx < canvas_width {
-                canvas[max_cy][min_cx] = '+';
-            }
-            if max_cy < canvas_height && max_cx < canvas_width {
-                canvas[max_cy][max_cx] = '+';
-            }
+        // Back to front: images and frames, bodies, curves, text, pins on top.
+        for img in symbol.images.iter().filter(|i| shown(i.owner_part_id)) {
+            canvas.rect_outline((img.x1, img.y1), (img.x2, img.y2), (':', ':', ':'));
         }
-
-        // Draw lines
-        for line in &symbol.lines {
-            if !matches_part(line.owner_part_id) {
-                continue;
-            }
-            Self::draw_line(
-                &mut canvas,
-                to_canvas(line.x1.round() as i32, line.y1.round() as i32),
-                to_canvas(line.x2.round() as i32, line.y2.round() as i32),
-                '-',
+        for f in symbol.text_frames.iter().filter(|f| shown(f.owner_part_id)) {
+            canvas.rect_outline((f.x1, f.y1), (f.x2, f.y2), ('=', '"', '+'));
+            canvas.label_at(f.x1.min(f.x2) + 10.0, f.y1.max(f.y2) - 10.0, &f.text);
+        }
+        for r in symbol.rectangles.iter().filter(|r| shown(r.owner_part_id)) {
+            canvas.rect_outline((r.x1, r.y1), (r.x2, r.y2), ('-', '|', '+'));
+        }
+        for r in symbol.round_rects.iter().filter(|r| shown(r.owner_part_id)) {
+            canvas.rect_outline((r.x1, r.y1), (r.x2, r.y2), ('-', '|', '('));
+        }
+        for pg in symbol.polygons.iter().filter(|p| shown(p.owner_part_id)) {
+            canvas.polyline(&pg.points, true, '-');
+        }
+        for l in symbol.lines.iter().filter(|l| shown(l.owner_part_id)) {
+            canvas.line(l.x1, l.y1, l.x2, l.y2, '-');
+        }
+        for pl in symbol.polylines.iter().filter(|p| shown(p.owner_part_id)) {
+            canvas.polyline(&pl.points, false, '-');
+        }
+        for a in symbol.arcs.iter().filter(|a| shown(a.owner_part_id)) {
+            canvas.arc(
+                (a.x, a.y),
+                (a.radius, a.radius),
+                (a.start_angle, a.end_angle),
+                'o',
             );
         }
-
-        // Draw polylines
-        for polyline in &symbol.polylines {
-            if !matches_part(polyline.owner_part_id) {
-                continue;
-            }
-            for i in 0..polyline.points.len().saturating_sub(1) {
-                let (x1, y1) = polyline.points[i];
-                let (x2, y2) = polyline.points[i + 1];
-                Self::draw_line(
-                    &mut canvas,
-                    to_canvas(x1.round() as i32, y1.round() as i32),
-                    to_canvas(x2.round() as i32, y2.round() as i32),
+        for ea in symbol
+            .elliptical_arcs
+            .iter()
+            .filter(|a| shown(a.owner_part_id))
+        {
+            canvas.arc(
+                (ea.x, ea.y),
+                (ea.radius, ea.secondary_radius),
+                (ea.start_angle, ea.end_angle),
+                'o',
+            );
+        }
+        for pie in symbol.pies.iter().filter(|p| shown(p.owner_part_id)) {
+            canvas.arc(
+                (pie.x, pie.y),
+                (pie.radius, pie.radius),
+                (pie.start_angle, pie.end_angle),
+                'o',
+            );
+            for angle in [pie.start_angle, pie.end_angle] {
+                let (sin, cos) = angle.to_radians().sin_cos();
+                canvas.line(
+                    pie.x,
+                    pie.y,
+                    pie.radius.mul_add(cos, pie.x),
+                    pie.radius.mul_add(sin, pie.y),
                     '-',
                 );
             }
         }
-
-        // Draw arcs (simplified as circles at centre)
-        for arc in &symbol.arcs {
-            if !matches_part(arc.owner_part_id) {
-                continue;
-            }
-            let (cx, cy) = to_canvas(arc.x.round() as i32, arc.y.round() as i32);
-            if cx < canvas_width && cy < canvas_height {
-                canvas[cy][cx] = 'o';
-            }
+        for e in symbol.ellipses.iter().filter(|e| shown(e.owner_part_id)) {
+            canvas.arc((e.x, e.y), (e.radius_x, e.radius_y), (0.0, 360.0), 'O');
         }
-
-        // Draw ellipses (simplified as circles at centre)
-        for ellipse in &symbol.ellipses {
-            if !matches_part(ellipse.owner_part_id) {
-                continue;
-            }
-            let (cx, cy) = to_canvas(ellipse.x.round() as i32, ellipse.y.round() as i32);
-            if cx < canvas_width && cy < canvas_height {
-                canvas[cy][cx] = 'O';
-            }
+        for b in symbol.beziers.iter().filter(|b| shown(b.owner_part_id)) {
+            canvas.polyline(&bezier_points(b), false, '~');
         }
-
-        // Draw pins with full designators
-        for pin in &symbol.pins {
-            if !matches_part(pin.owner_part_id) {
-                continue;
-            }
-            let (px, py) = (pin.x, pin.y);
-            let (end_x, end_y) = match pin.orientation {
-                PinOrientation::Right => (px + pin.length, py),
-                PinOrientation::Left => (px - pin.length, py),
-                PinOrientation::Up => (px, py + pin.length),
-                PinOrientation::Down => (px, py - pin.length),
-            };
-
-            // Draw pin line
-            Self::draw_line(&mut canvas, to_canvas(px, py), to_canvas(end_x, end_y), '~');
-
-            // Draw full designator at connection point
-            let (cx, cy) = to_canvas(px, py);
-            if cy < canvas_height {
-                let desig = &pin.designator;
-
-                // Place designator based on pin orientation
-                match pin.orientation {
-                    PinOrientation::Right => {
-                        // Pin points right, place designator to the left (inside symbol)
-                        for (i, ch) in desig.chars().enumerate() {
-                            let x = cx.saturating_sub(desig.len() - 1 - i);
-                            if x < canvas_width {
-                                canvas[cy][x] = ch;
-                            }
-                        }
-                    }
-                    PinOrientation::Left => {
-                        // Pin points left, place designator to the right (inside symbol)
-                        for (i, ch) in desig.chars().enumerate() {
-                            let x = cx + i;
-                            if x < canvas_width {
-                                canvas[cy][x] = ch;
-                            }
-                        }
-                    }
-                    PinOrientation::Up | PinOrientation::Down => {
-                        // Vertical pins: place designator horizontally centred
-                        let start_x = cx.saturating_sub(desig.len() / 2);
-                        for (i, ch) in desig.chars().enumerate() {
-                            let x = start_x + i;
-                            if x < canvas_width {
-                                canvas[cy][x] = ch;
-                            }
-                        }
-                    }
+        for g in symbol
+            .ieee_symbols
+            .iter()
+            .filter(|g| shown(g.owner_part_id))
+        {
+            canvas.plot(g.x, g.y, '@');
+        }
+        for l in symbol.labels.iter().filter(|l| shown(l.owner_part_id)) {
+            canvas.label_at(l.x, l.y, &l.text);
+        }
+        for pin in symbol.pins.iter().filter(|p| shown(p.owner_part_id)) {
+            let (px, py) = (f64::from(pin.x), f64::from(pin.y));
+            let (ex, ey) = pin_end(pin);
+            canvas.line(px, py, ex, ey, '~');
+            // The designator sits at the connection point, inside the body.
+            match pin.orientation {
+                PinOrientation::Right => canvas.label_ending_at(px, py, &pin.designator),
+                PinOrientation::Left => canvas.label_at(px, py, &pin.designator),
+                PinOrientation::Up | PinOrientation::Down => {
+                    canvas.label_centred(px, py, &pin.designator);
                 }
             }
         }
+        canvas.origin();
 
-        // Draw origin crosshair
-        let (ox, oy) = to_canvas(0, 0);
-        if ox < canvas_width && oy < canvas_height && canvas[oy][ox] == ' ' {
-            canvas[oy][ox] = '+';
-        }
-
-        // Count primitives for summary
+        let count = |n: usize| n;
         let pin_count = symbol
             .pins
             .iter()
-            .filter(|p| matches_part(p.owner_part_id))
+            .filter(|p| shown(p.owner_part_id))
             .count();
         let rect_count = symbol
             .rectangles
             .iter()
-            .filter(|r| matches_part(r.owner_part_id))
+            .filter(|r| shown(r.owner_part_id))
             .count();
         let line_count = symbol
             .lines
             .iter()
-            .filter(|l| matches_part(l.owner_part_id))
+            .filter(|l| shown(l.owner_part_id))
             .count();
+        let other: Vec<String> = [
+            (
+                "Polylines",
+                symbol
+                    .polylines
+                    .iter()
+                    .filter(|p| shown(p.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Polygons",
+                symbol
+                    .polygons
+                    .iter()
+                    .filter(|p| shown(p.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Arcs",
+                symbol
+                    .arcs
+                    .iter()
+                    .filter(|a| shown(a.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Pies",
+                symbol
+                    .pies
+                    .iter()
+                    .filter(|p| shown(p.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Ellipses",
+                symbol
+                    .ellipses
+                    .iter()
+                    .filter(|e| shown(e.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Round rects",
+                symbol
+                    .round_rects
+                    .iter()
+                    .filter(|r| shown(r.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Elliptical arcs",
+                symbol
+                    .elliptical_arcs
+                    .iter()
+                    .filter(|a| shown(a.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Beziers",
+                symbol
+                    .beziers
+                    .iter()
+                    .filter(|b| shown(b.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Images",
+                symbol
+                    .images
+                    .iter()
+                    .filter(|i| shown(i.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Text frames",
+                symbol
+                    .text_frames
+                    .iter()
+                    .filter(|f| shown(f.owner_part_id))
+                    .count(),
+            ),
+            (
+                "Labels",
+                symbol
+                    .labels
+                    .iter()
+                    .filter(|l| shown(l.owner_part_id))
+                    .count(),
+            ),
+            (
+                "IEEE symbols",
+                symbol
+                    .ieee_symbols
+                    .iter()
+                    .filter(|g| shown(g.owner_part_id))
+                    .count(),
+            ),
+        ]
+        .iter()
+        .filter(|(_, n)| count(*n) > 0)
+        .map(|(name, n)| format!(", {name}: {n}"))
+        .collect();
 
-        // Build output string
         let mut output = String::new();
         // Clamp the displayed part index to 1..=part_count so an out-of-range
         // part_id can't render a nonsensical header like "part 5/2".
@@ -736,26 +655,261 @@ impl McpServer {
         );
         let _ = writeln!(
             output,
-            "Pins: {pin_count}, Rectangles: {rect_count}, Lines: {line_count}"
+            "Pins: {pin_count}, Rectangles: {rect_count}, Lines: {line_count}{}",
+            other.concat()
         );
-        output.push_str(&"-".repeat(canvas_width + 2));
-        output.push('\n');
+        output.push_str(&canvas.framed());
+        output.push_str(
+            "Legend: |-+ = rectangle, ( = rounded rectangle, ~ = pin line or bezier, o = arc or \
+             pie, O = ellipse, : = image, =\" = text frame, @ = IEEE symbol, + = origin\n",
+        );
+        output
+    }
+}
 
-        for row in &canvas {
-            output.push('|');
-            for &ch in row {
-                output.push(ch);
-            }
-            output.push('|');
-            output.push('\n');
+/// The extent of everything drawn, in world units.
+#[derive(Debug, Default, Clone, Copy)]
+struct Bounds {
+    min_x: f64,
+    max_x: f64,
+    min_y: f64,
+    max_y: f64,
+    any: bool,
+}
+
+impl Bounds {
+    fn add(&mut self, x: f64, y: f64) {
+        if self.any {
+            self.min_x = self.min_x.min(x);
+            self.max_x = self.max_x.max(x);
+            self.min_y = self.min_y.min(y);
+            self.max_y = self.max_y.max(y);
+        } else {
+            (self.min_x, self.max_x, self.min_y, self.max_y) = (x, x, y, y);
+            self.any = true;
         }
+    }
 
-        output.push_str(&"-".repeat(canvas_width + 2));
-        output.push('\n');
-        output
-            .push_str("Legend: |-+ = rectangle, ~ = pin line, o = arc, O = ellipse, + = origin\n");
+    fn add_rect(&mut self, x1: f64, y1: f64, x2: f64, y2: f64) {
+        self.add(x1, y1);
+        self.add(x2, y2);
+    }
 
-        output
+    fn add_circle(&mut self, x: f64, y: f64, r: f64) {
+        self.add_rect(x - r, y - r, x + r, y + r);
+    }
+
+    fn add_points(&mut self, points: &[(f64, f64)]) {
+        for &(x, y) in points {
+            self.add(x, y);
+        }
+    }
+
+    const fn is_empty(self) -> bool {
+        !self.any
+    }
+
+    fn width(self) -> f64 {
+        self.max_x - self.min_x
+    }
+
+    fn height(self) -> f64 {
+        self.max_y - self.min_y
+    }
+}
+
+/// A character canvas over a world-coordinate window: `y` grows upwards in
+/// the world and downwards on the canvas.
+struct Canvas {
+    cells: Vec<Vec<char>>,
+    width: usize,
+    height: usize,
+    min_x: f64,
+    min_y: f64,
+    scale_x: f64,
+    scale_y: f64,
+}
+
+impl Canvas {
+    /// A canvas over `bounds` plus `margin` all round, at `scale` cells per
+    /// world unit, clamped to `max_width` x `max_height` (at least 10 x 5).
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    fn new(bounds: &Bounds, margin: f64, scale: f64, max_width: usize, max_height: usize) -> Self {
+        let (min_x, min_y) = (bounds.min_x - margin, bounds.min_y - margin);
+        let (width_units, height_units) = (
+            2.0_f64.mul_add(margin, bounds.width()),
+            2.0_f64.mul_add(margin, bounds.height()),
+        );
+        let width = ((width_units * scale).ceil() as usize).clamp(10, max_width.max(10));
+        let height = ((height_units * scale).ceil() as usize).clamp(5, max_height.max(5));
+        Self {
+            cells: vec![vec![' '; width]; height],
+            width,
+            height,
+            min_x,
+            min_y,
+            scale_x: width as f64 / width_units,
+            scale_y: height as f64 / height_units,
+        }
+    }
+
+    /// The cell for a world point, clamped to the canvas.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn cell(&self, x: f64, y: f64) -> (usize, usize) {
+        let cx = ((x - self.min_x) * self.scale_x).round().max(0.0) as usize;
+        let dy = (((y - self.min_y) * self.scale_y).round().max(0.0) as usize).min(self.height - 1);
+        (cx.min(self.width - 1), self.height - 1 - dy)
+    }
+
+    fn plot(&mut self, x: f64, y: f64, ch: char) {
+        let (cx, cy) = self.cell(x, y);
+        self.cells[cy][cx] = ch;
+    }
+
+    /// Bresenham between two world points.
+    #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+    fn line(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, ch: char) {
+        let (x0, y0) = self.cell(x1, y1);
+        let (xn, yn) = self.cell(x2, y2);
+        let (dx, dy) = (
+            (xn as isize - x0 as isize).abs(),
+            (yn as isize - y0 as isize).abs(),
+        );
+        let sx: isize = if x0 < xn { 1 } else { -1 };
+        let sy: isize = if y0 < yn { 1 } else { -1 };
+        let (mut err, mut x, mut y) = (dx - dy, x0 as isize, y0 as isize);
+        loop {
+            self.cells[y as usize][x as usize] = ch;
+            if x == xn as isize && y == yn as isize {
+                break;
+            }
+            let e2 = 2 * err;
+            if e2 > -dy {
+                err -= dy;
+                x += sx;
+            }
+            if e2 < dx {
+                err += dx;
+                y += sy;
+            }
+        }
+    }
+
+    fn polyline(&mut self, points: &[(f64, f64)], closed: bool, ch: char) {
+        for pair in points.windows(2) {
+            self.line(pair[0].0, pair[0].1, pair[1].0, pair[1].1, ch);
+        }
+        if closed && points.len() > 2 {
+            let (first, last) = (points[0], points[points.len() - 1]);
+            self.line(last.0, last.1, first.0, first.1, ch);
+        }
+        if points.len() == 1 {
+            self.plot(points[0].0, points[0].1, ch);
+        }
+    }
+
+    /// A box between two world corners, drawn with the `(horizontal,
+    /// vertical, corner)` characters of `style`.
+    fn rect_outline(&mut self, a: (f64, f64), b: (f64, f64), style: (char, char, char)) {
+        let (horizontal, vertical, corner) = style;
+        let (ax, ay) = self.cell(a.0, a.1);
+        let (bx, by) = self.cell(b.0, b.1);
+        let (left, right, top, bottom) = (ax.min(bx), ax.max(bx), ay.min(by), ay.max(by));
+        for cx in left..=right {
+            self.cells[top][cx] = horizontal;
+            self.cells[bottom][cx] = horizontal;
+        }
+        for cy in top..=bottom {
+            self.cells[cy][left] = vertical;
+            self.cells[cy][right] = vertical;
+        }
+        for (cy, cx) in [(top, left), (top, right), (bottom, left), (bottom, right)] {
+            self.cells[cy][cx] = corner;
+        }
+    }
+
+    fn rect_fill(&mut self, x1: f64, y1: f64, x2: f64, y2: f64, ch: char) {
+        let (ax, ay) = self.cell(x1, y1);
+        let (bx, by) = self.cell(x2, y2);
+        for cy in ay.min(by)..=ay.max(by) {
+            for cx in ax.min(bx)..=ax.max(bx) {
+                self.cells[cy][cx] = ch;
+            }
+        }
+    }
+
+    /// An elliptical arc sampled point by point: `centre`, `radii` (x, y)
+    /// and `angles` (start, end) in degrees counter-clockwise from the +X
+    /// axis; a full circle when the angles coincide.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn arc(&mut self, centre: (f64, f64), radii: (f64, f64), angles: (f64, f64), ch: char) {
+        let (cx, cy) = centre;
+        let (rx, ry) = radii;
+        let (start_deg, end_deg) = angles;
+        let mut sweep = (end_deg - start_deg).rem_euclid(360.0);
+        if sweep == 0.0 {
+            sweep = 360.0;
+        }
+        let perimeter_cells = (rx.max(ry) * self.scale_x.max(self.scale_y) * 6.3).ceil();
+        let steps = (perimeter_cells * sweep / 360.0).ceil().max(8.0) as u32;
+        for i in 0..=steps {
+            let fraction = f64::from(i) / f64::from(steps);
+            let angle = sweep.mul_add(fraction, start_deg).to_radians();
+            let (sin, cos) = angle.sin_cos();
+            self.plot(rx.mul_add(cos, cx), ry.mul_add(sin, cy), ch);
+        }
+    }
+
+    /// Text starting at a world point and running right.
+    fn label_at(&mut self, x: f64, y: f64, text: &str) {
+        let (cx, cy) = self.cell(x, y);
+        self.put(cx, cy, text);
+    }
+
+    /// Text ending at a world point (for a pin pointing right).
+    fn label_ending_at(&mut self, x: f64, y: f64, text: &str) {
+        let (cx, cy) = self.cell(x, y);
+        let start = cx.saturating_sub(text.chars().count().saturating_sub(1));
+        self.put(start, cy, text);
+    }
+
+    /// Text centred on a world point.
+    fn label_centred(&mut self, x: f64, y: f64, text: &str) {
+        let (cx, cy) = self.cell(x, y);
+        self.put(cx.saturating_sub(text.chars().count() / 2), cy, text);
+    }
+
+    fn put(&mut self, start: usize, cy: usize, text: &str) {
+        for (i, ch) in text.chars().enumerate() {
+            if let Some(cell) = self.cells[cy].get_mut(start + i) {
+                *cell = ch;
+            }
+        }
+    }
+
+    /// The origin as `+`, only onto a blank cell so it never hides a primitive.
+    fn origin(&mut self) {
+        let (cx, cy) = self.cell(0.0, 0.0);
+        if self.cells[cy][cx] == ' ' {
+            self.cells[cy][cx] = '+';
+        }
+    }
+
+    /// The canvas as rows between `|` bars, ruled above and below.
+    fn framed(&self) -> String {
+        let rule = format!("{}\n", "-".repeat(self.width + 2));
+        let mut out = rule.clone();
+        for row in &self.cells {
+            out.push('|');
+            out.extend(row.iter());
+            out.push_str("|\n");
+        }
+        out.push_str(&rule);
+        out
     }
 }
 
@@ -1171,6 +1325,101 @@ mod tests {
             get_result_text(&r).contains("Library is empty"),
             "{}",
             get_result_text(&r)
+        );
+    }
+
+    /// Every primitive kind is drawn and counted: a footprint holding only
+    /// the kinds the old renderer ignored is not "empty", each kind leaves
+    /// its marker, and the header counts every kind.
+    #[test]
+    fn render_footprint_draws_every_kind() {
+        use crate::altium::pcblib::{
+            Arc, ComponentBody, Fill, Layer, Pad, Region, Text, Track, Via,
+        };
+
+        let layer = Layer::TopOverlay;
+        let mut fp = Footprint::new("KINDS");
+        fp.add_via(Via::new(-3.0, 0.0, 0.6, 0.3));
+        fp.add_fill(Fill::new(-2.0, -2.0, -1.0, -1.0, layer));
+        fp.add_region(Region::rectangle(1.0, 1.0, 2.5, 2.5, layer));
+        fp.add_text(Text::new(0.0, 2.0, "T", 0.5, layer));
+        let mut body = ComponentBody::new("", "b.step");
+        body.embedded = false;
+        body.outline = vec![(-3.0, -3.0), (3.0, -3.0), (3.0, 3.0), (-3.0, 3.0)];
+        fp.add_component_body(body);
+        let without_pads = McpServer::render_footprint_ascii(&fp, 4.0, 120, 60);
+        assert!(!without_pads.starts_with("Empty"), "{without_pads}");
+        for marker in ['O', '=', '%', 'T', '.'] {
+            assert!(
+                without_pads.contains(marker),
+                "marker {marker:?} missing:
+{without_pads}"
+            );
+        }
+        assert!(without_pads.contains(
+            "Pads: 0, Tracks: 0, Arcs: 0, Vias: 1, Fills: 1, Regions: 1, Text: 1, Bodies: 1"
+        ));
+
+        fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+        fp.add_track(Track::new(-2.0, 2.5, 2.0, 2.5, 0.2, layer));
+        fp.add_arc(Arc::circle(0.0, -2.0, 0.5, 0.1, layer));
+        let everything = McpServer::render_footprint_ascii(&fp, 4.0, 120, 60);
+        for marker in ['#', '-', 'o'] {
+            assert!(
+                everything.contains(marker),
+                "marker {marker:?} missing:
+{everything}"
+            );
+        }
+        assert!(everything.contains("Pads: 1, Tracks: 1, Arcs: 1, Vias: 1"));
+    }
+
+    /// The same for a symbol: every record kind of the part is drawn and
+    /// counted, and a symbol made only of the kinds the old renderer
+    /// ignored is not "empty".
+    #[test]
+    fn render_symbol_draws_every_kind() {
+        use crate::altium::schlib::{
+            Bezier, EllipticalArc, IeeeSymbol, Image, Label, Pie, Polygon, RoundRect, Symbol,
+            TextFrame,
+        };
+
+        let mut sym = Symbol::new("KINDS");
+        sym.add_polygon(Polygon::new(vec![
+            (-40.0, -40.0),
+            (-20.0, -40.0),
+            (-30.0, -20.0),
+        ]));
+        sym.add_pie(Pie::new(30, 30, 8, 0.0, 180.0));
+        sym.add_round_rect(RoundRect::new(-40, 10, -10, 30, 2, 2));
+        sym.add_bezier(Bezier::new(0, -40, 5, -30, 15, -30, 20, -40));
+        sym.add_elliptical_arc(EllipticalArc::new(0, 0, 10, 5, 0.0, 270.0));
+        sym.add_image(Image::new(10, -20, 40, 0, "logo.bmp"));
+        sym.add_text_frame(TextFrame::new(-40, -10, -10, 0, "NOTE"));
+        sym.add_label(Label::new(20, 20, "LBL"));
+        sym.add_ieee_symbol(IeeeSymbol::new(1, 40.0, 40.0));
+
+        let render = McpServer::render_symbol_ascii(&sym, 2.0, 160, 80, 1);
+        assert!(!render.starts_with("Empty"), "{render}");
+        for marker in ['-', 'o', '(', '~', ':', '=', 'L', '@'] {
+            assert!(
+                render.contains(marker),
+                "marker {marker:?} missing:
+{render}"
+            );
+        }
+        assert!(
+            render.contains("NOTE") && render.contains("LBL"),
+            "{render}"
+        );
+        let header = render.lines().nth(1).expect("the count line");
+        assert_eq!(
+            header,
+            concat!(
+                "Pins: 0, Rectangles: 0, Lines: 0, Polygons: 1, Pies: 1, Round rects: 1, ",
+                "Elliptical arcs: 1, Beziers: 1, Images: 1, Text frames: 1, Labels: 1, ",
+                "IEEE symbols: 1"
+            )
         );
     }
 }


### PR DESCRIPTION
## Summary

Bug #55, the last of the hand-enumerated-kinds class (#440, #443, #445), in the ASCII previews:

- `render_footprint` sized its canvas from pads, tracks and arcs only and drew only those — a footprint made of regions, fills or vias rendered as **"Empty footprint (no primitives)"**, and the header counted three kinds.
- `render_symbol` likewise: polygons, pies, round-rects, beziers, elliptical arcs, images, text frames, labels and IEEE symbols were neither bounded, drawn nor counted.

Both renderers now draw **every kind** through one small canvas (bounds accumulator; world→cell mapping; Bresenham lines; outlined and filled boxes; arcs and ellipses sampled along their sweep; cubic beziers evaluated; labels placed), count every kind in the header (the old `Pads/Tracks/Arcs` and `Pins/Rectangles/Lines` prefixes are kept, so existing readers of the header still match), and explain every marker in the legend. Arcs are drawn along their actual sweep instead of a single `o` at the centre.

**Closing the class:** `PrimitiveKind` and `SchPrimitiveKind` are now declared by a `primitive_kinds!` macro from one list each — variants, `WRITE_ORDER`, `COUNT` and `name()` all derive from it — so adding a kind cannot leave any derived list short, and `diff_libraries`/`validate_library`/`rename_layer` already walk those lists.

## Verification

- fmt / clippy `-D warnings` / `cargo doc -D warnings`: clean; **1476 tests** green; `tools_md_in_sync` regenerated (both tool descriptions now say what they draw)
- New tests: `render_footprint_draws_every_kind` (a footprint of only the formerly-ignored kinds is not empty, every marker appears, every kind counted) and `render_symbol_draws_every_kind` (same for the nine formerly-ignored symbol kinds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)