### PR TITLE
docs: polish pass for the v1.0.0 climb

### DIFF
--- a/.github/release-assets/README.md
+++ b/.github/release-assets/README.md
@@ -76,6 +76,9 @@ The server refuses to read or write anything outside those folders. That confine
 safety property, so keep the list as narrow as the work allows — a single project's library folder
 rather than your whole home directory.
 
+No file at all is also fine: `altium-designer-mcp --allow <folder>` (repeatable) grants folders on
+the command line and takes defaults for everything else.
+
 ## Step 3 — Connect your AI assistant
 
 Every client below speaks the same protocol; they differ only in where the configuration lives.
@@ -142,8 +145,9 @@ snippet — plus a troubleshooting table.
 ### Any other MCP client
 
 The `mcpServers` block above is the de-facto standard schema. If your client supports MCP over
-stdio, give it the binary path as the command and the config-file path as the single argument; check
-its documentation for where its configuration file lives.
+stdio, give it the binary path as the command and the config-file path as the single argument (or
+`--allow` followed by your library folders instead); check its documentation for where its
+configuration file lives.
 
 ## Step 4 — Try it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   config file's `allowed_paths`, and works with no config file at all — the
   other settings then take their defaults. A config file that is named but
   missing, unreadable or invalid still fails loudly.
