### PR TITLE
fix(mcp): one message for a path that is neither a .PcbLib nor a .SchLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backup is made — naming the substitute for schematic text. Strings kept in binary fields — a pad
   designator, a PCB text's string, a pin's name and designator — may carry
   one.
+- **A path that is neither a `.PcbLib` nor a `.SchLib` is refused in one
+  voice.** Eighteen tools said it six ways (`Unknown file type`,
+  `Unsupported file type: .csv`, `File has no extension`, …); all now say
+  `Unsupported file type '.csv' for 'Parts.csv': expected .PcbLib or
+  .SchLib`, and a path without an extension says so.
 
 - **A solid symbol body no longer paints over the pin names inside it.**
   `write_schlib` recorded the order it happened to parse its input in — pins

--- a/src/mcp/tools/compare.rs
+++ b/src/mcp/tools/compare.rs
@@ -208,7 +208,7 @@ impl McpServer {
                 component_b,
                 include_geometry,
             ),
-            _ => ToolCallResult::error("Unknown file type. Expected .PcbLib or .SchLib extension."),
+            _ => ToolCallResult::error(super::unsupported_file_type(filepath_a)),
         }
     }
 
@@ -2632,7 +2632,7 @@ mod tests {
                 "filepath_b": path.to_string_lossy(), "component_b": "B",
             }));
             assert!(r.is_error);
-            assert!(get_result_text(&r).contains("Unknown file type"));
+            assert!(get_result_text(&r).contains("Unsupported file type"));
         }
 
         // ---- footprint comparison --------------------------------------------

--- a/src/mcp/tools/components.rs
+++ b/src/mcp/tools/components.rs
@@ -56,10 +56,7 @@ impl McpServer {
                 description,
                 dry_run,
             ),
-            Some(ext) => ToolCallResult::error(format!(
-                "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-            )),
-            None => ToolCallResult::error("File has no extension. Use .PcbLib or .SchLib"),
+            _ => ToolCallResult::error(super::unsupported_file_type(filepath)),
         }
     }
 
