### PR TITLE
fix: extract_style sees every primitive kind

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -102,8 +102,9 @@ additional details like part_count and pin_count.
 
 ## `extract_style`
 
-Extract style information from an existing Altium library file. Returns statistics about track widths, colours, pin lengths, layer usage, and other styling parameters.
-Use this to learn from existing libraries and create consistent new components.
+Extract style information from an existing Altium library file. A PcbLib reports track and arc widths per layer, pad shapes, text heights and the layer usage of every
+primitive kind (a via counts as Multi-Layer); a SchLib reports pin lengths, stroke widths and the stroke, fill and text colours of every record kind. Use this to learn
+from existing libraries and create consistent new components.
 
 **Example**
 

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -644,6 +644,27 @@ impl Footprint {
         }
     }
 
+    /// The layer each primitive of `kind` sits on, one entry per primitive.
+    /// A via spans the stack rather than sitting on one layer and counts as
+    /// `MultiLayer`, as Altium lists it.
+    #[must_use]
+    pub fn layers_of(&self, kind: PrimitiveKind) -> Vec<Layer> {
+        match kind {
+            PrimitiveKind::Arc => self.arcs.iter().map(|arc| arc.layer).collect(),
+            PrimitiveKind::Pad => self.pads.iter().map(|pad| pad.layer).collect(),
+            PrimitiveKind::Via => vec![Layer::MultiLayer; self.vias.len()],
+            PrimitiveKind::Track => self.tracks.iter().map(|track| track.layer).collect(),
+            PrimitiveKind::Text => self.text.iter().map(|text| text.layer).collect(),
+            PrimitiveKind::Region => self.regions.iter().map(|region| region.layer).collect(),
+            PrimitiveKind::Fill => self.fills.iter().map(|fill| fill.layer).collect(),
+            PrimitiveKind::ComponentBody => self
+                .component_bodies
+                .iter()
+                .map(|body| body.layer)
+                .collect(),
+        }
+    }
+
     /// How many primitives the footprint holds in total.
     #[must_use]
     pub fn primitive_count(&self) -> usize {
@@ -1025,6 +1046,34 @@ impl PcbLib {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every kind reports one layer per primitive — an arm that returned
+    /// nothing for a kind would hide that kind's layers.
+    #[test]
+    fn layers_of_reports_one_layer_per_primitive_of_every_kind() {
+        let mut fp = Footprint::new("KINDS");
+        let layer = Layer::Mechanical13;
+        fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+        fp.add_via(Via::new(0.0, 0.0, 0.6, 0.3));
+        fp.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.1, layer));
+        fp.add_arc(Arc::circle(0.0, 0.0, 1.0, 0.1, layer));
+        fp.add_text(Text::new(0.0, 0.0, "T", 1.0, layer));
+        fp.add_region(Region::rectangle(0.0, 0.0, 1.0, 1.0, layer));
+        fp.add_fill(Fill::new(0.0, 0.0, 1.0, 1.0, layer));
+        let mut body = ComponentBody::new("", "b.step");
+        body.layer = layer;
+        fp.add_component_body(body);
+        for kind in PrimitiveKind::WRITE_ORDER {
+            let layers = fp.layers_of(kind);
+            assert_eq!(layers.len(), fp.count_of(kind), "{kind:?}");
+            let expected = match kind {
+                PrimitiveKind::Via => Layer::MultiLayer,
+                PrimitiveKind::Pad => Layer::TopLayer,
+                _ => layer,
+            };
+            assert_eq!(layers, vec![expected], "{kind:?}");
+        }
+    }
 
     /// A footprint carrying an identity on every primitive kind, plus a via
     /// whose replayed block has identity bytes and one whose block is too

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -514,6 +514,56 @@ primitive_kinds! {
     }
 }
 
