### PR TITLE
fix(ci): remove the placeholder requirements file Dependabot choked on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dependabot can evaluate the repository's Python dependency files again.**
+  A placeholder `requirements.txt` in the Altium generator directory (whose
+  scripts need only the standard library) read `TODO: fill out this`, which
+  Dependabot parsed as an invalid requirement and gave up on the whole
+  ecosystem. The file is removed; the readability oracle's pinned
+  requirements are the only Python dependencies.
+
 ## [1.0.1] - 2026-09-02
 
 ### Added

--- a/scripts/altium/generate/requirements.txt
+++ b/scripts/altium/generate/requirements.txt
@@ -1,1 +1,0 @@
-TODO: fill out this


### PR DESCRIPTION
Dependabot's dependency-graph job fails with `InstallationError("Invalid requirement: 'TODO: fill out this'…")`: `scripts/altium/generate/requirements.txt` was a never-filled placeholder. The generator's Python (`preflight_names.py`) imports only `subprocess` and `sys`, and nothing references the file, so it is removed. `tests/integration/requirements.txt` (pyaltiumlib, olefile — pinned) remains the repository's only Python dependency file, and Dependabot can evaluate it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)