### PR TITLE
fix: a component named in another case keeps its spelling on file

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -207,9 +207,11 @@ component becomes, and how Altium resolves one. Every tool that creates a name
 `merge_libraries`, `update_component` with a new name) therefore treats a name differing
 from an existing one only in case as taken, and says so with the spelling on file:
 `Component 'res_0402' already exists in library as 'RES_0402' (component names are
-case-insensitive)`. Renaming a component to its own name in another case is allowed. Two
-such names within one `write_*` request are reported as a duplicate. A rename keeps the
-component's position in the library.
+case-insensitive)`. Renaming a component to its own name in another case is allowed,
+however the request spells the old name. Naming a component in another case when
+referring to it (`update_component`, `update_pad`, …) never changes the spelling on file:
+only an explicit new name renames. Two such names within one `write_*` request are
+reported as a duplicate. A rename keeps the component's position in the library.
 
 ---
 

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -295,7 +295,10 @@ impl McpServer {
 
         // Check if new name already exists. The component's own name in
         // another case resolves to itself and is a legitimate rename.
-        if let Some(existing) = library.get(new_name).filter(|c| c.name != old_name) {
+        if let Some(existing) = library
+            .get(new_name)
+            .filter(|c| !crate::altium::same_name(&c.name, old_name))
+        {
             return ToolCallResult::error(Self::taken_name_error(
                 format!("Component '{new_name}' already exists in library"),
                 new_name,
@@ -361,7 +364,10 @@ impl McpServer {
 
         // Check if new name already exists. The component's own name in
         // another case resolves to itself and is a legitimate rename.
-        if let Some(existing) = library.get(new_name).filter(|c| c.name != old_name) {
+        if let Some(existing) = library
+            .get(new_name)
+            .filter(|c| !crate::altium::same_name(&c.name, old_name))
+        {
             return ToolCallResult::error(Self::taken_name_error(
                 format!("Component '{new_name}' already exists in library"),
                 new_name,
@@ -3299,10 +3305,11 @@ mod tests {
         assert!(result.is_error);
         assert!(get_result_text(&result).contains("as 'CHIP_0603'"));
 
-        // The component's own name in another case is a legitimate rename.
+        // The component's own name in another case is a legitimate rename,
+        // however the caller spells the old name.
         let result = server.call_rename_component(&json!({
             "filepath": path.to_string_lossy(),
-            "old_name": "CHIP_0402",
+            "old_name": "Chip_0402",
             "new_name": "chip_0402",
         }));
         assert!(!result.is_error, "{}", get_result_text(&result));

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -470,10 +470,12 @@ impl McpServer {
             );
         }
 
-        // Validate new name if provided
-        let target_name = new_name.unwrap_or(component_name);
-        if let Err(e) = Self::validate_ole_name(target_name) {
-            return ToolCallResult::error(e);
+        // Validate the new name if provided; without one the copy keeps the
+        // source's name as its library spells it.
+        if let Some(new_name) = new_name {
+            if let Err(e) = Self::validate_ole_name(new_name) {
+                return ToolCallResult::error(e);
+            }
         }
 
         // Determine file types from extensions
@@ -500,7 +502,7 @@ impl McpServer {
                 source_filepath,
                 target_filepath,
                 component_name,
-                target_name,
+                new_name,
                 description,
                 ignore_missing_models,
                 preserve_external_paths,
@@ -509,7 +511,7 @@ impl McpServer {
                 source_filepath,
                 target_filepath,
                 component_name,
-                target_name,
+                new_name,
                 description,
             ),
             Some(ext) => ToolCallResult::error(format!(
@@ -525,7 +527,7 @@ impl McpServer {
         source_filepath: &str,
         target_filepath: &str,
         component_name: &str,
-        target_name: &str,
+        new_name: Option<&str>,
         description: Option<&str>,
         ignore_missing_models: bool,
         preserve_external_paths: bool,
@@ -545,7 +547,9 @@ impl McpServer {
             ));
         };
 
-        // Clone the footprint
+        // Clone the footprint under the new name, or the source's own as its
+        // library spells it — not as the caller happened to spell it.
+        let target_name = new_name.unwrap_or(&source.name);
         let mut new_footprint = source.clone();
         new_footprint.name = target_name.to_string();
         if let Some(desc) = description {
@@ -651,7 +655,7 @@ impl McpServer {
                 component_name,
                 source_filepath,
                 target_filepath,
-                if target_name == component_name {
+                if new_name.is_none() {
                     String::new()
                 } else {
                     format!(" as '{target_name}'")
@@ -699,7 +703,7 @@ impl McpServer {
         source_filepath: &str,
         target_filepath: &str,
         component_name: &str,
-        target_name: &str,
+        new_name: Option<&str>,
         description: Option<&str>,
     ) -> ToolCallResult {
         use crate::altium::SchLib;
@@ -717,7 +721,9 @@ impl McpServer {
             ));
         };
 
-        // Clone the symbol
+        // Clone the symbol under the new name, or the source's own as its
+        // library spells it — not as the caller happened to spell it.
+        let target_name = new_name.unwrap_or(&source.name);
         let mut new_symbol = source.clone();
         new_symbol.name = target_name.to_string();
         if let Some(desc) = description {
@@ -767,7 +773,7 @@ impl McpServer {
                 component_name,
                 source_filepath,
                 target_filepath,
-                if target_name == component_name {
+                if new_name.is_none() {
                     String::new()
                 } else {
                     format!(" as '{target_name}'")
@@ -3370,5 +3376,39 @@ mod tests {
             SchLib::open(&sch).unwrap().names(),
             ["Resistor", "CAPACITOR"]
         );
+    }
+
+    /// Without a new name a cross-library copy keeps the source's spelling,
+    /// however the caller spelt the component name.
+    #[test]
+    fn a_cross_library_copy_keeps_the_source_spelling() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Case.PcbLib");
+        create_test_pcblib(&path); // CHIP_0402 + CHIP_0603
+        let other = dir.path().join("Other.PcbLib");
+        create_test_pcblib(&other);
+
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": other.to_string_lossy(),
+            "target_filepath": path.to_string_lossy(),
+            "component_name": "chip_0603",
+        }));
+        assert!(result.is_error, "{}", get_result_text(&result));
+        assert!(
+            get_result_text(&result).contains("'CHIP_0603' already exists"),
+            "{}",
+            get_result_text(&result)
+        );
+        let spare = dir.path().join("Spare.PcbLib");
+        PcbLib::new().save(&spare).unwrap();
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": other.to_string_lossy(),
+            "target_filepath": spare.to_string_lossy(),
+            "component_name": "chip_0603",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["target_name"], "CHIP_0603");
+        assert_eq!(PcbLib::open(&spare).unwrap().names(), ["CHIP_0603"]);
     }
 }

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -70,18 +70,21 @@ impl McpServer {
             Err(e) => return ToolCallResult::error(format!("Failed to read library: {e}")),
         };
 
-        // Check component exists
-        if library.get(component_name).is_none() {
+        // The component as the library spells it: the caller may name it in
+        // another case, and that spelling must not leak into the file.
+        let Some(stored_name) = library.get(component_name).map(|f| f.name.clone()) else {
             let available: Vec<_> = library.names().into_iter().take(10).collect();
             return ToolCallResult::error(format!(
                 "Component '{component_name}' not found in library. Available: {}{}",
                 available.join(", "),
                 if library.len() > 10 { "..." } else { "" }
             ));
-        }
+        };
+        let component_name = stored_name.as_str();
 
         // Parse the replacement footprint — the same parser as write_pcblib,
-        // so an update accepts exactly what a write does.
+        // so an update accepts exactly what a write does. A replacement
+        // without a name keeps the stored one.
         let keys = crate::mcp::tools::allowed_keys::PcbLibKeys::new();
         let footprint = match self.parse_footprint_json(
             fp_json,
@@ -105,7 +108,10 @@ impl McpServer {
             }
             // The footprint's own name in another case resolves to itself
             // and is a legitimate rename; any other holder is a clash.
-            if let Some(existing) = library.get(name).filter(|f| f.name != component_name) {
+            if let Some(existing) = library
+                .get(name)
+                .filter(|f| !crate::altium::same_name(&f.name, component_name))
+            {
                 return ToolCallResult::error(Self::taken_name_error(
                     format!(
                         "Cannot rename '{component_name}' to '{name}': a footprint with that name already exists"
@@ -228,18 +234,21 @@ impl McpServer {
             Err(e) => return ToolCallResult::error(format!("Failed to read library: {e}")),
         };
 
-        // Check component exists
-        if library.get(component_name).is_none() {
+        // The component as the library spells it: the caller may name it in
+        // another case, and that spelling must not leak into the file.
+        let Some(stored_name) = library.get(component_name).map(|s| s.name.clone()) else {
             let available: Vec<_> = library.names().into_iter().take(10).collect();
             return ToolCallResult::error(format!(
                 "Component '{component_name}' not found in library. Available: {}{}",
                 available.join(", "),
                 if library.len() > 10 { "..." } else { "" }
             ));
-        }
+        };
+        let component_name = stored_name.as_str();
 
         // Parse the replacement symbol — the same parser as write_schlib, so
-        // an update accepts exactly what a write does.
+        // an update accepts exactly what a write does. A replacement without
+        // a name keeps the stored one.
         let keys = crate::mcp::tools::allowed_keys::SchLibKeys::new();
         let symbol = match self.parse_symbol_json(
             sym_json,
@@ -263,7 +272,10 @@ impl McpServer {
             }
             // The symbol's own name in another case resolves to itself and
             // is a legitimate rename; any other holder is a clash.
-            if let Some(existing) = library.get(name).filter(|s| s.name != component_name) {
+            if let Some(existing) = library
+                .get(name)
+                .filter(|s| !crate::altium::same_name(&s.name, component_name))
+            {
                 return ToolCallResult::error(Self::taken_name_error(
                     format!(
                         "Cannot rename '{component_name}' to '{name}': a symbol with that name already exists"
@@ -1274,6 +1286,67 @@ mod tests {
             "symbol": { "pins": [], "primitive_order": 42 },
         }));
         assert!(!result.is_error, "{}", get_result_text(&result));
+    }
+
+    /// The caller may name the component in another case: a replacement
+    /// without a name keeps the stored spelling (no rename happens, none is
+    /// reported), and an explicit name in another case is the one case-only
+    /// rename that is allowed.
+    #[test]
+    fn update_component_keeps_the_stored_spelling_unless_renamed() {
+        use crate::altium::{PcbLib, SchLib};
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        let pcb = dir.path().join("Spelling.PcbLib");
+        create_test_pcblib(&pcb); // CHIP_0402 + CHIP_0603
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "chip_0402",
+            "footprint": { "description": "touched", "pads": [] },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let parsed = parse_result_json(&result);
+        assert_eq!(parsed["renamed"], false, "{parsed}");
+        assert_eq!(parsed["component_name"], "CHIP_0402");
+        assert_eq!(
+            PcbLib::open(&pcb).unwrap().names(),
+            ["CHIP_0402", "CHIP_0603"]
+        );
+
+        let result = server.call_update_component(&json!({
+            "filepath": pcb.to_string_lossy(),
+            "component_name": "chip_0402",
+            "footprint": { "name": "Chip_0402", "pads": [] },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["renamed"], true);
+        assert_eq!(
+            PcbLib::open(&pcb).unwrap().names(),
+            ["Chip_0402", "CHIP_0603"]
+        );
+
+        let sch = dir.path().join("Spelling.SchLib");
+        create_test_schlib(&sch); // RESISTOR + CAPACITOR
+        let result = server.call_update_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "component_name": "resistor",
+            "symbol": { "pins": [] },
+            "dry_run": true,
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["would_rename"], false);
+        let result = server.call_update_component(&json!({
+            "filepath": sch.to_string_lossy(),
+            "component_name": "resistor",
+            "symbol": { "pins": [] },
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        assert_eq!(parse_result_json(&result)["renamed"], false);
+        assert_eq!(
+            SchLib::open(&sch).unwrap().names(),
+            ["RESISTOR", "CAPACITOR"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bug #60 (three faces of one gap in the case-insensitive-names work). Component lookup resolves a name in any case, but three places still used the **caller's spelling** as if it were the stored one:

1. `update_component` with a replacement that carries no `name` defaulted the name to the `component_name` argument. Referring to `CHIP_0402` as `chip_0402` therefore **re-spelt the component on file** as `chip_0402` — while reporting `renamed: false`.
2. The self-collision filter in `rename_component` and `update_component` compared `existing.name != old_name` exactly, so a case-only rename (`Chip_0402` → `chip_0402`) was refused as "already exists" whenever the old name was given in a case other than the stored one.
3. `copy_component_cross_library` without `new_name` named the copy after the caller's spelling, so copying `chip_0603` carried `CHIP_0603` into the target as `chip_0603` (second commit).

Fix: the tools resolve the stored spelling first and use it as the baseline — the parser's default name, the `renamed` / `would_rename` comparison, the echoed `component_name` / `target_name`; the self-check uses `same_name`. Only an explicit new name renames. `docs/errors.md` states the rule.

## Verification

- `update_component_keeps_the_stored_spelling_unless_renamed` (both formats), `a_cross_library_copy_keeps_the_source_spelling`, and the existing case-rename test now gives the old name in a third spelling
- fmt / clippy `-D warnings` clean (checked before committing); **1486 tests** green; markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)