### PR TITLE
fix: range-check every footprint kind; one layer-name parser for every tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,13 @@ Additional layers supported:
 |-------|-------|
 | Mid-Layer 1–30 | Internal copper layers |
 | Internal Plane 1–16 | Power/ground planes |
-| Mechanical 1–16 | User-defined mechanical layers |
+| Mechanical 1–32 | User-defined mechanical layers |
 | Drill Guide | Drill hole markers |
 | Drill Drawing | Drill chart/table |
 | Keep-Out Layer | Routing exclusion zones |
+
+A layer may be named as Altium spells it (`Top Overlay`, `Mechanical 13`) or in camel
+case (`TopOverlay`, `Mechanical13`), in any case; every tool accepts the same spellings.
 
 ---
 

--- a/src/altium/pcblib/primitives/layer.rs
+++ b/src/altium/pcblib/primitives/layer.rs
@@ -2,714 +2,320 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Altium layer identifiers.
-///
-/// # Recommended Layers for Footprints
-///
-/// AI assistants should prefer these dedicated layers over generic mechanical layers:
-///
-/// | Purpose | Recommended Layer |
-/// |---------|-------------------|
-/// | Pads (SMD) | `TopLayer` or `BottomLayer` |
-/// | Pads (through-hole) | `MultiLayer` |
-/// | Silkscreen | `TopOverlay` / `BottomOverlay` |
-/// | Assembly outline | `TopAssembly` / `BottomAssembly` |
-/// | Courtyard | `TopCourtyard` / `BottomCourtyard` |
-/// | 3D body outline | `Top3DBody` / `Bottom3DBody` |
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub enum Layer {
-    // Copper layers
-    /// Top copper layer (ID 1).
-    #[serde(rename = "Top Layer", alias = "TopLayer")]
-    TopLayer,
-    /// Mid layer 1 (ID 2).
-    #[serde(rename = "Mid-Layer 1", alias = "MidLayer1")]
-    MidLayer1,
-    /// Mid layer 2 (ID 3).
-    #[serde(rename = "Mid-Layer 2", alias = "MidLayer2")]
-    MidLayer2,
-    /// Mid layer 3 (ID 4).
-    #[serde(rename = "Mid-Layer 3", alias = "MidLayer3")]
-    MidLayer3,
-    /// Mid layer 4 (ID 5).
-    #[serde(rename = "Mid-Layer 4", alias = "MidLayer4")]
-    MidLayer4,
-    /// Mid layer 5 (ID 6).
-    #[serde(rename = "Mid-Layer 5", alias = "MidLayer5")]
-    MidLayer5,
-    /// Mid layer 6 (ID 7).
-    #[serde(rename = "Mid-Layer 6", alias = "MidLayer6")]
-    MidLayer6,
-    /// Mid layer 7 (ID 8).
-    #[serde(rename = "Mid-Layer 7", alias = "MidLayer7")]
-    MidLayer7,
-    /// Mid layer 8 (ID 9).
-    #[serde(rename = "Mid-Layer 8", alias = "MidLayer8")]
-    MidLayer8,
-    /// Mid layer 9 (ID 10).
-    #[serde(rename = "Mid-Layer 9", alias = "MidLayer9")]
-    MidLayer9,
-    /// Mid layer 10 (ID 11).
-    #[serde(rename = "Mid-Layer 10", alias = "MidLayer10")]
-    MidLayer10,
-    /// Mid layer 11 (ID 12).
-    #[serde(rename = "Mid-Layer 11", alias = "MidLayer11")]
-    MidLayer11,
-    /// Mid layer 12 (ID 13).
-    #[serde(rename = "Mid-Layer 12", alias = "MidLayer12")]
-    MidLayer12,
-    /// Mid layer 13 (ID 14).
-    #[serde(rename = "Mid-Layer 13", alias = "MidLayer13")]
-    MidLayer13,
-    /// Mid layer 14 (ID 15).
-    #[serde(rename = "Mid-Layer 14", alias = "MidLayer14")]
-    MidLayer14,
-    /// Mid layer 15 (ID 16).
-    #[serde(rename = "Mid-Layer 15", alias = "MidLayer15")]
-    MidLayer15,
-    /// Mid layer 16 (ID 17).
-    #[serde(rename = "Mid-Layer 16", alias = "MidLayer16")]
-    MidLayer16,
-    /// Mid layer 17 (ID 18).
-    #[serde(rename = "Mid-Layer 17", alias = "MidLayer17")]
-    MidLayer17,
-    /// Mid layer 18 (ID 19).
-    #[serde(rename = "Mid-Layer 18", alias = "MidLayer18")]
-    MidLayer18,
-    /// Mid layer 19 (ID 20).
-    #[serde(rename = "Mid-Layer 19", alias = "MidLayer19")]
-    MidLayer19,
-    /// Mid layer 20 (ID 21).
-    #[serde(rename = "Mid-Layer 20", alias = "MidLayer20")]
-    MidLayer20,
-    /// Mid layer 21 (ID 22).
-    #[serde(rename = "Mid-Layer 21", alias = "MidLayer21")]
-    MidLayer21,
-    /// Mid layer 22 (ID 23).
-    #[serde(rename = "Mid-Layer 22", alias = "MidLayer22")]
-    MidLayer22,
-    /// Mid layer 23 (ID 24).
-    #[serde(rename = "Mid-Layer 23", alias = "MidLayer23")]
-    MidLayer23,
-    /// Mid layer 24 (ID 25).
-    #[serde(rename = "Mid-Layer 24", alias = "MidLayer24")]
-    MidLayer24,
-    /// Mid layer 25 (ID 26).
-    #[serde(rename = "Mid-Layer 25", alias = "MidLayer25")]
-    MidLayer25,
-    /// Mid layer 26 (ID 27).
-    #[serde(rename = "Mid-Layer 26", alias = "MidLayer26")]
-    MidLayer26,
-    /// Mid layer 27 (ID 28).
-    #[serde(rename = "Mid-Layer 27", alias = "MidLayer27")]
-    MidLayer27,
-    /// Mid layer 28 (ID 29).
-    #[serde(rename = "Mid-Layer 28", alias = "MidLayer28")]
-    MidLayer28,
-    /// Mid layer 29 (ID 30).
-    #[serde(rename = "Mid-Layer 29", alias = "MidLayer29")]
-    MidLayer29,
-    /// Mid layer 30 (ID 31).
-    #[serde(rename = "Mid-Layer 30", alias = "MidLayer30")]
-    MidLayer30,
-    /// Bottom copper layer (ID 32).
-    #[serde(rename = "Bottom Layer", alias = "BottomLayer")]
-    BottomLayer,
-    /// Multi-layer (all copper layers, for through-hole pads).
-    #[default]
-    #[serde(rename = "Multi-Layer", alias = "MultiLayer")]
-    MultiLayer,
+/// Declares [`Layer`] and everything that must list every layer — the
+/// Altium name, the camel-case alias the JSON boundary also accepts, and
+/// [`Layer::ALL`] — from ONE list, so a layer cannot be missing from a table.
+macro_rules! layers {
+    (
+        $(#[$enum_doc:meta])*
+        $enum_name:ident {
+            $( $(#[$meta:meta])* $variant:ident => $name:literal | $alias:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_doc])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+        pub enum $enum_name {
+            $( $(#[$meta])* #[serde(rename = $name, alias = $alias)] $variant, )+
+        }
 
-    // Silkscreen
-    /// Top silkscreen (overlay).
-    #[serde(rename = "Top Overlay", alias = "TopOverlay")]
-    TopOverlay,
-    /// Bottom silkscreen.
-    #[serde(rename = "Bottom Overlay", alias = "BottomOverlay")]
-    BottomOverlay,
+        impl $enum_name {
+            /// Every layer, in declaration order.
+            pub const ALL: [Self; [$(stringify!($variant)),+].len()] = [$(Self::$variant,)+];
 
-    // Solder mask
-    /// Top solder mask.
-    #[serde(rename = "Top Solder", alias = "TopSolder")]
-    TopSolder,
-    /// Bottom solder mask.
-    #[serde(rename = "Bottom Solder", alias = "BottomSolder")]
-    BottomSolder,
+            /// Returns the Altium layer name string.
+            #[must_use]
+            pub const fn as_str(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name,)+
+                }
+            }
 
-    // Internal planes (IDs 39-54)
-    /// Internal plane 1 (ID 39).
-    #[serde(rename = "Internal Plane 1", alias = "InternalPlane1")]
-    InternalPlane1,
-    /// Internal plane 2 (ID 40).
-    #[serde(rename = "Internal Plane 2", alias = "InternalPlane2")]
-    InternalPlane2,
-    /// Internal plane 3 (ID 41).
-    #[serde(rename = "Internal Plane 3", alias = "InternalPlane3")]
-    InternalPlane3,
-    /// Internal plane 4 (ID 42).
-    #[serde(rename = "Internal Plane 4", alias = "InternalPlane4")]
-    InternalPlane4,
-    /// Internal plane 5 (ID 43).
-    #[serde(rename = "Internal Plane 5", alias = "InternalPlane5")]
-    InternalPlane5,
-    /// Internal plane 6 (ID 44).
-    #[serde(rename = "Internal Plane 6", alias = "InternalPlane6")]
-    InternalPlane6,
-    /// Internal plane 7 (ID 45).
-    #[serde(rename = "Internal Plane 7", alias = "InternalPlane7")]
-    InternalPlane7,
-    /// Internal plane 8 (ID 46).
-    #[serde(rename = "Internal Plane 8", alias = "InternalPlane8")]
-    InternalPlane8,
-    /// Internal plane 9 (ID 47).
-    #[serde(rename = "Internal Plane 9", alias = "InternalPlane9")]
-    InternalPlane9,
-    /// Internal plane 10 (ID 48).
-    #[serde(rename = "Internal Plane 10", alias = "InternalPlane10")]
-    InternalPlane10,
-    /// Internal plane 11 (ID 49).
-    #[serde(rename = "Internal Plane 11", alias = "InternalPlane11")]
-    InternalPlane11,
-    /// Internal plane 12 (ID 50).
-    #[serde(rename = "Internal Plane 12", alias = "InternalPlane12")]
-    InternalPlane12,
-    /// Internal plane 13 (ID 51).
-    #[serde(rename = "Internal Plane 13", alias = "InternalPlane13")]
-    InternalPlane13,
-    /// Internal plane 14 (ID 52).
-    #[serde(rename = "Internal Plane 14", alias = "InternalPlane14")]
-    InternalPlane14,
-    /// Internal plane 15 (ID 53).
-    #[serde(rename = "Internal Plane 15", alias = "InternalPlane15")]
-    InternalPlane15,
-    /// Internal plane 16 (ID 54).
-    #[serde(rename = "Internal Plane 16", alias = "InternalPlane16")]
-    InternalPlane16,
+            /// The camel-case alias (`TopOverlay` for `Top Overlay`), the
+            /// spelling the JSON boundary accepts besides the Altium name.
+            #[must_use]
+            pub const fn alias(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => $alias,)+
+                }
+            }
+        }
+    };
+}
 
-    // Drill layers
-    /// Drill guide layer (ID 55).
-    #[serde(rename = "Drill Guide", alias = "DrillGuide")]
-    DrillGuide,
-    /// Drill drawing layer (ID 73).
-    #[serde(rename = "Drill Drawing", alias = "DrillDrawing")]
-    DrillDrawing,
-
-    // Paste
-    /// Top solder paste.
-    #[serde(rename = "Top Paste", alias = "TopPaste")]
-    TopPaste,
-    /// Bottom solder paste.
-    #[serde(rename = "Bottom Paste", alias = "BottomPaste")]
-    BottomPaste,
-
-    // Component layer pairs (preferred over generic mechanical layers)
-    /// Top assembly outline (component body outline for documentation).
-    #[serde(rename = "Top Assembly", alias = "TopAssembly")]
-    TopAssembly,
-    /// Bottom assembly outline.
-    #[serde(rename = "Bottom Assembly", alias = "BottomAssembly")]
-    BottomAssembly,
-    /// Top courtyard (component keepout area per IPC-7351).
-    #[serde(rename = "Top Courtyard", alias = "TopCourtyard")]
-    TopCourtyard,
-    /// Bottom courtyard.
-    #[serde(rename = "Bottom Courtyard", alias = "BottomCourtyard")]
-    BottomCourtyard,
-    /// Top 3D body outline (for 3D model placement).
-    #[serde(rename = "Top 3D Body", alias = "Top3DBody")]
-    Top3DBody,
-    /// Bottom 3D body outline.
-    #[serde(rename = "Bottom 3D Body", alias = "Bottom3DBody")]
-    Bottom3DBody,
-
-    // Generic mechanical layers (use component layer pairs when possible)
-    /// Mechanical layer 1 (ID 57).
-    #[serde(rename = "Mechanical 1", alias = "Mechanical1")]
-    Mechanical1,
-    /// Mechanical layer 2 (ID 58 - aliased to `TopAssembly`).
-    #[serde(rename = "Mechanical 2", alias = "Mechanical2")]
-    Mechanical2,
-    /// Mechanical layer 3 (ID 59 - aliased to `BottomAssembly`).
-    #[serde(rename = "Mechanical 3", alias = "Mechanical3")]
-    Mechanical3,
-    /// Mechanical layer 4 (ID 60 - aliased to `TopCourtyard`).
-    #[serde(rename = "Mechanical 4", alias = "Mechanical4")]
-    Mechanical4,
-    /// Mechanical layer 5 (ID 61 - aliased to `BottomCourtyard`).
-    #[serde(rename = "Mechanical 5", alias = "Mechanical5")]
-    Mechanical5,
-    /// Mechanical layer 6 (ID 62 - aliased to `Top3DBody`).
-    #[serde(rename = "Mechanical 6", alias = "Mechanical6")]
-    Mechanical6,
-    /// Mechanical layer 7 (ID 63 - aliased to `Bottom3DBody`).
-    #[serde(rename = "Mechanical 7", alias = "Mechanical7")]
-    Mechanical7,
-    /// Mechanical layer 8 (ID 64).
-    #[serde(rename = "Mechanical 8", alias = "Mechanical8")]
-    Mechanical8,
-    /// Mechanical layer 9 (ID 65).
-    #[serde(rename = "Mechanical 9", alias = "Mechanical9")]
-    Mechanical9,
-    /// Mechanical layer 10 (ID 66).
-    #[serde(rename = "Mechanical 10", alias = "Mechanical10")]
-    Mechanical10,
-    /// Mechanical layer 11 (ID 67).
-    #[serde(rename = "Mechanical 11", alias = "Mechanical11")]
-    Mechanical11,
-    /// Mechanical layer 12 (ID 68).
-    #[serde(rename = "Mechanical 12", alias = "Mechanical12")]
-    Mechanical12,
-    /// Mechanical layer 13 (ID 69).
-    #[serde(rename = "Mechanical 13", alias = "Mechanical13")]
-    Mechanical13,
-    /// Mechanical layer 14 (ID 70).
-    #[serde(rename = "Mechanical 14", alias = "Mechanical14")]
-    Mechanical14,
-    /// Mechanical layer 15 (ID 71).
-    #[serde(rename = "Mechanical 15", alias = "Mechanical15")]
-    Mechanical15,
-    /// Mechanical layer 16 (ID 72).
-    #[serde(rename = "Mechanical 16", alias = "Mechanical16")]
-    Mechanical16,
-
-    // Extended mechanical layers (IDs 186-201, Altium Designer 18+)
-    /// Mechanical layer 17 (ID 186).
-    #[serde(rename = "Mechanical 17", alias = "Mechanical17")]
-    Mechanical17,
-    /// Mechanical layer 18 (ID 187).
-    #[serde(rename = "Mechanical 18", alias = "Mechanical18")]
-    Mechanical18,
-    /// Mechanical layer 19 (ID 188).
-    #[serde(rename = "Mechanical 19", alias = "Mechanical19")]
-    Mechanical19,
-    /// Mechanical layer 20 (ID 189).
-    #[serde(rename = "Mechanical 20", alias = "Mechanical20")]
-    Mechanical20,
-    /// Mechanical layer 21 (ID 190).
-    #[serde(rename = "Mechanical 21", alias = "Mechanical21")]
-    Mechanical21,
-    /// Mechanical layer 22 (ID 191).
-    #[serde(rename = "Mechanical 22", alias = "Mechanical22")]
-    Mechanical22,
-    /// Mechanical layer 23 (ID 192).
-    #[serde(rename = "Mechanical 23", alias = "Mechanical23")]
-    Mechanical23,
-    /// Mechanical layer 24 (ID 193).
-    #[serde(rename = "Mechanical 24", alias = "Mechanical24")]
-    Mechanical24,
-    /// Mechanical layer 25 (ID 194).
-    #[serde(rename = "Mechanical 25", alias = "Mechanical25")]
-    Mechanical25,
-    /// Mechanical layer 26 (ID 195).
-    #[serde(rename = "Mechanical 26", alias = "Mechanical26")]
-    Mechanical26,
-    /// Mechanical layer 27 (ID 196).
-    #[serde(rename = "Mechanical 27", alias = "Mechanical27")]
-    Mechanical27,
-    /// Mechanical layer 28 (ID 197).
-    #[serde(rename = "Mechanical 28", alias = "Mechanical28")]
-    Mechanical28,
-    /// Mechanical layer 29 (ID 198).
-    #[serde(rename = "Mechanical 29", alias = "Mechanical29")]
-    Mechanical29,
-    /// Mechanical layer 30 (ID 199).
-    #[serde(rename = "Mechanical 30", alias = "Mechanical30")]
-    Mechanical30,
-    /// Mechanical layer 31 (ID 200).
-    #[serde(rename = "Mechanical 31", alias = "Mechanical31")]
-    Mechanical31,
-    /// Mechanical layer 32 (ID 201).
-    #[serde(rename = "Mechanical 32", alias = "Mechanical32")]
-    Mechanical32,
-
-    // Special layers (IDs 75-85)
-    /// Connect layer (ID 75).
-    #[serde(rename = "Connect Layer", alias = "ConnectLayer")]
-    ConnectLayer,
-    /// Background layer (ID 76).
-    #[serde(rename = "Background Layer", alias = "BackgroundLayer")]
-    BackgroundLayer,
-    /// DRC error layer (ID 77).
-    #[serde(rename = "DRC Error Layer", alias = "DRCErrorLayer")]
-    DRCErrorLayer,
-    /// Highlight layer (ID 78).
-    #[serde(rename = "Highlight Layer", alias = "HighlightLayer")]
-    HighlightLayer,
-    /// Grid color 1 layer (ID 79).
-    #[serde(rename = "Grid Color 1", alias = "GridColor1")]
-    GridColor1,
-    /// Grid color 10 layer (ID 80).
-    #[serde(rename = "Grid Color 10", alias = "GridColor10")]
-    GridColor10,
-    /// Pad hole layer (ID 81).
-    #[serde(rename = "Pad Hole Layer", alias = "PadHoleLayer")]
-    PadHoleLayer,
-    /// Via hole layer (ID 82).
-    #[serde(rename = "Via Hole Layer", alias = "ViaHoleLayer")]
-    ViaHoleLayer,
-    /// Top pad master layer (ID 83).
-    #[serde(rename = "Top Pad Master", alias = "TopPadMaster")]
-    TopPadMaster,
-    /// Bottom pad master layer (ID 84).
-    #[serde(rename = "Bottom Pad Master", alias = "BottomPadMaster")]
-    BottomPadMaster,
-    /// DRC detail layer (ID 85).
-    #[serde(rename = "DRC Detail Layer", alias = "DRCDetailLayer")]
-    DRCDetailLayer,
-
-    // Keep-out
-    /// Keep-out layer (ID 56).
-    #[serde(rename = "Keep-Out Layer", alias = "KeepOut")]
-    KeepOut,
+layers! {
+    /// Altium layer identifiers.
+    ///
+    /// # Recommended Layers for Footprints
+    ///
+    /// AI assistants should prefer these dedicated layers over generic mechanical layers:
+    ///
+    /// | Purpose | Recommended Layer |
+    /// |---------|-------------------|
+    /// | Pads (SMD) | `TopLayer` or `BottomLayer` |
+    /// | Pads (through-hole) | `MultiLayer` |
+    /// | Silkscreen | `TopOverlay` / `BottomOverlay` |
+    /// | Assembly outline | `TopAssembly` / `BottomAssembly` |
+    /// | Courtyard | `TopCourtyard` / `BottomCourtyard` |
+    /// | 3D body outline | `Top3DBody` / `Bottom3DBody` |
+    Layer {
+        // Copper layers
+        /// Top copper layer (ID 1).
+        TopLayer => "Top Layer" | "TopLayer",
+        /// Mid layer 1 (ID 2).
+        MidLayer1 => "Mid-Layer 1" | "MidLayer1",
+        /// Mid layer 2 (ID 3).
+        MidLayer2 => "Mid-Layer 2" | "MidLayer2",
+        /// Mid layer 3 (ID 4).
+        MidLayer3 => "Mid-Layer 3" | "MidLayer3",
+        /// Mid layer 4 (ID 5).
+        MidLayer4 => "Mid-Layer 4" | "MidLayer4",
+        /// Mid layer 5 (ID 6).
+        MidLayer5 => "Mid-Layer 5" | "MidLayer5",
+        /// Mid layer 6 (ID 7).
+        MidLayer6 => "Mid-Layer 6" | "MidLayer6",
+        /// Mid layer 7 (ID 8).
+        MidLayer7 => "Mid-Layer 7" | "MidLayer7",
+        /// Mid layer 8 (ID 9).
+        MidLayer8 => "Mid-Layer 8" | "MidLayer8",
+        /// Mid layer 9 (ID 10).
+        MidLayer9 => "Mid-Layer 9" | "MidLayer9",
+        /// Mid layer 10 (ID 11).
+        MidLayer10 => "Mid-Layer 10" | "MidLayer10",
+        /// Mid layer 11 (ID 12).
+        MidLayer11 => "Mid-Layer 11" | "MidLayer11",
+        /// Mid layer 12 (ID 13).
+        MidLayer12 => "Mid-Layer 12" | "MidLayer12",
+        /// Mid layer 13 (ID 14).
+        MidLayer13 => "Mid-Layer 13" | "MidLayer13",
+        /// Mid layer 14 (ID 15).
+        MidLayer14 => "Mid-Layer 14" | "MidLayer14",
+        /// Mid layer 15 (ID 16).
+        MidLayer15 => "Mid-Layer 15" | "MidLayer15",
+        /// Mid layer 16 (ID 17).
+        MidLayer16 => "Mid-Layer 16" | "MidLayer16",
+        /// Mid layer 17 (ID 18).
+        MidLayer17 => "Mid-Layer 17" | "MidLayer17",
+        /// Mid layer 18 (ID 19).
+        MidLayer18 => "Mid-Layer 18" | "MidLayer18",
+        /// Mid layer 19 (ID 20).
+        MidLayer19 => "Mid-Layer 19" | "MidLayer19",
+        /// Mid layer 20 (ID 21).
+        MidLayer20 => "Mid-Layer 20" | "MidLayer20",
+        /// Mid layer 21 (ID 22).
+        MidLayer21 => "Mid-Layer 21" | "MidLayer21",
+        /// Mid layer 22 (ID 23).
+        MidLayer22 => "Mid-Layer 22" | "MidLayer22",
+        /// Mid layer 23 (ID 24).
+        MidLayer23 => "Mid-Layer 23" | "MidLayer23",
+        /// Mid layer 24 (ID 25).
+        MidLayer24 => "Mid-Layer 24" | "MidLayer24",
+        /// Mid layer 25 (ID 26).
+        MidLayer25 => "Mid-Layer 25" | "MidLayer25",
+        /// Mid layer 26 (ID 27).
+        MidLayer26 => "Mid-Layer 26" | "MidLayer26",
+        /// Mid layer 27 (ID 28).
+        MidLayer27 => "Mid-Layer 27" | "MidLayer27",
+        /// Mid layer 28 (ID 29).
+        MidLayer28 => "Mid-Layer 28" | "MidLayer28",
+        /// Mid layer 29 (ID 30).
+        MidLayer29 => "Mid-Layer 29" | "MidLayer29",
+        /// Mid layer 30 (ID 31).
+        MidLayer30 => "Mid-Layer 30" | "MidLayer30",
+        /// Bottom copper layer (ID 32).
+        BottomLayer => "Bottom Layer" | "BottomLayer",
+        /// Multi-layer (all copper layers, for through-hole pads).
+        #[default]
+        MultiLayer => "Multi-Layer" | "MultiLayer",
+        // Silkscreen
+        /// Top silkscreen (overlay).
+        TopOverlay => "Top Overlay" | "TopOverlay",
+        /// Bottom silkscreen.
+        BottomOverlay => "Bottom Overlay" | "BottomOverlay",
+        // Solder mask
+        /// Top solder mask.
+        TopSolder => "Top Solder" | "TopSolder",
+        /// Bottom solder mask.
+        BottomSolder => "Bottom Solder" | "BottomSolder",
+        // Internal planes (IDs 39-54)
+        /// Internal plane 1 (ID 39).
+        InternalPlane1 => "Internal Plane 1" | "InternalPlane1",
+        /// Internal plane 2 (ID 40).
+        InternalPlane2 => "Internal Plane 2" | "InternalPlane2",
+        /// Internal plane 3 (ID 41).
+        InternalPlane3 => "Internal Plane 3" | "InternalPlane3",
+        /// Internal plane 4 (ID 42).
+        InternalPlane4 => "Internal Plane 4" | "InternalPlane4",
+        /// Internal plane 5 (ID 43).
+        InternalPlane5 => "Internal Plane 5" | "InternalPlane5",
+        /// Internal plane 6 (ID 44).
+        InternalPlane6 => "Internal Plane 6" | "InternalPlane6",
+        /// Internal plane 7 (ID 45).
+        InternalPlane7 => "Internal Plane 7" | "InternalPlane7",
+        /// Internal plane 8 (ID 46).
+        InternalPlane8 => "Internal Plane 8" | "InternalPlane8",
+        /// Internal plane 9 (ID 47).
+        InternalPlane9 => "Internal Plane 9" | "InternalPlane9",
+        /// Internal plane 10 (ID 48).
+        InternalPlane10 => "Internal Plane 10" | "InternalPlane10",
+        /// Internal plane 11 (ID 49).
+        InternalPlane11 => "Internal Plane 11" | "InternalPlane11",
+        /// Internal plane 12 (ID 50).
+        InternalPlane12 => "Internal Plane 12" | "InternalPlane12",
+        /// Internal plane 13 (ID 51).
+        InternalPlane13 => "Internal Plane 13" | "InternalPlane13",
+        /// Internal plane 14 (ID 52).
+        InternalPlane14 => "Internal Plane 14" | "InternalPlane14",
+        /// Internal plane 15 (ID 53).
+        InternalPlane15 => "Internal Plane 15" | "InternalPlane15",
+        /// Internal plane 16 (ID 54).
+        InternalPlane16 => "Internal Plane 16" | "InternalPlane16",
+        // Drill layers
+        /// Drill guide layer (ID 55).
+        DrillGuide => "Drill Guide" | "DrillGuide",
+        /// Drill drawing layer (ID 73).
+        DrillDrawing => "Drill Drawing" | "DrillDrawing",
+        // Paste
+        /// Top solder paste.
+        TopPaste => "Top Paste" | "TopPaste",
+        /// Bottom solder paste.
+        BottomPaste => "Bottom Paste" | "BottomPaste",
+        // Component layer pairs (preferred over generic mechanical layers)
+        /// Top assembly outline (component body outline for documentation).
+        TopAssembly => "Top Assembly" | "TopAssembly",
+        /// Bottom assembly outline.
+        BottomAssembly => "Bottom Assembly" | "BottomAssembly",
+        /// Top courtyard (component keepout area per IPC-7351).
+        TopCourtyard => "Top Courtyard" | "TopCourtyard",
+        /// Bottom courtyard.
+        BottomCourtyard => "Bottom Courtyard" | "BottomCourtyard",
+        /// Top 3D body outline (for 3D model placement).
+        Top3DBody => "Top 3D Body" | "Top3DBody",
+        /// Bottom 3D body outline.
+        Bottom3DBody => "Bottom 3D Body" | "Bottom3DBody",
+        // Generic mechanical layers (use component layer pairs when possible)
+        /// Mechanical layer 1 (ID 57).
+        Mechanical1 => "Mechanical 1" | "Mechanical1",
+        /// Mechanical layer 2 (ID 58 - aliased to `TopAssembly`).
+        Mechanical2 => "Mechanical 2" | "Mechanical2",
+        /// Mechanical layer 3 (ID 59 - aliased to `BottomAssembly`).
+        Mechanical3 => "Mechanical 3" | "Mechanical3",
+        /// Mechanical layer 4 (ID 60 - aliased to `TopCourtyard`).
+        Mechanical4 => "Mechanical 4" | "Mechanical4",
+        /// Mechanical layer 5 (ID 61 - aliased to `BottomCourtyard`).
+        Mechanical5 => "Mechanical 5" | "Mechanical5",
+        /// Mechanical layer 6 (ID 62 - aliased to `Top3DBody`).
+        Mechanical6 => "Mechanical 6" | "Mechanical6",
+        /// Mechanical layer 7 (ID 63 - aliased to `Bottom3DBody`).
+        Mechanical7 => "Mechanical 7" | "Mechanical7",
+        /// Mechanical layer 8 (ID 64).
+        Mechanical8 => "Mechanical 8" | "Mechanical8",
+        /// Mechanical layer 9 (ID 65).
+        Mechanical9 => "Mechanical 9" | "Mechanical9",
+        /// Mechanical layer 10 (ID 66).
+        Mechanical10 => "Mechanical 10" | "Mechanical10",
+        /// Mechanical layer 11 (ID 67).
+        Mechanical11 => "Mechanical 11" | "Mechanical11",
+        /// Mechanical layer 12 (ID 68).
+        Mechanical12 => "Mechanical 12" | "Mechanical12",
+        /// Mechanical layer 13 (ID 69).
+        Mechanical13 => "Mechanical 13" | "Mechanical13",
+        /// Mechanical layer 14 (ID 70).
+        Mechanical14 => "Mechanical 14" | "Mechanical14",
+        /// Mechanical layer 15 (ID 71).
+        Mechanical15 => "Mechanical 15" | "Mechanical15",
+        /// Mechanical layer 16 (ID 72).
+        Mechanical16 => "Mechanical 16" | "Mechanical16",
+        // Extended mechanical layers (IDs 186-201, Altium Designer 18+)
+        /// Mechanical layer 17 (ID 186).
+        Mechanical17 => "Mechanical 17" | "Mechanical17",
+        /// Mechanical layer 18 (ID 187).
+        Mechanical18 => "Mechanical 18" | "Mechanical18",
+        /// Mechanical layer 19 (ID 188).
+        Mechanical19 => "Mechanical 19" | "Mechanical19",
+        /// Mechanical layer 20 (ID 189).
+        Mechanical20 => "Mechanical 20" | "Mechanical20",
+        /// Mechanical layer 21 (ID 190).
+        Mechanical21 => "Mechanical 21" | "Mechanical21",
+        /// Mechanical layer 22 (ID 191).
+        Mechanical22 => "Mechanical 22" | "Mechanical22",
+        /// Mechanical layer 23 (ID 192).
+        Mechanical23 => "Mechanical 23" | "Mechanical23",
+        /// Mechanical layer 24 (ID 193).
+        Mechanical24 => "Mechanical 24" | "Mechanical24",
+        /// Mechanical layer 25 (ID 194).
+        Mechanical25 => "Mechanical 25" | "Mechanical25",
+        /// Mechanical layer 26 (ID 195).
+        Mechanical26 => "Mechanical 26" | "Mechanical26",
+        /// Mechanical layer 27 (ID 196).
+        Mechanical27 => "Mechanical 27" | "Mechanical27",
+        /// Mechanical layer 28 (ID 197).
+        Mechanical28 => "Mechanical 28" | "Mechanical28",
+        /// Mechanical layer 29 (ID 198).
+        Mechanical29 => "Mechanical 29" | "Mechanical29",
+        /// Mechanical layer 30 (ID 199).
+        Mechanical30 => "Mechanical 30" | "Mechanical30",
+        /// Mechanical layer 31 (ID 200).
+        Mechanical31 => "Mechanical 31" | "Mechanical31",
+        /// Mechanical layer 32 (ID 201).
+        Mechanical32 => "Mechanical 32" | "Mechanical32",
+        // Special layers (IDs 75-85)
+        /// Connect layer (ID 75).
+        ConnectLayer => "Connect Layer" | "ConnectLayer",
+        /// Background layer (ID 76).
+        BackgroundLayer => "Background Layer" | "BackgroundLayer",
+        /// DRC error layer (ID 77).
+        DRCErrorLayer => "DRC Error Layer" | "DRCErrorLayer",
+        /// Highlight layer (ID 78).
+        HighlightLayer => "Highlight Layer" | "HighlightLayer",
+        /// Grid color 1 layer (ID 79).
+        GridColor1 => "Grid Color 1" | "GridColor1",
+        /// Grid color 10 layer (ID 80).
+        GridColor10 => "Grid Color 10" | "GridColor10",
+        /// Pad hole layer (ID 81).
+        PadHoleLayer => "Pad Hole Layer" | "PadHoleLayer",
+        /// Via hole layer (ID 82).
+        ViaHoleLayer => "Via Hole Layer" | "ViaHoleLayer",
+        /// Top pad master layer (ID 83).
+        TopPadMaster => "Top Pad Master" | "TopPadMaster",
+        /// Bottom pad master layer (ID 84).
+        BottomPadMaster => "Bottom Pad Master" | "BottomPadMaster",
+        /// DRC detail layer (ID 85).
+        DRCDetailLayer => "DRC Detail Layer" | "DRCDetailLayer",
+        // Keep-out
+        /// Keep-out layer (ID 56).
+        KeepOut => "Keep-Out Layer" | "KeepOut",
+    }
 }
 
 impl Layer {
-    /// Returns the Altium layer name string.
+    /// Parses a layer from its Altium name (`Top Overlay`) or camel-case
+    /// alias (`TopOverlay`). Case and the spaces, hyphens and underscores
+    /// between words do not matter, so `top overlay`, `TOPOVERLAY` and
+    /// `mid-layer 3` parse too. Every tool that takes a layer name resolves
+    /// it here, so they all accept the same spellings.
     #[must_use]
-    #[allow(clippy::too_many_lines)] // Layer name lookup for all layers
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::TopLayer => "Top Layer",
-            Self::MidLayer1 => "Mid-Layer 1",
-            Self::MidLayer2 => "Mid-Layer 2",
-            Self::MidLayer3 => "Mid-Layer 3",
-            Self::MidLayer4 => "Mid-Layer 4",
-            Self::MidLayer5 => "Mid-Layer 5",
-            Self::MidLayer6 => "Mid-Layer 6",
-            Self::MidLayer7 => "Mid-Layer 7",
-            Self::MidLayer8 => "Mid-Layer 8",
-            Self::MidLayer9 => "Mid-Layer 9",
-            Self::MidLayer10 => "Mid-Layer 10",
-            Self::MidLayer11 => "Mid-Layer 11",
-            Self::MidLayer12 => "Mid-Layer 12",
-            Self::MidLayer13 => "Mid-Layer 13",
-            Self::MidLayer14 => "Mid-Layer 14",
-            Self::MidLayer15 => "Mid-Layer 15",
-            Self::MidLayer16 => "Mid-Layer 16",
-            Self::MidLayer17 => "Mid-Layer 17",
-            Self::MidLayer18 => "Mid-Layer 18",
-            Self::MidLayer19 => "Mid-Layer 19",
-            Self::MidLayer20 => "Mid-Layer 20",
-            Self::MidLayer21 => "Mid-Layer 21",
-            Self::MidLayer22 => "Mid-Layer 22",
-            Self::MidLayer23 => "Mid-Layer 23",
-            Self::MidLayer24 => "Mid-Layer 24",
-            Self::MidLayer25 => "Mid-Layer 25",
-            Self::MidLayer26 => "Mid-Layer 26",
-            Self::MidLayer27 => "Mid-Layer 27",
-            Self::MidLayer28 => "Mid-Layer 28",
-            Self::MidLayer29 => "Mid-Layer 29",
-            Self::MidLayer30 => "Mid-Layer 30",
-            Self::BottomLayer => "Bottom Layer",
-            Self::MultiLayer => "Multi-Layer",
-            Self::TopOverlay => "Top Overlay",
-            Self::BottomOverlay => "Bottom Overlay",
-            Self::TopSolder => "Top Solder",
-            Self::BottomSolder => "Bottom Solder",
-            Self::InternalPlane1 => "Internal Plane 1",
-            Self::InternalPlane2 => "Internal Plane 2",
-            Self::InternalPlane3 => "Internal Plane 3",
-            Self::InternalPlane4 => "Internal Plane 4",
-            Self::InternalPlane5 => "Internal Plane 5",
-            Self::InternalPlane6 => "Internal Plane 6",
-            Self::InternalPlane7 => "Internal Plane 7",
-            Self::InternalPlane8 => "Internal Plane 8",
-            Self::InternalPlane9 => "Internal Plane 9",
-            Self::InternalPlane10 => "Internal Plane 10",
-            Self::InternalPlane11 => "Internal Plane 11",
-            Self::InternalPlane12 => "Internal Plane 12",
-            Self::InternalPlane13 => "Internal Plane 13",
-            Self::InternalPlane14 => "Internal Plane 14",
-            Self::InternalPlane15 => "Internal Plane 15",
-            Self::InternalPlane16 => "Internal Plane 16",
-            Self::DrillGuide => "Drill Guide",
-            Self::DrillDrawing => "Drill Drawing",
-            Self::TopPaste => "Top Paste",
-            Self::BottomPaste => "Bottom Paste",
-            Self::TopAssembly => "Top Assembly",
-            Self::BottomAssembly => "Bottom Assembly",
-            Self::TopCourtyard => "Top Courtyard",
-            Self::BottomCourtyard => "Bottom Courtyard",
-            Self::Top3DBody => "Top 3D Body",
-            Self::Bottom3DBody => "Bottom 3D Body",
-            Self::Mechanical1 => "Mechanical 1",
-            Self::Mechanical2 => "Mechanical 2",
-            Self::Mechanical3 => "Mechanical 3",
-            Self::Mechanical4 => "Mechanical 4",
-            Self::Mechanical5 => "Mechanical 5",
-            Self::Mechanical6 => "Mechanical 6",
-            Self::Mechanical7 => "Mechanical 7",
-            Self::Mechanical8 => "Mechanical 8",
-            Self::Mechanical9 => "Mechanical 9",
-            Self::Mechanical10 => "Mechanical 10",
-            Self::Mechanical11 => "Mechanical 11",
-            Self::Mechanical12 => "Mechanical 12",
-            Self::Mechanical13 => "Mechanical 13",
-            Self::Mechanical14 => "Mechanical 14",
-            Self::Mechanical15 => "Mechanical 15",
-            Self::Mechanical16 => "Mechanical 16",
-            Self::Mechanical17 => "Mechanical 17",
-            Self::Mechanical18 => "Mechanical 18",
-            Self::Mechanical19 => "Mechanical 19",
-            Self::Mechanical20 => "Mechanical 20",
-            Self::Mechanical21 => "Mechanical 21",
-            Self::Mechanical22 => "Mechanical 22",
-            Self::Mechanical23 => "Mechanical 23",
-            Self::Mechanical24 => "Mechanical 24",
-            Self::Mechanical25 => "Mechanical 25",
-            Self::Mechanical26 => "Mechanical 26",
-            Self::Mechanical27 => "Mechanical 27",
-            Self::Mechanical28 => "Mechanical 28",
-            Self::Mechanical29 => "Mechanical 29",
-            Self::Mechanical30 => "Mechanical 30",
-            Self::Mechanical31 => "Mechanical 31",
-            Self::Mechanical32 => "Mechanical 32",
-            Self::ConnectLayer => "Connect Layer",
-            Self::BackgroundLayer => "Background Layer",
-            Self::DRCErrorLayer => "DRC Error Layer",
-            Self::HighlightLayer => "Highlight Layer",
-            Self::GridColor1 => "Grid Color 1",
-            Self::GridColor10 => "Grid Color 10",
-            Self::PadHoleLayer => "Pad Hole Layer",
-            Self::ViaHoleLayer => "Via Hole Layer",
-            Self::TopPadMaster => "Top Pad Master",
-            Self::BottomPadMaster => "Bottom Pad Master",
-            Self::DRCDetailLayer => "DRC Detail Layer",
-            Self::KeepOut => "Keep-Out Layer",
-        }
-    }
-
-    /// Parses a layer from its Altium name string.
-    #[must_use]
-    #[allow(clippy::too_many_lines)] // Layer name parsing for all layers
     pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "Top Layer" => Some(Self::TopLayer),
-            "Mid-Layer 1" => Some(Self::MidLayer1),
-            "Mid-Layer 2" => Some(Self::MidLayer2),
-            "Mid-Layer 3" => Some(Self::MidLayer3),
-            "Mid-Layer 4" => Some(Self::MidLayer4),
-            "Mid-Layer 5" => Some(Self::MidLayer5),
-            "Mid-Layer 6" => Some(Self::MidLayer6),
-            "Mid-Layer 7" => Some(Self::MidLayer7),
-            "Mid-Layer 8" => Some(Self::MidLayer8),
-            "Mid-Layer 9" => Some(Self::MidLayer9),
-            "Mid-Layer 10" => Some(Self::MidLayer10),
-            "Mid-Layer 11" => Some(Self::MidLayer11),
-            "Mid-Layer 12" => Some(Self::MidLayer12),
-            "Mid-Layer 13" => Some(Self::MidLayer13),
-            "Mid-Layer 14" => Some(Self::MidLayer14),
-            "Mid-Layer 15" => Some(Self::MidLayer15),
-            "Mid-Layer 16" => Some(Self::MidLayer16),
-            "Mid-Layer 17" => Some(Self::MidLayer17),
-            "Mid-Layer 18" => Some(Self::MidLayer18),
-            "Mid-Layer 19" => Some(Self::MidLayer19),
-            "Mid-Layer 20" => Some(Self::MidLayer20),
-            "Mid-Layer 21" => Some(Self::MidLayer21),
-            "Mid-Layer 22" => Some(Self::MidLayer22),
-            "Mid-Layer 23" => Some(Self::MidLayer23),
-            "Mid-Layer 24" => Some(Self::MidLayer24),
-            "Mid-Layer 25" => Some(Self::MidLayer25),
-            "Mid-Layer 26" => Some(Self::MidLayer26),
-            "Mid-Layer 27" => Some(Self::MidLayer27),
-            "Mid-Layer 28" => Some(Self::MidLayer28),
-            "Mid-Layer 29" => Some(Self::MidLayer29),
-            "Mid-Layer 30" => Some(Self::MidLayer30),
-            "Bottom Layer" => Some(Self::BottomLayer),
-            "Multi-Layer" => Some(Self::MultiLayer),
-            "Top Overlay" => Some(Self::TopOverlay),
-            "Bottom Overlay" => Some(Self::BottomOverlay),
-            "Top Solder" => Some(Self::TopSolder),
-            "Bottom Solder" => Some(Self::BottomSolder),
-            "Internal Plane 1" => Some(Self::InternalPlane1),
-            "Internal Plane 2" => Some(Self::InternalPlane2),
-            "Internal Plane 3" => Some(Self::InternalPlane3),
-            "Internal Plane 4" => Some(Self::InternalPlane4),
-            "Internal Plane 5" => Some(Self::InternalPlane5),
-            "Internal Plane 6" => Some(Self::InternalPlane6),
-            "Internal Plane 7" => Some(Self::InternalPlane7),
-            "Internal Plane 8" => Some(Self::InternalPlane8),
-            "Internal Plane 9" => Some(Self::InternalPlane9),
-            "Internal Plane 10" => Some(Self::InternalPlane10),
-            "Internal Plane 11" => Some(Self::InternalPlane11),
-            "Internal Plane 12" => Some(Self::InternalPlane12),
-            "Internal Plane 13" => Some(Self::InternalPlane13),
-            "Internal Plane 14" => Some(Self::InternalPlane14),
-            "Internal Plane 15" => Some(Self::InternalPlane15),
-            "Internal Plane 16" => Some(Self::InternalPlane16),
-            "Drill Guide" => Some(Self::DrillGuide),
-            "Drill Drawing" => Some(Self::DrillDrawing),
-            "Top Paste" => Some(Self::TopPaste),
-            "Bottom Paste" => Some(Self::BottomPaste),
-            "Top Assembly" => Some(Self::TopAssembly),
-            "Bottom Assembly" => Some(Self::BottomAssembly),
-            "Top Courtyard" => Some(Self::TopCourtyard),
-            "Bottom Courtyard" => Some(Self::BottomCourtyard),
-            "Top 3D Body" => Some(Self::Top3DBody),
-            "Bottom 3D Body" => Some(Self::Bottom3DBody),
-            "Mechanical 1" => Some(Self::Mechanical1),
-            "Mechanical 2" => Some(Self::Mechanical2),
-            "Mechanical 3" => Some(Self::Mechanical3),
-            "Mechanical 4" => Some(Self::Mechanical4),
-            "Mechanical 5" => Some(Self::Mechanical5),
-            "Mechanical 6" => Some(Self::Mechanical6),
-            "Mechanical 7" => Some(Self::Mechanical7),
-            "Mechanical 8" => Some(Self::Mechanical8),
-            "Mechanical 9" => Some(Self::Mechanical9),
-            "Mechanical 10" => Some(Self::Mechanical10),
-            "Mechanical 11" => Some(Self::Mechanical11),
-            "Mechanical 12" => Some(Self::Mechanical12),
-            "Mechanical 13" => Some(Self::Mechanical13),
-            "Mechanical 14" => Some(Self::Mechanical14),
-            "Mechanical 15" => Some(Self::Mechanical15),
-            "Mechanical 16" => Some(Self::Mechanical16),
-            "Mechanical 17" => Some(Self::Mechanical17),
-            "Mechanical 18" => Some(Self::Mechanical18),
-            "Mechanical 19" => Some(Self::Mechanical19),
-            "Mechanical 20" => Some(Self::Mechanical20),
-            "Mechanical 21" => Some(Self::Mechanical21),
-            "Mechanical 22" => Some(Self::Mechanical22),
-            "Mechanical 23" => Some(Self::Mechanical23),
-            "Mechanical 24" => Some(Self::Mechanical24),
-            "Mechanical 25" => Some(Self::Mechanical25),
-            "Mechanical 26" => Some(Self::Mechanical26),
-            "Mechanical 27" => Some(Self::Mechanical27),
-            "Mechanical 28" => Some(Self::Mechanical28),
-            "Mechanical 29" => Some(Self::Mechanical29),
-            "Mechanical 30" => Some(Self::Mechanical30),
-            "Mechanical 31" => Some(Self::Mechanical31),
-            "Mechanical 32" => Some(Self::Mechanical32),
-            "Connect Layer" => Some(Self::ConnectLayer),
-            "Background Layer" => Some(Self::BackgroundLayer),
-            "DRC Error Layer" => Some(Self::DRCErrorLayer),
-            "Highlight Layer" => Some(Self::HighlightLayer),
-            "Grid Color 1" => Some(Self::GridColor1),
-            "Grid Color 10" => Some(Self::GridColor10),
-            "Pad Hole Layer" => Some(Self::PadHoleLayer),
-            "Via Hole Layer" => Some(Self::ViaHoleLayer),
-            "Top Pad Master" => Some(Self::TopPadMaster),
-            "Bottom Pad Master" => Some(Self::BottomPadMaster),
-            "DRC Detail Layer" => Some(Self::DRCDetailLayer),
-            "Keep-Out Layer" => Some(Self::KeepOut),
-            _ => None,
-        }
+        let wanted = fold_layer_name(s);
+        Self::ALL.into_iter().find(|layer| {
+            fold_layer_name(layer.as_str()) == wanted || fold_layer_name(layer.alias()) == wanted
+        })
     }
