### PR TITLE
feat: a Dockerfile that builds the same --locked release into a minimal image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Allow-list: the image build needs only the crate sources. Everything else —
+# target/, node_modules/, the golden fixtures, the Altium scripts, .git — would
+# bloat the build context without changing the binary.
+*
+!Cargo.toml
+!Cargo.lock
+!src/
+!docs/AGENT_GUIDE.md
+!LICENCE
+
+# rust-toolchain.toml is deliberately NOT sent: the builder image already
+# carries the pinned compiler, and the file would make rustup try to install
+# its listed components (rustfmt, clippy) at build time for no benefit.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,23 @@ updates:
           update-types: ["major", "minor", "patch"]
       labels: ["dependencies", "javascript"]
 
+    # Docker: the two Debian base images in the Dockerfile. The builder's Rust
+    # tag is pinned to rust-toolchain.toml and guarded by
+    # check-toolchain-pin.sh, so only the Debian suffix and the runtime image
+    # move here — same weekly batch.
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "saturday"
+        time: "00:00"
+        timezone: "Europe/Ljubljana"
+      groups:
+        docker:
+          patterns: ["*"]
+          update-types: ["major", "minor", "patch"]
+      labels: ["dependencies", "docker"]
+
     # Cargo: large transitive dependency surface. Weekly cadence +
     # grouping keeps PR noise manageable while still catching security
     # advisories within ~7 days. Grouping all updates into one PR per

--- a/.github/scripts/check-toolchain-pin.sh
+++ b/.github/scripts/check-toolchain-pin.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Verifies that every `dtolnay/rust-toolchain@<sha> # vX.Y.Z [(annotation)]`
-# pin in .github/workflows/ uses the same version comment, and that the
-# version matches the channel field in rust-toolchain.toml. Any trailing
+# pin in .github/workflows/ uses the same version comment, that the
+# version matches the channel field in rust-toolchain.toml, and that the
+# Dockerfile's builder image (`FROM rust:X.Y.Z-…`) is the same. Any trailing
 # annotation (e.g. " (latest stable)") is ignored — only the X.Y.Z token
 # is matched. Exits non-zero on mismatch.
 #
@@ -50,4 +51,17 @@ if [[ "$pin_version" != "$toml_channel" ]]; then
     exit 1
 fi
 
-echo "OK: Rust pinned to $pin_version (rust-toolchain.toml + dtolnay/rust-toolchain action)"
+dockerfile_version=$(sed -nE 's|^FROM[[:space:]]+rust:([0-9]+\.[0-9]+\.[0-9]+)[^[:space:]]*[[:space:]]+AS[[:space:]]+builder.*|\1|p' Dockerfile | head -n 1)
+
+if [[ -z "$dockerfile_version" ]]; then
+    echo "ERROR: no 'FROM rust:X.Y.Z-… AS builder' line found in Dockerfile" >&2
+    exit 1
+fi
+
+if [[ "$dockerfile_version" != "$toml_channel" ]]; then
+    echo "ERROR: Dockerfile builder image rust:$dockerfile_version does not match rust-toolchain.toml channel ($toml_channel)" >&2
+    echo "Bump all three together when updating Rust." >&2
+    exit 1
+fi
+
+echo "OK: Rust pinned to $pin_version (rust-toolchain.toml + dtolnay/rust-toolchain action + Dockerfile builder image)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A `Dockerfile`.** `docker build -t altium-designer-mcp .` produces the same
+  `--locked` release build as the published binaries on a minimal Debian image,
+  running unprivileged with the mounted `/libraries` folder as its whole
+  allow-list — for a Linux box, a NAS or a CI job that generates libraries into
+  a mounted folder. The builder's Rust tag is held to `rust-toolchain.toml` by
+  the same guard as the workflows, and Dependabot tracks the base images.
+
 ### Fixed
 
 - **Dependabot can evaluate the repository's Python dependency files again.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# Runs altium-designer-mcp in a container: the same `--locked` release build
