### PR TITLE
docs(todo): record every deferred item where its worklist lives

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,3 +19,19 @@ record). The specialised worklists stay the single source of truth for their are
       `.dxt`** — the same bundle format under its new and old names, so older Claude Desktop
       builds install it too. Claude Desktop now steers users to extensions over hand-edited
       JSON (pattern from coffeenmusic/altium-mcp).
+
+## C. Quality & coverage
+
+- [ ] **Test-coverage push** once the extension bundle ships: expand tests toward full
+      coverage again (baseline 99.32%; the remainder is mostly defensive/unreachable
+      branches, so each gain needs a deliberate fixture or restructure).
+
+## D. Maintenance & waiting
+
+- [ ] **Drop the `cfb` git pin** (`[patch.crates-io]`, rev `8c1ec76`) as soon as rust-cfb
+      publishes a release newer than v0.14.0 — check
+      [rust-cfb releases](https://github.com/mdsteele/rust-cfb/releases) at session start.
+- [ ] **Dismiss the recurring GitHub "AI findings"** (maintainer-only, in the repo's
+      Security → Quality UI): the same three findings keep regenerating autofix PRs
+      (#415/#416, #469/#470 all closed as verified non-bugs) until they are dismissed
+      there — the API cannot do it.

--- a/scripts/samples/COVERAGE.md
+++ b/scripts/samples/COVERAGE.md
@@ -147,7 +147,14 @@ not say which name was at fault.
 (`IntegratedModel=T|DatabaseModel=T`) is known from a hand-authored library and replayed
 verbatim, not from a golden.
 
-**PcbLib:** region net and the cavity/subpoly params.
+**PcbLib:** region net and the cavity/subpoly params. No scripted route to a region
+*hole* has been identified yet (2026-09-01 identifier sweep): the contour API itself is
+proven (`MainContour.Replicate`, 1-based `X[i]`/`Y[i]`, `SetOutlineContour`), and
+`PCBGeometricPolygonFactory` / `AddContour` / `SetState_GeometricPolygon` are all in the
+table, but no name for constructing a second (hole) contour resolved — the next probe
+should try a two-contour `TGeometricPolygon` through the factory. The region `NET` may
+be structurally absent like the net index (a `PcbLib` has no net table); one probe would
+settle whether its row becomes 🔒.
 A **text beyond U+00FF** (Ω, CJK) is 🚫 not scriptable: a source literal reaches Altium as
 its UTF-8 bytes widened through the machine's ANSI page and `Chr(N)` truncates modulo 256
 (`TEXT_WIDE_ONLY` pins the WideStrings-authoritative shape with a character the Data


### PR DESCRIPTION
Per request: everything identified as for-later this session is now written down.

- **TODO.md § C**: the test-coverage push queued behind the extension bundle.
- **TODO.md § D (new)**: drop the `cfb` `[patch.crates-io]` pin when rust-cfb releases past v0.14.0; the recurring GitHub AI-findings need a maintainer dismissal in the Security → Quality UI (the same three regenerate autofix PRs until then).
- **COVERAGE.md backlog**: the region-hole authoring route findings from today's identifier sweep (contour API proven; hole-contour construction unresolved; region `NET` possibly structural like the net index).

Fixture items stay in `scripts/samples/COVERAGE.md` — TODO.md's SSOT table already points there. Also resolved offline: the old auto-add-3D-body scoping concern is already shipped as the opt-in `auto_3d_body` flag, so it was noise, not a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)