### PR TITLE
chore(deps): pin cfb to the upstream merge of rust-cfb#81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "cfb"
 version = "0.14.0"
-source = "git+https://github.com/MatejGomboc/rust-cfb?rev=e3d61a77d2f072cf2ee0a6c65b4859546960bdd0#e3d61a77d2f072cf2ee0a6c65b4859546960bdd0"
+source = "git+https://github.com/mdsteele/rust-cfb?rev=8c1ec76#8c1ec76fb687a0b078032fc4d3f032cfb8c5c796"
 dependencies = [
  "fnv",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,10 @@ cargo = { level = "warn", priority = -1 }
 # Allow multiple versions of transitive dependencies (we can't control these)
 multiple_crate_versions = "allow"
 
-# cfb 0.14 walks the whole mini-stream FAT chain on every access to a small
-# stream, so a library of n components costs O(n^2) to read or write. This is
-# the fix sent upstream as mdsteele/rust-cfb#57's resolution; drop the patch
-# once a release carries it.
+# cfb 0.14.0 walks the whole mini-stream FAT chain on every access to a small
+# stream and every path lookup walks an unbalanced tree, so a library of n
+# components costs O(n^2) to read or write. Fixed upstream in
+# mdsteele/rust-cfb#81 (merged 2026-08-28); pinned to that merge until a
+# release carries it — then bump `cfb` above and delete this block.
 [patch.crates-io]
-cfb = { git = "https://github.com/MatejGomboc/rust-cfb", rev = "e3d61a77d2f072cf2ee0a6c65b4859546960bdd0" }
+cfb = { git = "https://github.com/mdsteele/rust-cfb", rev = "8c1ec76" }


### PR DESCRIPTION
## Summary

[mdsteele/rust-cfb#81](https://github.com/mdsteele/rust-cfb/pull/81) merged on 2026-08-28 (upstream master `8c1ec76`), so the `[patch.crates-io]` pin moves from my fork to upstream's own merge commit. Same code, sturdier source — the fork is no longer load-bearing. Still a git pin because crates.io has no release past 0.14.0 yet; when one ships, bump `cfb` and delete the block.

## Verification

- `cargo build` refreshes `Cargo.lock` to the upstream source; full suite green; release perf: open/save scaling ratios unchanged (~8 / ~13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)