### PR TITLE
fix: report an over-length description as a warning, not a refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A description longer than Altium will import is now refused instead of
-  written.** Altium silently accepts a component description of any length
-  through the file format but then fails to import the whole library if one
-  exceeds 256 characters, naming neither the library nor the component. So
-  `write_pcblib` and `write_schlib` now reject an over-length `description` at
-  the API boundary, before anything is written, and say which component it is
-  and by how many characters to shorten it. This applies to footprint, symbol
-  and footprint-link descriptions. `validate_library` reports the same thing as
-  an `error` on libraries this server did not author — an older build, or a
-  description copied in from elsewhere — and so does the post-write validation
-  that `copy_component` and `import_library` pass through.
+- **A description the Altium 365 library importer would refuse is reported
+  before the import fails.** That importer turns away a component whose
+  description exceeds 256 characters, naming neither the library nor the
+  component; Altium Designer itself opens and reads such a library whole. So
+  a longer footprint, symbol or footprint-link description is written as
+  asked, and every write, `validate_library` and the post-write validation of
+  every mutating tool report a warning that names the component and says by
+  how many characters to shorten it.
 
 - **A solid symbol body no longer paints over the pin names inside it.**
   `write_schlib` recorded the order it happened to parse its input in — pins

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -54,12 +54,14 @@ read off an existing file; it overrides the default.
 
 ## Description length
 
