### PR TITLE
docs: keep the old client-guide addresses working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The old `docs/CLAUDE_CODE_GUIDE.md` and `docs/ANTIGRAVITY_GUIDE.md` addresses,
+  still linked from search results and MCP directories, point at the merged
+  `docs/CLIENT_SETUP.md` instead of a missing page.
+
 ## [0.2.0] - 2026-08-24
 
 Everything in this release is the result of one campaign: hold the library

--- a/docs/ANTIGRAVITY_GUIDE.md
+++ b/docs/ANTIGRAVITY_GUIDE.md
@@ -1,0 +1,8 @@
+# This guide has moved
+
+The Google Antigravity setup for `altium-designer-mcp` now lives in
+[**CLIENT_SETUP.md § Google Antigravity**](CLIENT_SETUP.md#google-antigravity),
+alongside the verified wiring for every other MCP client. What to do once the
+server is connected — workflows, prompts and tips — is in [USAGE.md](USAGE.md).
+
+This page stays only so that links to the old address keep working.

--- a/docs/CLAUDE_CODE_GUIDE.md
+++ b/docs/CLAUDE_CODE_GUIDE.md
@@ -1,0 +1,8 @@
+# This guide has moved
+
+The Claude Code setup for `altium-designer-mcp` now lives in
+[**CLIENT_SETUP.md § Claude Code**](CLIENT_SETUP.md#claude-code), alongside the
+verified wiring for every other MCP client. What to do once the server is
+connected — workflows, prompts and tips — is in [USAGE.md](USAGE.md).
+
+This page stays only so that links to the old address keep working.


### PR DESCRIPTION
## Summary

Repo traffic for the last 14 days shows `docs/CLAUDE_CODE_GUIDE.md` as the **third most-visited path — 43 views from 35 unique visitors** — arriving from search engines and MCP directory listings. That file was deleted in #429 when the per-client guides merged into `docs/CLIENT_SETUP.md`, so every one of those visitors landed on a 404. `docs/ANTIGRAVITY_GUIDE.md` went in the same PR and sits in the same listings.

Both old addresses now hold a short page pointing at the matching section of `CLIENT_SETUP.md` and at `USAGE.md`, stating plainly that they exist only to keep old links working. They are not added to the README documentation index — they are redirects, not docs. CHANGELOG `[Unreleased]` notes it.

## Verification

- `lychee --offline --include-fragments`: 4 links OK (both section anchors resolve)
- markdownlint clean on the two stubs and the CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)