### PR TITLE
test(mcp): say what the space-less layer-name test pins

### DIFF
--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -2447,9 +2447,9 @@ mod tests {
             create_rich_pcblib(&path);
             let filepath = path.to_string_lossy().to_string();
 
-            // Space-less names bypass Layer::parse and exercise the alias arms.
-            // The last member of each numbered family pins the full range now
-            // that the aliases delegate to Layer::parse canonical names.
+            // The camel-case alias form (`MidLayer5`, the serde spelling) resolves
+            // through the same `Layer::parse` as the spaced Altium name; the last
+            // member of each numbered family pins the full range.
             for (input, expected) in [
                 ("MidLayer5", Layer::MidLayer5),
                 ("InternalPlane2", Layer::InternalPlane2),


### PR DESCRIPTION
Found while reviewing the regenerated AI-findings PR #469: the comment on `update_primitive_spaceless_layer_aliases_resolve` still described "alias arms" that space-less names "bypass `Layer::parse`" to reach — the hand-written match the finding was aimed at. That match is gone (every lookup goes through `Layer::parse`, which accepts the camel-case alias), so the comment now states the present invariant: the alias form resolves through the same parser as the spaced Altium name, and the last member of each numbered family pins the full range.

Comment-only; the test is unchanged and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
