### PR TITLE
fix: batch update_parameters matches names without regard to case

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -893,7 +893,7 @@ Manage component parameters in Altium SchLib files. Supports listing, getting, s
 | `hidden` | boolean | no | Whether the parameter is hidden (optional for set, add) |
 | `operation` | enum | yes | Operation to perform: list (all parameters), get (single parameter), set (update value), add (new parameter), delete (remove parameter) (one of: list, get, set, add, delete) |
 | `param_type` | integer | no | Parameter type (0=String, 1=Boolean, 2=Integer, 3=Float) (optional for set, add). Default: 0 |
-| `parameter_name` | string | no | Name of the parameter (required for get, set, add, delete) |
+| `parameter_name` | string | no | Name of the parameter (required for get, set, add, delete); matched without regard to case, as Altium treats parameter names |
 | `read_only_state` | integer | no | Read-only state (0=editable, 1=read-only) (optional for set, add). Default: 0 |
 | `unique_id` | string | no | 8-char Altium unique ID (optional for set, add). Default: auto-generated |
 | `value` | string | no | Parameter value (required for set, add) |

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -1414,7 +1414,7 @@ impl McpServer {
                                 },
                                 "param_name": {
                                     "type": "string",
-                                    "description": "For update_parameters: parameter name to update (e.g., 'Value')"
+                                    "description": "For update_parameters: parameter name to update (e.g., 'Value'); matched without regard to case, as Altium treats parameter names"
                                 },
                                 "param_value": {
                                     "type": "string",
@@ -1845,7 +1845,7 @@ impl McpServer {
                         },
                         "parameter_name": {
                             "type": "string",
-                            "description": "Name of the parameter (required for get, set, add, delete)"
+                            "description": "Name of the parameter (required for get, set, add, delete); matched without regard to case, as Altium treats parameter names"
                         },
                         "value": {
                             "type": "string",

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -170,9 +170,10 @@ impl McpServer {
             let mut updated_in_symbol = false;
             let mut added_in_symbol = false;
 
-            // Try to find and update existing parameter
+            // Find and update the existing parameter; names match without
+            // regard to case, as Altium and manage_schlib_parameters treat them.
             for param in &mut symbol.parameters {
-                if param.name == param_name {
+                if param.name.eq_ignore_ascii_case(param_name) {
                     let old_value = param.value.clone();
                     if !dry_run {
                         param.value = param_value.to_string();
@@ -843,6 +844,43 @@ mod tests {
         let lib = SchLib::open(&path).unwrap();
         assert_eq!(lib.get("RESISTOR").unwrap().parameters[0].value, "Initech");
         assert_eq!(lib.get("CAPACITOR").unwrap().parameters[0].value, "ACME");
+    }
+
+    /// A parameter name matches without regard to case, as Altium and
+    /// manage_schlib_parameters treat it: `MANUFACTURER` updates
+    /// `Manufacturer` rather than adding a case-twin beside it.
+    #[test]
+    fn schlib_update_parameters_matches_names_without_regard_to_case() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("BatchParamCase.SchLib");
+        create_test_schlib(&path);
+        let filepath = path.to_string_lossy().to_string();
+
+        for (name, value) in [("Manufacturer", "ACME"), ("MANUFACTURER", "Initech")] {
+            let result = server.call_batch_update(&json!({
+                "filepath": filepath,
+                "operation": "update_parameters",
+                "parameters": {
+                    "param_name": name,
+                    "param_value": value,
+                    "add_if_missing": true,
+                },
+            }));
+            assert!(!result.is_error, "{}", get_result_text(&result));
+        }
+
+        let lib = SchLib::open(&path).unwrap();
+        for symbol in lib.iter() {
+            let manufacturers: Vec<&str> = symbol
+                .parameters
+                .iter()
+                .filter(|p| p.name.eq_ignore_ascii_case("manufacturer"))
+                .map(|p| p.value.as_str())
+                .collect();
+            assert_eq!(manufacturers, ["Initech"], "{}", symbol.name);
+            assert_eq!(symbol.parameters[0].name, "Manufacturer", "{}", symbol.name);
+        }
     }
 
     #[test]

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -847,7 +847,7 @@ mod tests {
     }
 
     /// A parameter name matches without regard to case, as Altium and
-    /// manage_schlib_parameters treat it: `MANUFACTURER` updates
+    /// `manage_schlib_parameters` treat it: `MANUFACTURER` updates
     /// `Manufacturer` rather than adding a case-twin beside it.
     #[test]
     fn schlib_update_parameters_matches_names_without_regard_to_case() {


### PR DESCRIPTION
## Summary

Bug #59. `manage_schlib_parameters` matches a parameter name case-insensitively in every operation (get / set / add-refuses-duplicate / delete), the way Altium treats parameter names. `batch_update` → `update_parameters` compared the name exactly, so `param_name: "MANUFACTURER"` with `add_if_missing: true` on symbols that already carry `Manufacturer` added a second, case-twin parameter beside the first instead of updating it — a duplicate Altium itself refuses to create.

Fix: the batch operation matches with `eq_ignore_ascii_case` like the manage tool; both `param_name` / `parameter_name` schema descriptions state the rule (`TOOLS.md` regenerated).

## Verification

- `schlib_update_parameters_matches_names_without_regard_to_case`: two runs (`Manufacturer`=ACME, then `MANUFACTURER`=Initech, both `add_if_missing`) leave exactly one `Manufacturer` parameter per symbol, valued Initech, original spelling kept
- fmt / clippy `-D warnings` clean; full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)