### PR TITLE
test(altium): cover the readers' edge branches and the shape flags the defaults leave unset

### DIFF
--- a/src/altium/pcblib/reader/mod.rs
+++ b/src/altium/pcblib/reader/mod.rs
@@ -166,11 +166,9 @@ pub fn parse_unique_id_stream(data: &[u8]) -> UniqueIdMap {
     let mut entries = UniqueIdMap::new();
     let mut offset = 0;
 
-    while offset + 4 <= data.len() {
-        // Read 4-byte little-endian length
-        let Some(record_len) = read_u32(data, offset) else {
-            break;
-        };
+    // Each record is `[len:4][len bytes]`; the scan ends at the first offset
+    // without a whole length prefix.
+    while let Some(record_len) = read_u32(data, offset) {
         let record_len = record_len as usize;
         offset += 4;
 
@@ -650,14 +648,9 @@ pub fn parse_data_stream(
     data: &[u8],
     wide_strings: Option<&WideStrings>,
 ) {
-    if data.len() < 5 {
-        tracing::warn!("Data stream too short");
-        return;
-    }
-
     // Read name block: [block_len:4][str_len:1][name:str_len]
     let Some(name_block_len) = read_u32(data, 0) else {
-        tracing::warn!("Failed to read name block length");
+        tracing::warn!("Data stream too short for a name block");
         return;
     };
 
@@ -921,9 +914,11 @@ mod tests {
         assert_eq!(primitive_count(&fp), 0);
 
         // Too short to hold even the name block: returns without reading.
-        let mut fp = Footprint::new("FP");
-        parse_data_stream(&mut fp, &[0_u8; 4], None);
-        assert_eq!(primitive_count(&fp), 0);
+        for runt in [&[0_u8; 4][..], &[0_u8; 3][..]] {
+            let mut fp = Footprint::new("FP");
+            parse_data_stream(&mut fp, runt, None);
+            assert_eq!(primitive_count(&fp), 0);
+        }
     }
 
     #[test]
@@ -943,6 +938,14 @@ mod tests {
         let (block, offset) = read_block(&data, 0).unwrap();
         assert_eq!(block.len(), 5);
         assert_eq!(offset, 9);
+
+        // The 100 kB sanity cap: a block claiming more is refused as corrupt.
+        let mut over = 100_001_u32.to_le_bytes().to_vec();
+        over.resize(4 + 100_001, 0);
+        assert!(read_block(&over, 0).is_none());
+        let mut at_cap = 100_000_u32.to_le_bytes().to_vec();
+        at_cap.resize(4 + 100_000, 0);
+        assert!(read_block(&at_cap, 0).is_some());
     }
 
     #[test]
@@ -1130,16 +1133,79 @@ mod tests {
         let mut mixed = record("|NOTHING=USEFUL");
         mixed.extend_from_slice(&record(good));
         assert_eq!(parse_unique_id_stream(&mixed).len(), 1);
+
+        // So is a record that is not UTF-8.
+        let mut binary = 2_u32.to_le_bytes().to_vec();
+        binary.extend_from_slice(&[0xFF, 0xFE]);
+        binary.extend_from_slice(&record(good));
+        assert_eq!(parse_unique_id_stream(&binary).len(), 1);
+    }
+
+    /// A GUID record is attached only when its kind is known, its ordinal
+    /// lies within the footprint's write sequence and the kind there agrees;
+    /// kind 85 names the footprint itself.
+    #[test]
+    fn primitive_guids_attach_only_where_kind_and_ordinal_agree() {
+        use crate::altium::pcblib::{Pad, PrimitiveGuid, PrimitiveKind};
+
+        let mut fp = Footprint::new("FP");
+        fp.add_pad(Pad::smd("1", 0.0, 0.0, 1.0, 1.0));
+        fp.add_pad(Pad::smd("2", 2.0, 0.0, 1.0, 1.0));
+        let record = |object_kind: u32, index: u32, guid: &str| PrimitiveGuid {
+            object_kind,
+            index,
+            guid: guid.to_string(),
+        };
+        let records = [
+            record(85, 0, "{FOOTPRINT}"),
+            record(99, 0, "{UNKNOWN-KIND}"),
+            record(
+                PrimitiveKind::Track.altium_object_id(),
+                0,
+                "{KIND-MISMATCH}",
+            ),
+            record(
+                PrimitiveKind::Pad.altium_object_id(),
+                7,
+                "{BEYOND-SEQUENCE}",
+            ),
+            record(PrimitiveKind::Pad.altium_object_id(), 1, "{PAD-2}"),
+        ];
+        apply_primitive_guids(&mut fp, &records);
+        assert_eq!(fp.guid.as_deref(), Some("{FOOTPRINT}"));
+        assert_eq!(
+            fp.pads[0].guid, None,
+            "the mismatched and out-of-range records"
+        );
+        assert_eq!(fp.pads[1].guid.as_deref(), Some("{PAD-2}"));
+    }
+
+    /// A unique ID names a text primitive by its ordinal like any other.
+    #[test]
+    fn unique_ids_reach_text_primitives() {
+        use crate::altium::pcblib::{Layer, Text};
+
+        let mut fp = Footprint::new("FP");
+        fp.add_text(Text::new(0.0, 0.0, "T", 1.0, Layer::TopOverlay));
+        let ids = vec![UniqueIdEntry {
+            primitive_index: 0,
+            primitive_type: "Text".to_string(),
+            unique_id: "TEXTUID1".to_string(),
+        }];
+        apply_unique_ids(&mut fp, &ids);
+        assert_eq!(fp.text[0].unique_id.as_deref(), Some("TEXTUID1"));
     }
 
     #[test]
     fn wide_strings_skips_entries_it_cannot_decode() {
         // Malformed entries have to be dropped individually: one bad index
         // must not cost the caller the rest of the table.
-        let stream = b"|ENCODEDTEXT0=84,69,83,84|ENCODEDTEXTx=65|ENCODEDTEXT2=|NOTENCODED=1|";
+        let stream =
+            b"|ENCODEDTEXT0=84,69,83,84|ENCODEDTEXTx=65|ENCODEDTEXT2=|ENCODEDTEXT5|NOTENCODED=1|";
         let parsed = parse_wide_strings(stream);
         assert_eq!(parsed.get(&0).map(String::as_str), Some("TEST"));
-        // A non-numeric index, an empty payload and an unrelated key all drop.
+        // A non-numeric index, an empty payload, an entry with no `=` and an
+        // unrelated key all drop.
         assert_eq!(parsed.len(), 1, "{parsed:?}");
     }
 

--- a/src/altium/schlib/storage.rs
+++ b/src/altium/schlib/storage.rs
@@ -140,10 +140,9 @@ pub(super) fn for_each_entry<F: FnMut(&str, &[u8])>(
     };
     let mut offset = 4 + header_len as usize;
 
-    while offset + 4 <= raw.len() {
-        let Some(size_word) = read_u32_le(raw, offset) else {
-            break;
-        };
+    // Each block is `[u32 size word][block]`; the walk ends at the first
+    // offset without a whole size word.
+    while let Some(size_word) = read_u32_le(raw, offset) {
         let block_size = (size_word & 0x00FF_FFFF) as usize;
         if block_size == 0 {
             break;
@@ -297,6 +296,25 @@ mod tests {
         bad_tag.extend_from_slice(&(0x0100_0003_u32).to_le_bytes());
         bad_tag.extend_from_slice(&[0x00, 0x01, b'x']);
         assert_eq!(walk(&storage_stream(&bad_tag)).len(), 1, "missing 0xD0 tag");
+    }
+
+    /// A payload length running past its own block is skipped as an entry
+    /// and the walk carries on at the next block, whose size word is sound.
+    #[test]
+    fn an_entry_whose_payload_overruns_its_block_is_skipped_not_fatal() {
+        let mut first = Vec::new();
+        write_entry(&mut first, "a.bmp", b"AAA").expect("entry should write");
+        // The compressed length sits after [size:4][tag:1][name_len:1][name].
+        let comp_len_at = 4 + 1 + 1 + "a.bmp".len();
+        first[comp_len_at..comp_len_at + 4].copy_from_slice(&0xFFFF_u32.to_le_bytes());
+        let mut second = Vec::new();
+        write_entry(&mut second, "b.bmp", b"BBB").expect("entry should write");
+
+        let mut entries = first;
+        entries.extend_from_slice(&second);
+        let seen = walk(&storage_stream(&entries));
+        assert_eq!(seen.len(), 1, "{seen:?}");
+        assert_eq!(seen[0].0, "b.bmp");
     }
 
     #[test]

--- a/tests/file_io_roundtrip.rs
+++ b/tests/file_io_roundtrip.rs
@@ -503,6 +503,41 @@ fn schlib_preserves_unique_id_and_pin_accessibility() {
     );
 }
 
+#[test]
+fn schlib_preserves_shape_flags_the_defaults_leave_unset() {
+    // The writer emits Transparent=T only for a transparent polyline and
+    // omits IsNotAccesible for an accessible arc or ellipse; each must read
+    // back as set, not as the from-scratch default.
+    use altium_designer_mcp::altium::schlib::{Arc as SchArc, Ellipse, Polyline};
+
+    let temp_dir = test_temp_dir();
+    let file_path = temp_dir.path().join("test_shape_flags.SchLib");
+
+    let mut lib = SchLib::new();
+    let mut sym = Symbol::new("FLAGS");
+    sym.add_pin(Pin::new("1", "1", -20, 0, 10, PinOrientation::Left));
+    let mut polyline = Polyline::new(vec![(0.0, 0.0), (10.0, 10.0)]);
+    polyline.transparent = true;
+    sym.add_polyline(polyline);
+    let mut arc = SchArc::new(0, 0, 5, 0.0, 90.0);
+    arc.is_not_accessible = false;
+    sym.add_arc(arc);
+    let mut ellipse = Ellipse::new(0, 0, 4, 2);
+    ellipse.is_not_accessible = false;
+    sym.add_ellipse(ellipse);
+    lib.add(sym);
+    lib.save(&file_path).expect("Failed to write SchLib");
+
+    let read_lib = SchLib::open(&file_path).expect("Failed to read SchLib");
+    let read_sym = read_lib.get("FLAGS").expect("Symbol not found");
+    assert!(read_sym.polylines[0].transparent, "polyline Transparent");
+    assert!(!read_sym.arcs[0].is_not_accessible, "arc accessible");
+    assert!(
+        !read_sym.ellipses[0].is_not_accessible,
+        "ellipse accessible"
+    );
+}
+
 /// Returns the set of OLE stream paths (lower-cased) in a written library file,
 /// for asserting whether the optional pin auxiliary streams were emitted.
 fn ole_stream_paths(path: &std::path::Path) -> Vec<String> {


### PR DESCRIPTION
Coverage push into the format layer — the branches the golden fixtures never reach because a well-formed file never takes them.

## PcbLib reader (`src/altium/pcblib/reader/mod.rs`)
- `apply_primitive_guids`: a record with an unknown object kind, an ordinal beyond the footprint's write sequence, or a kind that disagrees with the one at that ordinal is left unattached; kind 85 still names the footprint.
- `apply_unique_ids`: a unique ID reaches a `Text` primitive (the one kind no golden exercised).
- `parse_unique_id_stream`: a record that is not UTF-8 is skipped; `parse_wide_strings`: an `ENCODEDTEXT` entry with no `=` drops.
- `read_block`: the 100 kB sanity cap refuses a block claiming more and accepts one at the cap.
- `parse_data_stream`: a three-byte stream stops before its name block.
- Two scans had an unreachable `else { break }` beneath a `while offset + 4 <= len` guard (`parse_unique_id_stream`, and the SchLib storage walker): each is now `while let Some(..) = read_u32(..)` — one condition instead of two saying the same thing, and no dead branch.

## SchLib
- Storage walker: an entry whose compressed-payload length overruns its own block is skipped and the walk carries on at the next block (`an_entry_whose_payload_overruns_its_block_is_skipped_not_fatal`).
- Writer: `Transparent=T` on a polyline and the omitted `IsNotAccesible` on an accessible arc / ellipse round-trip through save → open (`schlib_preserves_shape_flags_the_defaults_leave_unset` in `tests/file_io_roundtrip.rs`).

Full suite green (1267 lib + all suites), clippy `-D warnings`, rustdoc clean; every golden replay unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
