### PR TITLE
feat(release): Claude Desktop one-click extension as .mcpb + .dxt

### DIFF
--- a/.github/release-assets/README.md
+++ b/.github/release-assets/README.md
@@ -98,6 +98,11 @@ examples.
 
 ### Claude Desktop
 
+Skip this archive entirely if you like: the release also ships a one-click extension,
+`altium-designer-mcp.mcpb` (identical twin: `altium-designer-mcp.dxt` for older builds).
+Settings → **Extensions** → **Advanced settings** → **Install Extension…**, pick the
+file, choose your library folders — done. To wire this archive's binary by hand instead:
+
 Edit `claude_desktop_config.json` — **Settings → Developer → Edit Config** opens it, or find it at
 `%APPDATA%\Claude\` (Windows) or `~/Library/Application Support/Claude/` (macOS):
 

--- a/.github/release-assets/mcpb-manifest.json
+++ b/.github/release-assets/mcpb-manifest.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.3.schema.json",
+    "manifest_version": "0.3",
+    "name": "altium-designer-mcp",
+    "display_name": "Altium Designer MCP",
+    "version": "@VERSION@",
+    "description": "MCP server for AI-assisted Altium Designer component library management",
+    "long_description": "File I/O and primitive placement for Altium Designer `.PcbLib`/`.SchLib` component libraries: the AI calculates footprint and symbol geometry, this server reads and writes the binary library files. 34 tools covering read, write, update, compare, diff, merge, validation and repair. Only the folders granted below are ever touched.",
+    "author": {
+        "name": "The Embedded Society",
+        "url": "https://github.com/embedded-society"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/embedded-society/altium-designer-mcp"
+    },
+    "homepage": "https://github.com/embedded-society/altium-designer-mcp",
+    "documentation": "https://github.com/embedded-society/altium-designer-mcp/blob/main/docs/USAGE.md",
+    "support": "https://github.com/embedded-society/altium-designer-mcp/issues",
+    "license": "GPL-3.0-or-later",
+    "keywords": ["altium", "pcb", "eda", "footprint", "schematic", "library"],
+    "server": {
+        "type": "binary",
+        "entry_point": "server/linux/altium-designer-mcp",
+        "mcp_config": {
+            "command": "${__dirname}/server/linux/altium-designer-mcp",
+            "args": ["--allow", "${user_config.library_paths}"],
+            "platform_overrides": {
+                "win32": {
+                    "command": "${__dirname}/server/win32/altium-designer-mcp.exe"
+                },
+                "darwin": {
+                    "command": "${__dirname}/server/darwin/altium-designer-mcp"
+                }
+            }
+        }
+    },
+    "tools_generated": true,
+    "user_config": {
+        "library_paths": {
+            "type": "directory",
+            "title": "Library folders",
+            "description": "The folders holding your .PcbLib/.SchLib libraries. The server refuses to touch any file outside them, so keep the list narrow.",
+            "multiple": true,
+            "required": true
+        }
+    },
+    "compatibility": {
+        "platforms": ["darwin", "win32", "linux"]
+    }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,9 +354,109 @@ jobs:
                 path: ${{ matrix.artifact }}.zip
                 retention-days: 7
 
+    bundle:
+        name: Bundle Claude Desktop extension
+        needs: [validate, build]
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        # Read-only: assembles the extension from the build artefacts and
+        # uploads it to the workflow's ephemeral artifact store.
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Download all artifacts
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                path: artifacts
+
+            # One cross-platform bundle: the manifest's platform_overrides pick
+            # the right binary at install time, so a single download works on
+            # macOS, Windows and Linux alike.
+            - name: Assemble the extension layout
+              shell: bash
+              run: |
+                set -euo pipefail
+                mkdir -p bundle/server/win32 bundle/server/darwin bundle/server/linux
+
+                tar -xzf artifacts/altium-designer-mcp-linux-x86_64/altium-designer-mcp-linux-x86_64.tar.gz \
+                    -C bundle/server/linux altium-designer-mcp
+                tar -xzf artifacts/altium-designer-mcp-macos-aarch64/altium-designer-mcp-macos-aarch64.tar.gz \
+                    -C bundle/server/darwin altium-designer-mcp
+                unzip -q -j artifacts/altium-designer-mcp-windows-x86_64/altium-designer-mcp-windows-x86_64.zip \
+                    altium-designer-mcp.exe -d bundle/server/win32
+                chmod +x bundle/server/linux/altium-designer-mcp \
+                         bundle/server/darwin/altium-designer-mcp
+
+                # Stamp the manifest with the release version — the same
+                # @VERSION@ convention the release README uses.
+                sed "s/@VERSION@/${{ needs.validate.outputs.version }}/g" \
+                    .github/release-assets/mcpb-manifest.json > bundle/manifest.json
+
+            # The official packer validates the manifest against the MCPB
+            # schema while zipping. Version-pinned like every action here.
+            # The .dxt twin is the identical bundle under the format's old
+            # name, so older Claude Desktop builds install it too.
+            - name: Pack .mcpb and its .dxt twin
+              shell: bash
+              run: |
+                npx --yes @anthropic-ai/mcpb@2.1.2 pack bundle altium-designer-mcp.mcpb
+                cp altium-designer-mcp.mcpb altium-designer-mcp.dxt
+
+            - name: Verify the packed extension
+              shell: bash
+              env:
+                EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+              run: |
+                set -euo pipefail
+                # The two names must be byte-identical.
+                cmp altium-designer-mcp.mcpb altium-designer-mcp.dxt
+
+                mkdir -p verify-mcpb && unzip -q altium-designer-mcp.mcpb -d verify-mcpb
+                for f in manifest.json \
+                         server/win32/altium-designer-mcp.exe \
+                         server/darwin/altium-designer-mcp \
+                         server/linux/altium-designer-mcp; do
+                    if [[ ! -e "verify-mcpb/$f" ]]; then
+                        echo "Error: $f missing from the extension bundle"
+                        exit 1
+                    fi
+                done
+
+                grep -q "\"version\": \"${EXPECTED_VERSION}\"" verify-mcpb/manifest.json
+
+                # Run the binary the bundle actually carries, then speak MCP to
+                # it with the exact arguments the manifest starts it with.
+                chmod +x verify-mcpb/server/linux/altium-designer-mcp
+                OUT="$(verify-mcpb/server/linux/altium-designer-mcp --version)"
+                echo "Bundled binary reports: $OUT"
+                if [[ "$OUT" != *"${EXPECTED_VERSION%%-*}"* ]]; then
+                    echo "Error: expected version ${EXPECTED_VERSION%%-*} in --version output"
+                    exit 1
+                fi
+
+                mkdir -p smoke-libs
+                printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"release-smoke","version":"0"}}}\n' \
+                    | verify-mcpb/server/linux/altium-designer-mcp --allow smoke-libs \
+                    | grep -q '"jsonrpc":"2.0"'
+                echo "Bundled binary answers MCP initialize under --allow."
+
+            - name: Upload extension artifact
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                name: altium-designer-mcp-extension
+                path: |
+                    altium-designer-mcp.mcpb
+                    altium-designer-mcp.dxt
+                retention-days: 7
+
     release:
         name: Create Release
-        needs: [validate, build]
+        needs: [validate, build, bundle]
         # Dry runs stop here: everything above has built, been unpacked, run and
         # checksummed, but nothing is published.
         if: needs.validate.outputs.is-release == 'true'
@@ -395,21 +495,24 @@ jobs:
                 for expected in \
                     altium-designer-mcp-linux-x86_64.tar.gz \
                     altium-designer-mcp-macos-aarch64.tar.gz \
-                    altium-designer-mcp-windows-x86_64.zip; do
+                    altium-designer-mcp-windows-x86_64.zip \
+                    altium-designer-mcp.mcpb \
+                    altium-designer-mcp.dxt; do
                     if ! find artifacts -type f -name "$expected" | grep -q .; then
                         echo "Error: missing artefact $expected"
                         missing=1
                     fi
                 done
                 [[ $missing -eq 0 ]] || exit 1
-                echo "All three platform artefacts present."
+                echo "All platform artefacts and the extension bundle present."
 
             - name: Generate checksums
               shell: bash
               run: |
                 cd artifacts
-                find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} . \;
-                sha256sum *.tar.gz *.zip > SHA256SUMS.txt
+                find . -type f \( -name "*.tar.gz" -o -name "*.zip" \
+                    -o -name "*.mcpb" -o -name "*.dxt" \) -exec mv {} . \;
+                sha256sum *.tar.gz *.zip *.mcpb *.dxt > SHA256SUMS.txt
                 cat SHA256SUMS.txt
 
                 # Read the file back and re-hash: the checksums published beside
@@ -428,6 +531,8 @@ jobs:
                 subject-path: |
                     artifacts/*.tar.gz
                     artifacts/*.zip
+                    artifacts/*.mcpb
+                    artifacts/*.dxt
                     artifacts/SHA256SUMS.txt
 
             - name: Extract release notes from CHANGELOG
@@ -465,6 +570,15 @@ jobs:
                 {
                     echo ""
                     echo "---"
+                    echo ""
+                    echo "## Claude Desktop one-click install"
+                    echo ""
+                    echo "Download \`altium-designer-mcp.mcpb\` (older Claude Desktop"
+                    echo "builds: the identical bundle as \`altium-designer-mcp.dxt\`),"
+                    echo "then Claude Desktop → Settings → **Extensions** → **Advanced"
+                    echo "settings** → **Install Extension…**, pick the file and choose"
+                    echo "your library folders. One bundle carries the binary for macOS,"
+                    echo "Windows and Linux."
                     echo ""
                     echo "## Verifying this download"
                     echo ""
@@ -528,6 +642,8 @@ jobs:
                     "${RELEASE_FLAGS[@]}" \
                     artifacts/*.tar.gz \
                     artifacts/*.zip \
+                    artifacts/*.mcpb \
+                    artifacts/*.dxt \
                     artifacts/SHA256SUMS.txt
 
                 echo "Draft release created: $TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Claude Desktop one-click extension.** Every release now ships
+  `altium-designer-mcp.mcpb` — and the identical bundle as
+  `altium-designer-mcp.dxt`, the format's old name, so older Claude Desktop
+  builds install it too (pattern from
+  [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp)).
+  One bundle carries the binary for macOS, Windows and Linux; installing it
+  asks for your library folders and passes them to the server as `--allow`
+  grants, so no config file or JSON editing is needed. The bundle is packed
+  and schema-validated by the official MCPB CLI in the release workflow,
+  which also unpacks it again and speaks MCP to the bundled binary, and it
+  is checksummed and provenance-attested like every other artefact.
+- **`--allow <DIR>` grants on the command line.** Repeatable; adds to the
+  config file's `allowed_paths`, and works with no config file at all — the
+  other settings then take their defaults. A config file that is named but
+  missing, unreadable or invalid still fails loudly.
+
 - **Four more golden-fixture gaps closed with AD24-authored evidence.** The
   regenerated goldens now carry a pin in an alternate display mode
   (`DISPMODE` — the pin-record byte), a graphically locked pin (`LOCKFLAGS`

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ case (`TopOverlay`, `Mechanical13`), in any case; every tool accepts the same sp
 archive bundles a setup README plus [`docs/CLIENT_SETUP.md`](docs/CLIENT_SETUP.md), which
 wires the server into every MCP client we know of.
 
+**Claude Desktop users** need no archive at all: install the one-click extension
+`altium-designer-mcp.mcpb` from the same page (older builds: the identical
+`altium-designer-mcp.dxt`) via Settings → Extensions → Advanced settings →
+Install Extension… — see [CLIENT_SETUP.md § Claude Desktop](docs/CLIENT_SETUP.md#claude-desktop).
+
 To build from source instead, see
 [CONTRIBUTING.md § Development Setup](CONTRIBUTING.md#development-setup); an optimised
 binary comes from `cargo build --release` and lands at `target/release/altium-designer-mcp`.

--- a/TODO.md
+++ b/TODO.md
@@ -15,10 +15,6 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **Streamable HTTP transport** alongside stdio, so web-only assistants (claude.ai in
       the browser, ChatGPT) can connect as a remote server — today they cannot
       (`docs/CLIENT_SETUP.md` § Web-only assistants).
-- [ ] **Claude Desktop extension** for one-click install, published as **both `.mcpb` and
-      `.dxt`** — the same bundle format under its new and old names, so older Claude Desktop
-      builds install it too. Claude Desktop now steers users to extensions over hand-edited
-      JSON (pattern from coffeenmusic/altium-mcp).
 
 ## C. Quality & coverage
 

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -27,8 +27,10 @@ file is** — and differs only in where that pair is written down.
    altium-designer-mcp --version
    ```
 
