### PR TITLE
fix(mcp): hand a whole float to the tool as the integer it is; refuse an unusable page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   asked, and every write, `validate_library` and the post-write validation of
   every mutating tool report a warning that names the component and says by
   how many characters to shorten it.
+- **A whole float reaches the tool as the integer it is; a page is asked
+  for with a usable `limit` and `offset`.** The argument check accepts
+  `2.0` wherever an integer is expected, as JSON Schema requires, but every
+  handler then read the field as an integer, got nothing, and took the
+  default — `"limit": 2.0` returned everything, `"corner_radius_percent":
+  25.0` wrote no radius. Whole floats are now rewritten to integers at
+  dispatch, under every integer-typed field the schemas describe (a float
+  beyond 2^53 is refused as no integer). And `limit: 0` (a page that never
+  advances), a negative `limit` or `offset` (read as absent) are refused by
+  name on `read_pcblib`, `read_schlib`, `list_components` and
+  `list_step_models`.
 - **An empty `filepath` is refused as empty.** It was reported as "cannot
   create a file at the filesystem root" — the message for a path with no
   parent directory, which an empty path also happens to lack.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -40,8 +40,8 @@ footprints, or use limit/offset for pagination.
 | `compact` | boolean | no | If true (default), omit per-layer pad data when stack_mode is Simple. Set to false for full output. |
 | `component_name` | string | no | Optional: fetch only this footprint, by name in any case; a name the library does not hold is an error naming the available footprints |
 | `filepath` | string | yes | Path to the .PcbLib file |
-| `limit` | integer | no | Optional: maximum number of footprints to return (default: all) |
-| `offset` | integer | no | Optional: skip first N footprints (default: 0) |
+| `limit` | integer | no | Optional: maximum number of footprints to return, 1 or more (default: all) |
+| `offset` | integer | no | Optional: skip the first N footprints, 0 or more (default: 0) |
 
 ## `read_schlib`
 
@@ -69,8 +69,8 @@ component_name to fetch specific symbols, or use limit/offset for pagination.
 | --- | --- | --- | --- |
 | `component_name` | string | no | Optional: fetch only this symbol, by name in any case; a name the library does not hold is an error naming the available symbols |
 | `filepath` | string | yes | Path to the .SchLib file |
-| `limit` | integer | no | Optional: maximum number of symbols to return (default: all) |
-| `offset` | integer | no | Optional: skip first N symbols (default: 0) |
+| `limit` | integer | no | Optional: maximum number of symbols to return, 1 or more (default: all) |
+| `offset` | integer | no | Optional: skip the first N symbols, 0 or more (default: 0) |
 
 ## `list_components`
 
@@ -97,8 +97,8 @@ additional details like part_count and pin_count.
 | --- | --- | --- | --- |
 | `filepath` | string | yes | Path to the library file |
 | `include_metadata` | boolean | no | If true, return objects with metadata instead of just names: a footprint's description, one count per primitive kind and has_3d_model; a symbol's description, designator, part_count, pin_count and footprint_count. Default: false |
-| `limit` | integer | no | Maximum number of components to return (optional, default: all) |
-| `offset` | integer | no | Number of components to skip (optional, default: 0) |
+| `limit` | integer | no | Maximum number of components to return, 1 or more (optional, default: all) |
+| `offset` | integer | no | Number of components to skip, 0 or more (optional, default: 0) |
 
 ## `extract_style`
 
@@ -458,10 +458,10 @@ Supports multiple modes: 'auto' (default), 'list', 'extract_all', or 'extract_by
 | --- | --- | --- | --- |
 | `filepath` | string | yes | Path to the .PcbLib file containing embedded 3D models |
 | `footprint_name` | string | no | Footprint name to extract models for (required for 'extract_by_footprint' mode) |
-| `limit` | integer | no | Maximum number of models to list (for 'list' mode) |
+| `limit` | integer | no | Maximum number of models to list, 1 or more (for 'list' mode) |
 | `mode` | enum | no | Extraction mode: 'auto' (default) extracts single model or lists if multiple; 'list' always lists models; 'extract_all' extracts all models to output_dir; 'extract_by_footprint' extracts models used by specified footprint (one of: auto, list, extract_all, extract_by_footprint) |
 | `model` | string | no | Model name (e.g., 'RESC1005X04L.step') or GUID to extract (for 'auto' mode) |