-Altium will not import a library if any component description exceeds **256
-characters** — and it reports neither which library nor which component is at
-fault. `write_pcblib` and `write_schlib` therefore refuse an over-length
-`description` before writing anything, naming the component and the overshoot.
-Keep footprint, symbol and footprint-link descriptions inside the limit; put
-the long-form reasoning in your own notes, not the description field.
+The Altium 365 library importer refuses a component whose description exceeds
+**256 characters**, and it names neither the library nor the component at
+fault. Altium Designer itself opens and reads such a library whole, so a longer
+`description` is written as asked — and every write and `validate_library`
+reports it as a warning naming the component and the overshoot. If a library
+is bound for a workspace, keep footprint, symbol and footprint-link
+descriptions inside the limit; put the long-form reasoning in your own notes,
+not the description field.
 
 ## Filesystem sandbox
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -923,7 +923,7 @@ Manage footprint links in Altium SchLib symbols. Supports listing, adding, and r
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `component_name` | string | yes | Name of the symbol to manage footprints for |
-| `description` | string | no | Footprint description (optional for add). Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused. |
+| `description` | string | no | Footprint description (optional for add). Keep to 256 characters if the library will be imported into an Altium 365 workspace — that importer refuses longer ones; a longer description is written and reported as a validation warning. |
 | `filepath` | string | yes | Path to the Altium SchLib file |
 | `footprint_name` | string | no | Footprint name (required for add, remove) |
 | `library_path` | string | no | Optional (add): absolute path to the .PcbLib containing the footprint, written as ModelDatafile0 so Altium can resolve and preview the model. Omit to link by name only (requires the library to be installed/in the project, else 'footprint not found'). |

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -231,7 +231,7 @@ impl McpServer {
                                     },
                                     "description": {
                                         "type": "string",
-                                        "description": "Footprint description. Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused."
+                                        "description": "Footprint description. Keep to 256 characters if the library will be imported into an Altium 365 workspace — that importer refuses longer ones; a longer description is written and reported as a validation warning."
                                     },
                                     "pads": {
                                         "type": "array",
@@ -637,7 +637,7 @@ impl McpServer {
                                 "type": "object",
                                 "properties": {
                                     "name": { "type": "string" },
-                                    "description": { "type": "string", "description": "Symbol description. Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused." },
+                                    "description": { "type": "string", "description": "Symbol description. Keep to 256 characters if the library will be imported into an Altium 365 workspace — that importer refuses longer ones; a longer description is written and reported as a validation warning." },
                                     "designator_prefix": { "type": "string", "description": "Reference-designator class letter, e.g. 'R' for resistors, 'U' for ICs. Written as '<prefix>?'. If omitted, falls back to 'component_type' (IEEE 315 / ASME Y14.44 mapping), then to 'U'." },
                                     "designator_x": { "type": "number", "description": "X position of the designator text. Default: -5 (Altium's from-scratch placement)" },
                                     "designator_y": { "type": "number", "description": "Y position of the designator text. Default: 5 (Altium's from-scratch placement)" },
@@ -1911,7 +1911,7 @@ impl McpServer {
                         },
                         "description": {
                             "type": "string",
-                            "description": "Footprint description (optional for add). Max 256 characters — Altium will not import a library with a longer description, so an over-length value is refused."
+                            "description": "Footprint description (optional for add). Keep to 256 characters if the library will be imported into an Altium 365 workspace — that importer refuses longer ones; a longer description is written and reported as a validation warning."
                         },
                         "library_path": {
                             "type": "string",

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -48,18 +48,37 @@ const SCH_CSV_KINDS: [crate::altium::schlib::SchPrimitiveKind;
 };
 
 /// Records the "description too long" finding shared by all four validators,
-/// so the rule and its wording live in one place. An over-length description
-/// stops the whole library importing, hence `error` rather than `warning`.
+/// so the rule and its wording live in one place. A warning, not an error:
+/// Altium Designer opens and reads such a library whole; only the Altium 365
+/// library importer turns it away, naming neither library nor component —
+/// this finding names both and says by how much to shorten.
 fn push_over_length_description(issues: &mut Vec<Value>, name: &str, description: &str) {
     let desc_len = description.chars().count();
     if desc_len > DESCRIPTION_MAX_LEN {
         issues.push(json!({
-            "severity": "error",
+            "severity": "warning",
             "component": name,
             "issue": format!(
-                "Description is {desc_len} characters; Altium will not import a library whose description exceeds {DESCRIPTION_MAX_LEN}"
+                "Description is {desc_len} characters; the Altium 365 library importer refuses a component whose description exceeds {DESCRIPTION_MAX_LEN}, so shorten it by {} characters before importing this library into a workspace",
+                desc_len - DESCRIPTION_MAX_LEN
             )
         }));
+    }
+}
+
+/// The same finding for every footprint link a symbol carries, named
+/// `symbol -> link` so the right description is the one shortened.
+fn push_over_length_link_descriptions(
+    issues: &mut Vec<Value>,
+    name: &str,
+    links: &[crate::altium::schlib::FootprintModel],
+) {
+    for link in links {
+        push_over_length_description(
+            issues,
+            &format!("{name} -> {}", link.name),
+            &link.description,
+        );
     }
 }
 
@@ -431,7 +450,7 @@ impl McpServer {
                 }));
             }
 
-            // Altium refuses to import a library whose description is too long.
+            // The Altium 365 importer refuses an over-length description.
             push_over_length_description(&mut issues, name, &fp.description);
 
             // Check for no pads
@@ -659,8 +678,9 @@ impl McpServer {
                 }));
             }
 
-            // Altium refuses to import a library whose description is too long.
+            // The Altium 365 importer refuses an over-length description.
             push_over_length_description(&mut issues, name, &symbol.description);
+            push_over_length_link_descriptions(&mut issues, name, &symbol.footprints);
 
             // Check for no pins
             if symbol.pins.is_empty() {
@@ -764,7 +784,7 @@ impl McpServer {
                 }));
             }
 
-            // Altium refuses to import a library whose description is too long.
+            // The Altium 365 importer refuses an over-length description.
             push_over_length_description(&mut issues, name, &fp.description);
 
             // Check for duplicate pad designators
@@ -885,8 +905,9 @@ impl McpServer {
                 }));
             }
 
-            // Altium refuses to import a library whose description is too long.
+            // The Altium 365 importer refuses an over-length description.
             push_over_length_description(&mut issues, name, &symbol.description);
+            push_over_length_link_descriptions(&mut issues, name, &symbol.footprints);
 
             // Check for duplicate pin designators
             let mut seen_designators: HashSet<&str> = HashSet::new();

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -467,28 +467,13 @@ pub const PAD_SHAPE_HELP: &str = "Valid shapes are: rectangle (or rectangular), 
      circle), oval, octagonal, rounded_rectangle. Matching is case-insensitive and ignores \
      '_'/'-' separators.";
 
