### PR TITLE
ci(registry): publish every release to the official MCP Registry over OIDC

### DIFF
--- a/.github/release-assets/server.json
+++ b/.github/release-assets/server.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.embedded-society/altium-designer-mcp",
+    "description": "Lets an AI read, write and edit Altium Designer .PcbLib/.SchLib component libraries byte-exactly.",
+    "version": "@VERSION@",
+    "repository": {
+        "url": "https://github.com/embedded-society/altium-designer-mcp",
+        "source": "github"
+    },
+    "websiteUrl": "https://github.com/embedded-society/altium-designer-mcp/blob/main/docs/USAGE.md",
+    "packages": [
+        {
+            "registryType": "mcpb",
+            "identifier": "https://github.com/embedded-society/altium-designer-mcp/releases/download/v@VERSION@/altium-designer-mcp.mcpb",
+            "fileSha256": "@SHA256@",
+            "transport": {
+                "type": "stdio"
+            }
+        }
+    ]
+}

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -1,0 +1,102 @@
+name: Publish to MCP Registry
+
+# Lists the release's Claude Desktop bundle in the official MCP Registry
+# (https://registry.modelcontextprotocol.io) as
+# io.github.embedded-society/altium-designer-mcp, so client server browsers
+# find it. Runs when a release is published — a draft becoming public — or
+# by hand for a given tag.
+#
+# Authentication is GitHub's OIDC token: the registry grants an organisation
+# namespace to a workflow running in that organisation's own repository, so
+# no personal token or OAuth app is involved. The published server.json is
+# .github/release-assets/server.json stamped with the version and the
+# bundle's SHA-256, which is re-derived from the release asset itself and
+# checked against the SHA256SUMS.txt published beside it.
+
+permissions:
+    contents: read
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag to publish (for example v1.0.0)"
+                required: true
+                type: string
+
+concurrency:
+    group: registry-publish-${{ github.event.release.tag_name || inputs.tag }}
+    cancel-in-progress: false
+
+jobs:
+    publish:
+        name: Publish server.json
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        # id-token: write is what `mcp-publisher login github-oidc` needs.
+        permissions:
+            contents: read
+            id-token: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            - name: Stamp server.json from the release
+              shell: bash
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                TAG: ${{ github.event.release.tag_name || inputs.tag }}
+              run: |
+                set -euo pipefail
+                VERSION="${TAG#v}"
+                gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+                    --pattern altium-designer-mcp.mcpb --pattern SHA256SUMS.txt
+                # The asset must match the checksum published beside it.
+                sha256sum --check --ignore-missing --strict SHA256SUMS.txt
+                SHA="$(sha256sum altium-designer-mcp.mcpb | cut -d' ' -f1)"
+                sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+                    .github/release-assets/server.json > server.json
+                cat server.json
+
+            # Installed from its pinned release archive with a checksum check,
+            # like lychee in CI: the repository allow-lists actions, and a
+            # binary that publishes on our behalf deserves the same pinning.
+            - name: Install mcp-publisher
+              shell: bash
+              env:
+                MCP_PUBLISHER_VERSION: "1.8.1"
+                MCP_PUBLISHER_SHA256: "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+              run: |
+                set -euo pipefail
+                curl -sSfL -o mcp-publisher.tar.gz \
+                    "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+                echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check --strict
+                tar -xzf mcp-publisher.tar.gz mcp-publisher
+                ./mcp-publisher --version
+
+            - name: Validate server.json
+              shell: bash
+              run: ./mcp-publisher validate server.json
+
+            - name: Publish
+              shell: bash
+              run: |
+                set -euo pipefail
+                ./mcp-publisher login github-oidc
+                ./mcp-publisher publish server.json
+
+            - name: Confirm the listing
+              shell: bash
+              env:
+                TAG: ${{ github.event.release.tag_name || inputs.tag }}
+              run: |
+                set -euo pipefail
+                VERSION="${TAG#v}"
+                LISTING="$(curl -sSf "https://registry.modelcontextprotocol.io/v0/servers?search=altium-designer-mcp")"
+                echo "$LISTING" | grep -q "\"version\":\"${VERSION}\"" \
+                    || { echo "Error: version ${VERSION} not found in the registry listing"; echo "$LISTING"; exit 1; }
+                echo "Registry lists io.github.embedded-society/altium-designer-mcp ${VERSION}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   touches the network); the extension manifest links to it and carries the
   Embedded Society crest as its icon — both prerequisites for directory
   listings.
+- **Every published release is listed in the official MCP Registry.** A
+  workflow runs when a release goes public (or by hand for a tag), stamps
+  `server.json` with the version and the bundle's SHA-256 re-derived from the
+  release asset, and publishes it as
+  `io.github.embedded-society/altium-designer-mcp` over GitHub's OIDC token —
+  the registry the MCP clients' server browsers read.
 
 ## [1.0.0] - 2026-09-02
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,10 +33,6 @@ record). The specialised worklists stay the single source of truth for their are
       [desktop extension form](https://clau.de/desktop-extention-submission) once a
       release carries the annotations, icon and privacy policy (a `1.0.1`). Needs a
       human with the account: documentation URL, privacy policy URL, icon.
-- [ ] **Official MCP Registry, automated** — `io.github.embedded-society/altium-designer-mcp`
-      is published by hand from a `server.json` (mcpb package = the release asset + its
-      SHA-256); add a `release: published` workflow that runs `mcp-publisher login
-      github-oidc` + `publish` so every release updates the listing.
 - [ ] **OpenAI / ChatGPT** — its directory takes remote (HTTPS) servers only, so it waits
       for the v1.1.0 Streamable HTTP transport; Codex CLI users are covered already.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -130,6 +130,16 @@ Two notes on dry runs:
 
 10. **Announce** — including a note on the tracking issue if one is open.
 
+Publishing the release also triggers `.github/workflows/registry-publish.yml`,
+which lists the `.mcpb` in the official MCP Registry as
+`io.github.embedded-society/altium-designer-mcp` (version and bundle SHA-256
+stamped into `.github/release-assets/server.json`, authenticated with the
+workflow's OIDC token). Re-run it by hand for any tag:
+
+```bash
+gh workflow run registry-publish.yml -f tag=vX.Y.Z
+```
+
 ## Who can release
 
 A repository ruleset (`tags`, active, covering `~ALL` tags) restricts tag


### PR DESCRIPTION
Stacked on #493. Adds `.github/workflows/registry-publish.yml` + the `server.json` template:

- Triggers on `release: published` (a draft going public) and `workflow_dispatch` with a `tag` input.
- Downloads the tag's `altium-designer-mcp.mcpb` + `SHA256SUMS.txt`, verifies the asset against the published checksum, stamps version + SHA-256 into `server.json` (mcpb package → the release asset URL).
- Installs `mcp-publisher` 1.8.1 from its release archive with a checksum check (cross-checked against upstream's `registry_1.8.1_checksums.txt`), validates, `login github-oidc`, publishes, then asserts the version shows up in the registry listing.
- `id-token: write` only on this job; no secrets beyond `GITHUB_TOKEN` for the asset download.

Why OIDC: the registry grants `io.github.<org>/*` to workflows in the org's own repository; the manual CLI route needs the org's third-party OAuth-app policy to expose membership, which is what blocked today's hand publish. RELEASING.md documents the re-run command; the TODO "automate the registry" item is done by this PR.

After merge: `gh workflow run registry-publish.yml -f tag=v1.0.0` lists the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)