### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-09-02
+
+The first stable release. `altium-designer-mcp` reads and writes Altium Designer
+`.PcbLib` and `.SchLib` libraries the way Altium does: every record layout is
+verified against libraries authored by Altium Designer 24 and opened there again,
+and a library read and written back comes out byte-identical. It exposes 34 tools
+over MCP, wires into every MCP client we know of, and installs into Claude Desktop
+with one click. From here on the tool interface — argument names, accepted values
+and result shapes — follows semantic versioning: a change that breaks a caller
+means a new major version.
+
 ### Added
 
 - **Claude Desktop one-click extension.** Every release now ships

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "altium-designer-mcp"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altium-designer-mcp"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,10 @@ We take security seriously — particularly around file system access and input 
 
 | Version | Supported              |
 | ------- | ---------------------- |
-| 0.x.x   | Yes (development) |
+| 1.x.x   | Yes                    |
+| 0.x.x   | No — upgrade to 1.x    |
 
-Once we reach v1.0, we will maintain security updates for the current major version and one previous major version.
+We maintain security updates for the current major version and, once there is one, the previous major version. The 0.x pre-releases are not supported.
 
 ## Reporting a Vulnerability
 
@@ -104,4 +105,4 @@ We thank the security researchers and community members who help keep this proje
 
 ---
 
-*This security policy was last updated on 2026-01-17.*
+*This security policy was last updated on 2026-09-02.*

--- a/TODO.md
+++ b/TODO.md
@@ -7,21 +7,7 @@ record). The specialised worklists stay the single source of truth for their are
 |------|----------|
 | Golden-fixture enrichment and verified negatives | `scripts/samples/COVERAGE.md` |
 
-## B. The climb to v1.0.0 (active)
-
-- [ ] **Polish everything to perfection first** — a full pass over README, `docs/`, the
-      bundled release README, tool descriptions and CHANGELOG for anything stale,
-      pre-1.0-flavoured or unclear, before the version is bumped. Every feature the
-      1.0 line promises is built; the remaining gate is polish.
-- [ ] **Release dry run** (`workflow_dispatch` on `release.yml`) proving the full
-      pipeline, including the new extension `bundle` job, before any tag —
-      [`docs/RELEASING.md`](docs/RELEASING.md) is the proven runbook.
-- [ ] **v1.0.0**: stamp `CHANGELOG.md` (with a short lead paragraph on what 1.0 means),
-      bump the version in `Cargo.toml` / `Cargo.lock` / `package.json` / `package-lock.json`,
-      refresh the supported-versions table and date in `SECURITY.md`, dry-run once more,
-      tag, review the draft (install the `.mcpb` once), publish.
-
-## After v1.0.0
+## B. After v1.0.0
 
 - [ ] **Streamable HTTP transport** (v1.1.0) alongside stdio, so web-only assistants
       (claude.ai in the browser, ChatGPT) can connect as a remote server — today they

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "altium-designer-mcp",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "altium-designer-mcp",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "devDependencies": {
                 "markdownlint-cli2": "^0.23.2"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "altium-designer-mcp",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "private": true,
     "description": "An AI-operated Altium Designer libraries editor.",
     "scripts": {


### PR DESCRIPTION
The release commit for **v1.0.0**, per `docs/RELEASING.md` steps 2–4:

- `CHANGELOG.md`: `## [1.0.0] - 2026-09-02` with a lead paragraph on what 1.0 means; fresh empty `## [Unreleased]` above it.
- Version `1.0.0` in `Cargo.toml`, `Cargo.lock`, `package.json`, `package-lock.json` (`.vscode/launch.json`'s `0.2.0` is VS Code's schema version and stays).
- `SECURITY.md`: 1.x supported, 0.x pre-releases not; date refreshed.
- `TODO.md`: the finished climb items removed; § B is now "After v1.0.0".

Gates: full suite (14 binaries) ✓ · clippy 0 ✓ · fmt ✓ · markdownlint ✓ · offline link check ✓ · `--version` prints `altium-designer-mcp 1.0.0`.

A release dry run is dispatched on this exact commit (step 5) — see the workflow run linked in the comments. After merge: signed tag `v1.0.0` by the maintainer, then draft review and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)