### PR TITLE
fix: refuse a description Altium will not import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A description longer than Altium will import is now refused instead of
+  written.** Altium silently accepts a component description of any length
+  through the file format but then fails to import the whole library if one
+  exceeds 256 characters, naming neither the library nor the component. So
+  `write_pcblib` and `write_schlib` now reject an over-length `description` at
+  the API boundary, before anything is written, and say which component it is
+  and by how many characters to shorten it. This applies to footprint, symbol
+  and footprint-link descriptions. `validate_library` reports the same thing as
+  an `error` on libraries this server did not author — an older build, or a
+  description copied in from elsewhere — and so does the post-write validation
+  that `copy_component` and `import_library` pass through.
+
 - **A solid symbol body no longer paints over the pin names inside it.**
   `write_schlib` recorded the order it happened to parse its input in — pins
   before rectangles — and replayed that as if it were an authoring order, so a

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -52,6 +52,15 @@ behind their pin names. Keep bodies solid — a transparent body is not the fix
 for hidden pin names. Supply `primitive_order` only to reproduce an order you
 read off an existing file; it overrides the default.
 
+## Description length
+
+Altium will not import a library if any component description exceeds **256
+characters** — and it reports neither which library nor which component is at
+fault. `write_pcblib` and `write_schlib` therefore refuse an over-length
+`description` before writing anything, naming the component and the overshoot.
+Keep footprint, symbol and footprint-link descriptions inside the limit; put
+the long-form reasoning in your own notes, not the description field.
+
 ## Filesystem sandbox
 
 Only paths inside the configured `allowed_paths` (see `config.json`) can be read

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -923,7 +923,7 @@ Manage footprint links in Altium SchLib symbols. Supports listing, adding, and r
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `component_name` | string | yes | Name of the symbol to manage footprints for |
-| `description` | string | no | Footprint description (optional for add) |
+| `description` | string | no | Footprint description (optional for add). Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused. |
 | `filepath` | string | yes | Path to the Altium SchLib file |
 | `footprint_name` | string | no | Footprint name (required for add, remove) |
 | `library_path` | string | no | Optional (add): absolute path to the .PcbLib containing the footprint, written as ModelDatafile0 so Altium can resolve and preview the model. Omit to link by name only (requires the library to be installed/in the project, else 'footprint not found'). |

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -231,7 +231,7 @@ impl McpServer {
                                     },
                                     "description": {
                                         "type": "string",
-                                        "description": "Footprint description"
+                                        "description": "Footprint description. Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused."
                                     },
                                     "pads": {
                                         "type": "array",
@@ -637,7 +637,7 @@ impl McpServer {
                                 "type": "object",
                                 "properties": {
                                     "name": { "type": "string" },
-                                    "description": { "type": "string" },
+                                    "description": { "type": "string", "description": "Symbol description. Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused." },
                                     "designator_prefix": { "type": "string", "description": "Reference-designator class letter, e.g. 'R' for resistors, 'U' for ICs. Written as '<prefix>?'. If omitted, falls back to 'component_type' (IEEE 315 / ASME Y14.44 mapping), then to 'U'." },
                                     "designator_x": { "type": "number", "description": "X position of the designator text. Default: -5 (Altium's from-scratch placement)" },
                                     "designator_y": { "type": "number", "description": "Y position of the designator text. Default: 5 (Altium's from-scratch placement)" },
@@ -1911,7 +1911,7 @@ impl McpServer {
                         },
                         "description": {
                             "type": "string",
-                            "description": "Footprint description (optional for add)"
+                            "description": "Footprint description (optional for add). Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused."
                         },
                         "library_path": {
                             "type": "string",

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -3,6 +3,7 @@
 use serde_json::{json, Value};
 
 use crate::mcp::server::{McpServer, ToolCallResult};
+use crate::mcp::tools::parsing::DESCRIPTION_MAX_LEN;
 
 /// The footprint kinds a CSV export counts, in reading order — every kind,
 /// pads first (a test holds this to `PrimitiveKind::WRITE_ORDER`).
@@ -45,6 +46,22 @@ const SCH_CSV_KINDS: [crate::altium::schlib::SchPrimitiveKind;
         K::Parameter,
     ]
 };
+
+/// Records the "description too long" finding shared by all four validators,
+/// so the rule and its wording live in one place. An over-length description
+/// stops the whole library importing, hence `error` rather than `warning`.
+fn push_over_length_description(issues: &mut Vec<Value>, name: &str, description: &str) {
+    let desc_len = description.chars().count();
+    if desc_len > DESCRIPTION_MAX_LEN {
+        issues.push(json!({
+            "severity": "error",
+            "component": name,
+            "issue": format!(
+                "Description is {desc_len} characters; Altium will not import a library whose description exceeds {DESCRIPTION_MAX_LEN}"
+            )
+        }));
+    }
+}
 
 impl McpServer {
     // ==================== Library Management Tools ====================
@@ -414,6 +431,9 @@ impl McpServer {
                 }));
             }
 
+            // Altium refuses to import a library whose description is too long.
+            push_over_length_description(&mut issues, name, &fp.description);
+
             // Check for no pads
             if fp.pads.is_empty() {
                 issues.push(json!({
@@ -639,6 +659,9 @@ impl McpServer {
                 }));
             }
 
+            // Altium refuses to import a library whose description is too long.
+            push_over_length_description(&mut issues, name, &symbol.description);
+
             // Check for no pins
             if symbol.pins.is_empty() {
                 issues.push(json!({
@@ -740,6 +763,9 @@ impl McpServer {
                     "issue": "Footprint has empty name"
                 }));
             }
+
+            // Altium refuses to import a library whose description is too long.
+            push_over_length_description(&mut issues, name, &fp.description);
 
             // Check for duplicate pad designators
             let mut seen_designators: HashSet<&str> = HashSet::new();
@@ -858,6 +884,9 @@ impl McpServer {
                     "issue": "Symbol has empty name"
                 }));
             }
