### PR TITLE
refactor: kind walks in previews and listings derive from the enums

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -96,7 +96,7 @@ additional details like part_count and pin_count.
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `filepath` | string | yes | Path to the library file |
-| `include_metadata` | boolean | no | If true, return objects with metadata (part_count, pin_count, etc.) instead of just names. Default: false |
+| `include_metadata` | boolean | no | If true, return objects with metadata instead of just names: a footprint's description, one count per primitive kind and has_3d_model; a symbol's description, designator, part_count, pin_count and footprint_count. Default: false |
 | `limit` | integer | no | Maximum number of components to return (optional, default: all) |
 | `offset` | integer | no | Number of components to skip (optional, default: 0) |
 

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -145,7 +145,7 @@ impl McpServer {
                         },
                         "include_metadata": {
                             "type": "boolean",
-                            "description": "If true, return objects with metadata (part_count, pin_count, etc.) instead of just names. Default: false"
+                            "description": "If true, return objects with metadata instead of just names: a footprint's description, one count per primitive kind and has_3d_model; a symbol's description, designator, part_count, pin_count and footprint_count. Default: false"
                         }
                     },
                     "required": ["filepath"]

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -192,61 +192,13 @@ impl McpServer {
                     old.description, new.description
                 ));
             }
-            if old.pads.len() != new.pads.len() {
-                changes.push(format!(
-                    "pad_count: {} -> {}",
-                    old.pads.len(),
-                    new.pads.len()
-                ));
-            }
-            if old.tracks.len() != new.tracks.len() {
-                changes.push(format!(
-                    "track_count: {} -> {}",
-                    old.tracks.len(),
-                    new.tracks.len()
-                ));
-            }
-            if old.arcs.len() != new.arcs.len() {
-                changes.push(format!(
-                    "arc_count: {} -> {}",
-                    old.arcs.len(),
-                    new.arcs.len()
-                ));
-            }
-            if old.regions.len() != new.regions.len() {
-                changes.push(format!(
-                    "region_count: {} -> {}",
-                    old.regions.len(),
-                    new.regions.len()
-                ));
-            }
-            if old.text.len() != new.text.len() {
-                changes.push(format!(
-                    "text_count: {} -> {}",
-                    old.text.len(),
-                    new.text.len()
-                ));
-            }
-            if old.vias.len() != new.vias.len() {
-                changes.push(format!(
-                    "via_count: {} -> {}",
-                    old.vias.len(),
-                    new.vias.len()
-                ));
-            }
-            if old.fills.len() != new.fills.len() {
-                changes.push(format!(
-                    "fill_count: {} -> {}",
-                    old.fills.len(),
-                    new.fills.len()
-                ));
-            }
-            if old.component_bodies.len() != new.component_bodies.len() {
-                changes.push(format!(
-                    "component_body_count: {} -> {}",
-                    old.component_bodies.len(),
-                    new.component_bodies.len()
-                ));
+            // Every primitive kind, from the enum, so the preview cannot miss
+            // an added or removed kind.
+            for kind in crate::altium::pcblib::PrimitiveKind::WRITE_ORDER {
+                let (old_len, new_len) = (old.count_of(kind), new.count_of(kind));
+                if old_len != new_len {
+                    changes.push(format!("{}_count: {old_len} -> {new_len}", kind.name()));
+                }
             }
         } else {
             changes.push("component will be created".to_string());
@@ -410,59 +362,20 @@ impl McpServer {
                     old.part_count, new.part_count
                 ));
             }
