### PR TITLE
test: cover the stack-follow, body-compare, copy and merge branches; drop unreachable checks

### DIFF
--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -1925,6 +1925,35 @@ mod tests {
         }
         assert_eq!(diffs[0]["changes"][0]["first_mismatch_index"], 2);
 
+        // Every other property a body carries is a reported change too, and
+        // an outline of another vertex count is reported as such rather than
+        // as a drift.
+        let mut body_c = body_a.clone();
+        body_c.outline.push((1.0, 2.0));
+        body_c.kind = 1;
+        body_c.embedded = !body_a.embedded;
+        body_c.body_color_3d = 0x00_FF00;
+        body_c.name = "renamed".to_string();
+        body_c.standoff_height = 0.3;
+        body_c.rotation_z = 90.0;
+        let diffs = McpServer::compare_bodies(&[body_a.clone()], &[body_c], 0.001);
+        assert_eq!(diffs.len(), 1, "{diffs:?}");
+        for property in [
+            "vertex_count",
+            "kind",
+            "embedded",
+            "body_color_3d",
+            "name",
+            "standoff_height",
+            "rotation_z",
+        ] {
+            assert!(has_change(&diffs, property), "{property}: {diffs:?}");
+        }
+        assert!(
+            !has_change(&diffs, "outline"),
+            "a different vertex count is not also an outline drift: {diffs:?}"
+        );
+
         // A different model is a one-sided pair, described by layer and size.
         let other = ComponentBody::new("", "other.step");
         let diffs = McpServer::compare_bodies(&[body_a], &[other], 0.001);

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -3411,4 +3411,100 @@ mod tests {
         assert_eq!(parse_result_json(&result)["target_name"], "CHIP_0603");
         assert_eq!(PcbLib::open(&spare).unwrap().names(), ["CHIP_0603"]);
     }
+
+    /// A cross-library copy takes a new description when one is given, and
+    /// keeps the source's when not.
+    #[test]
+    fn a_cross_library_copy_takes_the_description_it_is_given() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+        let source = dir.path().join("Source.PcbLib");
+        create_test_pcblib(&source);
+        let target = dir.path().join("Target.PcbLib");
+        PcbLib::new().save(&target).unwrap();
+
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": source.to_string_lossy(),
+            "target_filepath": target.to_string_lossy(),
+            "component_name": "CHIP_0402",
+            "description": "described on the way over",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let lib = PcbLib::open(&target).unwrap();
+        assert_eq!(
+            lib.get("CHIP_0402").unwrap().description,
+            "described on the way over"
+        );
+
+        let result = server.call_copy_component_cross_library(&json!({
+            "source_filepath": source.to_string_lossy(),
+            "target_filepath": target.to_string_lossy(),
+            "component_name": "CHIP_0603",
+        }));
+        assert!(!result.is_error, "{}", get_result_text(&result));
+        let lib = PcbLib::open(&target).unwrap();
+        assert_eq!(
+            lib.get("CHIP_0603").unwrap().description,
+            PcbLib::open(&source)
+                .unwrap()
+                .get("CHIP_0603")
+                .unwrap()
+                .description,
+            "without a description the source's is kept"
+        );
+    }
+
+    /// `on_duplicate: "error"` stops a merge at the first name the target
+    /// already holds, naming it and its source, and writes nothing — in both
+    /// formats.
+    #[test]
+    fn a_merge_that_must_not_meet_a_duplicate_stops_at_the_first_one() {
+        let dir = test_temp_dir();
+        let server = create_test_server(dir.path());
+
+        let pcb_target = dir.path().join("Target.PcbLib");
+        create_test_pcblib(&pcb_target);
+        let pcb_source = dir.path().join("Source.PcbLib");
+        create_test_pcblib(&pcb_source); // the same two names again
+        let before = std::fs::read(&pcb_target).unwrap();
+        let result = server.call_merge_libraries(&json!({
+            "source_filepaths": [pcb_source.to_string_lossy()],
+            "target_filepath": pcb_target.to_string_lossy(),
+            "on_duplicate": "error",
+        }));
+        assert!(result.is_error, "{}", get_result_text(&result));
+        let text = get_result_text(&result);
+        assert!(
+            text.contains("Duplicate component name 'CHIP_0402'"),
+            "{text}"
+        );
+        assert!(text.contains("'skip' or 'rename'"), "{text}");
+        assert_eq!(
+            std::fs::read(&pcb_target).unwrap(),
+            before,
+            "nothing written"
+        );
+
+        let sch_target = dir.path().join("Target.SchLib");
+        create_test_schlib(&sch_target);
+        let sch_source = dir.path().join("Source.SchLib");
+        create_test_schlib(&sch_source);
+        let before = std::fs::read(&sch_target).unwrap();
+        let result = server.call_merge_libraries(&json!({
+            "source_filepaths": [sch_source.to_string_lossy()],
+            "target_filepath": sch_target.to_string_lossy(),
+            "on_duplicate": "error",
+        }));
+        assert!(result.is_error, "{}", get_result_text(&result));
+        let text = get_result_text(&result);
+        assert!(
+            text.contains("Duplicate component name 'RESISTOR'"),
+            "{text}"
+        );
+        assert_eq!(
+            std::fs::read(&sch_target).unwrap(),
+            before,
+            "nothing written"
+        );
+    }
 }

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -491,16 +491,6 @@ impl McpServer {
                             pad.designator, pad.width, pad.height)
                     }));
                 }
