### PR TITLE
docs(todo): the climb to v1.0.0 is the active chapter; HTTP moves to v1.1.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,22 +7,24 @@ record). The specialised worklists stay the single source of truth for their are
 |------|----------|
 | Golden-fixture enrichment and verified negatives | `scripts/samples/COVERAGE.md` |
 
-## B. Release & distribution
+## B. The climb to v1.0.0 (active)
 
-- [ ] **v1.0.0 is the real release**, gated on ALL features built (the 99% production
-      coverage gate is already met). The climb happens calmly;
+- [ ] **Polish everything to perfection first** — a full pass over README, `docs/`, the
+      bundled release README, tool descriptions and CHANGELOG for anything stale,
+      pre-1.0-flavoured or unclear, before the version is bumped. Every feature the
+      1.0 line promises is built; the remaining gate is polish.
+- [ ] **Release dry run** (`workflow_dispatch` on `release.yml`) proving the full
+      pipeline, including the new extension `bundle` job, before any tag —
       [`docs/RELEASING.md`](docs/RELEASING.md) is the proven runbook.
+- [ ] **v1.0.0**: stamp `CHANGELOG.md`, bump `Cargo.toml`, tag, review the draft, publish.
+
+## After v1.0.0 (v1.1.0)
+
 - [ ] **Streamable HTTP transport** alongside stdio, so web-only assistants (claude.ai in
       the browser, ChatGPT) can connect as a remote server — today they cannot
-      (`docs/CLIENT_SETUP.md` § Web-only assistants).
+      (`docs/CLIENT_SETUP.md` § Web-only assistants). Deliberately after 1.0.
 
-## C. Quality & coverage
-
-- [ ] **Test-coverage push** once the extension bundle ships: expand tests toward full
-      coverage again (baseline 99.32%; the remainder is mostly defensive/unreachable
-      branches, so each gain needs a deliberate fixture or restructure).
-
-## D. Maintenance & waiting
+## C. Maintenance & waiting
 
 - [ ] **Drop the `cfb` git pin** (`[patch.crates-io]`, rev `8c1ec76`) as soon as rust-cfb
       publishes a release newer than v0.14.0 — check


### PR DESCRIPTION
- Coverage push item removed (shipped in #489).
- § B is now the v1.0.0 climb: polish-to-perfection pass → release dry run (proves the new extension `bundle` job before any tag) → v1.0.0.
- Streamable HTTP transport moved under a new "After v1.0.0 (v1.1.0)" heading — deliberately post-1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)