+
+            // Altium refuses to import a library whose description is too long.
+            push_over_length_description(&mut issues, name, &symbol.description);
 
             // Check for duplicate pin designators
             let mut seen_designators: HashSet<&str> = HashSet::new();

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -467,6 +467,29 @@ pub const PAD_SHAPE_HELP: &str = "Valid shapes are: rectangle (or rectangular), 
      circle), oval, octagonal, rounded_rectangle. Matching is case-insensitive and ignores \
      '_'/'-' separators.";
 
+/// Longest component description Altium will accept. A library holding a
+/// longer one is written without complaint but then fails to import, so an
+/// over-length description is refused at the API boundary rather than baked
+/// into a file the user cannot open.
+pub const DESCRIPTION_MAX_LEN: usize = 256;
+
+/// Refuses a description Altium could not import. `kind` names the object
+/// ("Footprint", "Symbol") so the error says which one to shorten, and the
+/// message carries the overshoot so a caller can fix it in one edit.
+///
+/// The limit is counted in characters, matching how Altium states it; for the
+/// ASCII text these fields almost always hold, that is also the byte count.
+pub fn check_description_len(kind: &str, name: &str, desc: &str) -> Result<(), String> {
+    let len = desc.chars().count();
+    if len > DESCRIPTION_MAX_LEN {
+        return Err(format!(
+            "{kind} '{name}' has a {len}-character description, but Altium will not import a library whose description exceeds {DESCRIPTION_MAX_LEN} characters. Shorten it by {} characters.",
+            len - DESCRIPTION_MAX_LEN
+        ));
+    }
+    Ok(())
+}
+
 impl McpServer {
     /// Parses a pad shape name, shared by `write_pcblib` and `update_pad` so the
     /// same spelling is accepted everywhere.
@@ -518,6 +541,13 @@ impl McpServer {
         let mut symbol = Symbol::new(name);
 
         if let Some(desc) = sym_json.get("description").and_then(Value::as_str) {
+            if let Err(e) = check_description_len("Symbol", name, desc) {
+                return Err(ToolCallResult::error_with_context(
+                    ErrorContext::new(operation, e)
+                        .with_filepath(filepath)
+                        .with_component(name),
+                ));
+            }
             symbol.description = desc.to_string();
         }
 
@@ -883,6 +913,13 @@ impl McpServer {
                 {
                     let mut fp = FootprintModel::new(fp_name);
                     if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
+                        if let Err(e) = check_description_len("Footprint link", fp_name, desc) {
+                            return Err(ToolCallResult::error_with_context(
+                                ErrorContext::new(operation, e)
+                                    .with_filepath(filepath)
+                                    .with_component(name),
+                            ));
+                        }
                         fp.description = desc.to_string();
                     }
                     // Optional PcbLib path -> ModelDatafile0, so Altium can
@@ -998,6 +1035,13 @@ impl McpServer {
         let mut footprint = Footprint::new(name);
 
         if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
+            if let Err(e) = check_description_len("Footprint", name, desc) {
+                return Err(ToolCallResult::error_with_context(
+                    ErrorContext::new(operation, e)
+                        .with_filepath(filepath)
+                        .with_component(name),
+                ));
+            }
             footprint.description = desc.to_string();
         }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -3492,6 +3492,7 @@ mod tests {
     // contract and needs a test each. Grouped by handler, in call order.
 
     mod failure_paths {
+        use crate::mcp::tools::parsing::DESCRIPTION_MAX_LEN;
         use crate::mcp::tools::test_support::{
             create_test_server, get_result_text, parse_result_json, test_temp_dir,
         };
@@ -3522,6 +3523,171 @@ mod tests {
         /// Writes bytes that are not an OLE compound file, so `open` fails.
         fn write_garbage(path: &std::path::Path) {
             std::fs::write(path, b"not an OLE compound document").unwrap();
+        }
+
+        // ---------------------------------------------------------------
+        // Description length. Altium refuses to import a library whose
+        // component description exceeds 256 characters, and it gives no clue
+        // which component is at fault -- so an over-length description is
+        // rejected here instead of being written into an unopenable file.
+        // ---------------------------------------------------------------
+
+        /// A description of exactly `n` characters.
+        fn desc(n: usize) -> String {
+            "d".repeat(n)
+        }
+
+        #[test]
+        fn a_footprint_description_at_the_limit_is_accepted_and_round_trips() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("AtLimit.PcbLib");
+            let at_limit = desc(DESCRIPTION_MAX_LEN);
+
+            let write = server.call_write_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+                "footprints": [{
+                    "name": "FP", "description": at_limit, "pads": [pad("1")],
+                }],
+            }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+
+            let read = server.call_read_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            let got = parse_result_json(&read)["footprints"][0]["description"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_eq!(got.chars().count(), DESCRIPTION_MAX_LEN);
+            assert_eq!(got, at_limit, "a description at the limit must survive");
+        }
+
+        #[test]
+        fn an_over_length_footprint_description_is_refused() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("TooLong.PcbLib");
+
+            let write = server.call_write_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+                "footprints": [{
+                    "name": "WIDE_DESC",
+                    "description": desc(DESCRIPTION_MAX_LEN + 1),
+                    "pads": [pad("1")],
+                }],
+            }));
+            assert!(
+                write.is_error,
+                "one character over the limit must be refused"
+            );
+            let text = get_result_text(&write);
+            assert!(
+                text.contains("WIDE_DESC"),
+                "must name the footprint: {text}"
+            );
+            assert!(
+                text.contains(&DESCRIPTION_MAX_LEN.to_string()),
+                "must state the limit: {text}"
+            );
+            assert!(
+                text.contains("Shorten it by 1 characters"),
+                "must state the overshoot: {text}"
+            );
+            assert!(
+                !path.exists(),
+                "the refusal must come before the file is written"
+            );
+        }
+
+        #[test]
+        fn an_over_length_symbol_description_is_refused() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("TooLong.SchLib");
+
+            let mut sym = symbol("WIDE_SYM");
+            sym["description"] = json!(desc(DESCRIPTION_MAX_LEN + 40));
+            let write = server.call_write_schlib(&json!({
+                "filepath": path.to_string_lossy(),
+                "symbols": [sym],
+            }));
+            assert!(
+                write.is_error,
+                "an over-length symbol description must be refused"
+            );
+            let text = get_result_text(&write);
+            assert!(text.contains("WIDE_SYM"), "must name the symbol: {text}");
+            assert!(
+                text.contains("Shorten it by 40 characters"),
+                "must state the overshoot: {text}"
+            );
+            assert!(!path.exists(), "nothing should be written");
+        }
+
+        #[test]
+        fn an_over_length_footprint_link_description_is_refused() {
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Link.SchLib");
+
+            let mut sym = symbol("SYM");
+            sym["footprints"] = json!([{
+                "name": "LINKED_FP",
+                "description": desc(DESCRIPTION_MAX_LEN + 5),
+            }]);
+            let write = server.call_write_schlib(&json!({
+                "filepath": path.to_string_lossy(),
+                "symbols": [sym],
+            }));
+            assert!(
+                write.is_error,
+                "the description on a footprint link is stored in the SchLib too"
+            );
+            assert!(
+                get_result_text(&write).contains("LINKED_FP"),
+                "must name the link: {}",
+                get_result_text(&write)
+            );
+        }
+
+        /// `validate_library` has to catch libraries this server did not
+        /// author -- an older build, or a description copied in from another
+        /// library -- so the check exists in the validator as well as at the
+        /// API boundary. Built through the library API to sidestep the
+        /// parse-time refusal.
+        #[test]
+        fn validate_library_reports_an_over_length_description_as_an_error() {
+            use crate::altium::pcblib::{Footprint, Pad, PcbLib};
+
+            let dir = test_temp_dir();
+            let server = create_test_server(dir.path());
+            let path = dir.path().join("Legacy.PcbLib");
+
+            let mut fp = Footprint::new("LEGACY_FP");
+            fp.description = desc(DESCRIPTION_MAX_LEN + 90);
+            fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+            let mut lib = PcbLib::new();
+            lib.add(fp);
+            lib.save(&path).expect("writing directly must succeed");
+
+            let result = server.call_validate_library(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            let json_out = parse_result_json(&result);
+            assert!(
+                json_out["error_count"].as_u64().unwrap() >= 1,
+                "an unopenable description must count as an error: {json_out}"
+            );
+            let issues = json_out["issues"].as_array().unwrap();
+            assert!(
+                issues.iter().any(|i| {
+                    i["severity"] == "error"
+                        && i["component"] == "LEGACY_FP"
+                        && i["issue"].as_str().unwrap_or("").contains("Description is")
+                }),
+                "the offending component must be named: {json_out}"
+            );
         }
 
         /// Flips a file's read-only bit, used to make a save fail without


### PR DESCRIPTION
## The bug

Altium accepts a component description of any length through the file format, then **fails to import the whole library** if one exceeds 256 characters — naming neither the library nor the offending component. So a library written by this server could be silently unusable, and the only symptom was a failed import with nothing to go on.

Found in the field: a generated 62-part library had 12 footprint descriptions between 257 and 326 characters. `write_pcblib` reported `status: success` with `validation: {"error_count": 0, "warning_count": 0}`, and the library would not import.

## The fix

**Refuse it at the API boundary.** `write_pcblib` and `write_schlib` now reject an over-length `description` before anything is written:

```
Footprint 'MHS-JA0' has a 307-character description, but Altium will not import
a library whose description exceeds 256 characters. Shorten it by 51 characters.
```

The error names the component and the overshoot, so it is fixable in one edit. Covers all three description fields that reach a component record: footprint (`write_pcblib`), symbol (`write_schlib`), and the footprint link inside a symbol.

This is a hard error rather than a validation warning on purpose. Post-write validation runs *after* the file exists, so a warning there would still leave an unopenable library on disk.

**Also caught by the validators.** `validate_library` and the post-write validation now report the same finding as `severity: "error"`. That covers libraries this server did not author — an older build, or a description carried in verbatim by `copy_component` / `copy_component_cross_library` / `import_library`, which do not go through the parse path.

## Notes on the limit

- Counted in **characters**, matching how Altium states it. For the ASCII text these fields almost always hold, that is also the byte count. If the real constraint turns out to be bytes, `check_description_len` is the one place to change.
- Pin and parameter descriptions are **not** covered. They are separate fields and I have no evidence of a 256-character limit on them; adding a guess seemed worse than leaving them.

## Tests

Five new tests in `read_write::tests::failure_paths`:

- a description of exactly 256 characters is accepted and round-trips
- 257 characters is refused, the error names the footprint, states the limit and the overshoot, **and no file is created**
- an over-length symbol description is refused
- an over-length footprint-link description is refused
- `validate_library` reports an over-length description as an `error`, naming the component — built through the library API to sidestep the new parse-time refusal

`cargo test --lib`: 1239 passed, 0 failed. `cargo clippy --all-targets`: clean.

## Docs

- `CHANGELOG.md` under Unreleased/Fixed.
- `docs/AGENT_GUIDE.md` gains a short "Description length" section. That file ships in the `initialize` response, so binary-only users get the rule without reading the source.
- The limit is stated on the `description` fields in the tool schemas, so it appears in `tools/list` and in the generated `docs/TOOLS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