-/// Longest component description Altium will accept. A library holding a
-/// longer one is written without complaint but then fails to import, so an
-/// over-length description is refused at the API boundary rather than baked
-/// into a file the user cannot open.
+/// Longest component description the Altium 365 library importer accepts.
+/// Altium Designer itself opens a library with a longer one and reads it
+/// back whole (measured: 300 characters), so a longer description is written
+/// as asked and reported as a validation warning, not refused — the importer
+/// names neither the library nor the component when it turns one away, and
+/// the warning does.
 pub const DESCRIPTION_MAX_LEN: usize = 256;
-
-/// Refuses a description Altium could not import. `kind` names the object
-/// ("Footprint", "Symbol") so the error says which one to shorten, and the
-/// message carries the overshoot so a caller can fix it in one edit.
-///
-/// The limit is counted in characters, matching how Altium states it; for the
-/// ASCII text these fields almost always hold, that is also the byte count.
-pub fn check_description_len(kind: &str, name: &str, desc: &str) -> Result<(), String> {
-    let len = desc.chars().count();
-    if len > DESCRIPTION_MAX_LEN {
-        return Err(format!(
-            "{kind} '{name}' has a {len}-character description, but Altium will not import a library whose description exceeds {DESCRIPTION_MAX_LEN} characters. Shorten it by {} characters.",
-            len - DESCRIPTION_MAX_LEN
-        ));
-    }
-    Ok(())
-}
 
 impl McpServer {
     /// Parses a pad shape name, shared by `write_pcblib` and `update_pad` so the
@@ -541,13 +526,6 @@ impl McpServer {
         let mut symbol = Symbol::new(name);
 
         if let Some(desc) = sym_json.get("description").and_then(Value::as_str) {
-            if let Err(e) = check_description_len("Symbol", name, desc) {
-                return Err(ToolCallResult::error_with_context(
-                    ErrorContext::new(operation, e)
-                        .with_filepath(filepath)
-                        .with_component(name),
-                ));
-            }
             symbol.description = desc.to_string();
         }
 
@@ -913,13 +891,6 @@ impl McpServer {
                 {
                     let mut fp = FootprintModel::new(fp_name);
                     if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
-                        if let Err(e) = check_description_len("Footprint link", fp_name, desc) {
-                            return Err(ToolCallResult::error_with_context(
-                                ErrorContext::new(operation, e)
-                                    .with_filepath(filepath)
-                                    .with_component(name),
-                            ));
-                        }
                         fp.description = desc.to_string();
                     }
                     // Optional PcbLib path -> ModelDatafile0, so Altium can
@@ -1035,13 +1006,6 @@ impl McpServer {
         let mut footprint = Footprint::new(name);
 
         if let Some(desc) = fp_json.get("description").and_then(Value::as_str) {
-            if let Err(e) = check_description_len("Footprint", name, desc) {
-                return Err(ToolCallResult::error_with_context(
-                    ErrorContext::new(operation, e)
-                        .with_filepath(filepath)
-                        .with_component(name),
-                ));
-            }
             footprint.description = desc.to_string();
         }
 

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -3526,10 +3526,11 @@ mod tests {
         }
 
         // ---------------------------------------------------------------
-        // Description length. Altium refuses to import a library whose
-        // component description exceeds 256 characters, and it gives no clue
-        // which component is at fault -- so an over-length description is
-        // rejected here instead of being written into an unopenable file.
+        // Description length. The Altium 365 library importer refuses a
+        // component whose description exceeds 256 characters and names
+        // neither library nor component; Altium Designer itself opens and
+        // reads such a library whole. So the write goes ahead and the
+        // post-write validation carries a warning that names the component.
         // ---------------------------------------------------------------
 
         /// A description of exactly `n` characters.
@@ -3537,8 +3538,28 @@ mod tests {
             "d".repeat(n)
         }
 
+        /// The validation warnings a write reported, as `component: issue`.
+        fn warnings(result: &crate::mcp::server::ToolCallResult) -> Vec<String> {
+            parse_result_json(result)["validation"]["issues"]
+                .as_array()
+                .map(|issues| {
+                    issues
+                        .iter()
+                        .filter(|i| i["severity"] == "warning")
+                        .map(|i| {
+                            format!(
+                                "{}: {}",
+                                i["component"].as_str().unwrap_or(""),
+                                i["issue"].as_str().unwrap_or("")
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+
         #[test]
-        fn a_footprint_description_at_the_limit_is_accepted_and_round_trips() {
+        fn a_footprint_description_at_the_limit_is_accepted_without_a_warning() {
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
             let path = dir.path().join("AtLimit.PcbLib");
@@ -3551,6 +3572,13 @@ mod tests {
                 }],
             }));
             assert!(!write.is_error, "{}", get_result_text(&write));
+            assert!(
+                warnings(&write)
+                    .iter()
+                    .all(|w| !w.contains("Description is")),
+                "at the limit is not over it: {:?}",
+                warnings(&write)
+            );
 
             let read = server.call_read_pcblib(&json!({
                 "filepath": path.to_string_lossy(),
@@ -3559,12 +3587,11 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .to_string();
-            assert_eq!(got.chars().count(), DESCRIPTION_MAX_LEN);
             assert_eq!(got, at_limit, "a description at the limit must survive");
         }
 
         #[test]
-        fn an_over_length_footprint_description_is_refused() {
+        fn an_over_length_footprint_description_is_written_with_a_warning() {
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
             let path = dir.path().join("TooLong.PcbLib");
@@ -3578,30 +3605,43 @@ mod tests {
                 }],
             }));
             assert!(
-                write.is_error,
-                "one character over the limit must be refused"
+                !write.is_error,
+                "Altium Designer opens such a library; it is written: {}",
+                get_result_text(&write)
             );
-            let text = get_result_text(&write);
+            assert!(path.exists(), "the library is written as asked");
+            let found = warnings(&write);
+            let warning = found
+                .iter()
+                .find(|w| w.starts_with("WIDE_DESC: Description is"))
+                .unwrap_or_else(|| panic!("a warning must name the footprint: {found:?}"));
             assert!(
-                text.contains("WIDE_DESC"),
-                "must name the footprint: {text}"
-            );
-            assert!(
-                text.contains(&DESCRIPTION_MAX_LEN.to_string()),
-                "must state the limit: {text}"
-            );
-            assert!(
-                text.contains("Shorten it by 1 characters"),
-                "must state the overshoot: {text}"
+                warning.contains("Altium 365"),
+                "must name the importer: {warning}"
             );
             assert!(
-                !path.exists(),
-                "the refusal must come before the file is written"
+                warning.contains(&DESCRIPTION_MAX_LEN.to_string()),
+                "must state the limit: {warning}"
             );
+            assert!(
+                warning.contains("shorten it by 1 characters"),
+                "must state the overshoot: {warning}"
+            );
+
+            // The description itself is untouched on disk.
+            let read = server.call_read_pcblib(&json!({
+                "filepath": path.to_string_lossy(),
+            }));
+            let got = parse_result_json(&read)["footprints"][0]["description"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count();
+            assert_eq!(got, DESCRIPTION_MAX_LEN + 1, "written whole, not truncated");
         }
 
         #[test]
-        fn an_over_length_symbol_description_is_refused() {
+        fn an_over_length_symbol_description_is_written_with_a_warning() {
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
             let path = dir.path().join("TooLong.SchLib");
@@ -3612,21 +3652,19 @@ mod tests {
                 "filepath": path.to_string_lossy(),
                 "symbols": [sym],
             }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+            let found = warnings(&write);
             assert!(
-                write.is_error,
-                "an over-length symbol description must be refused"
+                found
+                    .iter()
+                    .any(|w| w.starts_with("WIDE_SYM: Description is")
+                        && w.contains("shorten it by 40 characters")),
+                "must name the symbol and the overshoot: {found:?}"
             );
-            let text = get_result_text(&write);
-            assert!(text.contains("WIDE_SYM"), "must name the symbol: {text}");
-            assert!(
-                text.contains("Shorten it by 40 characters"),
-                "must state the overshoot: {text}"
-            );
-            assert!(!path.exists(), "nothing should be written");
         }
 
         #[test]
-        fn an_over_length_footprint_link_description_is_refused() {
+        fn an_over_length_footprint_link_description_is_written_with_a_warning() {
             let dir = test_temp_dir();
             let server = create_test_server(dir.path());
             let path = dir.path().join("Link.SchLib");
@@ -3640,24 +3678,21 @@ mod tests {
                 "filepath": path.to_string_lossy(),
                 "symbols": [sym],
             }));
+            assert!(!write.is_error, "{}", get_result_text(&write));
+            let found = warnings(&write);
             assert!(
-                write.is_error,
-                "the description on a footprint link is stored in the SchLib too"
-            );
-            assert!(
-                get_result_text(&write).contains("LINKED_FP"),
-                "must name the link: {}",
-                get_result_text(&write)
+                found
+                    .iter()
+                    .any(|w| w.starts_with("SYM -> LINKED_FP: Description is")),
+                "the link's description is stored in the SchLib too, and named: {found:?}"
             );
         }
 
-        /// `validate_library` has to catch libraries this server did not
-        /// author -- an older build, or a description copied in from another
-        /// library -- so the check exists in the validator as well as at the
-        /// API boundary. Built through the library API to sidestep the
-        /// parse-time refusal.
+        /// `validate_library` reports the same finding on libraries this
+        /// server did not author — an older build, or a description carried
+        /// in by a copy — as a warning that names the component.
         #[test]
-        fn validate_library_reports_an_over_length_description_as_an_error() {
+        fn validate_library_reports_an_over_length_description_as_a_warning() {
             use crate::altium::pcblib::{Footprint, Pad, PcbLib};
 
             let dir = test_temp_dir();
@@ -3675,16 +3710,20 @@ mod tests {
                 "filepath": path.to_string_lossy(),
             }));
             let json_out = parse_result_json(&result);
-            assert!(
-                json_out["error_count"].as_u64().unwrap() >= 1,
-                "an unopenable description must count as an error: {json_out}"
+            assert_eq!(
+                json_out["error_count"].as_u64().unwrap(),
+                0,
+                "Altium Designer opens it, so not an error: {json_out}"
             );
             let issues = json_out["issues"].as_array().unwrap();
             assert!(
                 issues.iter().any(|i| {
-                    i["severity"] == "error"
+                    i["severity"] == "warning"
                         && i["component"] == "LEGACY_FP"
-                        && i["issue"].as_str().unwrap_or("").contains("Description is")
+                        && i["issue"]
+                            .as_str()
+                            .unwrap_or("")
+                            .contains("shorten it by 90 characters")
                 }),
                 "the offending component must be named: {json_out}"
             );


### PR DESCRIPTION
## Summary

Follow-up to #460, settled with @ande2407 on its thread. The failed import was the **Altium 365 library importer** (its message names 256 characters); measured against Altium Designer 24 itself, libraries with 200/255/256/257/300-character descriptions all **open and read back whole**. So the limit is the importer's, not the format's or Altium's reader's, and a write-time refusal made the server stricter than Altium for every file-based user.

This keeps every check and the 256 constant, and changes their shape:

- **No refusal at write time.** `write_pcblib` / `write_schlib` / `update_component` write the description as asked.
- **A validation warning instead** — from `validate_library` and from the post-write validation that every mutating tool already runs (write, update, copy, cross-copy, import, batch, `manage_schlib_*`), which also covers the three write paths the parse-time check missed. The warning names the component, the importer and the overshoot: `Description is 307 characters; the Altium 365 library importer refuses a component whose description exceeds 256, so shorten it by 51 characters before importing this library into a workspace`.
- **Footprint-link descriptions** are checked by the validators too (named `symbol -> link`), which the parse-time check covered but the validators did not.
- AGENT_GUIDE section, the three schema notes and the CHANGELOG line reworded to name the importer; `TOOLS.md` regenerated.

## Verification

- The five #460 tests rewritten to the new contract: at-limit writes without a warning; over-length footprint / symbol / link descriptions are written whole (file exists, description not truncated) with a warning naming them and the overshoot; `validate_library` reports a warning and `error_count` 0
- fmt / clippy `-D warnings` / markdownlint clean; full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)