### PR TITLE
fix: build a library in memory and read and write the file once

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -171,6 +171,12 @@ jobs:
             - name: Run tests
               run: cargo test --locked --verbose
 
+            # The absolute timing bounds in tests/perf_tests.rs are asserted
+            # only in an optimised build (a debug build measures the build,
+            # not the code); the release artefacts above make this cheap.
+            - name: Run performance bounds (release)
+              run: cargo test --locked --release --test perf_tests -- --nocapture
+
             # Independent-reader check that generated files are Altium-readable
             # (issue #68). Install is best-effort; the harness skips cleanly if
             # pyaltiumlib is unavailable and only fails on a NEW regression.

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -166,6 +166,12 @@ jobs:
             - name: Run tests
               run: cargo test --locked --verbose
 
+            # The absolute timing bounds in tests/perf_tests.rs are asserted
+            # only in an optimised build (a debug build measures the build,
+            # not the code); the release artefacts above make this cheap.
+            - name: Run performance bounds (release)
+              run: cargo test --locked --release --test perf_tests -- --nocapture
+
             # Independent-reader gate: confirm generated files are Altium-readable
             # (issue #68) by parsing them with pyaltiumlib. Dependencies are pinned
             # (requirements.txt) and isolated in a venv so the install is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trip each time; the readers seeked through an unbuffered file the same way.
   A library is now built in memory and written once, and read into memory
   before it is parsed; the bytes are identical.
+- **Reading and writing a library now scale linearly with its size.** The
+  compound-file crate rebuilt the whole mini-stream chain on every access to
+  a small stream and walked an unbalanced directory tree on every path
+  lookup, so a library of `n` components cost a term in `n²`: 500 footprints
+  opened in 135 ms where 50 took 4 ms. Both are fixed in a patched `cfb`
+  the build pins until the fix is released upstream; 500 footprints now open
+  in 20 ms, and the bytes written are identical.
 - The performance tests assert what they can prove: that saving and opening
   scale linearly with library size (the accidental-quadratic guard, valid in
   any build), and absolute bounds only in an optimised build, which CI now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Saving a library is about 40× faster.** Both writers serialised straight
-  into an unbuffered file, and a compound-file writer rewrites its sector and
-  directory tables constantly — a disk round trip each time. The image is now
-  built in memory and written once; the bytes are identical.
+- **Saving a library is about 40× faster, opening one about 6×.** Both
+  writers serialised straight into an unbuffered file, and a compound-file
+  writer rewrites its sector and directory tables constantly — a disk round
+  trip each time; the readers seeked through an unbuffered file the same way.
+  A library is now built in memory and written once, and read into memory
+  before it is parsed; the bytes are identical.
 - The performance tests assert what they can prove: that saving and opening
   scale linearly with library size (the accidental-quadratic guard, valid in
   any build), and absolute bounds only in an optimised build, which CI now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Saving a library is about 40× faster.** Both writers serialised straight