+/// What one symbol record draws with, as [`Symbol::styles_of`] reports it.
+///
+/// The stroke width and colour, the fill colour and the text colour, each
+/// `None` for a kind that has no such property. Colours are BGR.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RecordStyle {
+    /// Stroke width of an outline (`LineWidth`).
+    pub line_width: Option<u8>,
+    /// Stroke colour of an outline, or a pin's colour.
+    pub line_color: Option<u32>,
+    /// Fill colour of a fillable shape (`AreaColor`), whether or not it is
+    /// currently filled.
+    pub fill_color: Option<u32>,
+    /// Colour of the text a label, text frame or parameter shows.
+    pub text_color: Option<u32>,
+}
+
+impl RecordStyle {
+    /// An outline: a stroke width and colour, nothing filled, no text.
+    #[must_use]
+    pub const fn stroke(line_width: u8, line_color: u32) -> Self {
+        Self {
+            line_width: Some(line_width),
+            line_color: Some(line_color),
+            fill_color: None,
+            text_color: None,
+        }
+    }
+
+    /// A fillable shape: an outline plus its fill colour.
+    #[must_use]
+    pub const fn shape(line_width: u8, line_color: u32, fill_color: u32) -> Self {
+        Self {
+            fill_color: Some(fill_color),
+            ..Self::stroke(line_width, line_color)
+        }
+    }
+
+    /// Text alone, as a label or parameter draws.
+    #[must_use]
+    pub const fn text(text_color: u32) -> Self {
+        Self {
+            line_width: None,
+            line_color: None,
+            fill_color: None,
+            text_color: Some(text_color),
+        }
+    }
+}
+
 const fn default_part_count() -> u32 {
     1
 }
@@ -762,6 +812,97 @@ impl Symbol {
         .sum()
     }
 
