### PR TITLE
fix(schlib): write a symbol's body graphics behind its pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A solid symbol body no longer paints over the pin names inside it.**
+  `write_schlib` recorded the order it happened to parse its input in — pins
+  before rectangles — and replayed that as if it were an authoring order, so a
+  `"filled": true` body went out after the pins and hid their names. Symbols
+  authored from JSON now take the canonical write order, which leads with the
+  body graphics. An explicit `primitive_order` (as `read_schlib` echoes for a
+  read-modify-write) still overrides it, unchanged.
 - The old `docs/CLAUDE_CODE_GUIDE.md` and `docs/ANTIGRAVITY_GUIDE.md` addresses,
   still linked from search results and MCP directories, point at the merged
   `docs/CLIENT_SETUP.md` instead of a missing page.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -43,6 +43,15 @@ Overbar (active-low) pin names use a backslash **after** each barred character
 conventions and examples:
 [AI_WORKFLOW.md § Symbol Pin Conventions](AI_WORKFLOW.md#symbol-pin-conventions).
 
+## Symbol draw order
+
+Schematic records render in the order they are stored, so a filled body drawn
+after a pin hides that pin's name. You do not have to manage this: a symbol you
+author from JSON is written body-graphics-first, so `"filled": true` bodies sit
+behind their pin names. Keep bodies solid — a transparent body is not the fix
+for hidden pin names. Supply `primitive_order` only to reproduce an order you
+read off an existing file; it overrides the default.
+
 ## Filesystem sandbox
 
 Only paths inside the configured `allowed_paths` (see `config.json`) can be read

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -918,13 +918,23 @@ impl McpServer {
         // The interleaved record order `read_schlib` reported; replaying it
         // replaces the grouped order the add_* calls accumulated, so a
         // read-modify-write keeps the source's record order.
-        if let Some(order) = sym_json.get("primitive_order") {
-            match serde_json::from_value(order.clone()) {
+        //
+        // With no order to replay the accumulated one is discarded rather than
+        // kept: the add_* calls above ran in this function's parse order, which
+        // takes pins before rectangles. That is not an authoring order, and
+        // emitting it writes a solid-filled body *after* the pins it encloses,
+        // where it paints over their names. Clearing hands the sequence back to
+        // `SchPrimitiveKind::WRITE_ORDER`, which leads with the body graphics
+        // for exactly this reason.
+        match sym_json.get("primitive_order") {
+            Some(order) => match serde_json::from_value(order.clone()) {
                 Ok(kinds) => symbol.primitive_order = kinds,
                 Err(e) => {
                     tracing::debug!(error = %e, "invalid primitive_order; using default order");
+                    symbol.primitive_order.clear();
                 }
-            }
+            },
+            None => symbol.primitive_order.clear(),
         }
 
         // Out-of-range or non-finite geometry is refused here so both tools

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -2734,6 +2734,50 @@ mod tests {
             assert_eq!(symbol_after["part_id_locked"], true);
         }
 
+        /// A JSON-authored symbol has no authoring order to replay, so it
+        /// takes `SchPrimitiveKind::WRITE_ORDER` — body graphics first. The
+        /// parse order (pins, then rectangles) must not leak out as one: the
+        /// records render in stream order, so a solid-filled body emitted
+        /// after the pins paints over the pin names inside it.
+        #[test]
+        fn a_json_authored_symbol_writes_its_filled_body_before_the_pins() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+
+            let sch = dir.path().join("Body.SchLib");
+            let write = server.call_write_schlib(&json!({
+                "filepath": sch.to_string_lossy(),
+                "symbols": [{
+                    "name": "BODY",
+                    "pins": [
+                        { "designator": "1", "name": "VIN", "x": -50, "y": 20,
+                          "length": 30, "orientation": "left" },
+                        { "designator": "2", "name": "GND", "x": 50, "y": 20,
+                          "length": 30, "orientation": "right" },
+                    ],
+                    "rectangles": [
+                        { "x1": -50, "y1": 40, "x2": 50, "y2": -40, "filled": true },
+                    ],
+                }],
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+
+            let read = server.call_read_schlib(&json!({
+                "filepath": sch.to_string_lossy(),
+            }));
+            assert!(!read.is_error, "{}", get_result_text(&read));
+            let symbol = parse_result_json(&read)["symbols"][0].clone();
+            assert_eq!(
+                symbol["primitive_order"],
+                json!(["rectangle", "pin", "pin"]),
+                "the filled body must precede the pins it encloses"
+            );
+            assert_eq!(
+                symbol["rectangles"][0]["filled"], true,
+                "the body stays filled — transparency is not the fix"
+            );
+        }
+
         /// A malformed `primitive_order` is ignored with the default grouped
         /// order rather than failing the write — it is advisory, exactly as
         /// on the struct.


### PR DESCRIPTION
## The bug

A symbol authored through `write_schlib` with a `"filled": true` rectangle comes
out with the body drawn **after** its pins. Schematic records render in stream
order, so the fill paints over every pin name inside the body.

From a library a colleague built with the v0.2.0 binary — 21 pins, then the body:

```
  0  RECORD=1     (component header)
  1..21            21 binary PIN records
 22  RECORD=14    rectangle
```

Reproduced on current `main` with a two-pin control symbol:

```
  0  RECORD=1
  1  BIN(pin) VIN
  2  BIN(pin) GND
  3  RECORD=14  ...|IsSolid=T|...
```

Callers read this as "pin names can't sit on top of the body" and work around it
by making bodies transparent, which is the wrong fix for the wrong problem.

## Cause

`SchPrimitiveKind::WRITE_ORDER` already leads with the rectangles, and says why:

> The write order leads with rectangles so a solid-filled body sits behind the
> pins; emitting pins first would let the body paint over the pin names inside it.

That order is unreachable from `write_schlib`. `parse_symbol_json` parses pins
before rectangles, each `add_*` appends its kind to `Symbol::primitive_order`,
and `write_sequence()` replays `primitive_order` verbatim — falling back to
`WRITE_ORDER` only for kinds the recorded sequence never reaches. The parser was
filling that field with its own argument-parsing order, indistinguishable from a
real authoring order read off a file.

Introduced by `b6e89bf`, so it affects both v0.1.0 and v0.2.0.

## Fix

Discard the accumulated order when the caller supplied none, handing the sequence
back to `WRITE_ORDER`. An explicit `primitive_order` — what `read_schlib` echoes,
so a read-modify-write keeps its source's interleaving — still wins, unchanged;
`write_schlib_replays_the_symbol_primitive_order` covers that and still passes.

## Test

`a_json_authored_symbol_writes_its_filled_body_before_the_pins` writes a symbol
with two pins and a filled rectangle, reads it back and asserts the record order
is `["rectangle", "pin", "pin"]` with the body still filled. Without the fix it
fails with the bug verbatim:

```
assertion `left == right` failed: the filled body must precede the pins it encloses
  left: Array [String("pin"), String("pin"), String("rectangle")]
 right: Array [String("rectangle"), String("pin"), String("pin")]
```

## Deliberately not changed

The footprint parser has the same shape — it parses in an order that differs from
`PrimitiveKind::WRITE_ORDER`. Left alone: PCB rendering is governed by layer, not
record order, so there is no correctness claim to restore and no reason to churn
the bytes.

## Also

`docs/AGENT_GUIDE.md` gains a short **Symbol draw order** section. It is embedded
into the `initialize` response, so binary-only users get the "keep bodies solid,
this is handled for you" note without reading source — which is what would have
saved the colleague above.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and
`cargo test` all clean (1234 lib tests). One unrelated pre-existing flake on my
machine: `perf_pcblib_save_100_footprints` runs 2.0–2.8s against a 2s debug-build
threshold, and fails the same way on unmodified `main` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
