### PR TITLE
fix(mcp): one message for a component a tool cannot find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   answer with the spelling on file, and a name the library does not hold is
   an error naming the available components — the same words `get_component`
   and `update_component` use.
+- **Every tool that looks up a component reports a miss the same way.**
+  Seventeen lookups used six wordings — `Symbol 'X' not found in library`,
+  `Footprint 'X' not found. Available: ["A", "B"]`, `Source component 'X'
+  not found`, a five-name "include" hint — and most named nothing of what
+  the library holds. All of them now say
+  `Component 'X' not found in library. Available: A, B, C ... and N more`
+  (`compare_components` names the file it searched, the cross-library
+  tools the source library).
 - **`update_component` is type-checked as thoroughly as `write_pcblib` /
   `write_schlib`, and every key the tools accept is in `tools/list`.** The
   tool's `footprint` and `symbol` were untyped objects, so the check above

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -236,13 +236,17 @@ impl McpServer {
 
         // Get components
         let Some(fp_a) = lib_a.get(name_a) else {
-            return ToolCallResult::error(format!(
-                "Component '{name_a}' not found in '{filepath_a}'"
+            return ToolCallResult::error(super::component_not_found_in(
+                name_a,
+                &format!("'{filepath_a}'"),
+                &lib_a.names(),
             ));
         };
         let Some(fp_b) = lib_b.get(name_b) else {
-            return ToolCallResult::error(format!(
-                "Component '{name_b}' not found in '{filepath_b}'"
+            return ToolCallResult::error(super::component_not_found_in(
+                name_b,
+                &format!("'{filepath_b}'"),
+                &lib_b.names(),
             ));
         };
 
@@ -1381,13 +1385,17 @@ impl McpServer {
 
         // Get components
         let Some(sym_a) = lib_a.get(name_a) else {
-            return ToolCallResult::error(format!(
-                "Component '{name_a}' not found in '{filepath_a}'"
+            return ToolCallResult::error(super::component_not_found_in(
+                name_a,
+                &format!("'{filepath_a}'"),
+                &lib_a.names(),
             ));
         };
         let Some(sym_b) = lib_b.get(name_b) else {
-            return ToolCallResult::error(format!(
-                "Component '{name_b}' not found in '{filepath_b}'"
+            return ToolCallResult::error(super::component_not_found_in(
+                name_b,
+                &format!("'{filepath_b}'"),
+                &lib_b.names(),
             ));
         };
 

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -90,8 +90,9 @@ impl McpServer {
 
         // Find the source component
         let Some(source) = library.get(source_name) else {
-            return ToolCallResult::error(format!(
-                "Source component '{source_name}' not found in library"
+            return ToolCallResult::error(super::component_not_found(
+                source_name,
+                &library.names(),
             ));
         };
 
@@ -172,8 +173,9 @@ impl McpServer {
 
         // Find the source component
         let Some(source) = library.get(source_name) else {
-            return ToolCallResult::error(format!(
-                "Source component '{source_name}' not found in library"
+            return ToolCallResult::error(super::component_not_found(
+                source_name,
+                &library.names(),
             ));
         };
 
@@ -308,7 +310,7 @@ impl McpServer {
 
         // Renamed in place: the component keeps its position in the library.
         if !library.rename(old_name, new_name) {
-            return ToolCallResult::error(format!("Component '{old_name}' not found in library"));
+            return ToolCallResult::error(super::component_not_found(old_name, &library.names()));
         }
 
         // If dry_run, return what would happen without writing
@@ -377,7 +379,7 @@ impl McpServer {
 
         // Renamed in place: the symbol keeps its position in the library.
         if !library.rename(old_name, new_name) {
-            return ToolCallResult::error(format!("Component '{old_name}' not found in library"));
+            return ToolCallResult::error(super::component_not_found(old_name, &library.names()));
         }
 
         // If dry_run, return what would happen without writing
@@ -542,8 +544,10 @@ impl McpServer {
 
         // Find the source component
         let Some(source) = source_library.get(component_name) else {
-            return ToolCallResult::error(format!(
-                "Component '{component_name}' not found in source library"
+            return ToolCallResult::error(super::component_not_found_in(
+                component_name,
+                "source library",
+                &source_library.names(),
             ));
         };
 
@@ -716,8 +720,10 @@ impl McpServer {
 
         // Find the source component
         let Some(source) = source_library.get(component_name) else {
-            return ToolCallResult::error(format!(
-                "Component '{component_name}' not found in source library"
+            return ToolCallResult::error(super::component_not_found_in(
+                component_name,
+                "source library",
+                &source_library.names(),
             ));
         };
 
@@ -1575,7 +1581,7 @@ mod tests {
             "target_name": "NOPE_COPY",
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Source component 'NOPE' not found"));
+        assert!(get_result_text(&result).contains("Component 'NOPE' not found in library"));
     }
 
     #[test]

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -758,11 +758,9 @@ impl McpServer {
         };
 
         // Find footprint
+        let names = library.names();
         let Some(footprint) = library.get_mut(component_name) else {
-            let available: Vec<String> = library.names();
-            return ToolCallResult::error(format!(
-                "Footprint '{component_name}' not found. Available: {available:?}"
-            ));
+            return ToolCallResult::error(super::component_not_found(component_name, &names));
         };
 
         // Find pad by designator
@@ -875,11 +873,9 @@ impl McpServer {
         };
 
         // Find footprint
+        let names = library.names();
         let Some(footprint) = library.get_mut(component_name) else {
-            let available: Vec<String> = library.names();
-            return ToolCallResult::error(format!(
-                "Footprint '{component_name}' not found. Available: {available:?}"
-            ));
+            return ToolCallResult::error(super::component_not_found(component_name, &names));
         };
 
         let mut changes: Vec<Value> = Vec::new();

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -32,6 +32,13 @@ mod validation;
 /// a count of the rest — in the same words from every tool that looks one
 /// up.
 pub fn component_not_found(component_name: &str, names: &[String]) -> String {
+    component_not_found_in(component_name, "library", names)
+}
+
+/// [`component_not_found`] for a tool that holds more than one library,
+/// where `which` says which one was searched ("source library", a file
+/// name the caller passed).
+pub fn component_not_found_in(component_name: &str, which: &str, names: &[String]) -> String {
     const SHOWN: usize = 10;
     let available = if names.is_empty() {
         "none (the library is empty)".to_string()
@@ -47,12 +54,12 @@ pub fn component_not_found(component_name: &str, names: &[String]) -> String {
             rest => format!("{shown} ... and {rest} more"),
         }
     };
-    format!("Component '{component_name}' not found in library. Available: {available}")
+    format!("Component '{component_name}' not found in {which}. Available: {available}")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::component_not_found;
+    use super::{component_not_found, component_not_found_in};
 
     /// The message names the request, then the first ten names on file and
     /// how many more there are; an empty library says so.
@@ -75,6 +82,10 @@ mod tests {
             component_not_found("x", &names(12)),
             "Component 'x' not found in library. Available: C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 \
              ... and 2 more"
+        );
+        assert_eq!(
+            component_not_found_in("X", "source library", &names(1)),
+            "Component 'X' not found in source library. Available: C1"
         );
     }
 }

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -51,26 +51,9 @@ impl McpServer {
 
         // Find the footprint
         let Some(footprint) = library.get(component_name) else {
-            let available: Vec<_> = library.iter().take(5).map(|f| &f.name).collect();
-            let hint = if available.is_empty() {
-                "Library is empty".to_string()
-            } else {
-                format!(
-                    "Available footprints include: {}{}",
-                    available
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    if library.len() > 5 {
-                        format!(" (and {} more)", library.len() - 5)
-                    } else {
-                        String::new()
-                    }
-                )
-            };
-            return ToolCallResult::error(format!(
-                "Footprint '{component_name}' not found in library. {hint}"
+            return ToolCallResult::error(super::component_not_found(
+                component_name,
+                &library.names(),
             ));
         };
 
@@ -182,22 +165,9 @@ impl McpServer {
 
         // Find the symbol
         let Some(symbol) = library.get(component_name) else {
-            let available: Vec<_> = library.iter().take(5).map(|s| s.name.as_str()).collect();
-            let hint = if available.is_empty() {
-                "Library is empty".to_string()
-            } else {
-                format!(
-                    "Available symbols include: {}{}",
-                    available.join(", "),
-                    if library.len() > 5 {
-                        format!(" (and {} more)", library.len() - 5)
-                    } else {
-                        String::new()
-                    }
-                )
-            };
-            return ToolCallResult::error(format!(
-                "Symbol '{component_name}' not found in library. {hint}"
+            return ToolCallResult::error(super::component_not_found(
+                component_name,
+                &library.names(),
             ));
         };
 
@@ -1163,7 +1133,7 @@ mod tests {
             // Not-found with >5 candidates -> "and N more" hint.
             let many = dir.path().join("Many.PcbLib");
             let mut lib = PcbLib::new();
-            for i in 0..6 {
+            for i in 0..12 {
                 lib.add(Footprint::new(format!("FP{i}")));
             }
             lib.save(&many).unwrap();
@@ -1171,7 +1141,11 @@ mod tests {
                 "filepath": many.to_string_lossy(), "component_name": "GHOST",
             }));
             assert!(r.is_error);
-            assert!(get_result_text(&r).contains("more"));
+            let text = get_result_text(&r);
+            assert!(
+                text.contains("Available: FP0, FP1") && text.contains("... and 2 more"),
+                "{text}"
+            );
         }
 
         #[test]
@@ -1258,7 +1232,7 @@ mod tests {
             // Not-found with >5 candidates.
             let many = dir.path().join("ManySym.SchLib");
             let mut lib = SchLib::new();
-            for i in 0..6 {
+            for i in 0..12 {
                 lib.add(Symbol::new(format!("S{i}")));
             }
             lib.save(&many).unwrap();
@@ -1266,7 +1240,11 @@ mod tests {
                 "filepath": many.to_string_lossy(), "component_name": "GHOST",
             }));
             assert!(r.is_error);
-            assert!(get_result_text(&r).contains("more"));
+            let text = get_result_text(&r);
+            assert!(
+                text.contains("Available: S0, S1") && text.contains("... and 2 more"),
+                "{text}"
+            );
         }
     }
 
@@ -1307,8 +1285,8 @@ mod tests {
 
     #[test]
     fn rendering_from_an_empty_library_says_so_rather_than_listing_nothing() {
-        // "Available symbols include: " with an empty list reads as a bug in
-        // the tool; naming the real cause points at the file instead.
+        // An empty "Available:" list would read as a bug in the tool; naming
+        // the real cause points at the file instead.
         use crate::altium::schlib::SchLib;
 
         let dir = test_temp_dir();
@@ -1322,7 +1300,7 @@ mod tests {
         }));
         assert!(r.is_error);
         assert!(
-            get_result_text(&r).contains("Library is empty"),
+            get_result_text(&r).contains("Available: none (the library is empty)"),
             "{}",
             get_result_text(&r)
         );

--- a/src/mcp/tools/schlib_manage.rs
+++ b/src/mcp/tools/schlib_manage.rs
@@ -48,8 +48,9 @@ impl McpServer {
 
                 // Find the symbol
                 let Some(symbol) = library.get(component_name) else {
-                    return ToolCallResult::error(format!(
-                        "Symbol '{component_name}' not found in library"
+                    return ToolCallResult::error(super::component_not_found(
+                        component_name,
+                        &library.names(),
                     ));
                 };
 
@@ -112,9 +113,11 @@ impl McpServer {
                 };
 
                 // Find the symbol (mutable)
+                let names = library.names();
                 let Some(symbol) = library.get_mut(component_name) else {
-                    return ToolCallResult::error(format!(
-                        "Symbol '{component_name}' not found in library"
+                    return ToolCallResult::error(super::component_not_found(
+                        component_name,
+                        &names,
                     ));
                 };
 
@@ -367,8 +370,9 @@ impl McpServer {
 
                 // Find the symbol
                 let Some(symbol) = library.get(component_name) else {
-                    return ToolCallResult::error(format!(
-                        "Symbol '{component_name}' not found in library"
+                    return ToolCallResult::error(super::component_not_found(
+                        component_name,
+                        &library.names(),
                     ));
                 };
 
@@ -406,9 +410,11 @@ impl McpServer {
                 };
 
                 // Find the symbol (mutable)
+                let names = library.names();
                 let Some(symbol) = library.get_mut(component_name) else {
-                    return ToolCallResult::error(format!(
-                        "Symbol '{component_name}' not found in library"
+                    return ToolCallResult::error(super::component_not_found(
+                        component_name,
+                        &names,
                     ));
                 };
 
@@ -666,7 +672,7 @@ mod tests {
             "operation": "list",
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+        assert!(get_result_text(&result).contains("Component 'NOPE' not found in library"));
 
         // Get a parameter that does not exist.
         let result = server.call_manage_schlib_parameters(&json!({
@@ -883,7 +889,7 @@ mod tests {
             "operation": "list",
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+        assert!(get_result_text(&result).contains("Component 'NOPE' not found in library"));
 
         // Unknown operation.
         let result = server.call_manage_schlib_footprints(&json!({
@@ -1033,7 +1039,7 @@ mod tests {
                     "value": "1k",
                 }));
                 assert!(result.is_error, "{operation} must reject an unknown symbol");
-                assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+                assert!(get_result_text(&result).contains("Component 'NOPE' not found in library"));
             }
         }
 
@@ -1157,7 +1163,7 @@ mod tests {
                     "footprint_name": "SOIC-8",
                 }));
                 assert!(result.is_error, "{operation} must reject an unknown symbol");
-                assert!(get_result_text(&result).contains("Symbol 'NOPE' not found"));
+                assert!(get_result_text(&result).contains("Component 'NOPE' not found in library"));
             }
         }
 

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -339,11 +339,11 @@ impl McpServer {
     ) -> ToolCallResult {
         // Find the footprint
         let Some(footprint) = library.get(footprint_name) else {
-            let available: Vec<&str> = library.iter().map(|fp| fp.name.as_str()).collect();
+            let available = library.names();
             let result = json!({
                 "status": "error",
                 "filepath": filepath,
-                "error": format!("Footprint '{}' not found", footprint_name),
+                "error": super::component_not_found(footprint_name, &available),
                 "available_footprints": available,
             });
             return ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap());


### PR DESCRIPTION
Stacked on #473 (it introduces `component_not_found`); GitHub will retarget this to `main` when #473 merges.

## The class
"A component the tool was asked for is not in the library" was reported from 17 places in 6 wordings, and most of them said nothing about what *is* there:

| Where | Was |
|---|---|
| `manage_schlib_parameters` / `manage_schlib_footprints` (4) | `Symbol 'X' not found in library` |
| `update_pad` / `update_primitive` | `Footprint 'X' not found. Available: ["A", "B"]` — a `Vec`'s debug format |
| `copy_component`, `rename_component` (4) | `Source component 'X' not found in library`, `Component 'X' not found in library` |
| `copy_component_cross_library` (2) | `Component 'X' not found in source library` |
| `render_footprint` / `render_symbol` | `… not found in library. Available footprints include: A, B, C, D, E (and 7 more)` / `Library is empty` |
| `compare_components` (4) | `Component 'X' not found in 'path'` |
| `add_step_model` | JSON `Footprint 'X' not found` + `available_footprints` |

## Now
All of them: `Component 'X' not found in library. Available: A, B, C, D, E, F, G, H, I, J ... and 2 more` (an empty library: `Available: none (the library is empty)`), via `component_not_found` — plus `component_not_found_in(name, which, names)` for the tools that hold more than one library (`compare_components` names the file it searched, the cross-library copy the source library). `add_step_model` keeps its structured `available_footprints` array beside the same text.

Three `render` tests were pinned to the five-name hint; they now assert the shared wording (12 components → `... and 2 more`). Full suite green, clippy `-D warnings`, rustdoc, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