+    /// The stroke, fill and text colours every record of `kind` draws with,
+    /// one entry per record. A property the kind lacks is `None`: a pin has
+    /// a colour but no stroke width, a label only a text colour, an arc no
+    /// fill (Altium stores an `AreaColor` on arcs it never paints).
+    #[must_use]
+    pub fn styles_of(&self, kind: SchPrimitiveKind) -> Vec<RecordStyle> {
+        use RecordStyle as S;
+        match kind {
+            SchPrimitiveKind::Rectangle => self
+                .rectangles
+                .iter()
+                .map(|r| S::shape(r.line_width, r.line_color, r.fill_color))
+                .collect(),
+            SchPrimitiveKind::Pin => self
+                .pins
+                .iter()
+                .map(|pin| S {
+                    line_color: Some(pin.colour),
+                    ..S::default()
+                })
+                .collect(),
+            SchPrimitiveKind::Line => self
+                .lines
+                .iter()
+                .map(|line| S::stroke(line.line_width, line.color))
+                .collect(),
+            SchPrimitiveKind::Polyline => self
+                .polylines
+                .iter()
+                .map(|p| S::stroke(p.line_width, p.color))
+                .collect(),
+            SchPrimitiveKind::Polygon => self
+                .polygons
+                .iter()
+                .map(|p| S::shape(p.line_width, p.line_color, p.fill_color))
+                .collect(),
+            SchPrimitiveKind::Arc => self
+                .arcs
+                .iter()
+                .map(|arc| S::stroke(arc.line_width, arc.color))
+                .collect(),
+            SchPrimitiveKind::Pie => self
+                .pies
+                .iter()
+                .map(|pie| S::shape(pie.line_width, pie.line_color, pie.fill_color))
+                .collect(),
+            SchPrimitiveKind::Image => self
+                .images
+                .iter()
+                .map(|i| S::shape(i.line_width, i.line_color, i.fill_color))
+                .collect(),
+            SchPrimitiveKind::TextFrame => self
+                .text_frames
+                .iter()
+                .map(|f| S {
+                    text_color: Some(f.text_color),
+                    ..S::shape(f.line_width, f.color, f.area_color)
+                })
+                .collect(),
+            SchPrimitiveKind::Bezier => self
+                .beziers
+                .iter()
+                .map(|b| S::stroke(b.line_width, b.color))
+                .collect(),
+            SchPrimitiveKind::Ellipse => self
+                .ellipses
+                .iter()
+                .map(|e| S::shape(e.line_width, e.line_color, e.fill_color))
+                .collect(),
+            SchPrimitiveKind::RoundRect => self
+                .round_rects
+                .iter()
+                .map(|r| S::shape(r.line_width, r.line_color, r.fill_color))
+                .collect(),
+            SchPrimitiveKind::EllipticalArc => self
+                .elliptical_arcs
+                .iter()
+                .map(|arc| S::stroke(arc.line_width, arc.color))
+                .collect(),
+            SchPrimitiveKind::Label => self.labels.iter().map(|l| S::text(l.color)).collect(),
+            SchPrimitiveKind::IeeeSymbol => self
+                .ieee_symbols
+                .iter()
+                .map(|i| S::stroke(i.line_width, i.color))
+                .collect(),
+            SchPrimitiveKind::Parameter => {
+                self.parameters.iter().map(|p| S::text(p.color)).collect()
+            }
+        }
+    }
+
     /// How many content records of one kind the symbol holds.
     #[must_use]
     pub fn count_of(&self, kind: SchPrimitiveKind) -> usize {
@@ -789,6 +930,58 @@ impl Symbol {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every kind reports one style per record, and a record's colours land
+    /// in the right slot: strokes for outlines and pins, fills for fillable
+    /// shapes and frames, text colours for labels, frames and parameters.
+    #[test]
+    fn styles_of_reports_one_style_per_record_of_every_kind() {
+        use SchPrimitiveKind as K;
+
+        let mut sym = Symbol::new("KINDS");
+        sym.add_pin(Pin::new("1", "A", -10, 0, 10, PinOrientation::Right));
+        sym.add_rectangle(Rectangle::new(0, 0, 10, 10));
+        sym.add_line(Line::new(0, 0, 10, 10));
+        sym.add_polyline(Polyline::new(vec![(0.0, 0.0), (5.0, 5.0)]));
+        sym.add_polygon(Polygon::new(vec![(0.0, 0.0), (10.0, 0.0), (5.0, 10.0)]));
+        sym.add_arc(Arc::new(0, 0, 5, 0.0, 90.0));
+        sym.add_pie(Pie::new(0, 0, 5, 0.0, 90.0));
+        sym.add_image(Image::new(0, 0, 10, 10, "logo.bmp"));
+        sym.add_text_frame(TextFrame::new(0, 0, 10, 10, "note"));
+        sym.add_bezier(Bezier::new(0, 0, 3, 5, 7, 5, 10, 0));
+        sym.add_ellipse(Ellipse::new(0, 0, 5, 3));
+        sym.add_round_rect(RoundRect::new(0, 0, 10, 10, 2, 2));
+        sym.add_elliptical_arc(EllipticalArc::new(0, 0, 5, 3, 0.0, 180.0));
+        sym.add_label(Label::new(0, 0, "L"));
+        sym.add_ieee_symbol(IeeeSymbol::new(1, 0.0, 0.0));
+        sym.add_parameter(Parameter::new("Value", "1k"));
+
+        for kind in SchPrimitiveKind::WRITE_ORDER {
+            let styles = sym.styles_of(kind);
+            assert_eq!(styles.len(), sym.count_of(kind), "{kind:?}");
+            let style = styles[0];
+            let strokes = !matches!(kind, K::Pin | K::Label | K::Parameter);
+            assert_eq!(style.line_width.is_some(), strokes, "{kind:?} width");
+            assert_eq!(
+                style.line_color.is_some(),
+                strokes || kind == K::Pin,
+                "{kind:?} stroke colour"
+            );
+            let fills = matches!(
+                kind,
+                K::Rectangle
+                    | K::Polygon
+                    | K::Pie
+                    | K::Image
+                    | K::TextFrame
+                    | K::Ellipse
+                    | K::RoundRect
+            );
+            assert_eq!(style.fill_color.is_some(), fills, "{kind:?} fill");
+            let text = matches!(kind, K::Label | K::TextFrame | K::Parameter);
+            assert_eq!(style.text_color.is_some(), text, "{kind:?} text colour");
+        }
+    }
 
     /// A name that exactly fills the 31-unit storage cap is listed in
     /// `SectionKeys` although nothing was truncated — a UI-authored

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -162,10 +162,12 @@ impl McpServer {
                 serde_json::json!({"name": "extract_style", "arguments": {"filepath": "./MyLibrary.PcbLib"}}),
             ),
             description: Some(
-                "Extract style information from an existing Altium library file. Returns \
-                     statistics about track widths, colours, pin lengths, layer usage, and other \
-                     styling parameters. Use this to learn from existing libraries and create \
-                     consistent new components."
+                "Extract style information from an existing Altium library file. A PcbLib \
+                     reports track and arc widths per layer, pad shapes, text heights and the \
+                     layer usage of every primitive kind (a via counts as Multi-Layer); a \
+                     SchLib reports pin lengths, stroke widths and the stroke, fill and text \
+                     colours of every record kind. Use this to learn from existing libraries \
+                     and create consistent new components."
                     .to_string(),
             ),
             input_schema: json!({

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1152,76 +1152,55 @@ impl McpServer {
         }
     }
 
-    /// Extracts style from a `PcbLib` file.
+    /// Extracts style from a `PcbLib` file: stroke widths of tracks and arcs
+    /// per layer, pad shapes, text heights, and the layer usage of every
+    /// primitive kind.
     pub(crate) fn extract_pcblib_style(filepath: &str) -> ToolCallResult {
+        use crate::altium::pcblib::PrimitiveKind;
         use crate::altium::PcbLib;
         use std::collections::HashMap;
 
         match PcbLib::open(filepath) {
             Ok(library) => {
-                // Track widths by layer
+                // Stroke widths by layer
                 let mut track_widths: HashMap<String, Vec<f64>> = HashMap::new();
+                let mut arc_widths: HashMap<String, Vec<f64>> = HashMap::new();
                 // Pad shapes count
                 let mut pad_shapes: HashMap<String, usize> = HashMap::new();
                 // Text heights
                 let mut text_heights: Vec<f64> = Vec::new();
-                // Layers used
+                // Layers used, by every kind that sits on one
                 let mut layers_used: HashMap<String, usize> = HashMap::new();
 
                 for fp in library.iter() {
-                    // Analyse tracks
                     for track in &fp.tracks {
-                        let layer_name = track.layer.as_str().to_string();
                         track_widths
-                            .entry(layer_name.clone())
+                            .entry(track.layer.as_str().to_string())
                             .or_default()
                             .push(track.width);
-                        *layers_used.entry(layer_name).or_insert(0) += 1;
                     }
-
-                    // Analyse pads
+                    for arc in &fp.arcs {
+                        arc_widths
+                            .entry(arc.layer.as_str().to_string())
+                            .or_default()
+                            .push(arc.width);
+                    }
                     for pad in &fp.pads {
                         let shape_name = format!("{:?}", pad.shape);
                         *pad_shapes.entry(shape_name).or_insert(0) += 1;
-                        let layer_name = pad.layer.as_str().to_string();
-                        *layers_used.entry(layer_name).or_insert(0) += 1;
                     }
-
-                    // Analyse text
                     for text in &fp.text {
                         text_heights.push(text.height);
-                        let layer_name = text.layer.as_str().to_string();
-                        *layers_used.entry(layer_name).or_insert(0) += 1;
                     }
-
-                    // Analyse regions
-                    for region in &fp.regions {
-                        let layer_name = region.layer.as_str().to_string();
-                        *layers_used.entry(layer_name).or_insert(0) += 1;
+                    for kind in PrimitiveKind::WRITE_ORDER {
+                        for layer in fp.layers_of(kind) {
+                            *layers_used.entry(layer.as_str().to_string()).or_insert(0) += 1;
+                        }
                     }
                 }
 
-                // Calculate statistics for track widths
-                #[allow(clippy::cast_precision_loss)]
-                let track_width_stats: HashMap<String, Value> = track_widths
-                    .into_iter()
-                    .map(|(layer, widths)| {
-                        let min = widths.iter().copied().fold(f64::INFINITY, f64::min);
-                        let max = widths.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-                        let avg = widths.iter().sum::<f64>() / widths.len() as f64;
-                        let most_common = Self::most_common_f64(&widths);
-                        (
-                            layer,
-                            json!({
-                                "min_mm": min,
-                                "max_mm": max,
-                                "avg_mm": avg,
-                                "most_common_mm": most_common,
-                                "count": widths.len()
-                            }),
-                        )
-                    })
-                    .collect();
+                let track_width_stats = Self::width_stats_by_layer(track_widths);
+                let arc_width_stats = Self::width_stats_by_layer(arc_widths);
 
                 // Calculate text height stats
                 let text_height_stats = if text_heights.is_empty() {
@@ -1248,6 +1227,7 @@ impl McpServer {
                     "footprint_count": library.len(),
                     "style": {
                         "track_widths_by_layer": track_width_stats,
+                        "arc_widths_by_layer": arc_width_stats,
                         "pad_shapes": pad_shapes,
                         "text_heights": text_height_stats,
                         "layers_used": layers_used
@@ -1267,8 +1247,37 @@ impl McpServer {
         }
     }
 
-    /// Extracts style from a `SchLib` file.
+    /// Min / max / average / most common stroke width and the count, per
+    /// layer name.
+    #[allow(clippy::cast_precision_loss)]
+    fn width_stats_by_layer(
+        widths_by_layer: std::collections::HashMap<String, Vec<f64>>,
+    ) -> std::collections::HashMap<String, Value> {
+        widths_by_layer
+            .into_iter()
+            .map(|(layer, widths)| {
+                let min = widths.iter().copied().fold(f64::INFINITY, f64::min);
+                let max = widths.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let avg = widths.iter().sum::<f64>() / widths.len() as f64;
+                let most_common = Self::most_common_f64(&widths);
+                (
+                    layer,
+                    json!({
+                        "min_mm": min,
+                        "max_mm": max,
+                        "avg_mm": avg,
+                        "most_common_mm": most_common,
+                        "count": widths.len()
+                    }),
+                )
+            })
+            .collect()
+    }
+
+    /// Extracts style from a `SchLib` file: pin lengths, and the stroke
+    /// widths, stroke / fill / text colours of every record kind.
     pub(crate) fn extract_schlib_style(filepath: &str) -> ToolCallResult {
+        use crate::altium::schlib::SchPrimitiveKind;
         use crate::altium::SchLib;
         use std::collections::HashMap;
 
@@ -1281,35 +1290,38 @@ impl McpServer {
                 // Colours used
                 let mut line_colors: HashMap<String, usize> = HashMap::new();
                 let mut fill_colors: HashMap<String, usize> = HashMap::new();
+                let mut text_colors: HashMap<String, usize> = HashMap::new();
                 // Rectangle stats
                 let mut rect_filled_count = 0usize;
                 let mut rect_unfilled_count = 0usize;
 
+                let count_color = |colors: &mut HashMap<String, usize>, color: u32| {
+                    *colors.entry(format!("#{color:06X}")).or_insert(0) += 1;
+                };
                 for symbol in library.iter() {
-                    // Analyse pins
                     for pin in &symbol.pins {
                         pin_lengths.push(pin.length);
                     }
-
-                    // Analyse rectangles
                     for rect in &symbol.rectangles {
-                        line_widths.push(rect.line_width);
-                        let line_color = format!("#{:06X}", rect.line_color);
-                        let fill_color = format!("#{:06X}", rect.fill_color);
-                        *line_colors.entry(line_color).or_insert(0) += 1;
-                        *fill_colors.entry(fill_color).or_insert(0) += 1;
                         if rect.filled {
                             rect_filled_count += 1;
                         } else {
                             rect_unfilled_count += 1;
                         }
                     }
-
-                    // Analyse lines
-                    for line in &symbol.lines {
-                        line_widths.push(line.line_width);
-                        let color = format!("#{:06X}", line.color);
-                        *line_colors.entry(color).or_insert(0) += 1;
+                    for kind in SchPrimitiveKind::WRITE_ORDER {
+                        for style in symbol.styles_of(kind) {
+                            line_widths.extend(style.line_width);
+                            if let Some(color) = style.line_color {
+                                count_color(&mut line_colors, color);
+                            }
+                            if let Some(color) = style.fill_color {
+                                count_color(&mut fill_colors, color);
+                            }
+                            if let Some(color) = style.text_color {
+                                count_color(&mut text_colors, color);
+                            }
+                        }
                     }
                 }
 
@@ -1352,6 +1364,7 @@ impl McpServer {
                         "line_widths": line_width_stats,
                         "line_colors": line_colors,
                         "fill_colors": fill_colors,
+                        "text_colors": text_colors,
                         "rectangles": {
                             "filled_count": rect_filled_count,
                             "unfilled_count": rect_unfilled_count
@@ -2752,7 +2765,10 @@ mod tests {
     // ==================== extract_style ====================
 
     mod extract_style {
-        use crate::altium::pcblib::{Footprint, Layer, Pad, PcbLib, Track};
+        use crate::altium::pcblib::{
+            Arc, ComponentBody, Fill, Footprint, Layer, Pad, PcbLib, Track, Via,
+        };
+        use crate::altium::schlib::{Label, Pin, PinOrientation, Polygon, SchLib, Symbol};
         use crate::mcp::tools::test_support::{
             create_test_schlib, create_test_server, get_result_text, parse_result_json,
             test_temp_dir,
@@ -2831,6 +2847,83 @@ mod tests {
             assert_eq!(parsed["style"]["line_widths"]["count"], 1);
             assert_eq!(parsed["style"]["rectangles"]["filled_count"], 1);
             assert_eq!(parsed["style"]["rectangles"]["unfilled_count"], 0);
+        }
+
+        /// A layer used only by arcs, vias, fills or bodies is a used layer,
+        /// and silkscreen arcs report their stroke width like tracks do.
+        #[test]
+        fn extract_style_pcblib_counts_every_kind_in_layer_usage() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = PcbLib::new();
+            let mut fp = Footprint::new("ROUND_CAP");
+            fp.add_arc(Arc::circle(0.0, 0.0, 2.5, 0.15, Layer::TopOverlay));
+            fp.add_via(Via::new(0.0, 0.0, 0.6, 0.3));
+            fp.add_fill(Fill::new(-1.0, -1.0, 1.0, 1.0, Layer::TopPaste));
+            let mut body = ComponentBody::new("", "body.step");
+            body.layer = Layer::Mechanical13;
+            fp.add_component_body(body);
+            lib.add(fp);
+            let path = dir.path().join("Kinds.PcbLib");
+            lib.save(&path).unwrap();
+
+            let result = server.call_extract_style(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            let layers = &parsed["style"]["layers_used"];
+            assert_eq!(layers["Top Overlay"], 1, "{layers}");
+            assert_eq!(layers["Multi-Layer"], 1, "{layers}");
+            assert_eq!(layers["Top Paste"], 1, "{layers}");
+            assert_eq!(layers["Mechanical 13"], 1, "{layers}");
+            let arcs = &parsed["style"]["arc_widths_by_layer"]["Top Overlay"];
+            assert_eq!(arcs["count"], 1, "{arcs}");
+            assert!((arcs["most_common_mm"].as_f64().unwrap() - 0.15).abs() < 1e-9);
+            assert!(parsed["style"]["track_widths_by_layer"]
+                .as_object()
+                .unwrap()
+                .is_empty());
+        }
+
+        /// A symbol drawn with polygons (an op-amp triangle) has stroke widths
+        /// and colours; a pin's colour is a line colour, a label's a text one.
+        #[test]
+        fn extract_style_schlib_counts_every_kind_in_widths_and_colours() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let mut lib = SchLib::new();
+            let mut sym = Symbol::new("OPAMP");
+            let mut triangle = Polygon::new(vec![(0.0, 0.0), (0.0, 40.0), (40.0, 20.0)]);
+            triangle.line_width = 2;
+            triangle.line_color = 0x00_00FF;
+            triangle.fill_color = 0xB0_FFFF;
+            sym.add_polygon(triangle);
+            let mut pin = Pin::new("1", "IN+", -10, 10, 10, PinOrientation::Right);
+            pin.colour = 0x80_0000;
+            sym.add_pin(pin);
+            let mut label = Label::new(0, 50, "OP");
+            label.color = 0x00_8000;
+            sym.add_label(label);
+            lib.add(sym);
+            let path = dir.path().join("Kinds.SchLib");
+            lib.save(&path).unwrap();
+
+            let result = server.call_extract_style(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+            let parsed = parse_result_json(&result);
+            let style = &parsed["style"];
+            assert_eq!(style["line_widths"]["count"], 1, "{style}");
+            assert_eq!(style["line_widths"]["most_common"], 2, "{style}");
+            assert_eq!(style["line_colors"]["#0000FF"], 1, "{style}");
+            assert_eq!(style["line_colors"]["#800000"], 1, "{style}");
+            assert_eq!(style["fill_colors"]["#B0FFFF"], 1, "{style}");
+            assert_eq!(style["text_colors"]["#008000"], 1, "{style}");
+            assert_eq!(style["rectangles"]["filled_count"], 0);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Bug #57, same class as #440–#447 (hand-enumerated kinds). `extract_style` promises "layer usage" and "colours", but:

- **PcbLib** `layers_used` counted tracks, pads, text and regions only — a layer used by arcs, vias, fills or component bodies alone (a round capacitor's silkscreen circle, an assembly drawing made of bodies on Mechanical 13) was reported unused. Arcs' stroke widths were not reported at all although they share the silkscreen stroke with tracks.
- **SchLib** `line_widths` / `line_colors` / `fill_colors` came from rectangles and lines only — a library of polygon-drawn symbols (every op-amp triangle) reported `line_widths: null` and no colours; pins' colours, labels'/parameters' text colours were never counted.

Fix, structural: `Footprint::layers_of(kind)` and `Symbol::styles_of(kind) -> Vec<RecordStyle>` are exhaustive matches over the kind enums (a new kind is a compile error until it is placed), and the tool walks `WRITE_ORDER`. Vias count as `Multi-Layer`, as Altium lists them; an arc's stored `AreaColor` is not a fill (Altium never paints it). Output gains `arc_widths_by_layer` (PcbLib) and `text_colors` (SchLib); existing keys keep their shape. Tool description now says exactly what each format reports; `TOOLS.md` regenerated.

## Verification

- New tests: a footprint whose layers are used only by an arc, a via, a fill and a body; a polygon-only symbol with a coloured pin and label; model guards that every kind yields one entry per record in the right slots
- fmt / clippy `-D warnings` / rustdoc `-D warnings`: clean; **1480 tests** green

🤖 Generated with [Claude Code](https://claude.com/claude-code)