-The server speaks MCP over **stdio** and takes the config path as its **single argument**.
-Throughout this page:
+The server speaks MCP over **stdio**. Point it at your config file with its single
+positional argument — or skip the file entirely and grant folders directly with
+`--allow <DIR>` (repeatable; every other setting then takes its default). Throughout
+this page:
 
 | Placeholder | Linux / macOS example | Windows example (as written in JSON) |
 |-------------|-----------------------|--------------------------------------|
@@ -106,6 +108,19 @@ its 34 tools. See [`USAGE.md`](USAGE.md) for worked examples.
 ## Claude Desktop
 
 macOS and Windows only (there is no Linux build of Claude Desktop).
+
+**One-click extension (recommended):** download `altium-designer-mcp.mcpb` from the
+[latest release](https://github.com/embedded-society/altium-designer-mcp/releases/latest)
+— on an older Claude Desktop build that does not accept it, take the identical bundle
+under the format's old name, `altium-designer-mcp.dxt`. Then Settings → **Extensions** →
+**Advanced settings** → **Install Extension…**, pick the file, and choose your library
+folders when prompted. That folder list is the `allowed_paths` security boundary, so
+keep it narrow. No binary to place, no config file, no JSON: one bundle carries the
+server for macOS, Windows and Linux, and the picked folders reach it as `--allow`
+grants. (The extension route follows the pattern of
+[coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp).)
+
+**Manual config** — wiring the binary by hand instead:
 
 1. Claude menu → **Settings…** → **Developer** → **Edit Config**. This opens (or creates)
    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,13 +11,14 @@ only after a human has looked at the artefacts**.
 
 ## What is automated
 
-`.github/workflows/release.yml` runs in three jobs:
+`.github/workflows/release.yml` runs in four jobs:
 
 | Job | What it does | Can it publish? |
 |-----|--------------|-----------------|
 | `validate` | Tag format, `Cargo.toml` version match, tagged commit is on `main`, CHANGELOG entry exists, no release already exists | no |
 | `build` | Builds and tests on Linux / macOS / Windows, packages each archive, **unpacks it again and runs the packaged binary** | no |
-| `release` | Verifies all three artefacts arrived, generates and re-checks `SHA256SUMS.txt`, attests SLSA build provenance, creates a **draft** release | draft only |
+| `bundle` | Assembles the Claude Desktop extension (`altium-designer-mcp.mcpb` + its identical `.dxt` twin) from the three binaries, packs it with the official MCPB CLI (which validates the manifest), **unpacks it again and speaks MCP to the bundled binary** | no |
+| `release` | Verifies all five artefacts arrived, generates and re-checks `SHA256SUMS.txt`, attests SLSA build provenance, creates a **draft** release | draft only |
 
 The final publish is a manual click. Nothing in CI makes a release public.
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -78,6 +78,48 @@ pub fn load_config(path: Option<&Path>) -> Result<Config, ConfigError> {
     Ok(config)
 }
 
+/// Loads the configuration and grants access to `allow` directories on top of
+/// whatever the file lists.
+///
+/// With an empty `allow` this is exactly [`load_config`]. With directories
+/// given, a missing config file is no longer an error: the defaults stand in
+/// for it, so `altium-designer-mcp --allow <dir>` runs without any file — the
+/// path the Claude Desktop extension uses, where a directory picker supplies
+/// the grants and nothing writes `config.json`. An explicitly given `path`
+/// must still exist: naming a file that is not there stays an error rather
+/// than silently running on defaults.
+///
+/// # Errors
+///
+/// Returns an error if the configuration file exists but cannot be read,
+/// parsed or validated — or if `path` names a file that does not exist.
+pub fn load_config_with_allow(
+    path: Option<&Path>,
+    allow: Vec<PathBuf>,
+) -> Result<Config, ConfigError> {
+    merge_allow(load_config(path), path.is_none(), allow)
+}
+
+/// The pure half of [`load_config_with_allow`]: grants `allow` on top of the
+/// load result. `used_default_path` says the caller named no file, which is
+/// the only case where a missing file is excused.
+fn merge_allow(
+    loaded: Result<Config, ConfigError>,
+    used_default_path: bool,
+    allow: Vec<PathBuf>,
+) -> Result<Config, ConfigError> {
+    if allow.is_empty() {
+        return loaded;
+    }
+    let mut config = match loaded {
+        Ok(config) => config,
+        Err(ConfigError::NotFound { .. }) if used_default_path => Config::default(),
+        Err(e) => return Err(e),
+    };
+    config.allowed_paths.extend(allow);
+    Ok(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,6 +181,69 @@ mod tests {
         let config = load_config(Some(file.path())).expect("valid config loads");
         assert_eq!(config.allowed_paths.len(), 1);
         assert_eq!(config.logging.level, "warn");
+    }
+
+    #[test]
+    fn allow_alone_runs_on_defaults_without_any_config_file() {
+        // The Claude Desktop extension path: no config file anywhere the
+        // caller named, directories granted on the command line. Hermetic —
+        // through the pure half, so the machine's real default config (which
+        // load_config(None) would read) cannot leak in.
+        let not_found = Err(ConfigError::NotFound {
+            path: PathBuf::from("<default config path>"),
+        });
+        let config = merge_allow(not_found, true, vec![PathBuf::from("/tmp/libs")])
+            .expect("--allow must not require a config file");
+        assert_eq!(config.allowed_paths, vec![PathBuf::from("/tmp/libs")]);
+        assert_eq!(config.logging.level, "warn");
+        assert_eq!(config.rate_limit.max_burst, 120);
+    }
+
+    #[test]
+    fn allow_extends_an_explicit_config_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), r#"{"allowed_paths":["/tmp/from-file"]}"#).unwrap();
+        let config = load_config_with_allow(
+            Some(file.path()),
+            vec![PathBuf::from("/tmp/extra-a"), PathBuf::from("/tmp/extra-b")],
+        )
+        .expect("valid config with extra grants loads");
+        assert_eq!(
+            config.allowed_paths,
+            vec![
+                PathBuf::from("/tmp/from-file"),
+                PathBuf::from("/tmp/extra-a"),
+                PathBuf::from("/tmp/extra-b"),
+            ]
+        );
+    }
+
+    #[test]
+    fn allow_does_not_excuse_a_named_config_file_that_is_missing() {
+        // A caller who NAMED a file meant that file: running on defaults
+        // instead would silently drop their logging and rate settings.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.json");
+        let err =
+            load_config_with_allow(Some(&missing), vec![PathBuf::from("/tmp/libs")]).unwrap_err();
+        assert!(matches!(err, ConfigError::NotFound { .. }));
+    }
+
+    #[test]
+    fn allow_does_not_excuse_a_broken_config_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "{ not json ").unwrap();
+        let err = load_config_with_allow(Some(file.path()), vec![PathBuf::from("/tmp/libs")])
+            .unwrap_err();
+        assert!(matches!(err, ConfigError::ParseError { .. }));
+    }
+
+    #[test]
+    fn empty_allow_is_exactly_load_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.json");
+        let err = load_config_with_allow(Some(&missing), Vec::new()).unwrap_err();
+        assert!(matches!(err, ConfigError::NotFound { .. }));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -36,6 +36,20 @@ pub struct Config {
     pub rate_limit: RateLimitConfig,
 }
 
