### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Everything in this section is the result of one campaign: hold the library
+## [0.2.0] - 2026-08-24
+
+Everything in this release is the result of one campaign: hold the library
 files we write to exactly what Altium itself writes, and refuse — rather than
 quietly reinterpret — anything a caller gets wrong.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "altium-designer-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altium-designer-mcp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "altium-designer-mcp",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "altium-designer-mcp",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "devDependencies": {
                 "markdownlint-cli2": "^0.23.2"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "altium-designer-mcp",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "private": true,
     "description": "An AI-operated Altium Designer libraries editor.",
     "scripts": {


### PR DESCRIPTION
## Summary

Release prep for the **v0.2.0 pre-release** (step 3 of docs/RELEASING.md):

- CHANGELOG `[Unreleased]` stamped as `## [0.2.0] - 2026-08-24`, fresh empty `[Unreleased]` opened above it — the stamped text becomes the GitHub release notes verbatim
- Version `0.1.0` → `0.2.0` in `Cargo.toml`, `Cargo.lock`, `package.json`, `package-lock.json` (the tag and the crate version must agree or the release workflow's `validate` job fails)

No code changes. After this merges: one more dry run on the release commit, then the signed `v0.2.0` tag.

## Verification

- Full suite green on the release commit (**1488 tests**); markdownlint clean
- Release dry run on current main: green across all three platforms (run 32654681032)

🤖 Generated with [Claude Code](https://claude.com/claude-code)