### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-09-02
+
 ### Added
 
 - **Every tool carries MCP annotations.** `tools/list` now gives each tool a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "altium-designer-mcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "altium-designer-mcp"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75"
 license = "GPL-3.0-or-later"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "altium-designer-mcp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "altium-designer-mcp",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "devDependencies": {
                 "markdownlint-cli2": "^0.23.2"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "altium-designer-mcp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "description": "An AI-operated Altium Designer libraries editor.",
     "scripts": {


### PR DESCRIPTION
Patch release carrying #493/#494 into the shipped artefacts: MCP tool annotations on all 34 tools, the Privacy Policy link and the Embedded Society icon in the extension manifest — the Claude Connectors Directory prerequisites — plus the registry auto-publish on release.

- `CHANGELOG.md`: `## [1.0.1] - 2026-09-02`; fresh empty `## [Unreleased]` above.
- Version `1.0.1` in `Cargo.toml`, `Cargo.lock`, `package.json`, `package-lock.json`.
- Gates: full suite ✓ · clippy 0 ✓ · fmt ✓ · markdownlint ✓ · `--version` prints `altium-designer-mcp 1.0.1`.

Rehearsal dry run on this exact commit linked below. After merge: signed tag `v1.0.1` → draft review → publish (the new workflow then lists 1.0.1 in the MCP Registry automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)