+  into an unbuffered file, and a compound-file writer rewrites its sector and
+  directory tables constantly — a disk round trip each time. The image is now
+  built in memory and written once; the bytes are identical.
+- The performance tests assert what they can prove: that saving and opening
+  scale linearly with library size (the accidental-quadratic guard, valid in
+  any build), and absolute bounds only in an optimised build, which CI now
+  runs. A wall-clock bound on a debug build measured the machine, not the
+  code, and failed on a slow one.
 - The old `docs/CLAUDE_CODE_GUIDE.md` and `docs/ANTIGRAVITY_GUIDE.md` addresses,
   still linked from search results and MCP directories, point at the merged
   `docs/CLIENT_SETUP.md` instead of a missing page.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,8 +165,7 @@ dependencies = [
 [[package]]
 name = "cfb"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3"
+source = "git+https://github.com/MatejGomboc/rust-cfb?rev=e3d61a77d2f072cf2ee0a6c65b4859546960bdd0#e3d61a77d2f072cf2ee0a6c65b4859546960bdd0"
 dependencies = [
  "fnv",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,10 @@ nursery = { level = "warn", priority = -1 }
 cargo = { level = "warn", priority = -1 }
 # Allow multiple versions of transitive dependencies (we can't control these)
 multiple_crate_versions = "allow"
+
+# cfb 0.14 walks the whole mini-stream FAT chain on every access to a small
+# stream, so a library of n components costs O(n^2) to read or write. This is
+# the fix sent upstream as mdsteele/rust-cfb#57's resolution; drop the patch
+# once a release carries it.
+[patch.crates-io]
+cfb = { git = "https://github.com/MatejGomboc/rust-cfb", rev = "e3d61a77d2f072cf2ee0a6c65b4859546960bdd0" }

--- a/src/altium/mod.rs
+++ b/src/altium/mod.rs
@@ -554,26 +554,28 @@ pub(crate) fn create_storage<F: std::io::Read + std::io::Write + std::io::Seek>(
 
 /// Writes a library to `path` atomically.
 ///
-/// Serialises into a sibling temp file (named with `tmp_ext`) via `write`, then
-/// renames it over the destination, so a failed or partial write never clobbers
-/// an existing file. The temp file is removed on any failure. Shared by both
-/// library writers — they differ only in the temp extension and whether
-/// serialisation needs `&mut self`, both captured by `write`.
+/// `write` serialises into memory; the bytes then go to a sibling temp file
+/// (named with `tmp_ext`) in one write, which is renamed over the
+/// destination, so a failed or partial write never clobbers an existing
+/// file and nothing is left behind on failure. Serialising in memory rather
+/// than straight into the file matters: a compound-file writer seeks and
+/// rewrites its sector and directory tables constantly, and doing that
+/// against an unbuffered file costs a disk round trip each time — some 40×
+/// the time of building the image and writing it once. Shared by both
+/// library writers and by `restore_backup`.
 pub(crate) fn save_atomic(
     path: &std::path::Path,
     tmp_ext: &str,
-    write: impl FnOnce(std::fs::File) -> AltiumResult<()>,
+    write: impl FnOnce(&mut std::io::Cursor<Vec<u8>>) -> AltiumResult<()>,
 ) -> AltiumResult<()> {
+    let mut image = std::io::Cursor::new(Vec::new());
+    write(&mut image)?;
+
     // Temp file in the same directory ensures the rename stays on one filesystem.
     let temp_path = path.with_extension(tmp_ext);
-
-    let file =
-        std::fs::File::create(&temp_path).map_err(|e| AltiumError::file_write(&temp_path, e))?;
-
-    // Attempt to write; clean up the temp file on failure.
-    if let Err(e) = write(file) {
+    if let Err(e) = std::fs::write(&temp_path, image.get_ref()) {
         let _ = std::fs::remove_file(&temp_path);
-        return Err(e);
+        return Err(AltiumError::file_write(&temp_path, e));
     }
 
     // Atomically rename the temp file over the target (overwrites existing).

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -800,7 +800,7 @@ impl PcbLib {
     pub fn save(&mut self, path: impl AsRef<std::path::Path>) -> AltiumResult<()> {
         let path = path.as_ref();
         self.filepath = Some(path.display().to_string());
-        crate::altium::save_atomic(path, "pcblib.tmp", |file| self.write(file))
+        crate::altium::save_atomic(path, "pcblib.tmp", |image| self.write(image))
     }
 
     /// Returns the number of footprints in the library.

--- a/src/altium/pcblib/mod.rs
+++ b/src/altium/pcblib/mod.rs
@@ -780,9 +780,13 @@ impl PcbLib {
     /// Returns an error if the file cannot be read or is not a valid `PcbLib`.
     pub fn open(path: impl AsRef<std::path::Path>) -> AltiumResult<Self> {
         let path = path.as_ref();
-        let file = std::fs::File::open(path).map_err(|e| AltiumError::file_read(path, e))?;
+        // The whole file is read into memory first: a compound-file reader
+        // seeks through its sector chains constantly, and each seek against
+        // an unbuffered file is a system call — several times the cost of
+        // parsing the same bytes from memory.
+        let bytes = std::fs::read(path).map_err(|e| AltiumError::file_read(path, e))?;
 
-        let mut lib = Self::read(file)?;
+        let mut lib = Self::read(std::io::Cursor::new(bytes))?;
         lib.filepath = Some(path.display().to_string());
         Ok(lib)
     }

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -127,9 +127,13 @@ impl SchLib {
     /// Returns an error if the file cannot be opened or parsed.
     pub fn open(path: impl AsRef<Path>) -> AltiumResult<Self> {
         let path = path.as_ref();
-        let file = std::fs::File::open(path).map_err(|e| AltiumError::file_read(path, e))?;
+        // The whole file is read into memory first: a compound-file reader
+        // seeks through its sector chains constantly, and each seek against
+        // an unbuffered file is a system call — several times the cost of
+        // parsing the same bytes from memory.
+        let bytes = std::fs::read(path).map_err(|e| AltiumError::file_read(path, e))?;
 
-        let mut lib = Self::read(file)?;
+        let mut lib = Self::read(std::io::Cursor::new(bytes))?;
         lib.filepath = Some(path.display().to_string());
         Ok(lib)
     }

--- a/src/altium/schlib/mod.rs
+++ b/src/altium/schlib/mod.rs
@@ -296,7 +296,7 @@ impl SchLib {
     ///
     /// Returns an error if the file cannot be written.
     pub fn save(&self, path: impl AsRef<Path>) -> AltiumResult<()> {
-        crate::altium::save_atomic(path.as_ref(), "schlib.tmp", |file| self.write(file))
+        crate::altium::save_atomic(path.as_ref(), "schlib.tmp", |image| self.write(image))
     }
 }
 

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -565,9 +565,10 @@ impl McpServer {
             Ok(path) => path,
             Err(e) => return ToolCallResult::error(e),
         };
-        let written = crate::altium::save_atomic(Path::new(filepath), "restore.tmp", |mut file| {
+        let written = crate::altium::save_atomic(Path::new(filepath), "restore.tmp", |image| {
             use std::io::Write as _;
-            file.write_all(&bytes)
+            image
+                .write_all(&bytes)
                 .map_err(|e| crate::altium::AltiumError::file_write(Path::new(filepath), e))
         });
         if let Err(e) = written {

--- a/tests/perf_tests.rs
+++ b/tests/perf_tests.rs
@@ -1,28 +1,43 @@
-//! Performance baseline tests.
+//! Performance regression tests for the write/read and compression paths.
 //!
-//! These establish generous timing baselines for the write/read and
-//! compression paths so a future change that makes them dramatically slower
-//! (e.g. an accidental quadratic in the OLE writer or STEP compression) is
-//! caught. They use simple timing rather than statistical benchmarking to
-//! avoid heavy dependencies; thresholds are intentionally loose to stay
-//! non-flaky on shared CI runners.
+//! Two kinds of check, because a wall-clock number means different things in
+//! different builds:
 //!
-//! Run with: `cargo test --test perf_tests -- --nocapture`
+//! - **Scaling** — saving and opening ten times the footprints must cost on
+//!   the order of ten times the time, in any build on any machine. This is
+//!   what catches an accidental quadratic in the OLE writer or the reader,
+//!   which is the regression these tests exist for, and it is independent of
+//!   how fast the machine happens to be.
+//! - **Absolute bounds** — asserted only in an optimised build, where the
+//!   paths run well inside the bound and a miss is a real slowdown. An
+//!   unoptimised build on a busy shared runner can take longer than any
+//!   bound worth having, so there the timings are printed and not asserted.
+//!
+//! Timings are the minimum over several runs: the minimum is the closest
+//! measurement to the code's own cost, while an average carries whatever else
+//! the machine was doing.
+//!
+//! Run with: `cargo test --release --test perf_tests -- --nocapture`
 
-#![allow(clippy::cast_possible_truncation)] // Test file, iterations fit in u32
 #![allow(clippy::cast_precision_loss)] // Acceptable for timing display
 
 use std::time::{Duration, Instant};
 
 use altium_designer_mcp::altium::pcblib::{Footprint, Pad, PcbLib};
 
-/// Runs a closure `iterations` times and returns the average duration.
-fn measure_avg<F: FnMut()>(iterations: usize, mut f: F) -> Duration {
-    let start = Instant::now();
-    for _ in 0..iterations {
-        f();
-    }
-    start.elapsed() / iterations as u32
+/// True in an optimised build, where the absolute bounds are asserted.
+const OPTIMISED: bool = !cfg!(debug_assertions);
+
+/// Runs `f` `runs` times and returns the fastest run.
+fn measure_min<F: FnMut()>(runs: usize, mut f: F) -> Duration {
+    (0..runs)
+        .map(|_| {
+            let start = Instant::now();
+            f();
+            start.elapsed()
+        })
+        .min()
+        .expect("at least one run")
 }
 
 /// Formats a duration in a human-readable way.
@@ -50,40 +65,92 @@ fn build_library(n: usize) -> PcbLib {
     lib
 }
 
-#[test]
-fn perf_pcblib_save_100_footprints() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("perf.PcbLib");
-    let mut lib = build_library(100);
+/// The smaller and larger library sizes the scaling checks compare.
+const SMALL: usize = 20;
+const LARGE: usize = 200;
 
-    let avg = measure_avg(10, || {
-        lib.save(&path).expect("save");
-    });
+/// The most the large library may cost relative to the small one. Linear
+/// work would give `LARGE / SMALL` = 10; a fixed per-file cost pulls the
+/// ratio below that, while a quadratic would push it towards 100. A ceiling
+/// well above 10 keeps the check quiet under ordinary noise and still
+/// catches the regression it exists for.
+const MAX_SCALING_RATIO: f64 = 25.0;
+
+/// Asserts that `large` cost no more than [`MAX_SCALING_RATIO`] times
+/// `small`, printing both so a `--nocapture` run shows the numbers.
+fn assert_scales(what: &str, small: Duration, large: Duration) {
+    let ratio = large.as_secs_f64() / small.as_secs_f64().max(1e-9);
     println!(
-        "PcbLib save (100 footprints): {} per op",
-        format_duration(avg)
+        "{what}: {SMALL} footprints {} / {LARGE} footprints {} (ratio {ratio:.1})",
+        format_duration(small),
+        format_duration(large)
     );
-    assert!(avg < Duration::from_secs(2), "save regressed: {avg:?}");
+    assert!(
+        ratio <= MAX_SCALING_RATIO,
+        "{what} does not scale linearly: {LARGE} footprints cost {ratio:.1}x the {SMALL}-footprint time"
+    );
+}
+
+/// Asserts `measured < bound` in an optimised build; in a debug build only
+/// prints, since the bound would measure the build, not the code.
+fn assert_bound(what: &str, measured: Duration, bound: Duration) {
+    println!(
+        "{what}: {} per op (bound {} — {})",
+        format_duration(measured),
+        format_duration(bound),
+        if OPTIMISED {
+            "asserted"
+        } else {
+            "debug build, not asserted"
+        }
+    );
+    if OPTIMISED {
+        assert!(measured < bound, "{what} regressed: {measured:?}");
+    }
 }
 
 #[test]
-fn perf_pcblib_open_100_footprints() {
+fn pcblib_save_scales_linearly_with_footprint_count() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let path = dir.path().join("perf.PcbLib");
-    build_library(100).save(&path).expect("save");
+    let mut small = build_library(SMALL);
+    let mut large = build_library(LARGE);
+    let small_path = dir.path().join("small.PcbLib");
+    let large_path = dir.path().join("large.PcbLib");
 
-    let avg = measure_avg(10, || {
-        let _ = PcbLib::open(&path).expect("open");
-    });
-    println!(
-        "PcbLib open (100 footprints): {} per op",
-        format_duration(avg)
+    let small_time = measure_min(5, || small.save(&small_path).expect("save"));
+    let large_time = measure_min(5, || large.save(&large_path).expect("save"));
+    assert_scales("PcbLib save", small_time, large_time);
+    assert_bound(
+        "PcbLib save (200 footprints)",
+        large_time,
+        Duration::from_millis(500),
     );
-    assert!(avg < Duration::from_secs(2), "open regressed: {avg:?}");
 }
 
 #[test]
-fn perf_flate2_roundtrip_1mb() {
+fn pcblib_open_scales_linearly_with_footprint_count() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let small_path = dir.path().join("small.PcbLib");
+    let large_path = dir.path().join("large.PcbLib");
+    build_library(SMALL).save(&small_path).expect("save");
+    build_library(LARGE).save(&large_path).expect("save");
+
+    let small_time = measure_min(5, || {
+        let _ = PcbLib::open(&small_path).expect("open");
+    });
+    let large_time = measure_min(5, || {
+        let _ = PcbLib::open(&large_path).expect("open");
+    });
+    assert_scales("PcbLib open", small_time, large_time);
+    assert_bound(
+        "PcbLib open (200 footprints)",
+        large_time,
+        Duration::from_millis(500),
+    );
+}
+
+#[test]
+fn flate2_roundtrip_1mb_stays_fast() {
     use flate2::read::ZlibDecoder;
     use flate2::write::ZlibEncoder;
     use flate2::Compression;
@@ -93,7 +160,7 @@ fn perf_flate2_roundtrip_1mb() {
     // that compress/decompress path on ~1MB of data.
     let data = vec![0x5Au8; 1024 * 1024];
 
-    let avg = measure_avg(10, || {
+    let time = measure_min(5, || {
         let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
         enc.write_all(&data).expect("compress");
         let compressed = enc.finish().expect("finish");
@@ -103,9 +170,5 @@ fn perf_flate2_roundtrip_1mb() {
         dec.read_to_end(&mut out).expect("decompress");
         assert_eq!(out.len(), data.len());
     });
-    println!("flate2 1MB round-trip: {} per op", format_duration(avg));
-    assert!(
-        avg < Duration::from_secs(5),
-        "compression regressed: {avg:?}"
-    );
+    assert_bound("flate2 1MB round-trip", time, Duration::from_secs(1));
 }

--- a/tests/perf_tests.rs
+++ b/tests/perf_tests.rs
@@ -65,16 +65,19 @@ fn build_library(n: usize) -> PcbLib {
     lib
 }
 
-/// The smaller and larger library sizes the scaling checks compare.
-const SMALL: usize = 20;
-const LARGE: usize = 200;
+/// The smaller and larger library sizes the scaling checks compare. The
+/// small one is big enough that its timing is the code's, not the timer's:
+/// a library that opens in a couple of milliseconds measures scheduler
+/// noise, and a noisy denominator makes the ratio meaningless.
+const SMALL: usize = 50;
+const LARGE: usize = 500;
 
 /// The most the large library may cost relative to the small one. Linear
 /// work would give `LARGE / SMALL` = 10; a fixed per-file cost pulls the
-/// ratio below that, while a quadratic would push it towards 100. A ceiling
-/// well above 10 keeps the check quiet under ordinary noise and still
-/// catches the regression it exists for.
-const MAX_SCALING_RATIO: f64 = 25.0;
+/// ratio below that, while a quadratic would push it towards 100. Measured
+/// ratios sit between 8 and 14; the ceiling leaves room for a noisy runner
+/// and none for a quadratic.
+const MAX_SCALING_RATIO: f64 = 30.0;
 
 /// Asserts that `large` cost no more than [`MAX_SCALING_RATIO`] times
 /// `small`, printing both so a `--nocapture` run shows the numbers.
@@ -121,9 +124,9 @@ fn pcblib_save_scales_linearly_with_footprint_count() {
     let large_time = measure_min(5, || large.save(&large_path).expect("save"));
     assert_scales("PcbLib save", small_time, large_time);
     assert_bound(
-        "PcbLib save (200 footprints)",
+        &format!("PcbLib save ({LARGE} footprints)"),
         large_time,
-        Duration::from_millis(500),
+        Duration::from_secs(1),
     );
 }
 
@@ -143,9 +146,9 @@ fn pcblib_open_scales_linearly_with_footprint_count() {
     });
     assert_scales("PcbLib open", small_time, large_time);
     assert_bound(
-        "PcbLib open (200 footprints)",
+        &format!("PcbLib open ({LARGE} footprints)"),
         large_time,
-        Duration::from_millis(500),
+        Duration::from_secs(1),
     );
 }
 


### PR DESCRIPTION
## Summary

Started as the follow-up to the flake @ande2407 hit on #458 (`perf_pcblib_save_100_footprints` at 2.0–2.8 s against a 2 s bound on a debug build). Redesigning that test as a **scaling** check exposed three real bugs behind the number — two of them inside a dependency.

**Bug #65 — saving was ~40× slower than it needed to be.** `save_atomic` handed the `cfb` writer a raw unbuffered `File`; a compound-file writer seeks and rewrites its FAT, directory and mini-stream tables on every stream it adds, and each was a disk round trip. The image is now built in memory and written to the temp file once, then renamed exactly as before. `restore_backup` shares the path.

**Bug #66 — opening had the mirror problem.** The readers seeked through an unbuffered `File` the same way. Both `open()`s now read the file into memory first.

**Bug #67 — the `cfb` crate itself is O(n²) in the number of entries**, on two counts: `MiniAllocator::seek_within_mini_sector` rebuilt the whole mini-stream FAT chain on every access to a small stream (the mechanism behind upstream issue mdsteele/rust-cfb#57), and every path lookup walked an unbalanced sibling tree (`insert_dir_entry` never rebalances — `// TODO: rebalance tree`). Fixed in **[mdsteele/rust-cfb#81](https://github.com/mdsteele/rust-cfb/pull/81)** (chains walked once and extended in place; a name index for lookups; **the on-disk tree untouched**, so bytes are identical) and pinned here through `[patch.crates-io]` until a release carries it.

Measured in a **release** build, 500 two-pad footprints:

| | before | after |
|---|---|---|
| `open()` | 135 ms (ratio 35× for 10× the footprints) | **20 ms** (8×) |
| `save()` | 1.75 s → 180 ms after #65 | **87 ms** (13×) |

The golden byte-identity suite (every fixture, every corpus twin) proves the written bytes are identical throughout.

**The perf tests now assert what they can prove.**
- **Scaling** — 500 footprints must cost ≤ 30× the 50-footprint time (linear ≈ 10, a quadratic ≈ 100); measured 8–15 in both build modes. Valid in any build — this is what caught #67.
- **Absolute bounds** — asserted only in an optimised build, printed otherwise; fastest-of-five timings.
- CI runs `cargo test --release --test perf_tests` after the existing release build.

## Verification

- fmt / clippy `-D warnings` clean; **1488 tests** green on the pinned crate
- Release perf: open 19 ms, save 87 ms; debug ratios 9 / 14; every bound met
- CHANGELOG `[Unreleased]` carries the lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)