-| `offset` | integer | no | Number of models to skip when listing (for 'list' mode) |
+| `offset` | integer | no | Number of models to skip when listing, 0 or more (for 'list' mode) |
 | `output_path` | string | no | Meaning depends only on the mode, never on how many models match: for 'auto' it is the FILE path for the extracted .step; for 'extract_all' and 'extract_by_footprint' it is a DIRECTORY that receives one file per model (created if absent). Omit to get the model inline as base64 ('auto' single model, or 'extract_by_footprint' with a single match). |
 
 ## `diff_libraries`

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -183,8 +183,11 @@ of the wrong JSON type anywhere in the arguments, named by its path —
 `Argument 'footprints[0].pads[1].width' must be a number, got string "1.5"` — since a
 handler reading `"true"` where it expects `true`, or `"1.5"` where it expects `1.5`,
 would likewise take the default without a word. A whole number is accepted wherever an
-integer is expected (`2` and `2.0` alike); a field the schema types as several kinds
-(`flags`, a region's `kind`) accepts any of them. The parsers judge the *values*
+integer is expected (`2` and `2.0` alike, up to 2^53) and handed to the tool as the
+integer it is, so `"limit": 2.0` pages by two; a field the schema types as several kinds
+(`flags`, a region's `kind`) accepts any of them. A page is asked for with a `limit` of
+1 or more and an `offset` of 0 or more — `limit must be a whole number of 1 or more, got 0`
+— since a zero page would never advance and a negative one used to read as absent. The parsers judge the *values*
 themselves — spellings, ranges, layer names — and say so in their own errors. A pad or
 via stack is held to what the record stores — the entry count its stack mode takes
 (3 for `top_middle_bottom`, 32 for `full_stack`; 32 diameters for a stacked via), a shape

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -301,12 +301,62 @@ fn value_has_schema_type(value: &Value, type_name: &str) -> bool {
         "string" => value.is_string(),
         "boolean" => value.is_boolean(),
         "number" => value.is_number(),
-        "integer" => value.as_f64().is_some_and(|n| n.fract() == 0.0),
+        "integer" => value
+            .as_f64()
+            .is_some_and(|n| n.fract() == 0.0 && n.abs() <= EXACT_INTEGER_MAX),
         "array" => value.is_array(),
         "object" => value.is_object(),
         "null" => value.is_null(),
         // A type this checker does not know is not a reason to refuse.
         _ => true,
+    }
+}
+
+/// The largest magnitude a JSON number can carry as an exact integer
+/// (2^53): a whole float beyond it has no exact integer to become.
+const EXACT_INTEGER_MAX: f64 = 9_007_199_254_740_992.0;
+
+/// Rewrites, in place, every whole float under a schema node typed
+/// `integer` (alone or in a union) into a JSON integer, so a handler
+/// reading the field with `as_u64` / `as_i64` sees `2` where the caller
+/// sent `2.0` — the type check accepts both, as JSON Schema requires, and
+/// the handlers must not disagree with it by reading the float as absent.
+/// Descends the object `properties` and array `items` the schema describes.
+fn canonicalise_integers(value: &mut Value, schema: &Value) {
+    let integer_typed = match &schema["type"] {
+        Value::String(t) => t == "integer",
+        Value::Array(ts) => ts.iter().any(|t| t == "integer"),
+        _ => false,
+    };
+    if integer_typed && value.is_f64() {
+        if let Some(whole) = value
+            .as_f64()
+            .filter(|n| n.fract() == 0.0 && n.abs() <= EXACT_INTEGER_MAX)
+        {
+            #[allow(clippy::cast_possible_truncation)] // bounded by EXACT_INTEGER_MAX
+            let integer = whole as i64;
+            *value = Value::from(integer);
+        }
+    }
+    match value {
+        Value::Object(fields) => {
+            if let Some(properties) = schema["properties"].as_object() {
+                for (key, child) in fields.iter_mut() {
+                    if let Some(child_schema) = properties.get(key) {
+                        canonicalise_integers(child, child_schema);
+                    }
+                }
+            }
+        }
+        Value::Array(elements) => {
+            let items = &schema["items"];
+            if items.is_object() {
+                for element in elements.iter_mut() {
+                    canonicalise_integers(element, items);
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -458,6 +508,16 @@ impl McpServer {
         }
         check_value_against_schema(arguments, schema, "")
             .map_err(|e| format!("{e} (tool '{name}')"))
+    }
+
+    /// Hands the handler the arguments in the form it reads: every whole
+    /// float the schema types as an integer becomes one (see
+    /// [`canonicalise_integers`]). Runs only after [`Self::check_tool_arguments`]
+    /// has passed them.
+    fn canonicalise_tool_arguments(name: &str, arguments: &mut Value) {
+        if let Some(schema) = Self::tool_schemas().get(name) {
+            canonicalise_integers(arguments, schema);
+        }
     }
 
     /// Returns `true` if the named tool mutates a library file on disk.
@@ -901,7 +961,7 @@ impl McpServer {
     fn handle_tools_call(&self, req: &JsonRpcRequest) -> Result<JsonRpcResponse, JsonRpcError> {
         self.require_running(&req.id)?;
 
-        let params: ToolCallParams = req
+        let mut params: ToolCallParams = req
             .params
             .as_ref()
             .map(|p| serde_json::from_value(p.clone()))
@@ -918,7 +978,9 @@ impl McpServer {
 
         // Throttle mutating operations so a runaway AI loop cannot thrash the
         // disk with repeated full-file rewrites + backups. Reads are unmetered.
-        let result = if let Err(e) = Self::check_tool_arguments(&params.name, &params.arguments) {
+        let checked = Self::check_tool_arguments(&params.name, &params.arguments)
+            .map(|()| Self::canonicalise_tool_arguments(&params.name, &mut params.arguments));
+        let result = if let Err(e) = checked {
             ToolCallResult::error(e)
         } else if Self::is_mutating_tool(params.name.as_str()) && !self.rate_limiter.try_acquire() {
             tracing::warn!(
@@ -3144,7 +3206,7 @@ mod tests {
         /// otherwise get `None` and silently take the default.
         #[test]
         fn tools_call_refuses_a_value_of_the_wrong_type_wherever_it_is_nested() {
-            let cases: [(&str, Value, &str); 6] = [
+            let cases: [(&str, Value, &str); 7] = [
                 (
                     "write_schlib",
                     json!({
@@ -3193,6 +3255,11 @@ mod tests {
                     json!({ "filepath": "x.PcbLib", "limit": 2.5 }),
                     "Argument 'limit' must be an integer, got number 2.5",
                 ),
+                (
+                    "list_components",
+                    json!({ "filepath": "x.PcbLib", "limit": 1e20 }),
+                    "Argument 'limit' must be an integer, got number 1e+20",
+                ),
             ];
             for (tool, arguments, expected) in cases {
                 let err = McpServer::check_tool_arguments(tool, &arguments)
@@ -3212,6 +3279,67 @@ mod tests {
         /// however it is written, a union type in either of its forms, a key
         /// the schema does not describe (the tools' allow-lists judge those),
         /// and a string that only looks long.
+        #[test]
+        fn a_whole_float_reaches_the_handler_as_the_integer_it_is() {
+            // Under `integer` (alone or in a union) a whole float becomes an
+            // integer; a fraction, a number-typed field and a float beyond
+            // 2^53 are left as they are.
+            let mut arguments = json!({
+                "filepath": "x.PcbLib",
+                "footprints": [{
+                    "name": "F",
+                    "pads": [{
+                        "designator": "1", "x": 0, "y": 0, "width": 1.5, "height": 1,
+                        "corner_radius_percent": 25.0, "net_index": 65535.0, "flags": 4.0,
+                        "per_layer_corner_radii": [10.0, 20.0],
+                    }],
+                }],
+            });
+            McpServer::canonicalise_tool_arguments("write_pcblib", &mut arguments);
+            let pad = &arguments["footprints"][0]["pads"][0];
+            assert!(pad["corner_radius_percent"].is_i64(), "{pad}");
+            assert_eq!(pad["corner_radius_percent"].as_u64(), Some(25));
+            assert_eq!(pad["net_index"].as_u64(), Some(65535));
+            assert_eq!(pad["flags"].as_u64(), Some(4), "union with integer");
+            assert_eq!(
+                pad["per_layer_corner_radii"][1].as_u64(),
+                Some(20),
+                "array items"
+            );
+            assert!(pad["width"].is_f64(), "a number-typed field is untouched");
+
+            let mut arguments = json!({ "filepath": "x.PcbLib", "limit": 2.0, "offset": 1e300 });
+            McpServer::canonicalise_tool_arguments("list_components", &mut arguments);
+            assert_eq!(arguments["limit"].as_u64(), Some(2));
+            assert!(
+                arguments["offset"].is_f64(),
+                "beyond 2^53 has no exact integer"
+            );
+
+            // End to end: a page of `1.0` pages by one.
+            let dir = test_temp_dir();
+            let path = dir.path().join("Page.PcbLib");
+            create_test_pcblib(&path);
+            let mut server = McpServer::new(vec![dir.path().to_path_buf()]);
+            server.state = ServerState::Running;
+            let r = req(
+                "tools/call",
+                Some(json!({
+                    "name": "list_components",
+                    "arguments": { "filepath": path.to_string_lossy(), "limit": 1.0 },
+                })),
+            );
+            let response = server.handle_tools_call(&r).unwrap();
+            let result = &response.result;
+            assert_ne!(result["is_error"], true, "{result}");
+            let text = result["content"][0]["text"]
+                .as_str()
+                .expect("a text result");
+            let page: Value = serde_json::from_str(text).unwrap();
+            assert_eq!(page["returned_count"], 1, "{page}");
+            assert_eq!(page["has_more"], true, "{page}");
+        }
+
         #[test]
         fn tools_call_accepts_every_type_the_schema_allows() {
             let accepted: [(&str, Value); 5] = [

--- a/src/mcp/tool_definitions.rs
+++ b/src/mcp/tool_definitions.rs
@@ -63,11 +63,11 @@ impl McpServer {
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Optional: maximum number of footprints to return (default: all)"
+                            "description": "Optional: maximum number of footprints to return, 1 or more (default: all)"
                         },
                         "offset": {
                             "type": "integer",
-                            "description": "Optional: skip first N footprints (default: 0)"
+                            "description": "Optional: skip the first N footprints, 0 or more (default: 0)"
                         },
                         "compact": {
                             "type": "boolean",
@@ -110,11 +110,11 @@ impl McpServer {
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Optional: maximum number of symbols to return (default: all)"
+                            "description": "Optional: maximum number of symbols to return, 1 or more (default: all)"
                         },
                         "offset": {
                             "type": "integer",
-                            "description": "Optional: skip first N symbols (default: 0)"
+                            "description": "Optional: skip the first N symbols, 0 or more (default: 0)"
                         }
                     },
                     "required": ["filepath"]
@@ -138,11 +138,11 @@ impl McpServer {
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Maximum number of components to return (optional, default: all)"
+                            "description": "Maximum number of components to return, 1 or more (optional, default: all)"
                         },
                         "offset": {
                             "type": "integer",
-                            "description": "Number of components to skip (optional, default: 0)"
+                            "description": "Number of components to skip, 0 or more (optional, default: 0)"
                         },
                         "include_metadata": {
                             "type": "boolean",
@@ -1431,11 +1431,11 @@ impl McpServer {
                         },
                         "limit": {
                             "type": "integer",
-                            "description": "Maximum number of models to list (for 'list' mode)"
+                            "description": "Maximum number of models to list, 1 or more (for 'list' mode)"
                         },
                         "offset": {
                             "type": "integer",
-                            "description": "Number of models to skip when listing (for 'list' mode)"
+                            "description": "Number of models to skip when listing, 0 or more (for 'list' mode)"
                         }
                     },
                     "required": ["filepath"]

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -60,9 +60,68 @@ pub fn component_not_found_in(component_name: &str, which: &str, names: &[String
     format!("Component '{component_name}' not found in {which}. Available: {available}")
 }
 
+/// The `limit` / `offset` pair every paging tool takes: `limit` a whole
+/// number of 1 or more (absent = all), `offset` a whole number of 0 or more
+/// (absent = 0). Anything else is refused by name — `0` would page forever
+/// and a negative used to read as absent.
+pub fn page_arguments(arguments: &serde_json::Value) -> Result<(Option<usize>, usize), String> {
+    use serde_json::Value;
+
+    let whole = |value: &Value| value.as_u64().and_then(|n| usize::try_from(n).ok());
+    let limit =
+        match arguments.get("limit") {
+            None | Some(Value::Null) => None,
+            Some(value) => Some(whole(value).filter(|n| *n >= 1).ok_or_else(|| {
+                format!("limit must be a whole number of 1 or more, got {value}")
+            })?),
+        };
+    let offset = match arguments.get("offset") {
+        None | Some(Value::Null) => 0,
+        Some(value) => whole(value)
+            .ok_or_else(|| format!("offset must be a whole number of 0 or more, got {value}"))?,
+    };
+    Ok((limit, offset))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{component_not_found, component_not_found_in};
+    use super::{component_not_found, component_not_found_in, page_arguments};
+    use serde_json::json;
+
+    /// Absent means all / from the start; a zero or negative limit, a
+    /// negative offset and a fraction are refused by name.
+    #[test]
+    fn page_arguments_take_a_positive_limit_and_a_non_negative_offset() {
+        assert_eq!(page_arguments(&json!({})), Ok((None, 0)));
+        assert_eq!(
+            page_arguments(&json!({ "limit": null, "offset": null })),
+            Ok((None, 0))
+        );
+        assert_eq!(
+            page_arguments(&json!({ "limit": 3, "offset": 1 })),
+            Ok((Some(3), 1))
+        );
+        for (arguments, expected) in [
+            (
+                json!({ "limit": 0 }),
+                "limit must be a whole number of 1 or more, got 0",
+            ),
+            (
+                json!({ "limit": -1 }),
+                "limit must be a whole number of 1 or more, got -1",
+            ),
+            (
+                json!({ "limit": 2.5 }),
+                "limit must be a whole number of 1 or more, got 2.5",
+            ),
+            (
+                json!({ "offset": -1 }),
+                "offset must be a whole number of 0 or more, got -1",
+            ),
+        ] {
+            assert_eq!(page_arguments(&arguments), Err(expected.to_string()));
+        }
+    }
 
     /// The message names the request, then the first ten names on file and
     /// how many more there are; an empty library says so.

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -247,7 +247,6 @@ impl McpServer {
 
     /// Reads a `PcbLib` file and returns its contents.
     /// Supports pagination via limit/offset and filtering by `component_name`.
-    #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_lines)] // Complex formatting logic for compact mode
     pub(crate) fn call_read_pcblib(&self, arguments: &Value) -> ToolCallResult {
         use crate::altium::pcblib::primitives::PadStackMode;
@@ -264,14 +263,10 @@ impl McpServer {
 
         // Parse optional pagination/filter parameters
         let component_name = arguments.get("component_name").and_then(Value::as_str);
-        let limit = arguments
-            .get("limit")
-            .and_then(Value::as_u64)
-            .map(|v| v as usize);
-        let offset = arguments
-            .get("offset")
-            .and_then(Value::as_u64)
-            .map_or(0, |v| v as usize);
+        let (limit, offset) = match super::page_arguments(arguments) {
+            Ok(page) => page,
+            Err(e) => return ToolCallResult::error(e),
+        };
 
         // Parse compact parameter (default: true - omit redundant per-layer data)
         let compact = arguments
@@ -672,7 +667,6 @@ impl McpServer {
 
     /// Reads a `SchLib` file and returns its contents.
     /// Supports pagination via limit/offset and filtering by `component_name`.
-    #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn call_read_schlib(&self, arguments: &Value) -> ToolCallResult {
         use crate::altium::SchLib;
 
@@ -687,14 +681,10 @@ impl McpServer {
 
         // Parse optional pagination/filter parameters
         let component_name = arguments.get("component_name").and_then(Value::as_str);
-        let limit = arguments
-            .get("limit")
-            .and_then(Value::as_u64)
-            .map(|v| v as usize);
-        let offset = arguments
-            .get("offset")
-            .and_then(Value::as_u64)
-            .map_or(0, |v| v as usize);
+        let (limit, offset) = match super::page_arguments(arguments) {
+            Ok(page) => page,
+            Err(e) => return ToolCallResult::error(e),
+        };
 
         match SchLib::open(filepath) {
             Ok(library) => {
@@ -980,7 +970,7 @@ impl McpServer {
     }
 
     /// Lists component names in a library file.
-    #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn call_list_components(&self, arguments: &Value) -> ToolCallResult {
         use crate::altium::{PcbLib, SchLib};
 
@@ -994,14 +984,10 @@ impl McpServer {
         }
 
         // Parse optional pagination parameters
-        let limit = arguments
-            .get("limit")
-            .and_then(Value::as_u64)
-            .map(|v| v as usize);
-        let offset = arguments
-            .get("offset")
-            .and_then(Value::as_u64)
-            .map_or(0, |v| v as usize);
+        let (limit, offset) = match super::page_arguments(arguments) {
+            Ok(page) => page,
+            Err(e) => return ToolCallResult::error(e),
+        };
 
         // Parse include_metadata parameter (default: false)
         let include_metadata = arguments

--- a/src/mcp/tools/step.rs
+++ b/src/mcp/tools/step.rs
@@ -9,7 +9,7 @@ impl McpServer {
     // ==================== STEP Model Extraction ====================
 
     /// Extracts embedded STEP 3D models from a `PcbLib` file.
-    #[allow(clippy::too_many_lines, clippy::cast_possible_truncation)]
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn call_extract_step_model(&self, arguments: &Value) -> ToolCallResult {
         use crate::altium::PcbLib;
 
@@ -40,14 +40,10 @@ impl McpServer {
         let footprint_name = arguments.get("footprint_name").and_then(Value::as_str);
 
         // Parse optional pagination parameters (for listing models)
-        let limit = arguments
-            .get("limit")
-            .and_then(Value::as_u64)
-            .map(|v| usize::try_from(v).unwrap_or(usize::MAX));
-        let offset = arguments
-            .get("offset")
-            .and_then(Value::as_u64)
-            .map_or(0, |v| usize::try_from(v).unwrap_or(usize::MAX));
+        let (limit, offset) = match super::page_arguments(arguments) {
+            Ok(page) => page,
+            Err(e) => return ToolCallResult::error(e),
+        };
 
         // Read the library
         let library = match PcbLib::open(filepath) {


### PR DESCRIPTION
Bug #73 — the last seam between the dispatch type check (#465) and the handlers.

## What was wrong
`check_value_against_schema` accepts a whole float (`2.0`) wherever the schema says `integer` — JSON Schema requires it, and the docs say so. But every handler reads integer fields with `serde_json::Value::as_u64` / `as_i64`, which return `None` for a float, so the value read as *absent* and the default applied without a word: `"limit": 2.0` returned the whole library, `"corner_radius_percent": 25.0` wrote no radius, `"owner_part_id": 2.0` fell to 1, and so on across ~120 integer reads.

Separately, `limit` / `offset` were read leniently at four sites: `limit: 0` produced an empty page with `has_more: true` (a client paging by it never advances), and a negative `limit` or `offset` read as absent.

## What changed
- **One structural fix, not 120 edits:** after the type check passes, dispatch rewrites every whole float under an integer-typed schema node (properties, array items, unions like `flags`) into a JSON integer (`canonicalise_integers`). Because #467 made the schemas describe every accepted key, this walk is total. A whole float beyond 2^53 has no exact integer to become, so the type check now refuses it (`must be an integer, got number 1e+20`).
- `page_arguments` (`tools/mod.rs`) serves `read_pcblib`, `read_schlib`, `list_components` and `list_step_models`: `limit` must be a whole number of 1 or more, `offset` of 0 or more, refused by name otherwise. The four `#[allow(clippy::cast_possible_truncation)]` those handlers carried for the old casts are gone.
- Schema text for all eight paging arguments; `docs/TOOLS.md` regenerated; `docs/errors.md` and CHANGELOG describe both rules.

## Tests
`a_whole_float_reaches_the_handler_as_the_integer_it_is` (unit: nested properties, array items, a union, a number-typed field left alone, beyond-2^53 left alone; end to end: `list_components` with `limit: 1.0` pages by one through `handle_tools_call`), `page_arguments_take_a_positive_limit_and_a_non_negative_offset`, and the beyond-2^53 case in the wrong-type test. Full suite green (1266 lib + all suites), clippy `-D warnings`, rustdoc, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