+}
+
+/// A layer name without case, spaces, hyphens or underscores, so spellings
+/// that differ only in those compare equal.
+fn fold_layer_name(s: &str) -> String {
+    s.chars()
+        .filter(|c| !matches!(c, ' ' | '-' | '_'))
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::Layer;
 
-    /// Every `Layer` variant, mirroring the `as_str`/`parse` match arms.
-    const ALL: &[Layer] = &[
-        Layer::TopLayer,
-        Layer::MidLayer1,
-        Layer::MidLayer2,
-        Layer::MidLayer3,
-        Layer::MidLayer4,
-        Layer::MidLayer5,
-        Layer::MidLayer6,
-        Layer::MidLayer7,
-        Layer::MidLayer8,
-        Layer::MidLayer9,
-        Layer::MidLayer10,
-        Layer::MidLayer11,
-        Layer::MidLayer12,
-        Layer::MidLayer13,
-        Layer::MidLayer14,
-        Layer::MidLayer15,
-        Layer::MidLayer16,
-        Layer::MidLayer17,
-        Layer::MidLayer18,
-        Layer::MidLayer19,
-        Layer::MidLayer20,
-        Layer::MidLayer21,
-        Layer::MidLayer22,
-        Layer::MidLayer23,
-        Layer::MidLayer24,
-        Layer::MidLayer25,
-        Layer::MidLayer26,
-        Layer::MidLayer27,
-        Layer::MidLayer28,
-        Layer::MidLayer29,
-        Layer::MidLayer30,
-        Layer::BottomLayer,
-        Layer::MultiLayer,
-        Layer::TopOverlay,
-        Layer::BottomOverlay,
-        Layer::TopSolder,
-        Layer::BottomSolder,
-        Layer::InternalPlane1,
-        Layer::InternalPlane2,
-        Layer::InternalPlane3,
-        Layer::InternalPlane4,
-        Layer::InternalPlane5,
-        Layer::InternalPlane6,
-        Layer::InternalPlane7,
-        Layer::InternalPlane8,
-        Layer::InternalPlane9,
-        Layer::InternalPlane10,
-        Layer::InternalPlane11,
-        Layer::InternalPlane12,
-        Layer::InternalPlane13,
-        Layer::InternalPlane14,
-        Layer::InternalPlane15,
-        Layer::InternalPlane16,
-        Layer::DrillGuide,
-        Layer::DrillDrawing,
-        Layer::TopPaste,
-        Layer::BottomPaste,
-        Layer::TopAssembly,
-        Layer::BottomAssembly,
-        Layer::TopCourtyard,
-        Layer::BottomCourtyard,
-        Layer::Top3DBody,
-        Layer::Bottom3DBody,
-        Layer::Mechanical1,
-        Layer::Mechanical2,
-        Layer::Mechanical3,
-        Layer::Mechanical4,
-        Layer::Mechanical5,
-        Layer::Mechanical6,
-        Layer::Mechanical7,
-        Layer::Mechanical8,
-        Layer::Mechanical9,
-        Layer::Mechanical10,
-        Layer::Mechanical11,
-        Layer::Mechanical12,
-        Layer::Mechanical13,
-        Layer::Mechanical14,
-        Layer::Mechanical15,
-        Layer::Mechanical16,
-        Layer::Mechanical17,
-        Layer::Mechanical18,
-        Layer::Mechanical19,
-        Layer::Mechanical20,
-        Layer::Mechanical21,
-        Layer::Mechanical22,
-        Layer::Mechanical23,
-        Layer::Mechanical24,
-        Layer::Mechanical25,
-        Layer::Mechanical26,
-        Layer::Mechanical27,
-        Layer::Mechanical28,
-        Layer::Mechanical29,
-        Layer::Mechanical30,
-        Layer::Mechanical31,
-        Layer::Mechanical32,
-        Layer::ConnectLayer,
-        Layer::BackgroundLayer,
-        Layer::DRCErrorLayer,
-        Layer::HighlightLayer,
-        Layer::GridColor1,
-        Layer::GridColor10,
-        Layer::PadHoleLayer,
-        Layer::ViaHoleLayer,
-        Layer::TopPadMaster,
-        Layer::BottomPadMaster,
-        Layer::DRCDetailLayer,
-        Layer::KeepOut,
-    ];
+    const ALL: &[Layer] = &Layer::ALL;
 
     #[test]
     fn every_variant_round_trips_through_as_str_and_parse() {
@@ -726,6 +332,31 @@ mod tests {
         }
     }
 
+    /// Every spelling a caller may reach for resolves to the same layer: the
+    /// camel-case alias, the serde form, and the name in any case with or
+    /// without its separators.
+    #[test]
+    fn every_variant_parses_from_its_alias_and_folded_spellings() {
+        for layer in ALL {
+            let name = layer.as_str();
+            let alias = layer.alias();
+            assert_eq!(Layer::parse(alias), Some(*layer), "alias '{alias}'");
+            assert_eq!(
+                serde_json::from_value::<Layer>(serde_json::Value::String(alias.to_string())).ok(),
+                Some(*layer),
+                "serde alias '{alias}'"
+            );
+            for spelling in [
+                name.to_lowercase(),
+                name.to_uppercase(),
+                name.replace(' ', "_"),
+                name.replace([' ', '-'], ""),
+            ] {
+                assert_eq!(Layer::parse(&spelling), Some(*layer), "'{spelling}'");
+            }
+        }
+    }
+
     #[test]
     fn all_layer_names_are_unique() {
         let mut names: Vec<&str> = ALL.iter().map(Layer::as_str).collect();
@@ -739,9 +370,10 @@ mod tests {
     fn parse_rejects_unknown_names() {
         assert_eq!(Layer::parse(""), None);
         assert_eq!(Layer::parse("Not A Real Layer"), None);
-        // Layer::parse is exact — space-less aliases are not accepted here.
-        assert_eq!(Layer::parse("TopLayer"), None);
-        assert_eq!(Layer::parse("top layer"), None);
+        // A family prefix without its number, or past the family, is no layer.
+        assert_eq!(Layer::parse("MidLayer"), None);
+        assert_eq!(Layer::parse("Mechanical 33"), None);
+        assert_eq!(Layer::parse("Top"), None);
     }
 
     #[test]

--- a/src/mcp/tools/batch.rs
+++ b/src/mcp/tools/batch.rs
@@ -349,14 +349,14 @@ impl McpServer {
         };
 
         // Parse layer names (supports both "TopLayer" and "Top Layer" formats)
-        let Some(from_layer) = Self::parse_layer_name(from_layer_str) else {
+        let Some(from_layer) = crate::altium::pcblib::Layer::parse(from_layer_str) else {
             return ToolCallResult::error(format!(
                 "Invalid from_layer: '{from_layer_str}'. Use format like 'Top Layer', 'Bottom Layer', \
                  'Top Overlay', 'Mechanical 1', etc."
             ));
         };
 
-        let Some(to_layer) = Self::parse_layer_name(to_layer_str) else {
+        let Some(to_layer) = crate::altium::pcblib::Layer::parse(to_layer_str) else {
             return ToolCallResult::error(format!(
                 "Invalid to_layer: '{to_layer_str}'. Use format like 'Top Layer', 'Bottom Layer', \
                  'Top Overlay', 'Mechanical 1', etc."
@@ -416,45 +416,6 @@ impl McpServer {
         }
 
         ToolCallResult::text(serde_json::to_string_pretty(&result).unwrap())
-    }
-
-    /// Parses a layer name string, supporting both camelCase and spaced formats.
-    pub(crate) fn parse_layer_name(s: &str) -> Option<crate::altium::pcblib::Layer> {
-        use crate::altium::pcblib::Layer;
-
-        // First try direct parsing (handles "Top Layer" format)
-        if let Some(layer) = Layer::parse(s) {
-            return Some(layer);
-        }
-
-        // Convert camelCase to spaced format and try again
-        let spaced = match s {
-            "TopLayer" => "Top Layer",
-            "BottomLayer" => "Bottom Layer",
-            "TopOverlay" => "Top Overlay",
-            "BottomOverlay" => "Bottom Overlay",
-            "TopPaste" => "Top Paste",
-            "BottomPaste" => "Bottom Paste",
-            "TopSolder" => "Top Solder",
-            "BottomSolder" => "Bottom Solder",
-            "MultiLayer" => "Multi-Layer",
-            "KeepOutLayer" | "KeepOut" => "Keep-Out Layer",
-            s if s.starts_with("MidLayer") => {
-                let num = s.strip_prefix("MidLayer")?;
-                return Layer::parse(&format!("Mid-Layer {num}"));
-            }
-            s if s.starts_with("Mechanical") => {
-                let num = s.strip_prefix("Mechanical")?;
-                return Layer::parse(&format!("Mechanical {num}"));
-            }
-            s if s.starts_with("InternalPlane") => {
-                let num = s.strip_prefix("InternalPlane")?;
-                return Layer::parse(&format!("Internal Plane {num}"));
-            }
-            _ => return None,
-        };
-
-        Layer::parse(spaced)
     }
 }
 
@@ -939,25 +900,42 @@ mod tests {
         assert!(get_result_text(&result).contains("Invalid symbol_filter regex"));
     }
 
+    /// `rename_layer` resolves layer names exactly as every other tool does,
+    /// through `Layer::parse`: Altium's spelling, the camel-case alias, any
+    /// case.
     #[test]
-    fn parse_layer_name_accepts_both_formats() {
-        assert_eq!(
-            McpServer::parse_layer_name("Top Layer"),
-            Some(crate::altium::pcblib::Layer::TopLayer)
-        );
-        assert_eq!(
-            McpServer::parse_layer_name("BottomOverlay"),
-            Some(crate::altium::pcblib::Layer::BottomOverlay)
-        );
-        assert_eq!(
-            McpServer::parse_layer_name("Mechanical7"),
-            Some(crate::altium::pcblib::Layer::Mechanical7)
-        );
-        assert_eq!(
-            McpServer::parse_layer_name("MidLayer3"),
-            Some(crate::altium::pcblib::Layer::MidLayer3)
-        );
-        assert_eq!(McpServer::parse_layer_name("NotALayer"), None);
+    fn rename_layer_accepts_every_layer_spelling() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Spellings.PcbLib");
+        let mut lib = PcbLib::new();
+        let mut fp = Footprint::new("FP");
+        fp.add_track(Track::new(0.0, 0.0, 1.0, 0.0, 0.1, Layer::Mechanical13));
+        lib.add(fp);
+        lib.save(&path).unwrap();
+
+        for (from, to, expected) in [
+            ("mechanical13", "TopCourtyard", Layer::TopCourtyard),
+            ("Top Courtyard", "top-assembly", Layer::TopAssembly),
+            ("TopAssembly", "Mechanical 20", Layer::Mechanical20),
+        ] {
+            let result = server.call_batch_update(&json!({
+                "filepath": path.to_string_lossy(),
+                "operation": "rename_layer",
+                "parameters": { "from_layer": from, "to_layer": to },
+            }));
+            assert!(
+                !result.is_error,
+                "{from} -> {to}: {}",
+                get_result_text(&result)
+            );
+            let lib = PcbLib::open(&path).unwrap();
+            assert_eq!(
+                lib.get("FP").unwrap().tracks[0].layer,
+                expected,
+                "{from} -> {to}"
+            );
+        }
     }
 
     #[test]
@@ -1434,42 +1412,6 @@ mod tests {
                 block_save(&path, false);
                 assert!(r.is_error, "{operation}: {}", get_result_text(&r));
             }
-        }
-
-        // ---- parse_layer_name ----------------------------------------------------
-
-        #[test]
-        fn layer_names_are_accepted_in_camel_case_as_well_as_spaced() {
-            // The spaced form is Altium's own spelling; the camelCase form is
-            // what a caller reading the serde representation would reach for.
-            let cases = [
-                ("TopLayer", Layer::TopLayer),
-                ("BottomLayer", Layer::BottomLayer),
-                ("TopOverlay", Layer::TopOverlay),
-                ("BottomOverlay", Layer::BottomOverlay),
-                ("TopPaste", Layer::TopPaste),
-                ("BottomPaste", Layer::BottomPaste),
-                ("TopSolder", Layer::TopSolder),
-                ("BottomSolder", Layer::BottomSolder),
-                ("MultiLayer", Layer::MultiLayer),
-                ("KeepOutLayer", Layer::KeepOut),
-                ("KeepOut", Layer::KeepOut),
-                ("MidLayer1", Layer::MidLayer1),
-                ("Mechanical1", Layer::Mechanical1),
-            ];
-            for (name, expected) in cases {
-                assert_eq!(
-                    McpServer::parse_layer_name(name),
-                    Some(expected),
-                    "{name} should resolve"
-                );
-            }
-
-            // Numbered families resolve through the same suffix path.
-            assert!(McpServer::parse_layer_name("InternalPlane1").is_some());
-            // A prefix with no number behind it is not a layer.
-            assert_eq!(McpServer::parse_layer_name("MidLayer"), None);
-            assert_eq!(McpServer::parse_layer_name("Nowhere"), None);
         }
     }
 }

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -881,50 +881,6 @@ impl McpServer {
             ));
         };
 
-        // Parse layer from string if provided
-        // Use Layer::parse for exact Altium names (e.g., "Top Overlay")
-        // Also support common aliases for convenience
-        let parse_layer = |s: &str| -> Option<Layer> {
-            // First try exact parse (handles all Altium layer names like "Top Overlay")
-            if let Some(layer) = Layer::parse(s) {
-                return Some(layer);
-            }
-            // Fall back to common aliases (case-insensitive)
-            match s.to_lowercase().replace([' ', '-'], "").as_str() {
-                "toplayer" | "top" => Some(Layer::TopLayer),
-                "bottomlayer" | "bottom" => Some(Layer::BottomLayer),
-                "topoverlay" | "topsilk" => Some(Layer::TopOverlay),
-                "bottomoverlay" | "bottomsilk" => Some(Layer::BottomOverlay),
-                "multilayer" => Some(Layer::MultiLayer),
-                "topsolder" => Some(Layer::TopSolder),
-                "bottomsolder" => Some(Layer::BottomSolder),
-                "toppaste" => Some(Layer::TopPaste),
-                "bottompaste" => Some(Layer::BottomPaste),
-                "topassembly" => Some(Layer::TopAssembly),
-                "bottomassembly" => Some(Layer::BottomAssembly),
-                "top3dbody" => Some(Layer::Top3DBody),
-                "bottom3dbody" => Some(Layer::Bottom3DBody),
-                "keepout" | "keepoutlayer" => Some(Layer::KeepOut),
-                s if s.starts_with("mechanical") => {
-                    // Numbered families delegate to Layer::parse via the
-                    // canonical Altium name, so the Layer enum stays the single
-                    // source of truth: a variant added there is picked up here
-                    // automatically, and out-of-range numbers fall out as None.
-                    let num: u8 = s.strip_prefix("mechanical")?.parse().ok()?;
-                    Layer::parse(&format!("Mechanical {num}"))
-                }
-                s if s.starts_with("midlayer") => {
-                    let num: u8 = s.strip_prefix("midlayer")?.parse().ok()?;
-                    Layer::parse(&format!("Mid-Layer {num}"))
-                }
-                s if s.starts_with("internalplane") => {
-                    let num: u8 = s.strip_prefix("internalplane")?.parse().ok()?;
-                    Layer::parse(&format!("Internal Plane {num}"))
-                }
-                _ => None,
-            }
-        };
-
         let mut changes: Vec<Value> = Vec::new();
 
         match primitive_type {
@@ -959,7 +915,7 @@ impl McpServer {
                     track.width = width;
                 }
                 if let Some(layer_str) = updates.get("layer").and_then(Value::as_str) {
-                    if let Some(layer) = parse_layer(layer_str) {
+                    if let Some(layer) = Layer::parse(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", track.layer), "new": layer_str}));
                         track.layer = layer;
                         // A header byte carried from the read names the old
@@ -1015,7 +971,7 @@ impl McpServer {
                     arc.width = width;
                 }
                 if let Some(layer_str) = updates.get("layer").and_then(Value::as_str) {
-                    if let Some(layer) = parse_layer(layer_str) {
+                    if let Some(layer) = Layer::parse(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", arc.layer), "new": layer_str}));
                         arc.layer = layer;
                         // A header byte carried from the read names the old
@@ -1061,7 +1017,7 @@ impl McpServer {
                     text.text = content.to_string();
                 }
                 if let Some(layer_str) = updates.get("layer").and_then(Value::as_str) {
-                    if let Some(layer) = parse_layer(layer_str) {
+                    if let Some(layer) = Layer::parse(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", text.layer), "new": layer_str}));
                         text.layer = layer;
                         // A header byte carried from the read names the old
@@ -1113,7 +1069,7 @@ impl McpServer {
                     fill.rotation = rotation;
                 }
                 if let Some(layer_str) = updates.get("layer").and_then(Value::as_str) {
-                    if let Some(layer) = parse_layer(layer_str) {
+                    if let Some(layer) = Layer::parse(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", fill.layer), "new": layer_str}));
                         fill.layer = layer;
                         // A header byte carried from the read names the old
@@ -1136,7 +1092,7 @@ impl McpServer {
 
                 // Regions mainly have vertices and layer
                 if let Some(layer_str) = updates.get("layer").and_then(Value::as_str) {
-                    if let Some(layer) = parse_layer(layer_str) {
+                    if let Some(layer) = Layer::parse(layer_str) {
                         changes.push(json!({"property": "layer", "old": format!("{:?}", region.layer), "new": layer_str}));
                         region.layer = layer;
                         // A replayed V7_LAYER token names the layer the region
@@ -1197,7 +1153,7 @@ impl McpServer {
                 }
                 for (key, is_from) in [("from_layer", true), ("to_layer", false)] {
                     if let Some(layer_str) = updates.get(key).and_then(Value::as_str) {
-                        let Some(layer) = parse_layer(layer_str) else {
+                        let Some(layer) = Layer::parse(layer_str) else {
                             return ToolCallResult::error(format!("Invalid layer: {layer_str}"));
                         };
                         let old = if is_from {

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -234,6 +234,13 @@ fn json_guidless_opt(json: &Value, key: &str) -> Option<String> {
 
 /// Accepted pad-shape spellings, quoted in every shape error so the two tools
 /// give identical guidance.
+/// The spellings every layer-name field accepts; appended to each "invalid
+/// layer" error so a caller learns the rule, not just the rejection.
+pub const LAYER_NAME_HELP: &str =
+    "Valid layer names are Altium's ('Top Overlay', 'Mechanical 13', \
+                                   'Mid-Layer 2') or the camel-case form ('TopOverlay', \
+                                   'Mechanical13', 'MidLayer2'), in any case.";
+
 pub const PAD_SHAPE_HELP: &str = "Valid shapes are: rectangle (or rectangular), round (or \
      circle), oval, octagonal, rounded_rectangle. Matching is case-insensitive and ignores \
      '_'/'-' separators.";
@@ -1026,10 +1033,7 @@ impl McpServer {
         let layer_str = json.get("layer").and_then(Value::as_str);
         let layer = match layer_str {
             Some(s) => Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Pad '{designator}' has invalid layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Multi-Layer, Top Overlay, etc."
-                )
+                format!("Pad '{designator}' has invalid layer '{s}'. {LAYER_NAME_HELP}")
             })?,
             // SMD pads default to Top Layer, through-hole pads default to Multi-Layer
             None => {
@@ -1273,12 +1277,8 @@ impl McpServer {
 
         let layer_str = json.get("layer").and_then(Value::as_str);
         let layer = match layer_str {
-            Some(s) => Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Track has invalid layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Top Overlay, Top Assembly, etc."
-                )
-            })?,
+            Some(s) => Layer::parse(s)
+                .ok_or_else(|| format!("Track has invalid layer '{s}'. {LAYER_NAME_HELP}"))?,
             None => Layer::TopOverlay, // Default for tracks is Top Overlay
         };
 
@@ -1328,12 +1328,8 @@ impl McpServer {
 
         let layer_str = json.get("layer").and_then(Value::as_str);
         let layer = match layer_str {
-            Some(s) => Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Arc has invalid layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Top Overlay, Top Assembly, etc."
-                )
-            })?,
+            Some(s) => Layer::parse(s)
+                .ok_or_else(|| format!("Arc has invalid layer '{s}'. {LAYER_NAME_HELP}"))?,
             None => Layer::TopOverlay, // Default for arcs is Top Overlay
         };
 
@@ -1840,20 +1836,12 @@ impl McpServer {
         let mut via = Via::new(x, y, diameter, hole_size);
 
         if let Some(s) = json.get("from_layer").and_then(Value::as_str) {
-            via.from_layer = Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Via has invalid from_layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Mid-Layer 1, etc."
-                )
-            })?;
+            via.from_layer = Layer::parse(s)
+                .ok_or_else(|| format!("Via has invalid from_layer '{s}'. {LAYER_NAME_HELP}"))?;
         }
         if let Some(s) = json.get("to_layer").and_then(Value::as_str) {
-            via.to_layer = Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Via has invalid to_layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Mid-Layer 1, etc."
-                )
-            })?;
+            via.to_layer = Layer::parse(s)
+                .ok_or_else(|| format!("Via has invalid to_layer '{s}'. {LAYER_NAME_HELP}"))?;
         }
 
         if let Some(v) = json.get("solder_mask_expansion").and_then(Value::as_f64) {
@@ -2002,12 +1990,8 @@ impl McpServer {
 
         let layer_str = json.get("layer").and_then(Value::as_str);
         let layer = match layer_str {
-            Some(s) => Layer::parse(s).ok_or_else(|| {
-                format!(
-                    "Fill has invalid layer '{s}'. \
-                     Valid layers include: Top Layer, Bottom Layer, Top Overlay, Mechanical 1, etc."
-                )
-            })?,
+            Some(s) => Layer::parse(s)
+                .ok_or_else(|| format!("Fill has invalid layer '{s}'. {LAYER_NAME_HELP}"))?,
             None => Layer::TopLayer, // Default for fills is Top Layer
         };
 

--- a/src/mcp/tools/validation.rs
+++ b/src/mcp/tools/validation.rs
@@ -63,56 +63,105 @@ impl McpServer {
         Ok(())
     }
 
-    /// Validates all coordinates in a footprint before writing.
+    /// Validates every coordinate and size a footprint will write, kind by
+    /// kind from the enum, so a primitive kind cannot go unchecked: a value
+    /// past the safe range would otherwise saturate on save and land in the
+    /// file silently wrong.
     pub(crate) fn validate_footprint_coordinates(
         footprint: &crate::altium::pcblib::Footprint,
     ) -> Result<(), String> {
+        for kind in crate::altium::pcblib::PrimitiveKind::WRITE_ORDER {
+            Self::validate_footprint_kind(footprint, kind)?;
+        }
+        Ok(())
+    }
+
+    /// The range checks of one primitive kind.
+    fn validate_footprint_kind(
+        footprint: &crate::altium::pcblib::Footprint,
+        kind: crate::altium::pcblib::PrimitiveKind,
+    ) -> Result<(), String> {
+        use crate::altium::pcblib::PrimitiveKind;
+
         let name = &footprint.name;
-
-        for (i, pad) in footprint.pads.iter().enumerate() {
-            Self::validate_coordinate(pad.x, &format!("Footprint '{name}' pad {i} x"))?;
-            Self::validate_coordinate(pad.y, &format!("Footprint '{name}' pad {i} y"))?;
-            Self::validate_coordinate(pad.width, &format!("Footprint '{name}' pad {i} width"))?;
-            Self::validate_coordinate(pad.height, &format!("Footprint '{name}' pad {i} height"))?;
-            if let Some(hole) = pad.hole_size {
-                Self::validate_coordinate(hole, &format!("Footprint '{name}' pad {i} hole_size"))?;
+        let check = |value: f64, index: usize, field: &str| {
+            Self::validate_coordinate(
+                value,
+                &format!("Footprint '{name}' {} {index} {field}", kind.name()),
+            )
+        };
+        match kind {
+            PrimitiveKind::Pad => {
+                for (i, pad) in footprint.pads.iter().enumerate() {
+                    check(pad.x, i, "x")?;
+                    check(pad.y, i, "y")?;
+                    check(pad.width, i, "width")?;
+                    check(pad.height, i, "height")?;
+                    if let Some(hole) = pad.hole_size {
+                        check(hole, i, "hole_size")?;
+                    }
+                }
+            }
+            PrimitiveKind::Via => {
+                for (i, via) in footprint.vias.iter().enumerate() {
+                    check(via.x, i, "x")?;
+                    check(via.y, i, "y")?;
+                    check(via.diameter, i, "diameter")?;
+                    check(via.hole_size, i, "hole_size")?;
+                }
+            }
+            PrimitiveKind::Track => {
+                for (i, track) in footprint.tracks.iter().enumerate() {
+                    check(track.x1, i, "x1")?;
+                    check(track.y1, i, "y1")?;
+                    check(track.x2, i, "x2")?;
+                    check(track.y2, i, "y2")?;
+                    check(track.width, i, "width")?;
+                }
+            }
+            PrimitiveKind::Arc => {
+                for (i, arc) in footprint.arcs.iter().enumerate() {
+                    check(arc.x, i, "x")?;
+                    check(arc.y, i, "y")?;
+                    check(arc.radius, i, "radius")?;
+                    check(arc.width, i, "width")?;
+                }
+            }
+            PrimitiveKind::Region => {
+                for (i, region) in footprint.regions.iter().enumerate() {
+                    for (j, vertex) in region.vertices.iter().enumerate() {
+                        check(vertex.x, i, &format!("vertex {j} x"))?;
+                        check(vertex.y, i, &format!("vertex {j} y"))?;
+                    }
+                }
+            }
+            PrimitiveKind::Text => {
+                for (i, text) in footprint.text.iter().enumerate() {
+                    check(text.x, i, "x")?;
+                    check(text.y, i, "y")?;
+                    check(text.height, i, "height")?;
+                }
+            }
+            PrimitiveKind::Fill => {
+                for (i, fill) in footprint.fills.iter().enumerate() {
+                    check(fill.x1, i, "x1")?;
+                    check(fill.y1, i, "y1")?;
+                    check(fill.x2, i, "x2")?;
+                    check(fill.y2, i, "y2")?;
+                }
+            }
+            PrimitiveKind::ComponentBody => {
+                for (i, body) in footprint.component_bodies.iter().enumerate() {
+                    for (j, (x, y)) in body.outline.iter().enumerate() {
+                        check(*x, i, &format!("outline {j} x"))?;
+                        check(*y, i, &format!("outline {j} y"))?;
+                    }
+                    check(body.overall_height, i, "overall_height")?;
+                    check(body.standoff_height, i, "standoff_height")?;
+                    check(body.z_offset, i, "z_offset")?;
+                }
             }
         }
-
-        for (i, track) in footprint.tracks.iter().enumerate() {
-            Self::validate_coordinate(track.x1, &format!("Footprint '{name}' track {i} x1"))?;
-            Self::validate_coordinate(track.y1, &format!("Footprint '{name}' track {i} y1"))?;
-            Self::validate_coordinate(track.x2, &format!("Footprint '{name}' track {i} x2"))?;
-            Self::validate_coordinate(track.y2, &format!("Footprint '{name}' track {i} y2"))?;
-            Self::validate_coordinate(track.width, &format!("Footprint '{name}' track {i} width"))?;
-        }
-
-        for (i, arc) in footprint.arcs.iter().enumerate() {
-            Self::validate_coordinate(arc.x, &format!("Footprint '{name}' arc {i} x"))?;
-            Self::validate_coordinate(arc.y, &format!("Footprint '{name}' arc {i} y"))?;
-            Self::validate_coordinate(arc.radius, &format!("Footprint '{name}' arc {i} radius"))?;
-            Self::validate_coordinate(arc.width, &format!("Footprint '{name}' arc {i} width"))?;
-        }
-
-        for (i, region) in footprint.regions.iter().enumerate() {
-            for (j, vertex) in region.vertices.iter().enumerate() {
-                Self::validate_coordinate(
-                    vertex.x,
-                    &format!("Footprint '{name}' region {i} vertex {j} x"),
-                )?;
-                Self::validate_coordinate(
-                    vertex.y,
-                    &format!("Footprint '{name}' region {i} vertex {j} y"),
-                )?;
-            }
-        }
-
-        for (i, text) in footprint.text.iter().enumerate() {
-            Self::validate_coordinate(text.x, &format!("Footprint '{name}' text {i} x"))?;
-            Self::validate_coordinate(text.y, &format!("Footprint '{name}' text {i} y"))?;
-            Self::validate_coordinate(text.height, &format!("Footprint '{name}' text {i} height"))?;
-        }
-
         Ok(())
     }
 
@@ -468,6 +517,88 @@ mod tests {
             let r = server.call_write_schlib(&json!({
                 "filepath": path.to_string_lossy(),
                 "symbols": [symbol],
+            }));
+            let text = get_result_text(&r);
+            assert!(r.is_error, "{family} was not range-checked: {text}");
+            assert!(
+                text.contains(expected),
+                "{family}: expected the error to name {expected:?}, got: {text}"
+            );
+        }
+    }
+
+    /// Every footprint primitive kind has its coordinates and sizes
+    /// range-checked — a kind the validator skipped would saturate on save.
+    #[test]
+    fn every_footprint_primitive_kind_has_its_coordinates_range_checked() {
+        use crate::altium::pcblib::PrimitiveKind;
+        use crate::mcp::tools::test_support::{create_test_server, get_result_text, test_temp_dir};
+        use serde_json::json;
+
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let path = dir.path().join("Far.PcbLib");
+
+        let cases: [(PrimitiveKind, &str, serde_json::Value, &str); PrimitiveKind::COUNT] = [
+            (
+                PrimitiveKind::Pad,
+                "pads",
+                json!([{ "designator": "1", "x": FAR, "y": 0, "width": 1, "height": 1 }]),
+                "pad 0 x",
+            ),
+            (
+                PrimitiveKind::Via,
+                "vias",
+                json!([{ "x": 0, "y": FAR, "diameter": 0.6, "hole_size": 0.3 }]),
+                "via 0 y",
+            ),
+            (
+                PrimitiveKind::Track,
+                "tracks",
+                json!([{ "x1": 0, "y1": 0, "x2": FAR, "y2": 0, "width": 0.2, "layer": "TopOverlay" }]),
+                "track 0 x2",
+            ),
+            (
+                PrimitiveKind::Arc,
+                "arcs",
+                json!([{ "x": 0, "y": 0, "radius": FAR, "start_angle": 0, "end_angle": 360, "width": 0.2, "layer": "TopOverlay" }]),
+                "arc 0 radius",
+            ),
+            (
+                PrimitiveKind::Text,
+                "text",
+                json!([{ "x": 0, "y": 0, "text": "T", "height": FAR, "layer": "TopOverlay" }]),
+                "text 0 height",
+            ),
+            (
+                PrimitiveKind::Region,
+                "regions",
+                json!([{ "vertices": [{ "x": 0, "y": 0 }, { "x": 1, "y": 0 }, { "x": FAR, "y": 1 }], "layer": "TopCourtyard" }]),
+                "region 0 vertex 2 x",
+            ),
+            (
+                PrimitiveKind::Fill,
+                "fills",
+                json!([{ "x1": 0, "y1": 0, "x2": 1, "y2": FAR, "layer": "TopOverlay" }]),
+                "fill 0 y2",
+            ),
+            (
+                PrimitiveKind::ComponentBody,
+                "component_bodies",
+                json!([{ "outline": [[0, 0], [1, 0], [1, FAR]], "overall_height": 1 }]),
+                "component_body 0 outline 2 y",
+            ),
+        ];
+        let covered: std::collections::BTreeSet<&str> =
+            cases.iter().map(|(kind, ..)| kind.name()).collect();
+        assert_eq!(covered.len(), PrimitiveKind::COUNT, "one case per kind");
+
+        for (_, family, payload, expected) in cases {
+            let mut footprint = json!({ "name": "FAR" });
+            footprint[family] = payload;
+            let r = server.call_write_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+                "footprints": [footprint],
             }));
             let text = get_result_text(&r);
             assert!(r.is_error, "{family} was not range-checked: {text}");


### PR DESCRIPTION
## Summary

Two bugs, found together while testing the first.

**#61 — the write-path range check skipped vias, fills and bodies.** `validate_footprint_coordinates` covered pads, tracks, arcs, regions and text; a via, fill or component-body outline past ±5000 mm saturated in `from_mm` on save and landed in the file silently wrong. The check now runs kind by kind from `PrimitiveKind::WRITE_ORDER` (exhaustive match — a new kind is a compile error until it is placed), with vias (x, y, diameter, hole), fills (corners) and bodies (outline, heights, z offset) added. `every_footprint_primitive_kind_has_its_coordinates_range_checked` holds one out-of-range case per kind against `write_pcblib`, the twin of the existing symbol test.

**#62 — four layer-name parsers disagreed.** serde (`import_library`) accepted `Top Overlay` and `TopOverlay`; `Layer::parse` (`write_pcblib`, `update_pad`) only `Top Overlay`; batch `rename_layer` had its own camel-case table that knew `TopOverlay` but not `TopAssembly`, `TopCourtyard`, `Top3DBody`, `DrillGuide`…; `update_primitive` folded case and separators and knew undocumented extras (`top`, `topsilk`). So `TopOverlay` imported but would not write, and a layer could be renamed *to* `TopCourtyard` but not *from* it.

Fix, structural: `Layer` is declared by a `layers!` list (doc, name, alias per variant — the 107 variants unchanged) that also generates `ALL`, `as_str` and `alias()`; the hand-written 107-arm `as_str`/`parse` matches and the test-only `ALL` list are gone. `Layer::parse` folds case, spaces, hyphens and underscores and matches either spelling, and every tool resolves through it (batch's and update_primitive's private parsers deleted). The six "invalid layer" messages share `LAYER_NAME_HELP`. README states the accepted spellings and corrects the mechanical range to 1–32.

## Verification

- New: per-kind range guard; `every_variant_parses_from_its_alias_and_folded_spellings` (all 107 × alias / serde alias / lower / upper / underscored / separator-free); `rename_layer_accepts_every_layer_spelling` end-to-end
- fmt / clippy `-D warnings` / rustdoc `-D warnings` / markdownlint clean; **1487 tests** green

🤖 Generated with [Claude Code](https://claude.com/claude-code)