+impl Default for Config {
+    /// The configuration a missing config file stands for: no allowed paths
+    /// (until `--allow` grants some), `warn` logging, default rate limits.
+    fn default() -> Self {
+        Self {
+            _schema: None,
+            _comment: None,
+            allowed_paths: Vec::new(),
+            logging: LoggingConfig::default(),
+            rate_limit: RateLimitConfig::default(),
+        }
+    }
+}
+
 impl Config {
     /// Validates the configuration.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,12 @@ struct Args {
     #[arg(value_name = "CONFIG_FILE")]
     config: Option<PathBuf>,
 
+    /// Grant access to a library directory (repeatable). Adds to the config
+    /// file's allowed paths, and works with no config file at all — the other
+    /// settings then take their defaults
+    #[arg(long = "allow", value_name = "DIR", num_args = 1..)]
+    allow: Vec<PathBuf>,
+
     /// Increase logging verbosity (-v for info, -vv for debug, -vvv for trace)
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
@@ -81,14 +87,15 @@ fn main() -> ExitCode {
 
     // Load configuration
     let config_path = args.config.as_deref();
-    let cfg = match config::load_config(config_path) {
+    let cfg = match config::load_config_with_allow(config_path, args.allow) {
         Ok(cfg) => cfg,
         Err(e) => {
             eprintln!("Configuration error: {e}");
             if config_path.is_none() {
                 if let Some(default_path) = config::default_config_path() {
                     eprintln!("\nExpected config at: {}", default_path.display());
-                    eprintln!("Create one based on config/example-config.json");
+                    eprintln!("Create one based on config/example-config.json,");
+                    eprintln!("or grant directories directly: --allow <DIR>...");
                 }
             }
             return ExitCode::FAILURE;

--- a/tests/mcpb_manifest.rs
+++ b/tests/mcpb_manifest.rs
@@ -1,0 +1,71 @@
+//! Holds `.github/release-assets/mcpb-manifest.json` — the Claude Desktop
+//! extension manifest template release.yml stamps and zips into the
+//! `.mcpb`/`.dxt` bundle — to the crate it describes, so a rename, a licence
+//! change or a CLI change cannot ship a stale extension.
+
+use serde_json::Value;
+
+fn manifest() -> Value {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/.github/release-assets/mcpb-manifest.json"
+    );
+    let text = std::fs::read_to_string(path).expect("read mcpb-manifest.json");
+    serde_json::from_str(&text).expect("mcpb-manifest.json is valid JSON")
+}
+
+/// The template mirrors Cargo.toml: same name, description, licence and
+/// repository, with the version left as the `@VERSION@` stamp release.yml
+/// replaces (the same convention as the release README).
+#[test]
+fn manifest_mirrors_the_crate() {
+    let m = manifest();
+    assert_eq!(m["manifest_version"], "0.3");
+    assert_eq!(m["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(m["description"], env!("CARGO_PKG_DESCRIPTION"));
+    assert_eq!(m["license"], env!("CARGO_PKG_LICENSE"));
+    assert_eq!(m["version"], "@VERSION@");
+    assert_eq!(
+        m["repository"]["url"],
+        "https://github.com/embedded-society/altium-designer-mcp"
+    );
+    for field in ["author", "server", "user_config", "compatibility"] {
+        assert!(m.get(field).is_some(), "manifest must carry {field}");
+    }
+}
+
+/// The server block runs the bundled binary for each platform with the
+/// `--allow` grants the directory picker supplies — the exact CLI contract
+/// `load_config_with_allow` implements (no config file needed).
+#[test]
+fn manifest_server_block_matches_the_cli_contract() {
+    let m = manifest();
+    let server = &m["server"];
+    assert_eq!(server["type"], "binary");
+
+    let mcp = &server["mcp_config"];
+    assert_eq!(
+        mcp["args"],
+        serde_json::json!(["--allow", "${user_config.library_paths}"]),
+        "args must pass the picked directories straight to --allow"
+    );
+    assert_eq!(
+        mcp["command"], "${__dirname}/server/linux/altium-designer-mcp",
+        "the base command is the linux binary; win32/darwin override it"
+    );
+    assert_eq!(
+        mcp["platform_overrides"]["win32"]["command"],
+        "${__dirname}/server/win32/altium-designer-mcp.exe"
+    );
+    assert_eq!(
+        mcp["platform_overrides"]["darwin"]["command"],
+        "${__dirname}/server/darwin/altium-designer-mcp"
+    );
+
+    // The user_config key the args reference must exist, be a directory
+    // picker, allow several folders, and refuse to run without one.
+    let picker = &m["user_config"]["library_paths"];
+    assert_eq!(picker["type"], "directory");
+    assert_eq!(picker["multiple"], true);
+    assert_eq!(picker["required"], true);
+}


### PR DESCRIPTION
## What

Closes the TODO § B item: every release now ships a **Claude Desktop one-click extension** — `altium-designer-mcp.mcpb`, plus the byte-identical bundle as `altium-designer-mcp.dxt` (the format's old name) so older Claude Desktop builds install it too. Pattern from [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp), attributed in the docs.

- **One cross-platform bundle**: `server/{win32,darwin,linux}/` binaries with `platform_overrides` picking the right one; a required multi-directory picker supplies the library folders.
- **New server capability `--allow <DIR>` (repeatable)**: adds to the config file's allowed paths and works with **no config file at all** (defaults for the rest) — the exact contract the manifest encodes. A *named* config file that is missing/broken still fails loudly. Hermetic tests via the pure `merge_allow` half.
- **Manifest template** at `.github/release-assets/mcpb-manifest.json` (spec v0.3, `$schema` URL verified), stamped with `@VERSION@` like the release README; `tests/mcpb_manifest.rs` guards it against the crate's name/licence/description and the CLI shape.
- **`release.yml` fourth job `bundle`** (dry-run covered): assembles from the three build artefacts, packs with the official `@anthropic-ai/mcpb@2.1.2` CLI (schema-validates while packing), proves the two names byte-identical, then **unpacks the bundle again and speaks MCP `initialize` to the bundled Linux binary with the manifest's own `--allow` argument**. Both files join the presence check, `SHA256SUMS.txt`, the SLSA attestation, the draft release, and the release notes gain a one-click-install section.
- **Docs**: CLIENT_SETUP.md § Claude Desktop now leads with the extension (UI steps verified against the current Claude Desktop support article), release-asset README and repo README point at it, RELEASING.md documents the fourth job.

## Verified locally

- `mcpb pack` on a real assembled layout (9.3 MB bundle, validation passes).
- `altium-designer-mcp --allow <dir>` answers MCP `initialize` over stdio with no config file.
- Full suite (14 binaries) green; clippy/fmt/doc/markdownlint clean; `release.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)