@@ -273,10 +270,7 @@ impl McpServer {
         match ext.as_deref() {
             Some("pcblib") => Self::rename_pcblib_component(filepath, old_name, new_name, dry_run),
             Some("schlib") => Self::rename_schlib_component(filepath, old_name, new_name, dry_run),
-            Some(ext) => ToolCallResult::error(format!(
-                "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-            )),
-            None => ToolCallResult::error("File has no extension. Use .PcbLib or .SchLib"),
+            _ => ToolCallResult::error(super::unsupported_file_type(filepath)),
         }
     }
 
@@ -516,10 +510,7 @@ impl McpServer {
                 new_name,
                 description,
             ),
-            Some(ext) => ToolCallResult::error(format!(
-                "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-            )),
-            None => ToolCallResult::error("Files have no extension. Use .PcbLib or .SchLib"),
+            _ => ToolCallResult::error(super::unsupported_file_type(source_filepath)),
         }
     }
 
@@ -889,10 +880,7 @@ impl McpServer {
             Some("schlib") => {
                 Self::merge_schlib_libraries(&source_paths, target_filepath, on_duplicate, dry_run)
             }
-            Some(ext) => ToolCallResult::error(format!(
-                "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-            )),
-            None => ToolCallResult::error("Files have no extension. Use .PcbLib or .SchLib"),
+            _ => ToolCallResult::error(super::unsupported_file_type(source_paths[0])),
         }
     }
 
@@ -1290,7 +1278,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -2578,7 +2566,7 @@ mod tests {
                 "component_order": ["A"],
             }));
             assert!(r.is_error);
-            assert!(get_result_text(&r).contains("Unknown file type"));
+            assert!(get_result_text(&r).contains("Unsupported file type"));
 
             let ghost = dir.path().join("Ghost.PcbLib");
             let r = server.call_reorder_components(&json!({
@@ -2706,7 +2694,7 @@ mod tests {
             let no_ext = server.call_copy_component(&json!({
                 "filepath": fx.path("Lib"), "source_name": "A", "target_name": "B",
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_copy_component(&json!({
                 "filepath": fx.path("Lib.txt"), "source_name": "A", "target_name": "B",
@@ -2831,7 +2819,7 @@ mod tests {
             let no_ext = server.call_rename_component(&json!({
                 "filepath": fx.path("Lib"), "old_name": "A", "new_name": "B",
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_rename_component(&json!({
                 "filepath": fx.path("Lib.txt"), "old_name": "A", "new_name": "B",
@@ -2936,7 +2924,7 @@ mod tests {
                 "source_filepath": fx.path("S"), "target_filepath": fx.path("T"),
                 "component_name": "A",
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_copy_component_cross_library(&json!({
                 "source_filepath": fx.path("S.txt"), "target_filepath": fx.path("T.txt"),
@@ -3100,7 +3088,7 @@ mod tests {
             let no_ext = server.call_merge_libraries(&json!({
                 "source_filepaths": [fx.path("S")], "target_filepath": fx.path("M"),
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_merge_libraries(&json!({
                 "source_filepaths": [fx.path("S.txt")], "target_filepath": fx.path("M.txt"),
@@ -3219,7 +3207,7 @@ mod tests {
             let wrong_ext = server.call_reorder_components(&json!({
                 "filepath": fx.path("Lib.txt"), "component_order": ["A"],
             }));
-            assert_error_mentions(&wrong_ext, "Unknown file type");
+            assert_error_mentions(&wrong_ext, "Unsupported file type");
         }
 
         #[test]

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -55,7 +55,7 @@ impl McpServer {
             _ => {
                 let result = json!({
                     "status": "error",
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath_a),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -356,7 +356,7 @@ mod tests {
             "filepath_b": b.to_string_lossy(),
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Unknown file type"));
+        assert!(get_result_text(&result).contains("Unsupported file type"));
     }
 
     #[test]

--- a/src/mcp/tools/library_ops.rs
+++ b/src/mcp/tools/library_ops.rs
@@ -129,7 +129,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -384,7 +384,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -958,7 +958,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -1728,7 +1728,7 @@ mod tests {
             "component_names": ["A"],
         }));
         assert!(result.is_error);
-        assert!(get_result_text(&result).contains("Unknown file type"));
+        assert!(get_result_text(&result).contains("Unsupported file type"));
     }
 
     // ==================== validate_library ====================
@@ -3250,7 +3250,7 @@ mod tests {
             assert_eq!(parsed["status"], "error");
             assert_eq!(
                 parsed["error"],
-                "Unknown file type. Expected .PcbLib or .SchLib extension."
+                "Unsupported file type '.txt' for 'Notes.txt': expected .PcbLib or .SchLib"
             );
         }
 
@@ -3564,7 +3564,7 @@ mod tests {
             let parsed = parse_result_json(&result);
             assert_eq!(
                 parsed["error"],
-                "Unknown file type. Expected .PcbLib or .SchLib extension."
+                "Unsupported file type '.csv' for 'Parts.csv': expected .PcbLib or .SchLib"
             );
         }
 

--- a/src/mcp/tools/maintenance.rs
+++ b/src/mcp/tools/maintenance.rs
@@ -170,7 +170,7 @@ impl McpServer {
         } else if filepath_lower.ends_with(".schlib") {
             Self::bulk_rename_schlib(filepath, &regex, replacement, dry_run)
         } else {
-            ToolCallResult::error("Unsupported file type. Expected .PcbLib or .SchLib")
+            ToolCallResult::error(super::unsupported_file_type(filepath))
         }
     }
 

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -83,9 +83,23 @@ pub fn page_arguments(arguments: &serde_json::Value) -> Result<(Option<usize>, u
     Ok((limit, offset))
 }
 
+/// The error for a path that is neither a `.PcbLib` nor a `.SchLib`: the
+/// extension the caller gave (or its absence), the file's name and the two
+/// kinds accepted, in the same words from every tool that opens a library.
+pub fn unsupported_file_type(filepath: &str) -> String {
+    let path = std::path::Path::new(filepath);
+    let name = crate::altium::error::sanitise_path_for_client(path);
+    path.extension().and_then(|e| e.to_str()).map_or_else(
+        || format!("'{name}' has no file extension: expected .PcbLib or .SchLib"),
+        |ext| format!("Unsupported file type '.{ext}' for '{name}': expected .PcbLib or .SchLib"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{component_not_found, component_not_found_in, page_arguments};
+    use super::{
+        component_not_found, component_not_found_in, page_arguments, unsupported_file_type,
+    };
     use serde_json::json;
 
     /// Absent means all / from the start; a zero or negative limit, a
@@ -148,6 +162,20 @@ mod tests {
         assert_eq!(
             component_not_found_in("X", "source library", &names(1)),
             "Component 'X' not found in source library. Available: C1"
+        );
+    }
+
+    /// The message names the extension given, or its absence, and only the
+    /// file's name — never its directory.
+    #[test]
+    fn an_unsupported_file_type_is_named_with_the_file_alone() {
+        assert_eq!(
+            unsupported_file_type("C:/secret/dir/Parts.csv"),
+            "Unsupported file type '.csv' for 'Parts.csv': expected .PcbLib or .SchLib"
+        );
+        assert_eq!(
+            unsupported_file_type("/srv/libs/Parts"),
+            "'Parts' has no file extension: expected .PcbLib or .SchLib"
         );
     }
 }

--- a/src/mcp/tools/query_update.rs
+++ b/src/mcp/tools/query_update.rs
@@ -49,7 +49,7 @@ impl McpServer {
                 };
                 self.update_schlib_component(filepath, component_name, sym_json, dry_run)
             }
-            _ => ToolCallResult::error("Unknown file type. Expected .PcbLib or .SchLib extension."),
+            _ => ToolCallResult::error(super::unsupported_file_type(filepath)),
         }
     }
 
@@ -478,8 +478,7 @@ impl McpServer {
                     }
                     Err(e) => errors.push(format!("{path}: {e}")),
                 },
-                Some(ext) => errors.push(format!("{path}: Unsupported file type '.{ext}'")),
-                None => errors.push(format!("{path}: No file extension")),
+                _ => errors.push(super::unsupported_file_type(path)),
             }
         }
 
@@ -580,10 +579,7 @@ impl McpServer {
         match ext.as_deref() {
             Some("pcblib") => Self::get_pcblib_component(filepath, component_name),
             Some("schlib") => Self::get_schlib_component(filepath, component_name),
-            Some(ext) => ToolCallResult::error(format!(
-                "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-            )),
-            None => ToolCallResult::error("File has no extension. Use .PcbLib or .SchLib"),
+            _ => ToolCallResult::error(super::unsupported_file_type(filepath)),
         }
     }
 
@@ -707,12 +703,7 @@ impl McpServer {
                     })
                     .collect()
             }
-            Some(ext) => {
-                return ToolCallResult::error(format!(
-                    "Unsupported file type: .{ext}. Use .PcbLib or .SchLib"
-                ))
-            }
-            None => return ToolCallResult::error("File has no extension. Use .PcbLib or .SchLib"),
+            _ => return ToolCallResult::error(super::unsupported_file_type(filepath)),
         };
 
         let all_exist = results
@@ -1968,7 +1959,7 @@ mod tests {
             let wrong_ext = server.call_update_component(&json!({
                 "filepath": fx.path("Lib.txt"), "component_name": "A", "footprint": {},
             }));
-            assert_error_mentions(&wrong_ext, "Unknown file type");
+            assert_error_mentions(&wrong_ext, "Unsupported file type");
         }
 
         #[test]
@@ -2161,7 +2152,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n");
             assert!(joined.contains("Unsupported file type"), "{joined}");
-            assert!(joined.contains("No file extension"), "{joined}");
+            assert!(joined.contains("no file extension"), "{joined}");
         }
 
         // ---- get_component ------------------------------------------------------
@@ -2184,7 +2175,7 @@ mod tests {
             let no_ext = server.call_get_component(&json!({
                 "filepath": fx.path("Lib"), "component_name": "A",
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_get_component(&json!({
                 "filepath": fx.path("Lib.txt"), "component_name": "A",
@@ -2245,7 +2236,7 @@ mod tests {
             let no_ext = server.call_component_exists(&json!({
                 "filepath": fx.path("Lib"), "component_names": ["A"],
             }));
-            assert_error_mentions(&no_ext, "no extension");
+            assert_error_mentions(&no_ext, "no file extension");
 
             let wrong_ext = server.call_component_exists(&json!({
                 "filepath": fx.path("Lib.txt"), "component_names": ["A"],

--- a/src/mcp/tools/read_write.rs
+++ b/src/mcp/tools/read_write.rs
@@ -1125,7 +1125,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -1156,7 +1156,7 @@ impl McpServer {
                 let result = json!({
                     "status": "error",
                     "filepath": filepath,
-                    "error": "Unknown file type. Expected .PcbLib or .SchLib extension.",
+                    "error": super::unsupported_file_type(filepath),
                 });
                 ToolCallResult::error(serde_json::to_string_pretty(&result).unwrap())
             }
@@ -3142,7 +3142,7 @@ mod tests {
                 "filepath": txt.to_string_lossy(),
             }));
             assert!(result.is_error);
-            assert!(get_result_text(&result).contains("Unknown file type"));
+            assert!(get_result_text(&result).contains("Unsupported file type"));
 
             // Unreadable library.
             let missing = dir.path().join("Missing.PcbLib");


### PR DESCRIPTION
The "N wordings for one thing" class again — the same sweep as the not-found messages in #474.

## What was wrong
A path that is neither a `.PcbLib` nor a `.SchLib` was refused by 18 tools in six wordings: `Unknown file type. Expected .PcbLib or .SchLib extension.` (11 sites), `Unsupported file type: .csv. Use .PcbLib or .SchLib` (6), `File has no extension` / `Files have no extension`, `{path}: No file extension`, and a bare `Unsupported file type. Expected .PcbLib or .SchLib` in `bulk_rename`. Most did not name the extension they were given or the file it belonged to.

## What changed
`tools::unsupported_file_type(path)` produces one message from every site — `Unsupported file type '.csv' for 'Parts.csv': expected .PcbLib or .SchLib`, or `'Parts' has no file extension: expected .PcbLib or .SchLib` — naming the file only (sanitised, never its directory). The multi-library tools judge by the path they dispatch on (`compare_components` and `diff_libraries` by the first file, the cross-library copy by the source, `merge_libraries` by the first source). Seven tests that were pinned to the old phrasings now assert the shared one; two exact-text tests pin the full message.

Full suite green (1282 lib + all suites), clippy `-D warnings`, rustdoc, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