-            // Every primitive family, so the dry-run preview can never miss an
-            // added/removed family (a new family = one line here).
-            let family_counts = [
-                ("pin_count", old.pins.len(), new.pins.len()),
-                (
-                    "rectangle_count",
-                    old.rectangles.len(),
-                    new.rectangles.len(),
-                ),
-                ("line_count", old.lines.len(), new.lines.len()),
-                ("polyline_count", old.polylines.len(), new.polylines.len()),
-                ("arc_count", old.arcs.len(), new.arcs.len()),
-                ("ellipse_count", old.ellipses.len(), new.ellipses.len()),
-                ("label_count", old.labels.len(), new.labels.len()),
-                (
-                    "ieee_symbol_count",
-                    old.ieee_symbols.len(),
-                    new.ieee_symbols.len(),
-                ),
-                (
-                    "parameter_count",
-                    old.parameters.len(),
-                    new.parameters.len(),
-                ),
-                (
-                    "round_rect_count",
-                    old.round_rects.len(),
-                    new.round_rects.len(),
-                ),
-                ("polygon_count", old.polygons.len(), new.polygons.len()),
-                ("pie_count", old.pies.len(), new.pies.len()),
-                ("image_count", old.images.len(), new.images.len()),
-                (
-                    "text_frame_count",
-                    old.text_frames.len(),
-                    new.text_frames.len(),
-                ),
-                ("bezier_count", old.beziers.len(), new.beziers.len()),
-                (
-                    "elliptical_arc_count",
-                    old.elliptical_arcs.len(),
-                    new.elliptical_arcs.len(),
-                ),
-                (
-                    "footprint_count",
-                    old.footprints.len(),
-                    new.footprints.len(),
-                ),
-            ];
-            for (label, old_len, new_len) in family_counts {
+            // Every record kind, from the enum, so the preview cannot miss an
+            // added or removed kind; footprint links are not a kind.
+            for kind in crate::altium::schlib::SchPrimitiveKind::WRITE_ORDER {
+                let (old_len, new_len) = (old.count_of(kind), new.count_of(kind));
                 if old_len != new_len {
-                    changes.push(format!("{label}: {old_len} -> {new_len}"));
+                    changes.push(format!("{}_count: {old_len} -> {new_len}", kind.name()));
                 }
+            }
+            if old.footprints.len() != new.footprints.len() {
+                changes.push(format!(
+                    "footprint_count: {} -> {}",
+                    old.footprints.len(),
+                    new.footprints.len()
+                ));
             }
         } else {
             changes.push("component will be created".to_string());

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1008,16 +1008,21 @@ impl McpServer {
                             .skip(offset)
                             .take(limit.unwrap_or(usize::MAX))
                             .map(|fp| {
-                                json!({
-                                    "name": fp.name,
-                                    "description": fp.description,
-                                    "pad_count": fp.pads.len(),
-                                    "track_count": fp.tracks.len(),
-                                    "arc_count": fp.arcs.len(),
-                                    "region_count": fp.regions.len(),
-                                    "text_count": fp.text.len(),
-                                    "has_3d_model": fp.model_3d.is_some() || !fp.component_bodies.is_empty(),
-                                })
+                                let mut entry = serde_json::Map::new();
+                                entry.insert("name".to_string(), json!(fp.name));
+                                entry.insert("description".to_string(), json!(fp.description));
+                                // One count per primitive kind, every kind.
+                                for kind in crate::altium::pcblib::PrimitiveKind::WRITE_ORDER {
+                                    entry.insert(
+                                        format!("{}_count", kind.name()),
+                                        json!(fp.count_of(kind)),
+                                    );
+                                }
+                                entry.insert(
+                                    "has_3d_model".to_string(),
+                                    json!(fp.model_3d.is_some() || !fp.component_bodies.is_empty()),
+                                );
+                                Value::Object(entry)
                             })
                             .collect()
                     } else {
@@ -3345,6 +3350,15 @@ mod tests {
             assert_eq!(p["include_metadata"], true);
             assert_eq!(p["components"][0]["pad_count"], 2);
             assert_eq!(p["components"][0]["has_3d_model"], false);
+            // One count per primitive kind, every kind.
+            for kind in crate::altium::pcblib::PrimitiveKind::WRITE_ORDER {
+                let key = format!("{}_count", kind.name());
+                assert!(
+                    p["components"][0][&key].is_u64(),
+                    "{key} missing: {}",
+                    p["components"][0]
+                );
+            }
 
             let paged = server.call_list_components(&json!({
                 "filepath": path.to_string_lossy(), "limit": 1, "offset": 0,


### PR DESCRIPTION
## Summary

Closing out the hand-enumerated-kinds class at its root: the last three hand-written kind lists in the tools now walk `PrimitiveKind::WRITE_ORDER` / `SchPrimitiveKind::WRITE_ORDER` through `count_of`, like #445–#449 did for diff, render, CSV, style and compare.

- `update_component` dry-run previews (both formats) — were complete, now derived (−116 lines); footprint links stay a separate line since they are not a record kind.
- `list_components` `include_metadata` for a PcbLib — counted five of eight kinds (`pad/track/arc/region/text_count`, no via, fill or body counts); now one `<kind>_count` per kind plus `has_3d_model`, and the parameter description says exactly what each format returns (`TOOLS.md` regenerated).

## Verification

- Dry-run preview test unchanged in expectations (every count line still reported); `list_components` metadata test asserts a count for every kind from the enum
- fmt / clippy `-D warnings` clean; **1481 tests** green

🤖 Generated with [Claude Code](https://claude.com/claude-code)