-
-                // Check for invalid coordinates
-                if !pad.x.is_finite() || !pad.y.is_finite() {
-                    issues.push(json!({
-                        "severity": "error",
-                        "component": name,
-                        "issue": format!("Pad '{}' has invalid coordinates (x: {}, y: {})",
-                            pad.designator, pad.x, pad.y)
-                    }));
-                }
             }
 
             // Check tracks for invalid values
@@ -512,17 +502,6 @@ impl McpServer {
                         "issue": format!("Track {} has invalid width: {}", i, track.width)
                     }));
                 }
-                if !track.x1.is_finite()
-                    || !track.y1.is_finite()
-                    || !track.x2.is_finite()
-                    || !track.y2.is_finite()
-                {
-                    issues.push(json!({
-                        "severity": "error",
-                        "component": name,
-                        "issue": format!("Track {} has invalid coordinates", i)
-                    }));
-                }
             }
 
             // Check arcs for invalid values
@@ -532,13 +511,6 @@ impl McpServer {
                         "severity": "error",
                         "component": name,
                         "issue": format!("Arc {} has invalid radius: {}", i, arc.radius)
-                    }));
-                }
-                if !arc.x.is_finite() || !arc.y.is_finite() {
-                    issues.push(json!({
-                        "severity": "error",
-                        "component": name,
-                        "issue": format!("Arc {} has invalid centre coordinates", i)
                     }));
                 }
             }

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -1254,9 +1254,11 @@ impl McpServer {
 mod tests {
 
     use crate::altium::pcblib::{
-        ComponentBody, EmbeddedModel, Footprint, Layer, Pad, PcbLib, Track,
+        ComponentBody, EmbeddedModel, Footprint, Layer, Pad, PadShape, PadStackMode, PcbLib, Track,
+        Via, ViaStackMode,
     };
     use crate::altium::SchLib;
+    use crate::mcp::server::McpServer;
     use crate::mcp::tools::test_support::{
         create_test_pcblib, create_test_schlib, create_test_server, get_result_text,
         parse_result_json, test_temp_dir,
@@ -3462,5 +3464,48 @@ mod tests {
             block_save(std::path::Path::new(&lib), false);
             assert!(r.is_error, "{}", get_result_text(&r));
         }
+    }
+
+    /// A primary edit reaches only the per-layer entries that shared the old
+    /// value: a height change follows where the height matched, a shape
+    /// change where the shape matched, and a layer with its own value keeps
+    /// it.
+    #[test]
+    fn a_stacked_pad_follows_a_height_and_a_shape_edit_where_layers_matched() {
+        let mut pad = Pad::smd("1", 0.0, 0.0, 1.0, 2.0);
+        pad.stack_mode = PadStackMode::TopMiddleBottom;
+        pad.per_layer_sizes = Some(vec![(1.0, 2.0), (1.0, 2.0), (0.8, 1.5)]);
+        pad.per_layer_shapes = Some(vec![PadShape::Round, PadShape::Round, PadShape::Rectangle]);
+
+        // The edit: height 2.0 -> 2.6, shape Round -> Oval; width untouched.
+        pad.height = 2.6;
+        pad.shape = PadShape::Oval;
+        let followed = McpServer::propagate_pad_edit_to_stack(&mut pad, 1.0, 2.0, PadShape::Round);
+
+        assert_eq!(followed, 4, "two heights and two shapes followed");
+        assert_eq!(
+            pad.per_layer_sizes.as_ref().unwrap(),
+            &vec![(1.0, 2.6), (1.0, 2.6), (0.8, 1.5)],
+            "the layer with its own height keeps it"
+        );
+        assert_eq!(
+            pad.per_layer_shapes.as_ref().unwrap(),
+            &vec![PadShape::Oval, PadShape::Oval, PadShape::Rectangle],
+            "the layer with its own shape keeps it"
+        );
+    }
+
+    /// A via edit that leaves the diameter as it was touches no layer.
+    #[test]
+    fn a_via_edit_without_a_diameter_change_touches_no_layer() {
+        let mut via = Via::new(0.0, 0.0, 0.6, 0.3);
+        via.diameter_stack_mode = ViaStackMode::TopMiddleBottom;
+        via.per_layer_diameters = Some(vec![0.6, 0.6, 0.6]);
+        let followed = McpServer::propagate_via_edit_to_stack(&mut via, 0.6);
+        assert_eq!(followed, 0);
+        assert_eq!(
+            via.per_layer_diameters.as_ref().unwrap(),
+            &vec![0.6, 0.6, 0.6]
+        );
     }
 }

--- a/src/mcp/tools/parsing.rs
+++ b/src/mcp/tools/parsing.rs
@@ -4697,6 +4697,161 @@ mod tests {
             assert!(err.contains("bottom_left, bottom_center"), "{err}");
         }
 
+        /// Every enum-valued pad field refuses an unrecognised name, naming
+        /// the pad and the field; a non-string value is refused too.
+        #[test]
+        fn parse_pad_refuses_an_unrecognised_enum_name() {
+            let with = |key: &str, value: serde_json::Value| {
+                let mut json = pad_json();
+                json[key] = value;
+                McpServer::parse_pad(&json).unwrap_err()
+            };
+            for (key, accepted) in [
+                ("paste_mask_expansion_mode", "none, manual, from_rule"),
+                ("solder_mask_expansion_mode", "none, manual, from_rule"),
+                ("power_plane_connect_style", "relief, direct, no_connect"),
+                ("stack_mode", "simple, top_middle_bottom, full_stack"),
+            ] {
+                let err = with(key, json!("whatever"));
+                assert!(err.contains(&format!("Pad '1' {key} 'whatever'")), "{err}");
+                assert!(err.contains(accepted), "{err}");
+            }
+            let err = with("hole_shape", json!(5));
+            assert!(err.contains("hole_shape must be a string, got 5"), "{err}");
+            assert!(err.contains("round, square, slot"), "{err}");
+        }
+
+        /// A `PcbLib` text's kind, stroke font and justification refuse an
+        /// unrecognised name each.
+        #[test]
+        fn parse_text_refuses_an_unrecognised_enum_name() {
+            let with = |key: &str, value: &str| {
+                let mut json = json!({ "x": 0.0, "y": 0.0, "text": "T", "height": 1.0 });
+                json[key] = json!(value);
+                McpServer::parse_text(&json).unwrap_err()
+            };
+            let err = with("kind", "hologram");
+            assert!(
+                err.contains("Text kind 'hologram'") && err.contains("stroke, true_type, bar_code"),
+                "{err}"
+            );
+            let err = with("stroke_font", "comic");
+            assert!(
+                err.contains("Text stroke_font 'comic'")
+                    && err.contains("default, sans_serif, serif"),
+                "{err}"
+            );
+            let err = with("justification", "sideways");
+            assert!(
+                err.contains("Text justification 'sideways'") && err.contains("bottom_left"),
+                "{err}"
+            );
+        }
+
+        /// A pin's orientation, electrical type and decorations refuse an
+        /// unrecognised name each, naming the pin.
+        #[test]
+        fn parse_schlib_pin_refuses_an_unrecognised_enum_name() {
+            let with = |key: &str, value: &str| {
+                let mut json = json!({ "designator": "7", "x": 0, "y": 0 });
+                json[key] = json!(value);
+                McpServer::parse_schlib_pin(&json).unwrap_err()
+            };
+            let err = with("orientation", "sideways");
+            assert!(
+                err.contains("Pin '7' orientation 'sideways'")
+                    && err.contains("left, right, up, down"),
+                "{err}"
+            );
+            let err = with("electrical_type", "magic");
+            assert!(
+                err.contains("Pin '7' electrical_type 'magic'") && err.contains("open_collector"),
+                "{err}"
+            );
+            let err = with("symbol_inner_edge", "sparkle");
+            assert!(
+                err.contains("Pin '7' symbol_inner_edge 'sparkle'") && err.contains("clock"),
+                "{err}"
+            );
+        }
+
+        /// A region's holes are refused by name when malformed, its layer
+        /// when unknown, and its kind takes the serde object form a read
+        /// echoes for a non-standard KIND.
+        #[test]
+        fn parse_region_refuses_malformed_holes_and_layers_and_reads_the_other_kind() {
+            use crate::altium::pcblib::RegionKind;
+            let base = || {
+                json!({
+                    "layer": "Top Layer",
+                    "vertices": [
+                        { "x": 0.0, "y": 0.0 }, { "x": 1.0, "y": 0.0 }, { "x": 0.0, "y": 1.0 },
+                    ],
+                })
+            };
+            let with = |key: &str, value: serde_json::Value| {
+                let mut json = base();
+                json[key] = value;
+                McpServer::parse_region(&json)
+            };
+
+            let err = with("holes", json!("nope")).unwrap_err();
+            assert!(err.contains("holes must be an array"), "{err}");
+            let err = with("holes", json!(["nope"])).unwrap_err();
+            assert!(err.contains("hole 0 must be an array of vertices"), "{err}");
+            let err = with(
+                "holes",
+                json!([[{ "x": 0.0, "y": 0.0 }, { "x": 1.0, "y": 0.0 }]]),
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("hole 0 needs at least 3 vertices, got 2"),
+                "{err}"
+            );
+            let err = with(
+                "holes",
+                json!([[{ "x": 0.0, "y": 0.0 }, { "x": 1.0 }, { "x": 0.0, "y": 1.0 }]]),
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("hole 0 vertex 1 is missing a numeric 'y'"),
+                "{err}"
+            );
+
+            let err = with("layer", json!("Nowhere")).unwrap_err();
+            assert!(err.contains("Region has invalid layer 'Nowhere'"), "{err}");
+
+            assert_eq!(
+                with("kind", json!({ "other": 7 })).unwrap().kind,
+                RegionKind::Other(7)
+            );
+            let err = with("kind", json!({ "bogus": 1 })).unwrap_err();
+            assert!(
+                err.contains("Region kind") && err.contains("not recognised"),
+                "{err}"
+            );
+            let err = with("kind", json!(4.5)).unwrap_err();
+            assert!(err.contains("is not a KIND integer"), "{err}");
+        }
+
+        /// A track or arc without a layer lands on the overlay, the layer a
+        /// silkscreen outline is drawn on.
+        #[test]
+        fn a_track_or_arc_without_a_layer_defaults_to_the_top_overlay() {
+            use crate::altium::pcblib::Layer;
+            let track = McpServer::parse_track(&json!({
+                "x1": 0.0, "y1": 0.0, "x2": 1.0, "y2": 0.0, "width": 0.2,
+            }))
+            .expect("track should parse");
+            assert_eq!(track.layer, Layer::TopOverlay);
+            let arc = McpServer::parse_arc(&json!({
+                "x": 0.0, "y": 0.0, "radius": 1.0, "start_angle": 0.0, "end_angle": 90.0,
+                "width": 0.2,
+            }))
+            .expect("arc should parse");
+            assert_eq!(arc.layer, Layer::TopOverlay);
+        }
+
         /// Every value the schemas advertise parses, and every synonym lands
         /// on a name that does: a list entry that no longer matches its enum
         /// would advertise a value the parser then refuses.


### PR DESCRIPTION
## Summary

Coverage push, measured with CI's own command (`cargo llvm-cov … --ignore-filename-regex main.rs`): **99.15% → 99.31%** line coverage, 394 → 320 uncovered lines, in two commits.

**Removed, not covered:** `validate_library` checked pad, track and arc coordinates for being finite. A file stores coordinates as i32 units, which always convert to a finite `f64`, and the write path refuses a non-finite value before it is stored — the three branches could not run, so they are gone (`library_ops.rs` 43 → 26 uncovered lines).

**Covered by new tests**, each of a branch that was written but never exercised:
- `propagate_pad_edit_to_stack`: a height change and a shape change each reach only the per-layer entries that shared the old value (4 followed, 2 kept); `propagate_via_edit_to_stack`: an edit that leaves the diameter alone touches no layer
- `compare_bodies`: every property it reports — vertex count, kind, embedded, colour, name, standoff, rotation — and that a different vertex count is not also reported as drift
- `copy_component_cross_library`: the `description` argument is applied; without it the source's description is kept
- `merge_libraries` with `on_duplicate: "error"`: stops at the first duplicate, names it and its source, writes nothing — both formats
- The refusal edges the #454 tests had only for vias: every enum-valued **pad** field (mask modes, power-plane style, stack mode; a non-string value), **text** field (kind, stroke font, justification) and **pin** field (orientation, electrical type, decorations) refuses an unrecognised name by name; a **region**'s malformed holes (non-array, non-array contour, too few vertices, vertex missing a coordinate), unknown layer and non-integer kind are refused, its serde-form kind `{"other": n}` reads back; a track or arc without a layer lands on the top overlay (`parsing.rs` 26 → 0)

## Verification

fmt / clippy `-D warnings` clean; **1503 tests** green

🤖 Generated with [Claude Code](https://claude.com/claude-code)