+# the published binaries come from, on a minimal Debian base. Altium itself
+# never runs here — the container reads and writes library files under
+# /libraries, the only path it may touch, so mount your library folder there:
+#
+#     docker build -t altium-designer-mcp .
+#     docker run -i --rm -v /path/to/libraries:/libraries altium-designer-mcp
+#
+# See README.md § Installation. Both stages use the same Debian release so the
+# binary links against the glibc it will run on.
+
+# ---- builder ---------------------------------------------------------------
+# Pinned to the repository's Rust toolchain (rust-toolchain.toml); the tag is
+# held to it by .github/scripts/check-toolchain-pin.sh.
+FROM rust:1.95.0-slim-bookworm AS builder
+
+# git + CA certificates: Cargo.toml patches `cfb` to a git revision, which
+# cargo fetches over HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# --locked: the committed Cargo.lock, exactly as CI and the release build use it.
+RUN cargo build --locked --release --bin altium-designer-mcp
+
+# ---- runtime ---------------------------------------------------------------
+FROM debian:bookworm-slim
+
+LABEL org.opencontainers.image.title="altium-designer-mcp" \
+      org.opencontainers.image.description="MCP server for AI-assisted Altium Designer component library management" \
+      org.opencontainers.image.source="https://github.com/embedded-society/altium-designer-mcp" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later"
+
+# An unprivileged user owning the one folder the server is allowed to use.
+RUN useradd --system --create-home --uid 10001 mcp \
+    && mkdir -p /libraries \
+    && chown mcp:mcp /libraries
+
+COPY --from=builder /src/target/release/altium-designer-mcp /usr/local/bin/altium-designer-mcp
+
+USER mcp
+VOLUME ["/libraries"]
+
+# MCP over stdio; the mounted folder is the whole allow-list.
+ENTRYPOINT ["altium-designer-mcp"]
+CMD ["--allow", "/libraries"]

--- a/README.md
+++ b/README.md
@@ -287,6 +287,19 @@ wires the server into every MCP client we know of.
 `altium-designer-mcp.dxt`) via Settings → Extensions → Advanced settings →
 Install Extension… — see [CLIENT_SETUP.md § Claude Desktop](docs/CLIENT_SETUP.md#claude-desktop).
 
+**In a container** — for a Linux box, a NAS or a CI job that generates libraries into a
+mounted folder (Altium itself never needs to be inside): the repository's `Dockerfile`
+produces the same `--locked` release build as the published binaries.
+
+```bash
+docker build -t altium-designer-mcp .
+docker run -i --rm -v /path/to/libraries:/libraries altium-designer-mcp
+```
+
+The mounted `/libraries` folder is the container's whole allow-list. In a client's
+configuration that is `"command": "docker"` with
+`"args": ["run", "-i", "--rm", "-v", "/path/to/libraries:/libraries", "altium-designer-mcp"]`.
+
 To build from source instead, see
 [CONTRIBUTING.md § Development Setup](CONTRIBUTING.md#development-setup); an optimised
 binary comes from `cargo build --release` and lands at `target/release/altium-designer-mcp`.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://glama.ai/mcp/schemas/server.json",
+    "maintainers": ["MatejGomboc"]
+}


### PR DESCRIPTION
Adds a container route (prompted by the awesome-mcp-servers bot, which now requires a Glama listing with a working Dockerfile before merging #13495 — but useful on its own for a Linux box, a NAS or a CI job that generates libraries into a mounted folder).

- **`Dockerfile`**: `rust:1.95.0-slim-bookworm` builder running the same `cargo build --locked --release` as the published binaries → `debian:bookworm-slim` runtime, unprivileged `mcp` user, `VOLUME /libraries`, `ENTRYPOINT altium-designer-mcp`, `CMD --allow /libraries` (the mount is the whole allow-list). Same Debian release in both stages so glibc matches.
- **`.dockerignore`**: allow-list of what the build needs — `src/`, `Cargo.*`, `LICENCE`, and `docs/AGENT_GUIDE.md` (it's `include_str!`-ed into the server); `rust-toolchain.toml` deliberately excluded so rustup doesn't install rustfmt/clippy inside the build.
- **`check-toolchain-pin.sh`** now also holds the Dockerfile's `FROM rust:X.Y.Z` to `rust-toolchain.toml` — bumping Rust means bumping all three.
- **Dependabot**: `docker` ecosystem in the weekly batch for the base images.
- **README** § Installation: the container paragraph; **CHANGELOG** Added.

Verified locally: image builds (124 MB, ~3 min), `--version` → `altium-designer-mcp 1.0.1`, MCP `initialize` OK, `tools/list` → 34 tools with titles, runs as `uid=10001(mcp)`.

After merge, the remaining awesome-list steps are: claim the Glama listing and add the Dockerfile there (owner UI step), then add Glama's score badge to the PR entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)