-
 - **Four more golden-fixture gaps closed with AD24-authored evidence.** The
   regenerated goldens now carry a pin in an alternate display mode
   (`DISPMODE` — the pin-record byte), a graphically locked pin (`LOCKFLAGS`
@@ -38,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit 120×70 mil: AD computes the size lazily from the rendered extent,
   and a headless save caught it at 0. All validated from Altium's side via
   `Verify-Libraries.ps1 -Expect`.
-
 - **The on-site Altium harness asserts what Altium resolves, not just that a
   file opens.** `AltiumVerify.pas` now reports per-component primitive counts
   (all 8 PcbLib primitive kinds, all 16 SchLib record kinds) through the
@@ -166,7 +164,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Unsupported file type: .csv`, `File has no extension`, …); all now say
   `Unsupported file type '.csv' for 'Parts.csv': expected .PcbLib or
   .SchLib`, and a path without an extension says so.
-
 - **A solid symbol body no longer paints over the pin names inside it.**
   `write_schlib` recorded the order it happened to parse its input in — pins
   before rectangles — and replayed that as if it were an authoring order, so a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,8 +259,10 @@ The project holds **99% line coverage on production code** (`main.rs` excluded �
 exercised end-to-end across a process boundary instrumentation cannot see; measured with
 `cargo llvm-cov --all-features --workspace --ignore-filename-regex '(^|[/\\])main\.rs$'`).
 Two facts worth knowing when reading figures near the gate: the measured total flaps by a
-few lines between identical runs, so treat small movements as noise; and the cheapest
-remaining headroom sits in `mcp/server.rs` and `mcp/tools/library_ops.rs`.
+few lines between identical runs, so treat small movements as noise; and the remaining
+uncovered lines are, on inspection, ones a passing test cannot reach — assertion-failure
+formatting, `cfg(unix)` signal handling, manual-tooling branches and defence-in-depth
+behind the writers' own guarantees — so a new test should target a seam, not the number.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ altium-designer-mcp [OPTIONS] [CONFIG_FILE]
 | Option | Description |
 |--------|-------------|
 | `CONFIG_FILE` | Path to configuration file (optional, uses default location if omitted) |
+| `--allow <DIR>...` | Grant access to library folders directly (repeatable). Adds to the config file's `allowed_paths`, and works with no config file at all — the other settings then take their defaults |
 | `-v`, `--verbose` | Increase logging verbosity (`-v` info, `-vv` debug, `-vvv` trace) |
 | `-q`, `--quiet` | Decrease logging verbosity (only show errors) |
 | `-h`, `--help` | Print help information |
@@ -345,7 +346,9 @@ search `PATH` or expand `~` for you.
 
 ## Configuration
 
-Configuration file location:
+The server reads one JSON file — or none: `altium-designer-mcp --allow <DIR>` grants
+folders on the command line and runs on defaults for everything else, which is how the
+Claude Desktop extension starts it. Configuration file location:
 
 - **Linux/macOS:** `~/.altium-designer-mcp/config.json`
 - **Windows:** `%USERPROFILE%\.altium-designer-mcp\config.json`
@@ -366,7 +369,7 @@ Configuration file location:
 
 | Option | Description |
 |--------|-------------|
-| `allowed_paths` | Array of directory paths where library files can be accessed (default: current directory) |
+| `allowed_paths` | Array of directory paths where library files can be accessed; `--allow` adds to it (default when neither grants anything: the current working directory) |
 | `logging.level` | Log level: trace, debug, info, warn, error (default: warn) |
 | `logging.audit_log_path` | Path to an append-only JSON-lines audit log of destructive operations (default: null — no audit log is written) |
 | `rate_limit.max_burst` | Maximum burst of mutating operations before throttling; read-only tools are never rate limited (default: 120) |

--- a/TODO.md
+++ b/TODO.md
@@ -21,11 +21,25 @@ record). The specialised worklists stay the single source of truth for their are
       refresh the supported-versions table and date in `SECURITY.md`, dry-run once more,
       tag, review the draft (install the `.mcpb` once), publish.
 
-## After v1.0.0 (v1.1.0)
+## After v1.0.0
 
-- [ ] **Streamable HTTP transport** alongside stdio, so web-only assistants (claude.ai in
-      the browser, ChatGPT) can connect as a remote server — today they cannot
-      (`docs/CLIENT_SETUP.md` § Web-only assistants). Deliberately after 1.0.
+- [ ] **Streamable HTTP transport** (v1.1.0) alongside stdio, so web-only assistants
+      (claude.ai in the browser, ChatGPT) can connect as a remote server — today they
+      cannot (`docs/CLIENT_SETUP.md` § Web-only assistants). Deliberately after 1.0.
+- [ ] **Windows code signing through SignPath Foundation** — free for open-source
+      projects, HSM-held key, signs from GitHub Actions. Decided 2026-09-02 over the paid
+      routes (Azure Artifact Signing ~$10/month on a paid subscription, commercial OV/EV
+      $200–700/year): the publisher line reads "SignPath Foundation", which is fine, and
+      SmartScreen reputation then builds under an established identity. Steps: write the
+      short code-signing policy page their terms require (roles, MFA, credit), apply, add
+      their action to the repository's action allow-list, sign in the `build` job before
+      packaging so the attestation covers the signed binary, and drop the SmartScreen
+      caveat from the docs and release notes.
+- [ ] **Sign the `.mcpb` bundle too** (`mcpb sign` / `mcpb verify`) once a certificate
+      exists — after checking what Claude Desktop shows for a signed side-loaded bundle.
+- [ ] **macOS notarisation** (Apple Developer Program, $99/year) only when macOS downloads
+      justify it — 3 of the 81 v0.2.0 downloads today. Until then the docs' right-click →
+      Open note stands.
 
 ## C. Maintenance & waiting
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,10 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **Release dry run** (`workflow_dispatch` on `release.yml`) proving the full
       pipeline, including the new extension `bundle` job, before any tag —
       [`docs/RELEASING.md`](docs/RELEASING.md) is the proven runbook.
-- [ ] **v1.0.0**: stamp `CHANGELOG.md`, bump `Cargo.toml`, tag, review the draft, publish.
+- [ ] **v1.0.0**: stamp `CHANGELOG.md` (with a short lead paragraph on what 1.0 means),
+      bump the version in `Cargo.toml` / `Cargo.lock` / `package.json` / `package-lock.json`,
+      refresh the supported-versions table and date in `SECURITY.md`, dry-run once more,
+      tag, review the draft (install the `.mcpb` once), publish.
 
 ## After v1.0.0 (v1.1.0)
 
@@ -29,7 +32,3 @@ record). The specialised worklists stay the single source of truth for their are
 - [ ] **Drop the `cfb` git pin** (`[patch.crates-io]`, rev `8c1ec76`) as soon as rust-cfb
       publishes a release newer than v0.14.0 — check
       [rust-cfb releases](https://github.com/mdsteele/rust-cfb/releases) at session start.
-- [ ] **Dismiss the recurring GitHub "AI findings"** (maintainer-only, in the repo's
-      Security → Quality UI): the same three findings keep regenerating autofix PRs
-      (#415/#416, #469/#470 all closed as verified non-bugs) until they are dismissed
-      there — the API cannot do it.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -65,8 +65,9 @@ not the description field.
 
 ## Filesystem sandbox
 
-Only paths inside the configured `allowed_paths` (see `config.json`) can be read
-or written. Requests outside the sandbox are rejected. Writes create a timestamped
+Only paths inside the configured `allowed_paths` (`config.json`, or the folders
+granted with `--allow`) can be read or written. Requests outside the sandbox are
+rejected. Writes create a timestamped
 `.bak` of any existing file first.
 
 ## Typical build flow

--- a/docs/AI_WORKFLOW.md
+++ b/docs/AI_WORKFLOW.md
@@ -380,11 +380,11 @@ When calculating footprints, the AI should apply these IPC standards:
 
 **Density Levels:**
 
-| Level | Code | Application |
-|-------|------|-------------|
-| Most (M) | N/A | High-density designs, fine-pitch |
-| Nominal (N) | N | Standard manufacturing |
-| Least (L) | N/A | Wave soldering, hand assembly |
+| Level | Name suffix | Application |
+|-------|-------------|-------------|
+| Most | `M` | High-density designs, fine-pitch |
+| Nominal | `N` | Standard manufacturing |
+| Least | `L` | Wave soldering, hand assembly |
 
 **Naming Convention:**
 

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -351,8 +351,8 @@ is the de-facto interchange format — many clients import it directly.
 ### Web-only assistants
 
 claude.ai in the browser and ChatGPT connect only to *remote* MCP servers over HTTP.
-This server currently speaks stdio, so it pairs with the desktop, CLI and IDE clients
-above; an HTTP transport is on the roadmap for v1.0.0.
+This server speaks stdio, so it pairs with the desktop, CLI and IDE clients above; a
+Streamable HTTP transport is planned for v1.1.0, after the 1.0 release.
 
 ## Troubleshooting
 
@@ -362,5 +362,5 @@ above; an HTTP transport is on the roadmap for v1.0.0.
 | "Failed to connect" / spawn error | Run `<binary> <config>` in a terminal: it should sit silently waiting for input (press Ctrl+C to stop). If it prints an error, fix that first — a typo in `allowed_paths`, or a missing config file. |
 | Windows: path errors | Every `\` in JSON must be `\\`; or use forward slashes. `%APPDATA%`-style variables are not expanded inside JSON — write the real path. |
 | Windows SmartScreen / macOS Gatekeeper blocks the first run | The binaries are not code-signed. Windows: **More info → Run anyway**. macOS: right-click → **Open** once, or `xattr -d com.apple.quarantine <binary>`. The release's signed provenance attestation is the stronger check — see the release notes. |
-| Tools are listed but every call fails with a path error | The library file is outside `allowed_paths`. Add its folder to the config and restart the client. |
+| Tools are listed but every call fails with a path error | The library file is outside `allowed_paths`. Add its folder to the config (or, for the Claude Desktop extension, to its **Library folders** setting) and restart the client. |
 | Claude Desktop shows nothing | Read `mcp-server-altium.log` (locations above) — it holds the server's own error output. |

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -137,7 +137,8 @@ stderr, and `mcp.log` beside them the connection attempts.
 
 ## Google Antigravity
 
-Settings (bottom left) → **Customizations** → **Add MCP**, or edit the file directly:
+Settings (bottom left) → **Customizations** → **Installed MCP Servers** → **Add MCP**, or
+edit the file directly:
 
 - Linux / macOS: `~/.gemini/config/mcp_config.json`
 - Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`
@@ -151,8 +152,20 @@ list must show `altium` enabled. The official
 ## Cursor
 
 Global: `~/.cursor/mcp.json` (every project). Project: `.cursor/mcp.json` in the project
-root. Both take the standard block; `"type": "stdio"` is the default for a `command`
-entry.
+root. Both take the standard block with one addition — Cursor's docs mark
+`"type": "stdio"` as required for a local server:
+
+```json
+{
+    "mcpServers": {
+        "altium": {
+            "type": "stdio",
+            "command": "<binary>",
+            "args": ["<config>"]
+        }
+    }
+}
+```
 
 Check: Cursor Settings → **MCP** shows `altium` with a green dot and its tool list.
 
@@ -180,7 +193,8 @@ appear in Copilot Chat's **Agent** mode under the tools picker.
 
 Start `copilot`, enter `/mcp add`, and fill in the form: name `altium`, type
 **Local/STDIO**, the command *including its argument* (`<binary> <config>`), no
-environment variables, tools `*`. Or edit `~/.copilot/mcp-config.json`:
+environment variables, tools `*` — or `copilot mcp add` from a terminal does the same.
+Or edit `~/.copilot/mcp-config.json`:
 
 ```json
 {
@@ -240,9 +254,10 @@ Q Developer CLI — migrated automatically in November 2025) reads the same file
 
 ## JetBrains AI Assistant
 
-**Settings → Tools → AI Assistant → Model Context Protocol (MCP)** → **+** → choose
-**As JSON** and paste the standard block. Pick *Global* or *Project* level. (IntelliJ,
-PyCharm, CLion, Rider and the rest share this dialog.)
+**Settings → Tools → AI Assistant → Model Context Protocol (MCP)** → **+** → either fill
+in the stdio form (command `<binary>`, argument `<config>`) or choose **As JSON** and paste
+the standard block. Pick *Global* or *Project* as the server level. (IntelliJ, PyCharm,
+CLion, Rider and the rest share this dialog.)
 
 ## Zed
 
@@ -322,7 +337,8 @@ extensions:
     timeout: 300
 ```
 
-Restart Goose after editing; `goose configure` offers the same through a menu.
+Restart Goose after editing; `goose configure` → **Add Extension** → **Command-line
+Extension** offers the same through a menu.
 
 ## OpenCode
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,6 +34,16 @@ server into Claude Code, Claude Desktop, Antigravity, Cursor and VS Code — not
 the repository's own contributor-facing README. Edit it when the setup steps
 change; the `build` job fails if any expected file is missing from an archive.
 
+### What ships as the extension
+
+`altium-designer-mcp.mcpb` and its byte-identical `.dxt` twin: one bundle holding
+the three platform binaries under `server/{win32,darwin,linux}/` and a
+`manifest.json` stamped from
+[`.github/release-assets/mcpb-manifest.json`](../.github/release-assets/mcpb-manifest.json)
+(`@VERSION@` substituted, like the README). `tests/mcpb_manifest.rs` holds the
+template to the crate's name, licence and CLI shape; the `bundle` job fails if
+a binary or the manifest is missing from the packed file.
+
 ## Dry run — do this first
 
 The whole pipeline can be exercised without a tag:
@@ -43,9 +53,10 @@ gh workflow run release.yml --ref main
 gh run watch
 ```
 
-This builds, packages, smoke-tests and checksums all three platforms, then stops
-before the `release` job. Artefacts are kept for 7 days on the workflow run page,
-so you can download the real archives and try them on a real machine.
+This builds, packages and smoke-tests all three platforms and the extension
+bundle, then stops before the `release` job. Artefacts are kept for 7 days on
+the workflow run page, so you can download the real archives — and the `.mcpb`
+— and try them on a real machine.
 
 Do this **before** stamping the changelog or tagging. It is the only way to find a
 packaging problem that costs nothing to fix.
@@ -72,8 +83,11 @@ Two notes on dry runs:
    stranger would. Add a fresh empty `## [Unreleased]` above it for the next
    cycle.
 
-3. **Set the version in `Cargo.toml`** if it is not already `X.Y.Z`. The tag and
-   the `[package]` version must agree or `validate` fails.
+3. **Set the version** to `X.Y.Z` in `Cargo.toml` and `Cargo.lock` (`cargo update
+   -p altium-designer-mcp` refreshes the lockfile entry) and in `package.json` /
+   `package-lock.json`, which carry the same number. The tag and the `[package]`
+   version must agree or `validate` fails. For a major release, also refresh the
+   supported-versions table and date in the root `SECURITY.md`.
 
 4. **Merge those to main** through a PR, and let CI go green.
 
@@ -88,8 +102,8 @@ Two notes on dry runs:
 
    ```bash
    git switch main && git pull
-   git tag -s v0.1.0 -m "v0.1.0"
-   git push origin v0.1.0
+   git tag -s vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
    ```
 
 7. **Watch the workflow.**
@@ -98,18 +112,20 @@ Two notes on dry runs:
    gh run watch
    ```
 
-8. **Review the draft.** Download the three archives from the draft release page,
-   check `SHA256SUMS.txt`, and run at least one binary on a real machine:
+8. **Review the draft.** Download the three archives and the extension bundle
+   from the draft release page, check `SHA256SUMS.txt`, run at least one binary
+   on a real machine, and install the `.mcpb` in Claude Desktop once:
 
    ```bash
-   gh release view v0.1.0
+   gh release view vX.Y.Z
    sha256sum -c SHA256SUMS.txt
    ```
 
-9. **Publish.**
+9. **Publish.** A tag without a pre-release suffix is published as the latest
+   release; add `--prerelease --latest=false` for a pre-release that has none.
 
    ```bash
-   gh release edit v0.1.0 --draft=false
+   gh release edit vX.Y.Z --draft=false
    ```
 
 10. **Announce** — including a note on the tracking issue if one is open.
@@ -155,12 +171,13 @@ draft than after the release is public.
   ruleset; if the delete is refused, that is the ruleset working as intended.
 
   ```bash
-  gh release delete v0.1.0 --yes
-  git push --delete origin v0.1.0
-  git tag -d v0.1.0
+  gh release delete vX.Y.Z --yes
+  git push --delete origin vX.Y.Z
+  git tag -d vX.Y.Z
   ```
 
-- **After publishing** — do not delete or move the tag. Ship `v0.1.1`. A version
+- **After publishing** — do not delete or move the tag. Ship the next patch
+  version. A version
   someone already downloaded should keep meaning what it meant.
 
 ## Reproducible dependencies

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -190,8 +190,10 @@ deliberate commits (`cargo update`, run the full suite, commit the lockfile).
 
 ## Known gaps
 
-- **No code signing.** Windows SmartScreen and macOS Gatekeeper will warn on
+- **No code signing yet.** Windows SmartScreen and macOS Gatekeeper will warn on
   first run; macOS users need right-click → Open. The generated release notes say
-  so, and point at the provenance attestation as the stronger check. Proper
-  signing needs a paid Apple Developer account and a Windows certificate, so it
-  is a cost decision rather than a technical one.
+  so, and point at the provenance attestation as the stronger check. The plan
+  (`TODO.md` § After v1.0.0) is Windows signing through SignPath Foundation's
+  free open-source programme, wired into the `build` job so the attestation
+  covers the signed binary; macOS notarisation waits until macOS downloads
+  justify the Apple Developer Program fee.

--- a/docs/SCHLIB_FORMAT.md
+++ b/docs/SCHLIB_FORMAT.md
@@ -850,8 +850,8 @@ A parameter-record variant selected by `Name=Designator`. As written by this cra
 > **Note:** `DatafileCount=1` plus the `ModelDatafileEntity0` link is what lets Altium *resolve*
 > the model to an actual footprint in a `PcbLib`; a name-only record with `DatafileCount=0` shows
 > in the list but reports "model not found". AltiumSharp indexes the datafile keys 1-based
-> (`MODELDATAFILEKIND1`); this crate writes 0-based, matching observed files — the index base is
-> still under golden verification (TODO §B).
+> (`MODELDATAFILEKIND1`); this crate writes 0-based — the `IMPLCHAIN` golden, authored by AD24,
+> stores `ModelDatafile0` / `ModelDatafileEntity0` / `ModelDatafileKind0`.
 
 ## Default Values
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -193,8 +193,8 @@ appear in the client at all, or will not start, is a wiring problem —
 ### "Access denied" error
 
 The target path is outside the server's `allowed_paths`. Add the directory to your
-`config.json` (see [README.md § Configuration](../README.md#configuration)) and restart the
-client.
+`config.json` (see [README.md § Configuration](../README.md#configuration)) — or, for the
+Claude Desktop extension, to its **Library folders** setting — and restart the client.
 
 ### Library won't open in Altium
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -197,7 +197,14 @@ via stack is held to what the record stores — the entry count its stack mode t
 (3 for `top_middle_bottom`, 32 for `full_stack`; 32 diameters for a stacked via), a shape
 per entry, a whole-number 0-100 corner radius —
 `Pad '1' per_layer_shapes[2] 'oblongish' is not a shape` — rather than filling a
-missing layer from the main size or ignoring an extra one.
+missing layer from the main size or ignoring an extra one. A `rounded_rectangle` slot is
+`full_stack`-only, because the rounding lives in per-layer corner-radius bytes that a
+`top_middle_bottom` stack has nowhere to store —
+`Pad '1' per_layer_shapes[1]: rounded_rectangle needs a per-layer corner radius, which
+only a full_stack pad stores; a top_middle_bottom stack cannot hold it`. A text's
+`font_name` or `barcode_font_name` is held to the 31 UTF-16 units its field carries —
+`Text font_name '…' is 32 UTF-16 units long; a Windows font face name has at most 31` —
+rather than written cut short.
 
 `write_pcblib`, `write_schlib`, `update_component`, `update_pad`, `update_primitive` and
 `batch_update` refuse any JSON object key they do not know —


### PR DESCRIPTION
Stacked on #490 (base: `docs/todo-v1-climb`; GitHub retargets to `main` when that merges).

The first "docs must sparkle" pass — a full read-through of README, every `docs/*.md`, the bundled release README, CONTRIBUTING and CHANGELOG with 1.0 in mind. Fixes:

- **README**: `--allow <DIR>...` in the CLI table; configuration section says the file is optional (and how the extension starts the server); `allowed_paths` default stated precisely.
- **CLIENT_SETUP**: the HTTP transport is **v1.1.0**, not "on the roadmap for v1.0.0"; troubleshooting covers the extension's folder list. USAGE / AGENT_GUIDE mention both grant routes.
- **RELEASING**: five artefacts; new "What ships as the extension" section; the version-bump step names `Cargo.toml` / `Cargo.lock` / `package.json` / `package-lock.json` and the `SECURITY.md` refresh for a major; `vX.Y.Z` example tags; publish step records the pre-release flags.
- **errors.md**: the TMB `rounded_rectangle` and font-face-name refusals.
- **SCHLIB_FORMAT**: datafile index base is golden-verified (IMPLCHAIN) — the "TODO §B" hedge is gone.
- **AI_WORKFLOW**: IPC density codes M/N/L (were "N/A").
- **CONTRIBUTING**: coverage paragraph describes the saturated remainder.
- **TODO**: v1.0.0 step lists every bump target; AI-findings item removed as requested.

Verified while reading (no change needed): the CLI really does substitute `["."]` when nothing is granted, so README/SECURITY.md are correct; the SECURITY.md contact address matches the git author.

markdownlint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)